### PR TITLE
combine + sync engine initial work

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -398,6 +398,11 @@
 		B98E9D122372236300934B51 /* QueryField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98E9D0A2372236200934B51 /* QueryField.swift */; };
 		B98E9D132372236300934B51 /* QueryOperator+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98E9D0B2372236200934B51 /* QueryOperator+Equatable.swift */; };
 		B98E9D142372236300934B51 /* QueryPredicate+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98E9D0C2372236200934B51 /* QueryPredicate+Equatable.swift */; };
+		B98E9D17237279B400934B51 /* SyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98E9D16237279B400934B51 /* SyncEngine.swift */; };
+		B98E9D1A23727A5600934B51 /* MutationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98E9D1923727A5600934B51 /* MutationEvent.swift */; };
+		B98E9D1C23727BAC00934B51 /* MutationEvent+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98E9D1B23727BAC00934B51 /* MutationEvent+Schema.swift */; };
+		B98E9D1E2372854B00934B51 /* MutationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98E9D1D2372854B00934B51 /* MutationQueue.swift */; };
+		B98E9D202374077500934B51 /* Mutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98E9D1F2374077400934B51 /* Mutation.swift */; };
 		C5C50BA1A2A489CE4977238C /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSS3StoragePluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A6F9B0E5C7D07F29BE4BEE9 /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSS3StoragePluginTests.framework */; };
 		D14215EF16B9D090DF17C71D /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_CoreMLPredictionsPluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 590F2A08ED60BB9A54788F50 /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_CoreMLPredictionsPluginTests.framework */; };
 		E9E4AB6175A0B21B46C875CE /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsTestCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34A4D98AFFD4B65AEAE350EC /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsTestCommon.framework */; };
@@ -1526,6 +1531,11 @@
 		B98E9D0A2372236200934B51 /* QueryField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryField.swift; sourceTree = "<group>"; };
 		B98E9D0B2372236200934B51 /* QueryOperator+Equatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "QueryOperator+Equatable.swift"; sourceTree = "<group>"; };
 		B98E9D0C2372236200934B51 /* QueryPredicate+Equatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "QueryPredicate+Equatable.swift"; sourceTree = "<group>"; };
+		B98E9D16237279B400934B51 /* SyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEngine.swift; sourceTree = "<group>"; };
+		B98E9D1923727A5600934B51 /* MutationEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEvent.swift; sourceTree = "<group>"; };
+		B98E9D1B23727BAC00934B51 /* MutationEvent+Schema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MutationEvent+Schema.swift"; sourceTree = "<group>"; };
+		B98E9D1D2372854B00934B51 /* MutationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationQueue.swift; sourceTree = "<group>"; };
+		B98E9D1F2374077400934B51 /* Mutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mutation.swift; sourceTree = "<group>"; };
 		BAFD88194E245D6B82399825 /* Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.release.xcconfig"; path = "Target Support Files/Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests/Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.release.xcconfig"; sourceTree = "<group>"; };
 		BB548811E9281F8547D83681 /* Pods-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.release.xcconfig"; path = "Target Support Files/Pods-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests/Pods-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.release.xcconfig"; sourceTree = "<group>"; };
 		BCF5BF94BA714000C1C44713 /* Pods-Amplify-AmplifyAWSPlugins-AWSPluginsCore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AmplifyAWSPlugins-AWSPluginsCore.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AmplifyAWSPlugins-AWSPluginsCore/Pods-Amplify-AmplifyAWSPlugins-AWSPluginsCore.debug.xcconfig"; sourceTree = "<group>"; };
@@ -3261,7 +3271,9 @@
 		B92E03C12367CFF2006CEB8D /* AWSDataStoreCategoryPlugin */ = {
 			isa = PBXGroup;
 			children = (
+				B98E9D1823727A1200934B51 /* Model */,
 				B92E03DD2367D2A4006CEB8D /* Storage */,
+				B98E9D152372795700934B51 /* Sync */,
 				B92E03E62367D2A4006CEB8D /* AWSDataStoreCategoryPlugin.swift */,
 				B92E03C32367CFF2006CEB8D /* Info.plist */,
 			);
@@ -3351,6 +3363,25 @@
 				B98E9D092372236200934B51 /* QueryTranslator.swift */,
 			);
 			path = Query;
