### PR TITLE
Fix new file header in plugin projects

### DIFF
--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+    <string>
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//</string>
+</dict>
+</plist>

--- a/AmplifyPlugins/Analytics/AnalyticsCategoryPlugin.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/AmplifyPlugins/Analytics/AnalyticsCategoryPlugin.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+    <string>
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//</string>
+</dict>
+</plist>

--- a/AmplifyPlugins/Predictions/PredictionsCategoryPlugin.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/AmplifyPlugins/Predictions/PredictionsCategoryPlugin.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+    <string>
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//</string>
+</dict>
+</plist>

--- a/AmplifyPlugins/Storage/StoragePlugin.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/AmplifyPlugins/Storage/StoragePlugin.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+    <string>
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//</string>
+</dict>
+</plist>


### PR DESCRIPTION
*Description of changes:*

After moving plugins to their own projects, new files created in those projects had an incorrect header because the `IDETemplateMacros.plist` file was missing. This PR re-adds those.

I did a quick scan for Swift files without the project header and didn't see any, but I know there are a number of in-process PRs, so if you happen to see any files that don't have our project header, please replace it with this one:

```swift
//
// Copyright 2018-2019 Amazon.com,
// Inc. or its affiliates. All Rights Reserved.
//
// SPDX-License-Identifier: Apache-2.0
//
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
