### PR TITLE
Provide request retry advice based on URLErrors & HTTPURLResponses

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -69,6 +69,13 @@
 		6B1F15162383671B00AB23EF /* NetworkReachabilityNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1F15112383671B00AB23EF /* NetworkReachabilityNotifier.swift */; };
 		6B1F15172383671B00AB23EF /* NetworkReachabilityNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1F15112383671B00AB23EF /* NetworkReachabilityNotifier.swift */; };
 		6B1F15192383691B00AB23EF /* NetworkReachabilityNotifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1F15182383691B00AB23EF /* NetworkReachabilityNotifierTests.swift */; };
+		6BAD766C2386181B004482F6 /* RequestRetryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BAD766A2386181B004482F6 /* RequestRetryable.swift */; };
+		6BAD766D2386181B004482F6 /* RequestRetryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BAD766A2386181B004482F6 /* RequestRetryable.swift */; };
+		6BAD766E2386181B004482F6 /* RequestRetryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BAD766A2386181B004482F6 /* RequestRetryable.swift */; };
+		6BAD766F2386181B004482F6 /* RequestRetryablePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BAD766B2386181B004482F6 /* RequestRetryablePolicy.swift */; };
+		6BAD76702386181B004482F6 /* RequestRetryablePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BAD766B2386181B004482F6 /* RequestRetryablePolicy.swift */; };
+		6BAD76712386181B004482F6 /* RequestRetryablePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BAD766B2386181B004482F6 /* RequestRetryablePolicy.swift */; };
+		6BAD767423865EDB004482F6 /* RequestRetryablePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BAD767223865E65004482F6 /* RequestRetryablePolicyTests.swift */; };
 		7D5ED6C78E25246DDAF2F2EC /* Pods_Amplify.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84F3A76FB68CEFA45F4BB1BB /* Pods_Amplify.framework */; platformFilter = ios; };
 		7F27B1DCE59C1E674172CCD6 /* Pods_Amplify_AmplifyTestConfigs_AmplifyTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 976D972EC2BBCAAD023694EB /* Pods_Amplify_AmplifyTestConfigs_AmplifyTests.framework */; };
 		80CF9ED038D61833716854B8 /* Pods_Amplify_AWSPluginsCore_AWSDataStoreCategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ED013FD8A569C8E3D67506B /* Pods_Amplify_AWSPluginsCore_AWSDataStoreCategoryPlugin.framework */; };
@@ -611,6 +618,9 @@
 		6B1F15112383671B00AB23EF /* NetworkReachabilityNotifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachabilityNotifier.swift; sourceTree = "<group>"; };
 		6B1F15182383691B00AB23EF /* NetworkReachabilityNotifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkReachabilityNotifierTests.swift; sourceTree = "<group>"; };
 		6BAC32194A15ACB56F07DC87 /* Pods-AWSS3StoragePlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSS3StoragePlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSS3StoragePlugin/Pods-AWSS3StoragePlugin.debug.xcconfig"; sourceTree = "<group>"; };
+		6BAD766A2386181B004482F6 /* RequestRetryable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestRetryable.swift; sourceTree = "<group>"; };
+		6BAD766B2386181B004482F6 /* RequestRetryablePolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestRetryablePolicy.swift; sourceTree = "<group>"; };
+		6BAD767223865E65004482F6 /* RequestRetryablePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestRetryablePolicyTests.swift; sourceTree = "<group>"; };
 		6C41D3730B7ED4FD62A43E40 /* Pods-Amplify-AmplifyAWSPlugins-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AmplifyAWSPlugins-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AmplifyAWSPlugins-AWSAPICategoryPlugin-AWSAPICategoryPluginTests/Pods-Amplify-AmplifyAWSPlugins-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6D51240C78418B733FFA6829 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSDataStoreCategoryPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSDataStoreCategoryPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSDataStoreCategoryPluginTests/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSDataStoreCategoryPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6D62C9C57736C3BEADEB1E30 /* Pods-AWSPinpointAnalyticsPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSPinpointAnalyticsPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSPinpointAnalyticsPlugin/Pods-AWSPinpointAnalyticsPlugin.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1505,6 +1515,7 @@
 				B92E03D12367CFF3006CEB8D /* Info.plist */,
 				6B1F15182383691B00AB23EF /* NetworkReachabilityNotifierTests.swift */,
 				B922E27B236BC59F00D09250 /* QueryPredicateTests.swift */,
