### PR TITLE
Update to Xcode 11 project settings

### DIFF
--- a/AWSPlugins/AWSS3StoragePlugin/Service/Auth/AWSAuthServiceBehavior.swift
+++ b/AWSPlugins/AWSS3StoragePlugin/Service/Auth/AWSAuthServiceBehavior.swift
@@ -12,7 +12,7 @@ import Amplify
 protocol AWSAuthServiceBehavior {
 
     func reset()
-    
+
     func getCognitoCredentialsProvider() -> AWSCognitoCredentialsProvider
 
     func getIdentityId() -> Result<String, StorageError>

--- a/AWSPlugins/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginAccessLevelTests.swift
+++ b/AWSPlugins/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginAccessLevelTests.swift
@@ -227,7 +227,7 @@ class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase {
         waitForExpectations(timeout: 5)
     }
 
-    // Mark: Commonn test functions
+    // MARK: - Common test functions
 
     func putThenListThenGetThenRemoveForSingleUser(username: String, key: String, accessLevel: StorageAccessLevel) {
         signIn(username: username)

--- a/AWSPlugins/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginResumabilityTests.swift
+++ b/AWSPlugins/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginResumabilityTests.swift
@@ -30,5 +30,4 @@ class AWSS3StoragePluginResumabilityTests: AWSS3StoragePluginTestBase {
     //        XCTFail("Not yet implemented")
     //    }
 
-    
 }

--- a/AWSPlugins/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginTestBase.swift
+++ b/AWSPlugins/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginTestBase.swift
@@ -52,7 +52,8 @@ class AWSS3StoragePluginTestBase: XCTestCase {
 
         // TODO: Set up Amplify Hub configuration, and others like logging, auth
         let amplifyConfig = AmplifyConfiguration(storage: storageConfig)
-        //TODO: let amplifyConfig = AmplifyConfiguration(analytics: nil, api: nil, hub: hubConfig, logging: nil, storage: storageConfig)
+        //TODO: let amplifyConfig = AmplifyConfiguration(analytics: nil, api: nil, hub: hubConfig,
+        //logging: nil, storage: storageConfig)
 
         // Set up Amplify
         do {
@@ -71,7 +72,7 @@ class AWSS3StoragePluginTestBase: XCTestCase {
     }
 
     // MARK: Common Helper functions
-    
+
     func putData(key: String, dataString: String) {
         putData(key: key, data: dataString.data(using: .utf8)!)
     }

--- a/AWSPlugins/AWSS3StoragePluginTests/AWSS3StoragePluginAPIBehaviorTests.swift
+++ b/AWSPlugins/AWSS3StoragePluginTests/AWSS3StoragePluginAPIBehaviorTests.swift
@@ -95,7 +95,6 @@ class AWSS3StoragePluginAPIBehaviorTests: AWSS3StoragePluginTests {
         XCTAssertEqual(queue.size, 1)
     }
 
-
     // MARK: DownloadFile API Tests
 
     func testPluginDownloadFile() {

--- a/AWSPlugins/AWSS3StoragePluginTests/Mocks/MockAWSS3TransferUtility.swift
+++ b/AWSPlugins/AWSS3StoragePluginTests/Mocks/MockAWSS3TransferUtility.swift
@@ -35,7 +35,7 @@ public class MockAWSS3TransferUtility: AWSS3TransferUtilityBehavior {
         }
 
         let task = AWSS3TransferUtilityDownloadTask()
-        
+
         //let url = URL(fileURLWithPath: "path")
         //let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
         //task.response = response

--- a/AWSPlugins/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceConfigureTests.swift
+++ b/AWSPlugins/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceConfigureTests.swift
@@ -8,7 +8,4 @@
 import XCTest
 
 class AWSS3StorageServiceConfigureTests: AWSS3StorageServiceTestBase {
-
-   
-
 }

--- a/AWSPlugins/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceDeleteBehaviorTests.swift
+++ b/AWSPlugins/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceDeleteBehaviorTests.swift
@@ -8,7 +8,4 @@
 import XCTest
 
 class AWSS3StorageServiceDeleteBehaviorTests: AWSS3StorageServiceTestBase {
-
-    
-
 }

--- a/AWSPlugins/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceEscapeHatchBehaviorTests.swift
+++ b/AWSPlugins/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceEscapeHatchBehaviorTests.swift
@@ -8,7 +8,4 @@
 import XCTest
 
 class AWSS3StorageServiceEscapeHatchBehaviorTests: AWSS3StorageServiceTestBase {
-
-    
-
 }

--- a/AWSPlugins/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceMultiPartUploadBehaviorTests.swift
+++ b/AWSPlugins/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceMultiPartUploadBehaviorTests.swift
@@ -8,6 +8,4 @@
 import XCTest
 
 class AWSS3StorageServiceMultiPartUploadBehaviorTests: AWSS3StorageServiceTestBase {
-
-
 }

--- a/AWSPlugins/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceUploadBehaviorTests.swift
+++ b/AWSPlugins/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceUploadBehaviorTests.swift
@@ -8,7 +8,4 @@
 import XCTest
 
 class AWSS3StorageServiceUploadBehaviorTests: AWSS3StorageServiceTestBase {
-
-   
-
 }

--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -123,11 +123,11 @@
 		21FFFA1F2313453D005878EA /* MockOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFF9E1230F08F7005878EA /* MockOperationQueue.swift */; };
 		21FFFA2023134542005878EA /* MockAWSS3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFF9D8230E1851005878EA /* MockAWSS3.swift */; };
 		3263D332138415AF42E64FF7 /* Pods_AmplifyTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC7F1C368154B364CB74742 /* Pods_AmplifyTestApp.framework */; };
-		7D5ED6C78E25246DDAF2F2EC /* Pods_Amplify.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84F3A76FB68CEFA45F4BB1BB /* Pods_Amplify.framework */; };
+		7D5ED6C78E25246DDAF2F2EC /* Pods_Amplify.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84F3A76FB68CEFA45F4BB1BB /* Pods_Amplify.framework */; platformFilter = ios; };
 		9A7FF1D19CF0F11F96312DA4 /* Pods_AmplifyTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 176E334A02509BD4CE8866A6 /* Pods_AmplifyTests.framework */; };
 		9F1570B537834ED7F87E6CE2 /* Pods_AWSS3StoragePluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CED44BE0096B074979532239 /* Pods_AWSS3StoragePluginTests.framework */; };
