### PR TITLE
Adding ReachabilityNotifier publisher and dependence on ReachabilityS…

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -57,6 +57,13 @@
 		21FFF9A2230C9731005878EA /* StorageListResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFF9A1230C9730005878EA /* StorageListResult.swift */; };
 		2861F5F799C24671B5C4DB8D /* Pods_Amplify_AmplifyTestConfigs_AmplifyTestCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C448F4F6DD01A268675E1C68 /* Pods_Amplify_AmplifyTestConfigs_AmplifyTestCommon.framework */; };
 		3263D332138415AF42E64FF7 /* Pods_AmplifyTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC7F1C368154B364CB74742 /* Pods_AmplifyTestApp.framework */; };
+		6B1F15122383671B00AB23EF /* NetworkReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1F15102383671B00AB23EF /* NetworkReachability.swift */; };
+		6B1F15132383671B00AB23EF /* NetworkReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1F15102383671B00AB23EF /* NetworkReachability.swift */; };
+		6B1F15142383671B00AB23EF /* NetworkReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1F15102383671B00AB23EF /* NetworkReachability.swift */; };
+		6B1F15152383671B00AB23EF /* NetworkReachabilityNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1F15112383671B00AB23EF /* NetworkReachabilityNotifier.swift */; };
+		6B1F15162383671B00AB23EF /* NetworkReachabilityNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1F15112383671B00AB23EF /* NetworkReachabilityNotifier.swift */; };
+		6B1F15172383671B00AB23EF /* NetworkReachabilityNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1F15112383671B00AB23EF /* NetworkReachabilityNotifier.swift */; };
+		6B1F15192383691B00AB23EF /* NetworkReachabilityNotifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1F15182383691B00AB23EF /* NetworkReachabilityNotifierTests.swift */; };
 		7D5ED6C78E25246DDAF2F2EC /* Pods_Amplify.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84F3A76FB68CEFA45F4BB1BB /* Pods_Amplify.framework */; platformFilter = ios; };
 		7F27B1DCE59C1E674172CCD6 /* Pods_Amplify_AmplifyTestConfigs_AmplifyTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 976D972EC2BBCAAD023694EB /* Pods_Amplify_AmplifyTestConfigs_AmplifyTests.framework */; };
 		80CF9ED038D61833716854B8 /* Pods_Amplify_AWSPluginsCore_AWSDataStoreCategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ED013FD8A569C8E3D67506B /* Pods_Amplify_AWSPluginsCore_AWSDataStoreCategoryPlugin.framework */; };
@@ -591,6 +598,9 @@
 		65CCD77CBA8619E2E9D41196 /* Pods-AWSPinpointAnalyticsPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSPinpointAnalyticsPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-AWSPinpointAnalyticsPluginTests/Pods-AWSPinpointAnalyticsPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		687B09E9348F8D29979A2404 /* Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests/Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6AF0E4775809F0866F9C44D9 /* Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig"; path = "Target Support Files/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig"; sourceTree = "<group>"; };
+		6B1F15102383671B00AB23EF /* NetworkReachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachability.swift; sourceTree = "<group>"; };
+		6B1F15112383671B00AB23EF /* NetworkReachabilityNotifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachabilityNotifier.swift; sourceTree = "<group>"; };
+		6B1F15182383691B00AB23EF /* NetworkReachabilityNotifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkReachabilityNotifierTests.swift; sourceTree = "<group>"; };
 		6BAC32194A15ACB56F07DC87 /* Pods-AWSS3StoragePlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSS3StoragePlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSS3StoragePlugin/Pods-AWSS3StoragePlugin.debug.xcconfig"; sourceTree = "<group>"; };
 		6C41D3730B7ED4FD62A43E40 /* Pods-Amplify-AmplifyAWSPlugins-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AmplifyAWSPlugins-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AmplifyAWSPlugins-AWSAPICategoryPlugin-AWSAPICategoryPluginTests/Pods-Amplify-AmplifyAWSPlugins-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6D51240C78418B733FFA6829 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSDataStoreCategoryPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSDataStoreCategoryPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSDataStoreCategoryPluginTests/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSDataStoreCategoryPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1462,6 +1472,7 @@
 			isa = PBXGroup;
 			children = (
 				B92E03D12367CFF3006CEB8D /* Info.plist */,
