### PR TITLE
Sample event documentation for StorageDownloadFileRequest

### DIFF
--- a/Amplify/Categories/Hub/HubPayload.swift
+++ b/Amplify/Categories/Hub/HubPayload.swift
@@ -8,7 +8,7 @@
 /// The payload of a Hub message
 public struct HubPayload {
 
-    /// A struct containing event names registered by Amplify Operations
+    /// Event names registered by Amplify Operations
     public struct EventName {}
 
     /// The name, tag, or grouping of the HubPayload. Recommended to be a small string without spaces,

--- a/Amplify/Categories/Storage/Operation/StorageDownloadFileOperation.swift
+++ b/Amplify/Categories/Storage/Operation/StorageDownloadFileOperation.swift
@@ -7,6 +7,15 @@
 
 import Foundation
 
+/// This operation encapsulates work to download an object from cloud storage to local storage.
+///
+/// ## Event descriptions
+/// - InProcess: `Progress` - representing the progress of the download. This event will be emitted as controlled by the
+///   underlying NSURLSession behavior, but could be multiple times per second. Apps should not rely on Progress to be
+///   1.0 to determine a completed operation
+/// - Completed: `Void` - Receipt of a `.completed` event indicates the download is complete and the file has been
+///   successfully stored to the local URL supplied in the original `StorageDownloadFileRequest`
+/// - Error: `StorageError` - Emitted if the download encounters an error.
 public protocol StorageDownloadFileOperation: AmplifyOperation<StorageDownloadFileRequest, Progress, Void,
 StorageError> { }
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A declarative library for application development using cloud services.
 
+- **API Documentation**
+  https://aws-amplify.github.io/amplify-ios/docs
+
 ## Platform Support
 
 Amplify supports iOS 11 and above. There are currently no plans to support Amplify on WatchOS, tvOS, or MacOS.


### PR DESCRIPTION
Sample event docs for StorageDownloadFileRequest. Let's decide on a format for documenting events and see how they look in generated docs.

This PR generated the docs at: https://aws-amplify.github.io/amplify-ios/docs/Protocols.html#/s:7Amplify28StorageDownloadFileOperationP

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
