### PR TITLE
Basic interface for retry logic for sync engine

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -173,6 +173,22 @@
 		490586942D1AF4C5FC2F6821 /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSAPICategoryPluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C26953F5040100E59C970065 /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSAPICategoryPluginTests.framework */; };
 		4F796DBB8AE6B73FEA5AB94E /* Pods_Amplify_AWSPluginsCore_CoreMLPredictionsPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73C2E5FA55C85539AD9E39EE /* Pods_Amplify_AWSPluginsCore_CoreMLPredictionsPlugin.framework */; };
 		6127B967CDAE66CC63BBE661 /* Pods_AmplifyTestApp_AWSPredictionsPluginIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B98A93BFFD5E72827BDCC750 /* Pods_AmplifyTestApp_AWSPredictionsPluginIntegrationTests.framework */; };
+		6BCAE80E2374AC0100E062AC /* AWSDataStoreRetryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCAE80D2374AC0100E062AC /* AWSDataStoreRetryable.swift */; };
+		6BCAE80F2374AC0100E062AC /* AWSDataStoreRetryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCAE80D2374AC0100E062AC /* AWSDataStoreRetryable.swift */; };
+		6BCAE8102374AC0100E062AC /* AWSDataStoreRetryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCAE80D2374AC0100E062AC /* AWSDataStoreRetryable.swift */; };
+		6BCAE8112374AC0100E062AC /* AWSDataStoreRetryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCAE80D2374AC0100E062AC /* AWSDataStoreRetryable.swift */; };
+		6BCAE8132374ADAE00E062AC /* AWSDataStoreClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCAE8122374ADAE00E062AC /* AWSDataStoreClientError.swift */; };
+		6BCAE8142374ADAE00E062AC /* AWSDataStoreClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCAE8122374ADAE00E062AC /* AWSDataStoreClientError.swift */; };
+		6BCAE8152374ADAE00E062AC /* AWSDataStoreClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCAE8122374ADAE00E062AC /* AWSDataStoreClientError.swift */; };
+		6BCAE8162374ADAE00E062AC /* AWSDataStoreClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCAE8122374ADAE00E062AC /* AWSDataStoreClientError.swift */; };
+		6BCAE8182374AEA000E062AC /* AWSDataStoreRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCAE8172374AEA000E062AC /* AWSDataStoreRequestStrategy.swift */; };
+		6BCAE8192374AEA000E062AC /* AWSDataStoreRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCAE8172374AEA000E062AC /* AWSDataStoreRequestStrategy.swift */; };
+		6BCAE81A2374AEA000E062AC /* AWSDataStoreRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCAE8172374AEA000E062AC /* AWSDataStoreRequestStrategy.swift */; };
+		6BCAE81B2374AEA000E062AC /* AWSDataStoreRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCAE8172374AEA000E062AC /* AWSDataStoreRequestStrategy.swift */; };
+		6BCAE8222374E9CC00E062AC /* AWSDataStoreSyncEngineRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCAE8212374E9CC00E062AC /* AWSDataStoreSyncEngineRetryPolicy.swift */; };
+		6BCAE8232374E9CC00E062AC /* AWSDataStoreSyncEngineRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCAE8212374E9CC00E062AC /* AWSDataStoreSyncEngineRetryPolicy.swift */; };
+		6BCAE8242374E9CC00E062AC /* AWSDataStoreSyncEngineRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCAE8212374E9CC00E062AC /* AWSDataStoreSyncEngineRetryPolicy.swift */; };
+		6BCAE8252374E9CC00E062AC /* AWSDataStoreSyncEngineRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCAE8212374E9CC00E062AC /* AWSDataStoreSyncEngineRetryPolicy.swift */; };
 		7D5ED6C78E25246DDAF2F2EC /* Pods_Amplify.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84F3A76FB68CEFA45F4BB1BB /* Pods_Amplify.framework */; platformFilter = ios; };
 		7F27B1DCE59C1E674172CCD6 /* Pods_Amplify_AmplifyTestConfigs_AmplifyTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 976D972EC2BBCAAD023694EB /* Pods_Amplify_AmplifyTestConfigs_AmplifyTests.framework */; };
 		80CF9ED038D61833716854B8 /* Pods_Amplify_AWSPluginsCore_AWSDataStoreCategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ED013FD8A569C8E3D67506B /* Pods_Amplify_AWSPluginsCore_AWSDataStoreCategoryPlugin.framework */; };