+				6B1F15182383691B00AB23EF /* NetworkReachabilityNotifierTests.swift */,
 				B922E27B236BC59F00D09250 /* QueryPredicateTests.swift */,
 				B922E275236A083B00D09250 /* SQLiteQueryTranslatorTests.swift */,
 				B92E03EF2367D2BB006CEB8D /* SQLiteStorageEngineAdapterTests.swift */,
@@ -1804,6 +1815,8 @@
 			children = (
 				FA9FD2372381CFC300A7CAF5 /* CloudSyncEngine.swift */,
 				FA9FD2392381CFC300A7CAF5 /* OutgoingMutationQueue.swift */,
+				6B1F15102383671B00AB23EF /* NetworkReachability.swift */,
+				6B1F15112383671B00AB23EF /* NetworkReachabilityNotifier.swift */,
 				FAA274B02382EA7100EDD2EA /* SyncingMutationSubscriber.swift */,
 			);
 			path = Sync;
@@ -3310,6 +3323,7 @@
 				B92E03E72367D2A4006CEB8D /* StorageEngineBehavior.swift in Sources */,
 				B92E03E92367D2A4006CEB8D /* StorageEngine.swift in Sources */,
 				B92E03EA2367D2A4006CEB8D /* ModelSchema+SQLite.swift in Sources */,
+				6B1F15152383671B00AB23EF /* NetworkReachabilityNotifier.swift in Sources */,
 				B92E03EE2367D2A4006CEB8D /* AWSDataStoreCategoryPlugin.swift in Sources */,
 				FA9FD23A2381CFC300A7CAF5 /* CloudSyncEngine.swift in Sources */,
 				FAA274B12382EA7100EDD2EA /* SyncingMutationSubscriber.swift in Sources */,
@@ -3319,6 +3333,7 @@
 				B92E03ED2367D2A4006CEB8D /* Statement+Model.swift in Sources */,
 				FAD393732381FF4200463F5E /* DataStorePublisher.swift in Sources */,
 				B922E273236A07CA00D09250 /* QueryPredicate+SQLite.swift in Sources */,
+				6B1F15122383671B00AB23EF /* NetworkReachability.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3330,7 +3345,10 @@
 				FAD393762382036000463F5E /* SubscribeTests.swift in Sources */,
 				B922E27C236BC5A000D09250 /* QueryPredicateTests.swift in Sources */,
 				B922E276236A083B00D09250 /* SQLiteQueryTranslatorTests.swift in Sources */,
+				6B1F15172383671B00AB23EF /* NetworkReachabilityNotifier.swift in Sources */,
 				FAD3937823820BB000463F5E /* SyncTests.swift in Sources */,
+				6B1F15142383671B00AB23EF /* NetworkReachability.swift in Sources */,
+				6B1F15192383691B00AB23EF /* NetworkReachabilityNotifierTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3338,7 +3356,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6B1F15162383671B00AB23EF /* NetworkReachabilityNotifier.swift in Sources */,
 				B92E04112368FE5B006CEB8D /* AWSDataStoreCategoryPluginIntegrationTests.swift in Sources */,