+			sourceTree = "<group>";
+		};
+		B98E9D152372795700934B51 /* Sync */ = {
+			isa = PBXGroup;
+			children = (
+				B98E9D1F2374077400934B51 /* Mutation.swift */,
+				B98E9D1D2372854B00934B51 /* MutationQueue.swift */,
+				B98E9D16237279B400934B51 /* SyncEngine.swift */,
+			);
+			path = Sync;
+			sourceTree = "<group>";
+		};
+		B98E9D1823727A1200934B51 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				B98E9D1923727A5600934B51 /* MutationEvent.swift */,
+				B98E9D1B23727BAC00934B51 /* MutationEvent+Schema.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		B9DD3F0B23552C4E00D62C65 /* DataStore */ = {
@@ -7027,12 +7058,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				B922E274236A07CA00D09250 /* QueryTranslator+SQLite.swift in Sources */,
+				B98E9D17237279B400934B51 /* SyncEngine.swift in Sources */,
+				B98E9D1E2372854B00934B51 /* MutationQueue.swift in Sources */,
 				B92E03E72367D2A4006CEB8D /* StorageEngineBehavior.swift in Sources */,
+				B98E9D202374077500934B51 /* Mutation.swift in Sources */,
 				B92E03E92367D2A4006CEB8D /* StorageEngine.swift in Sources */,
 				B92E03EA2367D2A4006CEB8D /* ModelSchema+SQLite.swift in Sources */,
 				B92E03EE2367D2A4006CEB8D /* AWSDataStoreCategoryPlugin.swift in Sources */,
 				B92E03E82367D2A4006CEB8D /* StorageEngineAdapter.swift in Sources */,
 				B92E03EB2367D2A4006CEB8D /* Model+SQLite.swift in Sources */,
+				B98E9D1A23727A5600934B51 /* MutationEvent.swift in Sources */,
+				B98E9D1C23727BAC00934B51 /* MutationEvent+Schema.swift in Sources */,
 				B92E03EC2367D2A4006CEB8D /* StorageEngineAdapter+SQLite.swift in Sources */,
 				B92E03ED2367D2A4006CEB8D /* Statement+Model.swift in Sources */,
 				B922E273236A07CA00D09250 /* QueryPredicate+SQLite.swift in Sources */,

--- a/Amplify/Categories/DataStore/Model/Model+Schema.swift
+++ b/Amplify/Categories/DataStore/Model/Model+Schema.swift
@@ -14,6 +14,8 @@ extension Model {
         return ModelSchema(name: String(describing: self), fields: [:])
     }
 
+    public typealias ModelSchemaDefinitionBuiler = (inout ModelSchemaDefinition) -> Void
+
     /// Utility function that enables a DSL-like `ModelSchema` definition. Instead of building
     /// objects individually, developers can use this to create the schema with a more fluid
     /// programming model.
@@ -34,7 +36,7 @@ extension Model {
     /// - Returns: a valid `ModelSchema` instance
     public static func defineSchema(name: String? = nil,
                                     attributes: ModelAttribute...,
-                                    define: (inout ModelSchemaDefinition) -> Void) -> ModelSchema {
+                                    define: ModelSchemaDefinitionBuiler) -> ModelSchema {
         var definition = ModelSchemaDefinition(name: name ?? String(describing: self))
         define(&definition)
         return definition.build()

--- a/Amplify/Categories/DataStore/Model/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/ModelSchema+Definition.swift
@@ -15,7 +15,7 @@ public enum ModelFieldType: CustomStringConvertible {
     case date
     case dateTime
     case bool
-    case `enum`(type: Any.Type)
+    case `enum`(Any.Type)
     case model(type: Model.Type)
     case collection(of: Model.Type)
 
@@ -96,12 +96,16 @@ public enum ModelFieldRelationship {
 public struct ModelSchemaDefinition {
 
     internal let name: String
+    internal let namespace: ModelSchemaNamespace
     internal var fields: ModelFields
     internal var attributes: [ModelAttribute]
 
-    init(name: String) {
+    public var syncable: Bool = true
+
+    init(name: String, namespace: ModelSchemaNamespace = .user) {
         self.name = name
-        self.fields = [:] as ModelFields
+        self.namespace = namespace
+        self.fields = ModelFields.init()
         self.attributes = []
     }
 
@@ -117,7 +121,7 @@ public struct ModelSchemaDefinition {
     }
 
     internal func build() -> ModelSchema {
-        return ModelSchema(name: name, fields: fields)
+        return ModelSchema(name: name, syncable: syncable, fields: fields)
     }
 }
 

--- a/Amplify/Categories/DataStore/Model/ModelSchema.swift
+++ b/Amplify/Categories/DataStore/Model/ModelSchema.swift
@@ -67,11 +67,17 @@ public struct ModelField {
 
 public typealias ModelFields = [String: ModelField]
 
+public enum ModelSchemaNamespace: String {
+    case system
+    case user
+}
+
 public struct ModelSchema {
 
     public let name: String
     public let targetName: String?
     public let syncable: Bool
+    public let namespace: ModelSchemaNamespace
     public let fields: ModelFields
 
     public let allFields: [ModelField]
@@ -85,10 +91,12 @@ public struct ModelSchema {
     init(name: String,
          targetName: String? = nil,
          syncable: Bool = true,
+         namespace: ModelSchemaNamespace = .user,
          fields: ModelFields = [:]) {
         self.name = name
         self.targetName = targetName
         self.syncable = syncable
+        self.namespace = namespace
         self.fields = fields
 
         self.allFields = fields.sortedFields()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Model/MutationEvent+Schema.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Model/MutationEvent+Schema.swift
@@ -1,0 +1,45 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Foundation
+
+extension MutationEvent {
+    // MARK: - CodingKeys
+
+    public enum CodingKeys: String, ModelKey {
+        case id
+        case modelName
+        case data
+        case type
+        case source
+        case predicate
+        case createdAt
+    }
+
+    public static let keys = CodingKeys.self
+
+    // MARK: - ModelSchema
+
+    public static let schema = defineSchema { model in
+        let mutation = MutationEvent.keys
+
+        model.syncable = false
+        // TODO how to make this non-acessible to developers?
+//        model.namespace = .system
+
+        model.fields(
+            .id(),
+            .field(mutation.modelName, is: .required, ofType: .string),
+            .field(mutation.data, is: .required, ofType: .string),
+            .field(mutation.type, is: .required, ofType: .enum(MutationEventType.self)),
+            .field(mutation.source, is: .required, ofType: .enum(MutationEventSource.self)),
+            .field(mutation.predicate, is: .optional, ofType: .string),
+            .field(mutation.createdAt, is: .required, ofType: .dateTime)
+        )
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Model/MutationEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Model/MutationEvent.swift
@@ -1,0 +1,77 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Foundation
+
+enum MutationEventSource: String, Codable {
+    case dataStore
+    case syncEngine
+    case storageEngine
+}
+
+enum MutationEventType: String, Codable {
+    case save
+    case delete
+}
+
+enum MutationEventStatus: String, Codable {
+    case synced
+    case pending
+    case failed
+}
+
+internal struct MutationEvent: Model {
+
+    internal let id: Identifier
+    internal let modelName: String
+    internal let data: String
+    internal let type: MutationEventType
+    internal let source: MutationEventSource
+    internal let predicate: String?
+    internal let createdAt: Date
+
+    init(id: Identifier = UUID().uuidString,
+         modelName: String,
+         data: String,
+         type: MutationEventType,
+         source: MutationEventSource,
+         predicate: String? = nil,
+         createdAt: Date = Date()) {
+        self.id = id
+        self.modelName = modelName
+        self.data = data
+        self.type = type
+        self.source = source
+        self.predicate = predicate
+        self.createdAt = createdAt
+    }
+
+    func getModel<M: Model>() throws -> M {
+        let model = try M.from(json: data)
+        return model
+    }
+
+}
+
+// MARK: - Factory
+
+extension MutationEvent {
+
+    static func from<M: Model>(model: M,
+                               type: MutationEventType,
+                               source: MutationEventSource,
+                               predicate: QueryPredicate? = nil) throws -> MutationEvent {
+        let modelType = Swift.type(of: model)
+        let data = try model.toJSON()
+        return MutationEvent(modelName: modelType.schema.name,
+                             data: data,
+                             type: type,
+                             source: source)
+    }
+
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -69,6 +69,12 @@ final public class SQLiteStorageEngineAdapter: StorageEngineAdapter {
         }
     }
 
+    public func delete<M: Model>(_ modelType: M.Type,
+                                 withId id: Identifier,
+                                 completion: DataStoreCallback<Void>) {
+        // TODO implement
+    }
+
     public func query<M: Model>(_ modelType: M.Type,
                                 predicate: QueryPredicate? = nil,
                                 completion: DataStoreCallback<[M]>) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -6,7 +6,13 @@
 //
 
 import Amplify
+import Combine
 import Foundation
+
+public typealias ModelSubscription<M: Model> = AnySubscriber<M, DataStoreError>
+
+// TODO we might need to define `AnyModel` so we can have some type easure
+public typealias ModelSubject<M: Model> = PassthroughSubject<M, DataStoreError>
 
 final public class StorageEngine: StorageEngineBehavior {
 
@@ -28,13 +34,39 @@ final public class StorageEngine: StorageEngineBehavior {
     }
 
     public func save<M: Model>(_ model: M, completion: DataStoreCallback<M>) {
-        adapter.save(model, completion: completion)
+        let modelType = type(of: model)
+        adapter.save(model) {
+            switch $0 {
+            case .result:
+                do {
+                    let event = try MutationEvent.from(model: model,
+                                                       type: .save,
+                                                       source: .storageEngine)
+                    // TODO update the mutation queue (sync engine)
+                    // define the responsability of each layer
+                } catch {
+                    completion(.failure(causedBy: error))
+                }
+            case .error(let error):
+                completion(.error(error))
+            }
+        }
+    }
+
+    public func delete<M: Model>(_ modelType: M.Type,
+                                 withId id: Identifier,
+                                 completion: DataStoreCallback<Void>) {
+        adapter.delete(modelType, withId: id, completion: completion)
     }
 
     public func query<M: Model>(_ modelType: M.Type,
                                 predicate: QueryPredicate? = nil,
                                 completion: DataStoreCallback<[M]>) {
         return adapter.query(modelType, predicate: predicate, completion: completion)
+    }
+
+    public func subscribe<M: Model>(_ modelType: M.Type) -> ModelSubscription<M> {
+        fatalError("subscribe not implemented yet")
     }
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineBehavior.swift
@@ -14,6 +14,10 @@ public protocol StorageEngineBehavior {
 
     func save<M: Model>(_ model: M, completion: DataStoreCallback<M>)
 
+    func delete<M: Model>(_ modelType: M.Type,
+                          withId id: Identifier,
+                          completion: DataStoreCallback<Void>)
+
     func query<M: Model>(_ modelType: M.Type,
                          predicate: QueryPredicate?,
                          completion: DataStoreCallback<[M]>)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Mutation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Mutation.swift
@@ -1,0 +1,19 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Foundation
+
+struct Mutation<M: Model> {
+
+    let model: M
+    let event: MutationEvent
+
+    var modelType: M.Type {
+        type(of: model)
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationQueue.swift
@@ -1,0 +1,88 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Combine
+import Foundation
+
+typealias MutationEventSubject = PassthroughSubject<MutationEvent, DataStoreError>
+
+typealias MutationEventFuture = Future<MutationEvent, DataStoreError>
+
+typealias PendingMutationEvents = Record<MutationEvent, DataStoreError>
+
+typealias MutationEventPublisher = AnyPublisher<MutationEvent, DataStoreError>
+
+final class MutationQueue {
+
+    let storageAdapter: StorageEngineAdapter
+    let pendingMutations: MutationEventSubject
+
+    internal init(pendingMutations: MutationEventSubject = MutationEventSubject(),
+                  storageAdapter: StorageEngineAdapter) {
+        self.pendingMutations = pendingMutations
+        self.storageAdapter = storageAdapter
+    }
+
+    func enqueue(event: MutationEvent) -> MutationEventPublisher {
+        return Deferred {
+            MutationEventFuture { future in
+                self.storageAdapter.save(event) {
+                    switch $0 {
+                    case .result:
+                        // TODO revisit this (should we call future after append is resolved?)
+                        _ = self.pendingMutations.append(event)
+                        future(.success(event))
+                    case .error(let error):
+                        future(.failure(error))
+                    }
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+
+    func dequeue(event: MutationEvent) -> MutationEventPublisher {
+        return Deferred {
+            MutationEventFuture { future in
+                self.storageAdapter.delete(MutationEvent.self, withId: event.id) {
+                    switch $0 {
+                    case .result:
+                        future(.success(event))
+                    case .error(let error):
+                        future(.failure(error))
+                    }
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+
+    func previouslyPendingMutations() -> MutationEventPublisher {
+        return Deferred {
+            PendingMutationEvents { record in
+                // TODO sort order?
+                self.storageAdapter.query(MutationEvent.self, predicate: nil) {
+                    switch $0 {
+                    case .result(let events):
+                        events.forEach { event in
+                            record.receive(event)
+                        }
+                        record.receive(completion: .finished)
+                    case .error(let error):
+                        record.receive(completion: .failure(error))
+                    }
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+
+    func observe() -> MutationEventPublisher {
+        return pendingMutations
+            .prepend(previouslyPendingMutations())
+            .filter { event in event.source != .syncEngine }
+            .eraseToAnyPublisher()
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SyncEngine.swift
@@ -1,0 +1,65 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Combine
+import Foundation
+
+typealias MutationFuture = Future<MutationEvent, DataStoreError>
+
+class SyncEngine {
+
+    let api: APICategoryGraphQLBehavior
+    let mutationQueue: MutationQueue
+
+    init(api: APICategoryGraphQLBehavior = Amplify.API,
+         mutationQueue: MutationQueue) {
+        self.api = api
+        self.mutationQueue = mutationQueue
+    }
+
+    func start() {
+        // TODO revisit thread strategy (not only here)
+        _ = mutationQueue.observe()
+            .subscribe(on: DispatchQueue.global(qos: .background))
+            .filter { $0.source != .syncEngine }
+            .sink(
+                receiveCompletion: {
+                    print("Queue exhausted! (bring it some fruits and water)")
+                    print($0)
+                }, receiveValue: { event in
+                    // TODO handle result
+                    _ = self.submit(event: event)
+                }
+            )
+    }
+
+    func submit(event: MutationEvent) -> MutationFuture {
+        // TODO how to get the API name?
+        let apiName = ""
+        let type = modelType(from: event.modelName)
+        return MutationFuture { future in
+//            _ = self.api.mutate(apiName: apiName,
+//                                document: "",
+//                                variables: nil,
+//                                responseType: type) {
+//                switch $0 {
+//                case .unknown:
+//                    print("")
+//                case .notInProcess:
+//                    print("")
+//                case .inProcess:
+//                    print("")
+//                case .completed:
+//                    future(.success(event))
+//                case .failed(let error):
+//                    future(.failure(.invalidOperation(causedBy: error)))
+//                }
+//            }
+        }
+    }
+}


### PR DESCRIPTION
**Notes:**

This is an exploration of how to use Combine to achieve the multi-subscription model needed by the DataStore + SyncEngine.
    
Be advised that this work is not final, the responsibilities of each layer are not well defined and the correct thread model is not in place.

**ps**: this branch was created based on the `feature/datastore-query` branch that needs to be merged into master.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