+				6BAD767223865E65004482F6 /* RequestRetryablePolicyTests.swift */,
 				B92E03EF2367D2BB006CEB8D /* SQLiteStorageEngineAdapterTests.swift */,
 				B922E275236A083B00D09250 /* SQLStatementTests.swift */,
 				FAD393752382036000463F5E /* SubscribeTests.swift */,
@@ -1869,6 +1880,8 @@
 				6B1F15102383671B00AB23EF /* NetworkReachability.swift */,
 				6B1F15112383671B00AB23EF /* NetworkReachabilityNotifier.swift */,
 				FAA274B02382EA7100EDD2EA /* SyncEngineMutationSubscriber.swift */,
+				6BAD766A2386181B004482F6 /* RequestRetryable.swift */,
+				6BAD766B2386181B004482F6 /* RequestRetryablePolicy.swift */,
 			);
 			path = Sync;
 			sourceTree = "<group>";
@@ -3442,9 +3455,11 @@
 				FAA274B12382EA7100EDD2EA /* SyncEngineMutationSubscriber.swift in Sources */,
 				B92E03E82367D2A4006CEB8D /* StorageEngineAdapter.swift in Sources */,
 				B92E03EB2367D2A4006CEB8D /* Model+SQLite.swift in Sources */,
+				6BAD766F2386181B004482F6 /* RequestRetryablePolicy.swift in Sources */,
 				B92E03EC2367D2A4006CEB8D /* StorageEngineAdapter+SQLite.swift in Sources */,
 				B92E03ED2367D2A4006CEB8D /* Statement+Model.swift in Sources */,
 				FAD393732381FF4200463F5E /* DataStorePublisher.swift in Sources */,
+				6BAD766C2386181B004482F6 /* RequestRetryable.swift in Sources */,
 				B922E273236A07CA00D09250 /* QueryPredicate+SQLite.swift in Sources */,
 				6B1F15122383671B00AB23EF /* NetworkReachability.swift in Sources */,
 			);
@@ -3454,6 +3469,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6BAD767423865EDB004482F6 /* RequestRetryablePolicyTests.swift in Sources */,
+				6BAD766E2386181B004482F6 /* RequestRetryable.swift in Sources */,
 				B92E040423680E2C006CEB8D /* SQLiteStorageEngineAdapterTests.swift in Sources */,
 				FAD393762382036000463F5E /* SubscribeTests.swift in Sources */,
 				B922E27C236BC5A000D09250 /* QueryPredicateTests.swift in Sources */,
@@ -3462,6 +3479,7 @@
 				FAD3937823820BB000463F5E /* SyncTests.swift in Sources */,
 				6B1F15142383671B00AB23EF /* NetworkReachability.swift in Sources */,
 				6B1F15192383691B00AB23EF /* NetworkReachabilityNotifierTests.swift in Sources */,
+				6BAD76712386181B004482F6 /* RequestRetryablePolicy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3472,6 +3490,8 @@
 				6B1F15162383671B00AB23EF /* NetworkReachabilityNotifier.swift in Sources */,
 				B92E04112368FE5B006CEB8D /* AWSDataStoreCategoryPluginIntegrationTests.swift in Sources */,
 				6B1F15132383671B00AB23EF /* NetworkReachability.swift in Sources */,