+				6B1F15132383671B00AB23EF /* NetworkReachability.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/NetworkReachability.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/NetworkReachability.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Reachability
+
+/// Defines a factory to return a NetworkReachabilityProviding instance
+public protocol NetworkReachabilityProvidingFactory {
+    /// Abstracting the only of Reachability's initializers that we care about into a factory method. Since Reachability isn't
+    /// final, we'd have to add a lot of code to conform its initializers otherwise.
+    static func make(for hostname: String) -> NetworkReachabilityProviding?
+}
+
+/// Wraps methods and properties of Reachability
+public protocol NetworkReachabilityProviding: class {
+    /// If `true`, device can attempt to reach the host using a cellular connection (WAN). If `false`, host is only considered
+    /// reachable if it can be accessed via WiFi
+    var allowsCellularConnection: Bool { get set }
+
+    var connection: Reachability.Connection { get }
+
+    /// The notification center on which "reachability changed" events are being posted
+    var notificationCenter: NotificationCenter { get set }
+
+    /// Starts notifications for reachability changes
+    func startNotifier() throws
+
+    /// Pauses notifications for reachability changes
+    func stopNotifier()
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/NetworkReachabilityNotifier.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/NetworkReachabilityNotifier.swift
@@ -1,0 +1,87 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Reachability
+import Combine
+
+struct ReachabilityUpdate {
+    let isOnline: Bool
+}
+
+class NetworkReachabilityNotifier {
+    private var reachability: NetworkReachabilityProviding?
+    private var allowsCellularAccess = true
+
+    let reachabilityPublisher = PassthroughSubject<ReachabilityUpdate, Never>()
+
+    public init(host: String,
+                allowsCellularAccess: Bool,
+                reachabilityFactory: NetworkReachabilityProvidingFactory.Type = Reachability.self) {
+        self.reachability = reachabilityFactory.make(for: host)
+        self.allowsCellularAccess = allowsCellularAccess
+
+        // Add listener for Reachability and start its notifier
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(respondToReachabilityChange),
+                                               name: .reachabilityChanged,
+                                               object: nil)
+        do {
+            try reachability?.startNotifier()
+        } catch {
+        }
+
+        //TODO: Do we really need this reachability observer as well?
+        // Add listener for KSReachability's notification
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(respondToReachabilityChange),
+            name: NSNotification.Name(rawValue: "kAWSNetworkReachabilityChangedNotification"),
+            object: nil)
+    }
+
+    deinit {
+        reachability?.stopNotifier()
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    func publisher() -> AnyPublisher<ReachabilityUpdate, Never> {
+        return reachabilityPublisher
+            .filter { $0.isOnline == true }
+            .eraseToAnyPublisher()
+    }
+
+    // MARK: - Notifications
+    @objc private func respondToReachabilityChange() {
+        guard let reachability = reachability else {
+            return
+        }
+
+        let isReachable: Bool
+        switch reachability.connection {
+        case .wifi:
+            isReachable = true
+        case .cellular:
+            isReachable = allowsCellularAccess
+        case .none, .unavailable:
+            isReachable = false
+        }
+
+        let reachabilityMessageUpdate =  ReachabilityUpdate(isOnline: isReachable)
+        reachabilityPublisher.send(reachabilityMessageUpdate)
+    }
+
+}
+
+// MARK: - Reachability
+extension Reachability: NetworkReachabilityProvidingFactory {
+    public static func make(for hostname: String) -> NetworkReachabilityProviding? {
+        return try? Reachability(hostname: hostname)
+    }
+}
+
+extension Reachability: NetworkReachabilityProviding { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/NetworkReachabilityNotifierTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/NetworkReachabilityNotifierTests.swift
@@ -1,0 +1,146 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+import Reachability
+import Combine
+
+class NetworkReachabilityNotifierTests: XCTestCase {
+    var networkReach: NetworkReachabilityNotifier!
+    var notification: Notification!
+
+    override func setUp() {
+        networkReach = NetworkReachabilityNotifier(host: "localhost",
+                                                   allowsCellularAccess: true,
+                                                   reachabilityFactory: MockNetworkReachabilityProvidingFactory.self)
+        notification = Notification.init(name: NSNotification.Name(rawValue: "kAWSNetworkReachabilityChangedNotification"))
+        MockReachability.iConnection = .wifi
+    }
+
+    func testWifiConnectivity() {
+        MockReachability.iConnection = .wifi
+        let expect = expectation(description: ".sink receives value")
+        let cancellable = networkReach.publisher()
+            .sink { value in
+                XCTAssert(value.isOnline)
+                expect.fulfill()
+        }
+
+        NotificationCenter.default.post(notification)
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCellularConnectivity() {
+        MockReachability.iConnection = .cellular
+        let expect = expectation(description: ".sink receives value")
+        let cancellable = networkReach.publisher()
+            .sink { value in
+                XCTAssert(value.isOnline)
+                expect.fulfill()
+        }
+
+        NotificationCenter.default.post(notification)
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testNoConnectivity() {
+        MockReachability.iConnection = .unavailable
+        let expect = expectation(description: ".sink receives value")
+        expect.isInverted = true
+        let cancellable = networkReach.publisher()
+            .sink { value in
+                //If the network state changes to .unavailable
+                //we should not see an update
+                expect.fulfill()
+        }
+
+        NotificationCenter.default.post(notification)
+
+        waitForExpectations(timeout: 2)
+    }
+
+    func testWifiConnectivity_usingReachabilityChanged() {
+        MockReachability.iConnection = .wifi
+        let expect = expectation(description: ".sink receives value")
+        let cancellable = networkReach.publisher()
+            .sink { value in
+                XCTAssert(value.isOnline)
+                expect.fulfill()
+        }
+
+        notification = Notification.init(name: .reachabilityChanged)
+        NotificationCenter.default.post(notification)
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCellularConnectivity_usingReachabilityChanged() {
+        MockReachability.iConnection = .cellular
+        let expect = expectation(description: ".sink receives value")
+        let cancellable = networkReach.publisher()
+            .sink { value in
+                XCTAssert(value.isOnline)
+                expect.fulfill()
+        }
+
+        notification = Notification.init(name: .reachabilityChanged)
+        NotificationCenter.default.post(notification)
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testNoConnectivity_usingReachabilityChanged() {
+        MockReachability.iConnection = .unavailable
+        let expect = expectation(description: ".sink receives value")
+        expect.isInverted = true
+        let cancellable = networkReach.publisher()
+            .sink { value in
+                //If the network state changes to .unavailable
+                //we should not see an update
+                expect.fulfill()
+        }
+
+        notification = Notification.init(name: .reachabilityChanged)
+        NotificationCenter.default.post(notification)
+
+        waitForExpectations(timeout: 2)
+    }
+}
+
+class MockNetworkReachabilityProvidingFactory: NetworkReachabilityProvidingFactory {
+    public static func make(for hostname: String) -> NetworkReachabilityProviding? {
+        return try? MockReachability()
+    }
+}
+
+class MockReachability: NetworkReachabilityProviding {
+    var allowsCellularConnection = true
+    static var iConnection = Reachability.Connection.wifi
+    var connection: Reachability.Connection {
+        get {
+            return MockReachability.iConnection
+        }
+        set(conn) {
+            MockReachability.iConnection = conn
+        }
+    }
+
+    var notificationCenter: NotificationCenter = .default
+
+    func setConnection(connection: Reachability.Connection) {
+        self.connection = connection
+    }
+
+    func startNotifier() throws {
+    }
+
+    func stopNotifier() {
+    }
+}

--- a/Podfile
+++ b/Podfile
@@ -34,7 +34,7 @@ target "Amplify" do
 
     target "AWSDataStoreCategoryPlugin" do
       inherit! :complete
-      
+      pod "ReachabilitySwift", "~> 5.0.0"
       pod "SQLite.swift", "~> 0.12.0"
     end
 
@@ -46,6 +46,7 @@ target "Amplify" do
       end
 
       target "AWSDataStoreCategoryPluginTests" do
+        pod "ReachabilitySwift", "~> 5.0.0"
       end
 
     end


### PR DESCRIPTION
This PR adds a Reachability Notifier largely taken from AWS Appsync.  Major difference is that this Reachability notifier exposes a Combine.Publisher which we intend to use in conjunction (via Combine.merge) with re-enqueued retryable mutations to the backend.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