-		DA8076A12E27D05D777F4F11 /* Pods_AWSS3StoragePlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A4AE82D161DB4E9B6EC9281 /* Pods_AWSS3StoragePlugin.framework */; };
-		E2404F97BAFBE14273B869B2 /* Pods_AmplifyTestCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A758B7EC0289740B40CF0BE8 /* Pods_AmplifyTestCommon.framework */; };
+		DA8076A12E27D05D777F4F11 /* Pods_AWSS3StoragePlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A4AE82D161DB4E9B6EC9281 /* Pods_AWSS3StoragePlugin.framework */; platformFilter = ios; };
+		E2404F97BAFBE14273B869B2 /* Pods_AmplifyTestCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A758B7EC0289740B40CF0BE8 /* Pods_AmplifyTestCommon.framework */; platformFilter = ios; };
 		FA09B92B2321A10E000E064D /* AnalyticsCategory+CategoryConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA09B92A2321A10E000E064D /* AnalyticsCategory+CategoryConfigurable.swift */; };
 		FA09B92D2321A27F000E064D /* CategoryConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA09B92C2321A27F000E064D /* CategoryConfigurable.swift */; };
 		FA09B92F2321A2DE000E064D /* APICategory+CategoryConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA09B92E2321A2DE000E064D /* APICategory+CategoryConfigurable.swift */; };