+				6BAD766D2386181B004482F6 /* RequestRetryable.swift in Sources */,
+				6BAD76702386181B004482F6 /* RequestRetryablePolicy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RequestRetryable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RequestRetryable.swift
@@ -1,0 +1,20 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+struct RequestRetryAdvice {
+    let shouldRetry: Bool
+    let retryInterval: DispatchTimeInterval?
+
+}
+
+protocol RequestRetryable {
+    func retryRequestAdvice(urlError: URLError?,
+                            httpURLResponse: HTTPURLResponse?,
+                            attemptNumber: Int) -> RequestRetryAdvice
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RequestRetryablePolicy.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RequestRetryablePolicy.swift
@@ -1,0 +1,100 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+class RequestRetryablePolicy: RequestRetryable {
+
+    private static let maxWaitMilliseconds = 300 * 1_000 // 5 minutes of max retry duration.
+    private static let jitterMilliseconds: Float = 100.0
+
+    public func retryRequestAdvice(urlError: URLError?,
+                                   httpURLResponse: HTTPURLResponse?,
+                                   attemptNumber: Int) -> RequestRetryAdvice {
+        var attemptNumber = attemptNumber
+        if attemptNumber <= 0 {
+            assertionFailure("attemptNumber should be > 0")
+            attemptNumber = 1
+        }
+
+        if let urlError = urlError {
+            return determineRetryRequestAdvice(basedOn: urlError, attemptNumber: attemptNumber)
+        } else {
+            return determineRetryRequestAdvice(basedOn: httpURLResponse, attemptNumber: attemptNumber)
+        }
+    }
+
+    private func determineRetryRequestAdvice(basedOn urlError: URLError,
+                                             attemptNumber: Int) -> RequestRetryAdvice {
+        switch urlError.code {
+        case .notConnectedToInternet,
+             .dnsLookupFailed,
+             .cannotConnectToHost,
+             .cannotFindHost,
+             .timedOut:
+            let waitMillis = retryDelayInMillseconds(for: attemptNumber)
+            return RequestRetryAdvice(shouldRetry: true, retryInterval: .milliseconds(waitMillis))
+        default:
+            break
+        }
+        return RequestRetryAdvice(shouldRetry: false, retryInterval: nil)
+    }
+
+    private func determineRetryRequestAdvice(basedOn httpURLResponse: HTTPURLResponse?,
+                                             attemptNumber: Int) -> RequestRetryAdvice {
+        /// If there was no error and no response, then we should not retry.
+        guard let httpURLResponse = httpURLResponse else {
+            return RequestRetryAdvice(shouldRetry: false, retryInterval: nil)
+        }
+
+        if let retryAfterValueInSeconds = getRetryAfterHeaderValue(from: httpURLResponse) {
+            return RequestRetryAdvice(shouldRetry: true, retryInterval: .seconds(retryAfterValueInSeconds))
+        }
+
+        switch httpURLResponse.statusCode {
+        case 500 ... 599, 429:
+            let waitMillis = retryDelayInMillseconds(for: attemptNumber)
+            if waitMillis <= RequestRetryablePolicy.maxWaitMilliseconds {
+                return RequestRetryAdvice(shouldRetry: true, retryInterval: .milliseconds(waitMillis))
+            }
+        default:
+            break
+        }
+        return RequestRetryAdvice(shouldRetry: false, retryInterval: nil)
+    }
+
+    /// Returns a delay in milliseconds for the current attempt number. The delay includes random jitter as
+    /// described in https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+    private func retryDelayInMillseconds(for attemptNumber: Int) -> Int {
+        let jitter = Double(getRandomBetween0And1() * RequestRetryablePolicy.jitterMilliseconds)
+        let delay = Int(Double(truncating: pow(2.0, attemptNumber) as NSNumber) * 100.0 + jitter)
+        return delay
+    }
+
+    private func getRandomBetween0And1() -> Float {
+        return Float.random(in: 0 ... 1)
+    }
+
+    /// Returns the value of the "Retry-After" header as an Int, or nil if the value isn't present or cannot
+    /// be converted to an Int
+    ///
+    /// - Parameter response: The response to get the header from
+    /// - Returns: The value of the "Retry-After" header, or nil if not present or not convertable to Int
+    private func getRetryAfterHeaderValue(from response: HTTPURLResponse) -> Int? {
+        let waitTime: Int?
+        switch response.allHeaderFields["Retry-After"] {
+        case let retryTime as String:
+            waitTime = Int(retryTime)
+        case let retryTime as Int:
+            waitTime = retryTime
+        default:
+            waitTime = nil
+        }
+
+        return waitTime
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/RequestRetryablePolicyTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/RequestRetryablePolicyTests.swift
@@ -1,0 +1,218 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+
+class RequestRetryablePolicyTests: XCTestCase {
+    var retryPolicy: RequestRetryablePolicy!
+
+    override func setUp() {
+        super.setUp()
+        retryPolicy = RequestRetryablePolicy()
+    }
+
+    func testNoErrorNoHttpURLResponse() {
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: nil,
+                                                         httpURLResponse: nil,
+                                                         attemptNumber: 1)
+
+        XCTAssertFalse(retryAdvice.shouldRetry)
+        XCTAssertNil(retryAdvice.retryInterval)
+    }
+
+    func testNoErrorWithHttpURLResponseWithRetryAfterInHeader() {
+        let headerFields = ["Retry-After": "42"]
+        let url = URL(string: "http://www.amazon.com")!
+        let httpURLResponse = HTTPURLResponse(url: url,
+                                              statusCode: 429,
+                                              httpVersion: "HTTP/1.1",
+                                              headerFields: headerFields)!
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: nil,
+                                                         httpURLResponse: httpURLResponse,
+                                                         attemptNumber: 1)
+        XCTAssert(retryAdvice.shouldRetry)
+        assertSeconds(retryAdvice.retryInterval, seconds: 42)
+    }
+
+    func testNoErrorWithHttpURLResponseWithoutRetryAfterInHeader_attempt1() {
+        let url = URL(string: "http://www.amazon.com")!
+        let httpURLResponse = HTTPURLResponse(url: url,
+                                              statusCode: 429,
+                                              httpVersion: "HTTP/1.1",
+                                              headerFields: nil)!
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: nil,
+                                                         httpURLResponse: httpURLResponse,
+                                                         attemptNumber: 1)
+        XCTAssert(retryAdvice.shouldRetry)
+        assertMilliseconds(retryAdvice.retryInterval, greaterThan: 200, lessThan: 300)
+    }
+
+    func testNoErrorWithHttpURLResponseWithoutRetryAfterInHeader_attempt2() {
+        let url = URL(string: "http://www.amazon.com")!
+        let httpURLResponse = HTTPURLResponse(url: url,
+                                              statusCode: 429,
+                                              httpVersion: "HTTP/1.1",
+                                              headerFields: nil)!
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: nil,
+                                                         httpURLResponse: httpURLResponse,
+                                                         attemptNumber: 2)
+        XCTAssert(retryAdvice.shouldRetry)
+        assertMilliseconds(retryAdvice.retryInterval, greaterThan: 400, lessThan: 500)
+    }
+
+    func testNoErrorWithHttpURLResponseBeyondMaxWaitTime() {
+        let url = URL(string: "http://www.amazon.com")!
+        let httpURLResponse = HTTPURLResponse(url: url,
+                                              statusCode: 429,
+                                              httpVersion: "HTTP/1.1",
+                                              headerFields: nil)!
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: nil,
+                                                         httpURLResponse: httpURLResponse,
+                                                         attemptNumber: 12)
+        XCTAssertFalse(retryAdvice.shouldRetry)
+        XCTAssertNil(retryAdvice.retryInterval)
+    }
+
+    func testNoErrorWithHttpURLResponseNotRetryable() {
+        let url = URL(string: "http://www.amazon.com")!
+        let httpURLResponse = HTTPURLResponse(url: url,
+                                              statusCode: 204,
+                                              httpVersion: "HTTP/1.1",
+                                              headerFields: nil)!
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: nil,
+                                                         httpURLResponse: httpURLResponse,
+                                                         attemptNumber: 1)
+        XCTAssertFalse(retryAdvice.shouldRetry)
+        XCTAssertNil(retryAdvice.retryInterval)
+    }
+
+    func testNotConnectedToInternetErrorCode() {
+        let retryableErrorCode = URLError.init(.notConnectedToInternet)
+        let attemptNumber = 1
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: retryableErrorCode,
+                                                         httpURLResponse: nil,
+                                                         attemptNumber: attemptNumber)
+
+        XCTAssert(retryAdvice.shouldRetry)
+        assertMilliseconds(retryAdvice.retryInterval, greaterThan: 200, lessThan: 300)
+    }
+
+    func testNotConnectedToInternetErrorCode_attempt2() {
+        let retryableErrorCode = URLError.init(.notConnectedToInternet)
+        let attemptNumber = 2
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: retryableErrorCode,
+                                                         httpURLResponse: nil,
+                                                         attemptNumber: attemptNumber)
+
+        XCTAssert(retryAdvice.shouldRetry)
+        assertMilliseconds(retryAdvice.retryInterval, greaterThan: 400, lessThan: 500)
+    }
+
+    func testNotConnectedToInternetErrorCode_attempt3() {
+        let retryableErrorCode = URLError.init(.notConnectedToInternet)
+        let attemptNumber = 3
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: retryableErrorCode,
+                                                         httpURLResponse: nil,
+                                                         attemptNumber: attemptNumber)
+
+        XCTAssert(retryAdvice.shouldRetry)
+        assertMilliseconds(retryAdvice.retryInterval, greaterThan: 800, lessThan: 900)
+    }
+
+    func testDNSLookupFailedError() {
+        let retryableErrorCode = URLError.init(.dnsLookupFailed)
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: retryableErrorCode,
+                                                         httpURLResponse: nil,
+                                                         attemptNumber: 1)
+
+        XCTAssert(retryAdvice.shouldRetry)
+        assertMilliseconds(retryAdvice.retryInterval, greaterThan: 200, lessThan: 300)
+    }
+
+    func testCannotConnectToHostError() {
+        let retryableErrorCode = URLError.init(.cannotConnectToHost)
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: retryableErrorCode,
+                                                         httpURLResponse: nil,
+                                                         attemptNumber: 1)
+
+        XCTAssert(retryAdvice.shouldRetry)
+        assertMilliseconds(retryAdvice.retryInterval, greaterThan: 200, lessThan: 300)
+    }
+
+    func testCannotFindHostError() {
+        let retryableErrorCode = URLError.init(.cannotFindHost)
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: retryableErrorCode,
+                                                         httpURLResponse: nil,
+                                                         attemptNumber: 1)
+
+        XCTAssert(retryAdvice.shouldRetry)
+        assertMilliseconds(retryAdvice.retryInterval, greaterThan: 200, lessThan: 300)
+    }
+
+    func testTimedOutError() {
+        let retryableErrorCode = URLError.init(.timedOut)
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: retryableErrorCode,
+                                                         httpURLResponse: nil,
+                                                         attemptNumber: 1)
+
+        XCTAssert(retryAdvice.shouldRetry)
+        assertMilliseconds(retryAdvice.retryInterval, greaterThan: 200, lessThan: 300)
+    }
+
+    func testHTTPTooManyRedirectsError() {
+        let nonRetryableErrorCode = URLError.init(.httpTooManyRedirects)
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: nonRetryableErrorCode,
+                                                         httpURLResponse: nil,
+                                                         attemptNumber: 1)
+
+        XCTAssertFalse(retryAdvice.shouldRetry)
+        XCTAssertNil(retryAdvice.retryInterval)
+    }
+
+    func assertMilliseconds(_ retryInterval: DispatchTimeInterval?, greaterThan: Int, lessThan: Int) {
+        guard let retryInterval = retryInterval else {
+            XCTFail("retryInterval is nil")
+            return
+        }
+
+        switch retryInterval {
+        case .milliseconds(let milliseconds):
+            XCTAssertGreaterThanOrEqual(milliseconds, greaterThan)
+            XCTAssertLessThanOrEqual(milliseconds, lessThan)
+        default:
+            XCTFail("Expected milliseconds, but recieved \(retryInterval)")
+        }
+    }
+
+    func assertSeconds(_ retryInterval: DispatchTimeInterval?, seconds expectedSeconds: Int) {
+        guard let retryInterval = retryInterval else {
+            XCTFail("retryInterval is nil")
+            return
+        }
+
+        switch retryInterval {
+        case .seconds(let seconds):
+            XCTAssertEqual(seconds, expectedSeconds)
+        default:
+            XCTFail("Expected seconds, but recieved \(retryInterval)")
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Interface for looking at both URLError and HTTPURLResponse.  Gives precedence to URLError, if that isn't there, then looks at the HTTPURLResponse

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