@@ -1120,6 +1136,10 @@
 		687B09E9348F8D29979A2404 /* Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests/Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6AF0E4775809F0866F9C44D9 /* Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig"; path = "Target Support Files/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6BAC32194A15ACB56F07DC87 /* Pods-AWSS3StoragePlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSS3StoragePlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSS3StoragePlugin/Pods-AWSS3StoragePlugin.debug.xcconfig"; sourceTree = "<group>"; };
+		6BCAE80D2374AC0100E062AC /* AWSDataStoreRetryable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreRetryable.swift; sourceTree = "<group>"; };
+		6BCAE8122374ADAE00E062AC /* AWSDataStoreClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreClientError.swift; sourceTree = "<group>"; };
+		6BCAE8172374AEA000E062AC /* AWSDataStoreRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreRequestStrategy.swift; sourceTree = "<group>"; };
+		6BCAE8212374E9CC00E062AC /* AWSDataStoreSyncEngineRetryPolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSDataStoreSyncEngineRetryPolicy.swift; sourceTree = "<group>"; };
 		6C41D3730B7ED4FD62A43E40 /* Pods-Amplify-AmplifyAWSPlugins-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AmplifyAWSPlugins-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AmplifyAWSPlugins-AWSAPICategoryPlugin-AWSAPICategoryPluginTests/Pods-Amplify-AmplifyAWSPlugins-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6D51240C78418B733FFA6829 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSDataStoreCategoryPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSDataStoreCategoryPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSDataStoreCategoryPluginTests/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSDataStoreCategoryPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6D62C9C57736C3BEADEB1E30 /* Pods-AWSPinpointAnalyticsPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSPinpointAnalyticsPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSPinpointAnalyticsPlugin/Pods-AWSPinpointAnalyticsPlugin.debug.xcconfig"; sourceTree = "<group>"; };
@@ -2447,6 +2467,17 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		6BCAE80723749C8200E062AC /* Sync */ = {
+			isa = PBXGroup;
+			children = (
+				6BCAE80D2374AC0100E062AC /* AWSDataStoreRetryable.swift */,
+				6BCAE8212374E9CC00E062AC /* AWSDataStoreSyncEngineRetryPolicy.swift */,
+				6BCAE8122374ADAE00E062AC /* AWSDataStoreClientError.swift */,
+				6BCAE8172374AEA000E062AC /* AWSDataStoreRequestStrategy.swift */,
+			);
+			path = Sync;
+			sourceTree = "<group>";
+		};
 		95DAA9662371CC830028544F /* Service */ = {
 			isa = PBXGroup;
 			children = (
@@ -2726,6 +2757,7 @@
 		B92E03C12367CFF2006CEB8D /* AWSDataStoreCategoryPlugin */ = {
 			isa = PBXGroup;
 			children = (
+				6BCAE80723749C8200E062AC /* Sync */,
 				B92E03DD2367D2A4006CEB8D /* Storage */,
 				B92E03E62367D2A4006CEB8D /* AWSDataStoreCategoryPlugin.swift */,
 				B92E03C32367CFF2006CEB8D /* Info.plist */,
@@ -6487,11 +6519,15 @@
 				B92E03E92367D2A4006CEB8D /* StorageEngine.swift in Sources */,
 				B92E03EA2367D2A4006CEB8D /* ModelSchema+SQLite.swift in Sources */,
 				B92E03EE2367D2A4006CEB8D /* AWSDataStoreCategoryPlugin.swift in Sources */,
+				6BCAE8142374ADAE00E062AC /* AWSDataStoreClientError.swift in Sources */,
 				B92E03E82367D2A4006CEB8D /* StorageEngineAdapter.swift in Sources */,
+				6BCAE8192374AEA000E062AC /* AWSDataStoreRequestStrategy.swift in Sources */,
 				B92E03EB2367D2A4006CEB8D /* Model+SQLite.swift in Sources */,
 				B92E03EC2367D2A4006CEB8D /* StorageEngineAdapter+SQLite.swift in Sources */,
+				6BCAE80F2374AC0100E062AC /* AWSDataStoreRetryable.swift in Sources */,
 				B92E03ED2367D2A4006CEB8D /* Statement+Model.swift in Sources */,
 				B922E273236A07CA00D09250 /* QueryPredicate+SQLite.swift in Sources */,
+				6BCAE8232374E9CC00E062AC /* AWSDataStoreSyncEngineRetryPolicy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6500,8 +6536,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				B92E040523680E36006CEB8D /* Comment+Schema.swift in Sources */,
+				6BCAE8252374E9CC00E062AC /* AWSDataStoreSyncEngineRetryPolicy.swift in Sources */,
+				6BCAE81B2374AEA000E062AC /* AWSDataStoreRequestStrategy.swift in Sources */,
+				6BCAE8112374AC0100E062AC /* AWSDataStoreRetryable.swift in Sources */,
 				B92E040723680E36006CEB8D /* Comment.swift in Sources */,
 				B92E040823680E36006CEB8D /* Post+Schema.swift in Sources */,
+				6BCAE8162374ADAE00E062AC /* AWSDataStoreClientError.swift in Sources */,
 				B92E040423680E2C006CEB8D /* SQLiteStorageEngineAdapterTests.swift in Sources */,
 				B922E27C236BC5A000D09250 /* QueryPredicateTests.swift in Sources */,
 				B922E276236A083B00D09250 /* SQLiteQueryTranslatorTests.swift in Sources */,
@@ -6513,7 +6553,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6BCAE81A2374AEA000E062AC /* AWSDataStoreRequestStrategy.swift in Sources */,
 				B92E04112368FE5B006CEB8D /* AWSDataStoreCategoryPluginIntegrationTests.swift in Sources */,
+				6BCAE8152374ADAE00E062AC /* AWSDataStoreClientError.swift in Sources */,
+				6BCAE8242374E9CC00E062AC /* AWSDataStoreSyncEngineRetryPolicy.swift in Sources */,
+				6BCAE8102374AC0100E062AC /* AWSDataStoreRetryable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6618,6 +6662,7 @@
 				216879FE23636A0A004A056E /* RepeatingTimer.swift in Sources */,
 				FAC23542227A055200424678 /* Foundation+Utils.swift in Sources */,
 				FAC0A2AF22B4400100B50912 /* LoggingCategory+ClientBehavior.swift in Sources */,
+				6BCAE8132374ADAE00E062AC /* AWSDataStoreClientError.swift in Sources */,
 				FA6BC87F235F5DAE0001A882 /* APICategoryInterceptorBehavior.swift in Sources */,
 				FAC23545227A055200424678 /* AmplifyConfiguration.swift in Sources */,
 				B4D38536236C97360014653D /* CallType.swift in Sources */,
@@ -6683,6 +6728,7 @@
 				FA9FB77B2329D4FB00C04D32 /* UnsubscribeToken.swift in Sources */,
 				B4D38531236C97360014653D /* PredictionsCategoryClientBehavior.swift in Sources */,
 				95DAA9522371CB3B0028544F /* IdentifyLabelsResult.swift in Sources */,
+				6BCAE8222374E9CC00E062AC /* AWSDataStoreSyncEngineRetryPolicy.swift in Sources */,
 				FAC428A2235F80000000F221 /* APICategory+GraphQLBehavior.swift in Sources */,
 				B4BD6B392370932300A1F0A7 /* PredictionsIdentifyRequest.swift in Sources */,
 				B4D38532236C97360014653D /* ConvertResult.swift in Sources */,
@@ -6698,6 +6744,7 @@
 				FA09B92D2321A27F000E064D /* CategoryConfigurable.swift in Sources */,
 				B92E03B72367CE7A006CEB8D /* ModelRegistry.swift in Sources */,
 				FA09B93B2321A36F000E064D /* StorageCategory+CategoryConfigurable.swift in Sources */,
+				6BCAE8182374AEA000E062AC /* AWSDataStoreRequestStrategy.swift in Sources */,
 				B4D38539236C97360014653D /* PredictionsCategory+ClientBehavior.swift in Sources */,
 				210DBC142332B3C6009B9E51 /* StorageGetURLOperation.swift in Sources */,
 				FA09B94D2322CC05000E064D /* StorageCategoryConfiguration.swift in Sources */,
@@ -6743,6 +6790,7 @@
 				B92E03B42367CE7A006CEB8D /* DataStoreCategory+Configurable.swift in Sources */,
 				FAC23522227A053D00424678 /* LoggingCategory.swift in Sources */,
 				FAC2358F227A4A6E00424678 /* HubCategory.swift in Sources */,
+				6BCAE80E2374AC0100E062AC /* AWSDataStoreRetryable.swift in Sources */,
 				B98E9D0E2372236300934B51 /* ModelKey.swift in Sources */,
 				B98E9D0D2372236300934B51 /* Query.swift in Sources */,
 				B98E9D122372236300934B51 /* QueryField.swift in Sources */,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/AWSDataStoreClientError.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/AWSDataStoreClientError.swift
@@ -1,0 +1,14 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+public enum AWSDataStoreClientError: Error {
+    case requestFailed(Data?, HTTPURLResponse?, Error?)
+    case noData(HTTPURLResponse)
+    case parseError(Data, HTTPURLResponse, Error?)
+    case authenticationError(Error)
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/AWSDataStoreRequestStrategy.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/AWSDataStoreRequestStrategy.swift
@@ -1,0 +1,12 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public enum AWSDataStoreRetryStrategy {
+    case exponential, aggressive
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/AWSDataStoreRetryable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/AWSDataStoreRetryable.swift
@@ -1,0 +1,18 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+struct AWSDataStoreRetryAdvice {
+    let shouldRetry: Bool
+    let retryInterval: DispatchTimeInterval?
+}
+
+protocol AWSDataStoreRetryable {
+    func shouldRetryRequest(for error: AWSDataStoreClientError) -> AWSDataStoreRetryAdvice
+    func shouldRetryMutationRequest(for error: Error) -> AWSDataStoreRetryAdvice
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/AWSDataStoreSyncEngineRetryPolicy.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/AWSDataStoreSyncEngineRetryPolicy.swift
@@ -1,0 +1,153 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+class AWSDataStoreSyncEngineRetryPolicy: AWSDataStoreRetryable {
+    static let maxWaitMilliseconds = 300 * 1_000 // 5 minutes of max retry duration.
+    static let maxRetryAttemptsWhenUsingAggresiveMode = 30
+
+    private static let jitterMilliseconds: Float = 100.0
+    private var currentAttemptNumber = 0
+    private var retryStrategy: AWSDataStoreRetryStrategy
+
+    init(retryStrategy: AWSDataStoreRetryStrategy = .exponential) {
+        self.retryStrategy = retryStrategy
+    }
+
+    //Largely a copy of AWSAppSyncRetryHandler
+    func shouldRetryRequest(for error: AWSDataStoreClientError) -> AWSDataStoreRetryAdvice {
+        currentAttemptNumber += 1
+
+        var httpResponse: HTTPURLResponse?
+
+        switch error {
+        case .requestFailed(_, let reponse, _):
+            httpResponse = reponse
+        case .noData(let response):
+            httpResponse = response
+        case .parseError(_, let response, _):
+            httpResponse = response
+        case .authenticationError:
+            httpResponse = nil
+        }
+
+        /// If no known error and we did not receive an HTTP response, we return false.
+        guard let unwrappedResponse = httpResponse else {
+            return AWSDataStoreRetryAdvice(shouldRetry: false, retryInterval: nil)
+        }
+
+        if let retryAfterValueInSeconds = AWSDataStoreSyncEngineRetryPolicy.getRetryAfterHeaderValue(from: unwrappedResponse) {
+            return AWSDataStoreRetryAdvice(shouldRetry: true, retryInterval: .seconds(retryAfterValueInSeconds))
+        }
+
+        // If using aggressive retry strategy, we attempt a maximum 12 times.
+        if retryStrategy == .aggressive &&
+            currentAttemptNumber > AWSDataStoreSyncEngineRetryPolicy.maxRetryAttemptsWhenUsingAggresiveMode {
+            return AWSDataStoreRetryAdvice(shouldRetry: false, retryInterval: nil)
+        }
+
+        let waitMillis = AWSDataStoreSyncEngineRetryPolicy.retryDelayInMillseconds(for: currentAttemptNumber, retryStrategy: retryStrategy)
+
+        switch unwrappedResponse.statusCode {
+        case 500 ... 599, 429:
+            if waitMillis > AWSDataStoreSyncEngineRetryPolicy.maxWaitMilliseconds {
+                break
+            } else {
+                return AWSDataStoreRetryAdvice(shouldRetry: true, retryInterval: .milliseconds(waitMillis))
+            }
+        default:
+            break
+        }
+        return AWSDataStoreRetryAdvice(shouldRetry: false, retryInterval: nil)
+    }
+
+    /// Returns a delay in milliseconds for the current attempt number. The delay includes random jitter as
+    /// described in https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+    private static func retryDelayInMillseconds(for attemptNumber: Int, retryStrategy: AWSDataStoreRetryStrategy) -> Int {
+        let jitter = Double(getRandomBetween0And1() * jitterMilliseconds)
+        switch retryStrategy {
+        case .aggressive:
+            let delay = Int(Double(1_000.0 + jitter))
+            return delay
+        case .exponential:
+            let delay = Int(Double(truncating: pow(2.0, attemptNumber) as NSNumber) * 100.0 + jitter)
+            return delay
+        }
+    }
+
+    private static func getRandomBetween0And1() -> Float {
+        return Float.random(in: 0 ... 1)
+    }
+
+    /// Returns the value of the "Retry-After" header as an Int, or nil if the value isn't present or cannot
+    /// be converted to an Int
+    ///
+    /// - Parameter response: The response to get the header from
+    /// - Returns: The value of the "Retry-After" header, or nil if not present or not convertable to Int
+    private static func getRetryAfterHeaderValue(from response: HTTPURLResponse) -> Int? {
+        let waitTime: Int?
+        switch response.allHeaderFields["Retry-After"] {
+        case let retryTime as String:
+            waitTime = Int(retryTime)
+        case let retryTime as Int:
+            waitTime = retryTime
+        default:
+            waitTime = nil
+        }
+
+        return waitTime
+    }
+
+    // This function is largely a copy of AWSMutationRetryAdviceHelper
+    func shouldRetryMutationRequest(for error: Error) -> AWSDataStoreRetryAdvice {
+        if let appsyncError = error as? AWSDataStoreClientError {
+            switch appsyncError {
+            case .authenticationError(let authError):
+                // We are currently checking for this error due to IAM auth.
+                // If Cognito Identity SDK does not have an identity id available,
+                // It tries to get one before giving the callback to appsync SDK.
+                // If Cognito Identity SDK cannot reach the service to fetch identityd id,
+                // it will propogate the error it encoutered to AppSync. We specifically
+                // check if the error is of type internet not available and then retry.
+                return AWSDataStoreSyncEngineRetryPolicy.isErrorURLDomainError(error: authError)
+            case .requestFailed(_, _, let urlError):
+                if let urlError = urlError {
+                    return AWSDataStoreSyncEngineRetryPolicy.isErrorURLDomainError(error: urlError)
+                }
+            default:
+                break
+            }
+        } else {
+            return AWSDataStoreSyncEngineRetryPolicy.isErrorURLDomainError(error: error)
+        }
+        return AWSDataStoreRetryAdvice(shouldRetry: false, retryInterval: nil)
+    }
+
+    /// We evaluate the error against known error codes which could result due to
+    /// unavailable internet or spotty network connection.
+    private static func isErrorURLDomainError(error: Error) -> AWSDataStoreRetryAdvice {
+        let nsError = error as NSError
+        guard nsError.domain == NSURLErrorDomain else {
+            return AWSDataStoreRetryAdvice(shouldRetry: false, retryInterval: nil)
+        }
+        switch nsError.code {
+        case NSURLErrorNotConnectedToInternet,
+             NSURLErrorDNSLookupFailed,
+             NSURLErrorCannotConnectToHost,
+             NSURLErrorCannotFindHost,
+             NSURLErrorTimedOut:
+            //TODO: In the AWSMutationRetryAdviceHelper implementation, there was no exponential
+            // backoff.  We could easily implement one here if needed, but to get some
+            // feedback quickly, I decided to just a 25ms delay here.
+            return AWSDataStoreRetryAdvice(shouldRetry: false, retryInterval: .milliseconds(25))
+        default:
+            break
+        }
+        return AWSDataStoreRetryAdvice(shouldRetry: false, retryInterval: nil)
+    }
+}


### PR DESCRIPTION
*Description of changes:*
* **Pushing this out prematurely** to get some fast feedback around how we want to handle retries in the SyncEngine
* Logic mostly copy and pasted from AWSAppSync . (`AWSAppSyncRetryHandler` and `AWSMutationRetryAdviceHelper`)
* There seems to be some hacks around how we handle mutation retry logic that I wasn't super confident in unifying with the other retryable logic... May need to discuss how we want to unify (or keep just the interface separate)
* Not sure if we should be introduce exponential backoff logic for mutation requests (there didn't seem to be any in aws app sync)
* Will write unit tests after we decide on how we move forward.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