@@ -1640,7 +1640,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1030;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1100;
 				ORGANIZATIONNAME = "Amazon Web Services";
 				TargetAttributes = {
 					2125E1FD2318327300B3DEB5 = {
@@ -2449,7 +2449,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = W3DRXD72QU;
 				INFOPLIST_FILE = AmplifyTestApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2470,7 +2470,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = W3DRXD72QU;
 				INFOPLIST_FILE = AmplifyTestApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2487,7 +2487,7 @@
 			baseConfigurationReference = 6BAC32194A15ACB56F07DC87 /* Pods-AWSS3StoragePlugin.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = W3DRXD72QU;
@@ -2633,7 +2633,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -2691,7 +2691,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;

--- a/Amplify.xcodeproj/xcshareddata/xcschemes/AWSS3StoragePlugin.xcscheme
+++ b/Amplify.xcodeproj/xcshareddata/xcschemes/AWSS3StoragePlugin.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1030"
+   LastUpgradeVersion = "1100"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,9 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "21265DA32307389A004CCE39"
+            BuildableName = "AWSS3StoragePlugin.framework"
+            BlueprintName = "AWSS3StoragePlugin"
+            ReferencedContainer = "container:Amplify.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -55,17 +64,6 @@
             </SkippedTests>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "21265DA32307389A004CCE39"
-            BuildableName = "AWSS3StoragePlugin.framework"
-            BlueprintName = "AWSS3StoragePlugin"
-            ReferencedContainer = "container:Amplify.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -86,8 +84,6 @@
             ReferencedContainer = "container:Amplify.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Amplify.xcodeproj/xcshareddata/xcschemes/AWSS3StoragePluginIntegrationTests.xcscheme
+++ b/Amplify.xcodeproj/xcshareddata/xcschemes/AWSS3StoragePluginIntegrationTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1030"
+   LastUpgradeVersion = "1100"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -10,8 +10,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -29,8 +29,6 @@
             </SkippedTests>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -42,8 +40,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Amplify.xcodeproj/xcshareddata/xcschemes/Amplify.xcscheme
+++ b/Amplify.xcodeproj/xcshareddata/xcschemes/Amplify.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1100"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,9 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FAC234D12279F8DA00424678"
+            BuildableName = "Amplify.framework"
+            BlueprintName = "Amplify"
+            ReferencedContainer = "container:Amplify.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -67,17 +76,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "FAC234D12279F8DA00424678"
-            BuildableName = "Amplify.framework"
-            BlueprintName = "Amplify"
-            ReferencedContainer = "container:Amplify.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -98,8 +96,6 @@
             ReferencedContainer = "container:Amplify.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
@@ -143,7 +143,7 @@ class StorageCategoryConfigurationTests: XCTestCase {
 
         try Amplify.configure(amplifyConfig)
 
-        Amplify.Storage.getData(key: "", options: nil, onEvent: nil)
+        _ = Amplify.Storage.getData(key: "", options: nil, onEvent: nil)
 
         waitForExpectations(timeout: 1.0)
     }
@@ -181,7 +181,7 @@ class StorageCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(storage: storageConfig)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.Storage.getData(key: "", options: nil, onEvent: nil)
+        _ = Amplify.Storage.getData(key: "", options: nil, onEvent: nil)
         waitForExpectations(timeout: 1.0)
     }
 
@@ -219,7 +219,8 @@ class StorageCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(storage: storageConfig)
 
         try Amplify.configure(amplifyConfig)
-        try Amplify.Storage.getPlugin(for: "MockSecondStorageCategoryPlugin").getData(key: "", options: nil, onEvent: nil)
+        _ = try Amplify.Storage.getPlugin(for: "MockSecondStorageCategoryPlugin")
+            .getData(key: "", options: nil, onEvent: nil)
         waitForExpectations(timeout: 1.0)
     }
 

--- a/AmplifyTests/CoreTests/JSONValueTests.swift
+++ b/AmplifyTests/CoreTests/JSONValueTests.swift
@@ -25,6 +25,8 @@ class JSONValueTests: XCTestCase {
         XCTAssertEqual(decodedObject, expectedObject)
     }
 
+    // This test relies on `sortedKeys` to make string comparison easier
+    @available(iOS 11.0, *)
     func testEncode() throws {
         let encoder = JSONEncoder()
         encoder.outputFormatting = .sortedKeys


### PR DESCRIPTION
Updates Amplify to Xcode 11 project support, fixes some minor linting issues to make it easier to catch the major linting issues (TODO, class/file body length). Once this is merged, everybody needs to be using Xcode11 to develop Amplify.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
