### PR TITLE
Fixing lint swift lint script to reference DataStoreCategory

### DIFF
--- a/AmplifyPlugins/DataStore/.swiftlint.yml
+++ b/AmplifyPlugins/DataStore/.swiftlint.yml
@@ -1,7 +1,7 @@
 included:
-  - AWSS3StoragePlugin
-  - AWSS3StoragePluginTests
-  - AWSS3StoragePluginIntegrationTests
+  - AWSDataStoreCategoryPlugin
+  - AWSDataStoreCategoryPluginTests
+  - AWSDataStoreCategoryPluginIntegrationTests
 
 # Note: This feature is experimental. As of this writing (4-Dec-2018) warnings
 # triggered by these rules should not be used to fail builds. Known issues:

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -585,7 +585,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" --path \"${SRCROOT}/$(PRODUCT_NAME)\"\n";
+			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" --path \"${SRCROOT}\" --config \"${SRCROOT}/.swiftlint.yml\"\n\n";
 		};
 		2149E63023886EE400873955 /* Swift Format */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
I was having problems with building the data store category project... this seems to be the correct fix?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
