### PR TITLE
Fix podspec to add coreml as a dependency to AWSPredictionsPlugin

### DIFF
--- a/AmplifyPlugins.podspec
+++ b/AmplifyPlugins.podspec
@@ -44,6 +44,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'AWSPredictionsPlugin' do |ss|
+    ss.platform = :ios, '13.0'
     ss.source_files = 'AmplifyPlugins/Predictions/AWSPredictionsPlugin/**/*.swift'
     ss.dependency 'AWSPluginsCore', AMPLIFY_VERSION
     ss.dependency 'AWSTranslate', AWS_SDK_VERSION
@@ -52,7 +53,7 @@ Pod::Spec.new do |s|
     ss.dependency 'AWSTranscribe', AWS_SDK_VERSION
     ss.dependency 'AWSComprehend', AWS_SDK_VERSION
     ss.dependency 'AWSTextract', AWS_SDK_VERSION
-
+    ss.dependency 'CoreMLPredictionsPlugin', AMPLIFY_VERSION
   end
 
   s.subspec 'AWSS3StoragePlugin' do |ss|

--- a/CoreMLPredictionsPlugin.podspec
+++ b/CoreMLPredictionsPlugin.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+
+  s.name         = 'CoreMLPredictionsPlugin'
+  s.version      = '0.0.1'
+  s.summary      = 'Amazon Web Services Amplify for iOS.'
+
+  s.description  = 'AWS Amplify for iOS provides a declarative library for application development using cloud services'
+
+  s.homepage     = 'https://aws.amazon.com/amplify/'
+  s.license      = 'Apache License, Version 2.0'
+  s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
+  s.platform     = :ios, '13.0'
+  s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => s.version}
+  
+  s.requires_arc = true
+  s.source_files = 'AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/**/*.swift'
+  s.dependency 'Amplify', '0.0.1'
+
+end


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
