### PR TITLE
Rename AWSAPICategoryPlugin class to AWSAPIPlugin

### DIFF
--- a/AmplifyPlugins.podspec
+++ b/AmplifyPlugins.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   AWS_SDK_VERSION = '~> 2.12.0'
   AMPLIFY_VERSION = '0.0.1'
   
-  s.subspec 'AWSAPICategoryPlugin' do |ss|
+  s.subspec 'AWSAPIPlugin' do |ss|
     ss.source_files = 'AmplifyPlugins/API/AWSAPICategoryPlugin/**/*.swift'
     ss.dependency 'AWSPluginsCore', AMPLIFY_VERSION
     ss.dependency 'Starscream', '~> 3.0.2'

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		21409C4F2384BA7E000A53C9 /* APIOperationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21409C4E2384BA7E000A53C9 /* APIOperationResponse.swift */; };
-		21409C5E2384DE2C000A53C9 /* AWSAPICategoryPlugin+GraphQLModelBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21409C5D2384DE2C000A53C9 /* AWSAPICategoryPlugin+GraphQLModelBehavior.swift */; };
+		21409C5E2384DE2C000A53C9 /* AWSAPIPlugin+GraphQLModelBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21409C5D2384DE2C000A53C9 /* AWSAPIPlugin+GraphQLModelBehavior.swift */; };
 		21409C602384DF17000A53C9 /* RESTOperationRequest+RESTRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21409C5F2384DF17000A53C9 /* RESTOperationRequest+RESTRequest.swift */; };
 		21409C7223850BEE000A53C9 /* Todo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21409C7123850BEE000A53C9 /* Todo.swift */; };
 		21409C7423850BFD000A53C9 /* AWSMobileClient+Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21409C7323850BFD000A53C9 /* AWSMobileClient+Message.swift */; };
@@ -39,11 +39,11 @@
 		21D7A0E4237B54D90057D00D /* APIOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A092237B54D90057D00D /* APIOperation.swift */; };
 		21D7A0E5237B54D90057D00D /* AWSAPICategoryPluginConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A094237B54D90057D00D /* AWSAPICategoryPluginConfiguration.swift */; };
 		21D7A0E6237B54D90057D00D /* AWSAPICategoryPluginConfiguration+EndpointConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A095237B54D90057D00D /* AWSAPICategoryPluginConfiguration+EndpointConfig.swift */; };
-		21D7A0E7237B54D90057D00D /* AWSAPICategoryPlugin+Reset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A096237B54D90057D00D /* AWSAPICategoryPlugin+Reset.swift */; };
-		21D7A0E8237B54D90057D00D /* AWSAPICategoryPlugin+Configure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A098237B54D90057D00D /* AWSAPICategoryPlugin+Configure.swift */; };
-		21D7A0E9237B54D90057D00D /* AWSAPICategoryPlugin+InterceptorBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A099237B54D90057D00D /* AWSAPICategoryPlugin+InterceptorBehavior.swift */; };
-		21D7A0EA237B54D90057D00D /* AWSAPICategoryPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A09A237B54D90057D00D /* AWSAPICategoryPlugin.swift */; };
-		21D7A0EB237B54D90057D00D /* AWSAPICategoryPlugin+URLSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A09B237B54D90057D00D /* AWSAPICategoryPlugin+URLSessionDelegate.swift */; };
+		21D7A0E7237B54D90057D00D /* AWSAPIPlugin+Reset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A096237B54D90057D00D /* AWSAPIPlugin+Reset.swift */; };
+		21D7A0E8237B54D90057D00D /* AWSAPIPlugin+Configure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A098237B54D90057D00D /* AWSAPIPlugin+Configure.swift */; };
+		21D7A0E9237B54D90057D00D /* AWSAPIPlugin+InterceptorBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A099237B54D90057D00D /* AWSAPIPlugin+InterceptorBehavior.swift */; };
+		21D7A0EA237B54D90057D00D /* AWSAPIPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A09A237B54D90057D00D /* AWSAPIPlugin.swift */; };
+		21D7A0EB237B54D90057D00D /* AWSAPIPlugin+URLSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A09B237B54D90057D00D /* AWSAPIPlugin+URLSessionDelegate.swift */; };
 		21D7A0EC237B54D90057D00D /* WebsocketProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A09E237B54D90057D00D /* WebsocketProvider.swift */; };
 		21D7A0ED237B54D90057D00D /* WebsocketProviderResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A09F237B54D90057D00D /* WebsocketProviderResponse.swift */; };
 		21D7A0EE237B54D90057D00D /* StarscreamWebsocketProvider+ConnectionInterceptable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0A0237B54D90057D00D /* StarscreamWebsocketProvider+ConnectionInterceptable.swift */; };
@@ -59,7 +59,7 @@
 		21D7A0F8237B54D90057D00D /* RetryableConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0AD237B54D90057D00D /* RetryableConnection.swift */; };
 		21D7A0F9237B54D90057D00D /* SubscriptionConnectionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0AF237B54D90057D00D /* SubscriptionConnectionFactory.swift */; };
 		21D7A0FA237B54D90057D00D /* AWSSubscriptionConnectionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0B0237B54D90057D00D /* AWSSubscriptionConnectionFactory.swift */; };
-		21D7A0FB237B54D90057D00D /* AWSAPICategoryPlugin+GraphQLBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0B1237B54D90057D00D /* AWSAPICategoryPlugin+GraphQLBehavior.swift */; };
+		21D7A0FB237B54D90057D00D /* AWSAPIPlugin+GraphQLBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0B1237B54D90057D00D /* AWSAPIPlugin+GraphQLBehavior.swift */; };
 		21D7A0FC237B54D90057D00D /* URLSessionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0B3237B54D90057D00D /* URLSessionFactory.swift */; };
 		21D7A0FD237B54D90057D00D /* URLSession+URLSessionBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0B4237B54D90057D00D /* URLSession+URLSessionBehavior.swift */; };
 		21D7A0FE237B54D90057D00D /* URLSessionDataTaskBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0B5237B54D90057D00D /* URLSessionDataTaskBehavior.swift */; };
@@ -85,8 +85,8 @@
 		21D7A112237B54D90057D00D /* GraphQLOperationRequestUtils+Validator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0CD237B54D90057D00D /* GraphQLOperationRequestUtils+Validator.swift */; };
 		21D7A113237B54D90057D00D /* GraphQLResponseDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0CE237B54D90057D00D /* GraphQLResponseDecoder.swift */; };
 		21D7A114237B54D90057D00D /* GraphQLOperationRequest+Validate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0CF237B54D90057D00D /* GraphQLOperationRequest+Validate.swift */; };
-		21D7A115237B54D90057D00D /* AWSAPICategoryPlugin+RESTBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0D0237B54D90057D00D /* AWSAPICategoryPlugin+RESTBehavior.swift */; };
-		21D7A116237B54D90057D00D /* AWSAPICategoryPlugin+URLSessionBehaviorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0D1237B54D90057D00D /* AWSAPICategoryPlugin+URLSessionBehaviorDelegate.swift */; };
+		21D7A115237B54D90057D00D /* AWSAPIPlugin+RESTBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0D0237B54D90057D00D /* AWSAPIPlugin+RESTBehavior.swift */; };
+		21D7A116237B54D90057D00D /* AWSAPIPlugin+URLSessionBehaviorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0D1237B54D90057D00D /* AWSAPIPlugin+URLSessionBehaviorDelegate.swift */; };
 		21D7A117237B54D90057D00D /* UserPoolRequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0D4237B54D90057D00D /* UserPoolRequestInterceptor.swift */; };
 		21D7A118237B54D90057D00D /* APIKeyURLRequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0D5237B54D90057D00D /* APIKeyURLRequestInterceptor.swift */; };
 		21D7A119237B54D90057D00D /* IAMURLRequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0D6237B54D90057D00D /* IAMURLRequestInterceptor.swift */; };
@@ -144,7 +144,7 @@
 		B952182C237DFDA600F53237 /* GraphQLDocument+Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = B952182B237DFDA600F53237 /* GraphQLDocument+Query.swift */; };
 		B952183A237E251C00F53237 /* GraphQLDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9521839237E251C00F53237 /* GraphQLDocumentTests.swift */; };
 		B9FB05E823821A7500DE1FD4 /* GraphQLRequest+Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FB05E723821A7500DE1FD4 /* GraphQLRequest+Model.swift */; };
-		FA8EE785238632620097E4F1 /* AWSAPICategoryPlugin+Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8EE784238632620097E4F1 /* AWSAPICategoryPlugin+Log.swift */; };
+		FA8EE785238632620097E4F1 /* AWSAPIPlugin+Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8EE784238632620097E4F1 /* AWSAPIPlugin+Log.swift */; };
 		FA8EE787238634FB0097E4F1 /* GraphQLAnyModelDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8EE786238634FB0097E4F1 /* GraphQLAnyModelDocumentTests.swift */; };
 		FA8EE789238636410097E4F1 /* GraphQLDocument+AnyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8EE788238636410097E4F1 /* GraphQLDocument+AnyModel.swift */; };
 		FA8EE78B238639CE0097E4F1 /* GraphQLRequest+AnyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8EE78A238639CE0097E4F1 /* GraphQLRequest+AnyModel.swift */; };
@@ -259,7 +259,7 @@
 		1B30959CE873C097E54BDFD6 /* Pods-GraphQLWithAPIKeyIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GraphQLWithAPIKeyIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-GraphQLWithAPIKeyIntegrationTests/Pods-GraphQLWithAPIKeyIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		1FDC07084023DEF205FF6598 /* Pods-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-AWSAPICategoryPlugin-AWSAPICategoryPluginTests/Pods-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		21409C4E2384BA7E000A53C9 /* APIOperationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIOperationResponse.swift; sourceTree = "<group>"; };
-		21409C5D2384DE2C000A53C9 /* AWSAPICategoryPlugin+GraphQLModelBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSAPICategoryPlugin+GraphQLModelBehavior.swift"; sourceTree = "<group>"; };
+		21409C5D2384DE2C000A53C9 /* AWSAPIPlugin+GraphQLModelBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSAPIPlugin+GraphQLModelBehavior.swift"; sourceTree = "<group>"; };
 		21409C5F2384DF17000A53C9 /* RESTOperationRequest+RESTRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RESTOperationRequest+RESTRequest.swift"; sourceTree = "<group>"; };
 		21409C6723850A9E000A53C9 /* AWSAPICategoryPluginTestCommon.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSAPICategoryPluginTestCommon.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		21409C6A23850A9E000A53C9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -292,11 +292,11 @@
 		21D7A092237B54D90057D00D /* APIOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIOperation.swift; sourceTree = "<group>"; };
 		21D7A094237B54D90057D00D /* AWSAPICategoryPluginConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSAPICategoryPluginConfiguration.swift; sourceTree = "<group>"; };
 		21D7A095237B54D90057D00D /* AWSAPICategoryPluginConfiguration+EndpointConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSAPICategoryPluginConfiguration+EndpointConfig.swift"; sourceTree = "<group>"; };
-		21D7A096237B54D90057D00D /* AWSAPICategoryPlugin+Reset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSAPICategoryPlugin+Reset.swift"; sourceTree = "<group>"; };
-		21D7A098237B54D90057D00D /* AWSAPICategoryPlugin+Configure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSAPICategoryPlugin+Configure.swift"; sourceTree = "<group>"; };
-		21D7A099237B54D90057D00D /* AWSAPICategoryPlugin+InterceptorBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSAPICategoryPlugin+InterceptorBehavior.swift"; sourceTree = "<group>"; };
-		21D7A09A237B54D90057D00D /* AWSAPICategoryPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSAPICategoryPlugin.swift; sourceTree = "<group>"; };
-		21D7A09B237B54D90057D00D /* AWSAPICategoryPlugin+URLSessionDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSAPICategoryPlugin+URLSessionDelegate.swift"; sourceTree = "<group>"; };
+		21D7A096237B54D90057D00D /* AWSAPIPlugin+Reset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSAPIPlugin+Reset.swift"; sourceTree = "<group>"; };
+		21D7A098237B54D90057D00D /* AWSAPIPlugin+Configure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSAPIPlugin+Configure.swift"; sourceTree = "<group>"; };
+		21D7A099237B54D90057D00D /* AWSAPIPlugin+InterceptorBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSAPIPlugin+InterceptorBehavior.swift"; sourceTree = "<group>"; };
+		21D7A09A237B54D90057D00D /* AWSAPIPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSAPIPlugin.swift; sourceTree = "<group>"; };
+		21D7A09B237B54D90057D00D /* AWSAPIPlugin+URLSessionDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSAPIPlugin+URLSessionDelegate.swift"; sourceTree = "<group>"; };
 		21D7A09E237B54D90057D00D /* WebsocketProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebsocketProvider.swift; sourceTree = "<group>"; };
 		21D7A09F237B54D90057D00D /* WebsocketProviderResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebsocketProviderResponse.swift; sourceTree = "<group>"; };
 		21D7A0A0237B54D90057D00D /* StarscreamWebsocketProvider+ConnectionInterceptable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StarscreamWebsocketProvider+ConnectionInterceptable.swift"; sourceTree = "<group>"; };
@@ -312,7 +312,7 @@
 		21D7A0AD237B54D90057D00D /* RetryableConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryableConnection.swift; sourceTree = "<group>"; };
 		21D7A0AF237B54D90057D00D /* SubscriptionConnectionFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionConnectionFactory.swift; sourceTree = "<group>"; };
 		21D7A0B0237B54D90057D00D /* AWSSubscriptionConnectionFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSSubscriptionConnectionFactory.swift; sourceTree = "<group>"; };
-		21D7A0B1237B54D90057D00D /* AWSAPICategoryPlugin+GraphQLBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSAPICategoryPlugin+GraphQLBehavior.swift"; sourceTree = "<group>"; };
+		21D7A0B1237B54D90057D00D /* AWSAPIPlugin+GraphQLBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSAPIPlugin+GraphQLBehavior.swift"; sourceTree = "<group>"; };
 		21D7A0B3237B54D90057D00D /* URLSessionFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionFactory.swift; sourceTree = "<group>"; };
 		21D7A0B4237B54D90057D00D /* URLSession+URLSessionBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URLSession+URLSessionBehavior.swift"; sourceTree = "<group>"; };
 		21D7A0B5237B54D90057D00D /* URLSessionDataTaskBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionDataTaskBehavior.swift; sourceTree = "<group>"; };
@@ -338,8 +338,8 @@
 		21D7A0CD237B54D90057D00D /* GraphQLOperationRequestUtils+Validator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQLOperationRequestUtils+Validator.swift"; sourceTree = "<group>"; };
 		21D7A0CE237B54D90057D00D /* GraphQLResponseDecoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQLResponseDecoder.swift; sourceTree = "<group>"; };
 		21D7A0CF237B54D90057D00D /* GraphQLOperationRequest+Validate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQLOperationRequest+Validate.swift"; sourceTree = "<group>"; };
-		21D7A0D0237B54D90057D00D /* AWSAPICategoryPlugin+RESTBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSAPICategoryPlugin+RESTBehavior.swift"; sourceTree = "<group>"; };
-		21D7A0D1237B54D90057D00D /* AWSAPICategoryPlugin+URLSessionBehaviorDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSAPICategoryPlugin+URLSessionBehaviorDelegate.swift"; sourceTree = "<group>"; };
+		21D7A0D0237B54D90057D00D /* AWSAPIPlugin+RESTBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSAPIPlugin+RESTBehavior.swift"; sourceTree = "<group>"; };
+		21D7A0D1237B54D90057D00D /* AWSAPIPlugin+URLSessionBehaviorDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSAPIPlugin+URLSessionBehaviorDelegate.swift"; sourceTree = "<group>"; };
 		21D7A0D4237B54D90057D00D /* UserPoolRequestInterceptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserPoolRequestInterceptor.swift; sourceTree = "<group>"; };
 		21D7A0D5237B54D90057D00D /* APIKeyURLRequestInterceptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIKeyURLRequestInterceptor.swift; sourceTree = "<group>"; };
 		21D7A0D6237B54D90057D00D /* IAMURLRequestInterceptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IAMURLRequestInterceptor.swift; sourceTree = "<group>"; };
@@ -443,7 +443,7 @@
 		E199BA19FD0A130933EDF93F /* Pods-HostApp-AWSAPICategoryPluginTestCommon-AWSAPICategoryPluginFunctionalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAPICategoryPluginTestCommon-AWSAPICategoryPluginFunctionalTests.debug.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAPICategoryPluginTestCommon-AWSAPICategoryPluginFunctionalTests/Pods-HostApp-AWSAPICategoryPluginTestCommon-AWSAPICategoryPluginFunctionalTests.debug.xcconfig"; sourceTree = "<group>"; };
 		E3E855FC9186F25F5FBF8A06 /* Pods_GraphQLWithAPIKeyIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GraphQLWithAPIKeyIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F2E34DE129C74003DCC9F6A2 /* Pods-AWSAPICategoryHostAppWithIAM.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAPICategoryHostAppWithIAM.release.xcconfig"; path = "Target Support Files/Pods-AWSAPICategoryHostAppWithIAM/Pods-AWSAPICategoryHostAppWithIAM.release.xcconfig"; sourceTree = "<group>"; };
-		FA8EE784238632620097E4F1 /* AWSAPICategoryPlugin+Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSAPICategoryPlugin+Log.swift"; sourceTree = "<group>"; };
+		FA8EE784238632620097E4F1 /* AWSAPIPlugin+Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSAPIPlugin+Log.swift"; sourceTree = "<group>"; };
 		FA8EE786238634FB0097E4F1 /* GraphQLAnyModelDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLAnyModelDocumentTests.swift; sourceTree = "<group>"; };
 		FA8EE788238636410097E4F1 /* GraphQLDocument+AnyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLDocument+AnyModel.swift"; sourceTree = "<group>"; };
 		FA8EE78A238639CE0097E4F1 /* GraphQLRequest+AnyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLRequest+AnyModel.swift"; sourceTree = "<group>"; };
@@ -645,16 +645,16 @@
 		21D7A08B237B54D90057D00D /* AWSAPICategoryPlugin */ = {
 			isa = PBXGroup;
 			children = (
-				21D7A09A237B54D90057D00D /* AWSAPICategoryPlugin.swift */,
-				21D7A098237B54D90057D00D /* AWSAPICategoryPlugin+Configure.swift */,
-				21D7A0B1237B54D90057D00D /* AWSAPICategoryPlugin+GraphQLBehavior.swift */,
-				21409C5D2384DE2C000A53C9 /* AWSAPICategoryPlugin+GraphQLModelBehavior.swift */,
-				21D7A099237B54D90057D00D /* AWSAPICategoryPlugin+InterceptorBehavior.swift */,
-				FA8EE784238632620097E4F1 /* AWSAPICategoryPlugin+Log.swift */,
-				21D7A096237B54D90057D00D /* AWSAPICategoryPlugin+Reset.swift */,
-				21D7A0D0237B54D90057D00D /* AWSAPICategoryPlugin+RESTBehavior.swift */,
-				21D7A0D1237B54D90057D00D /* AWSAPICategoryPlugin+URLSessionBehaviorDelegate.swift */,
-				21D7A09B237B54D90057D00D /* AWSAPICategoryPlugin+URLSessionDelegate.swift */,
+				21D7A09A237B54D90057D00D /* AWSAPIPlugin.swift */,
+				21D7A098237B54D90057D00D /* AWSAPIPlugin+Configure.swift */,
+				21D7A0B1237B54D90057D00D /* AWSAPIPlugin+GraphQLBehavior.swift */,
+				21409C5D2384DE2C000A53C9 /* AWSAPIPlugin+GraphQLModelBehavior.swift */,
+				21D7A099237B54D90057D00D /* AWSAPIPlugin+InterceptorBehavior.swift */,
+				FA8EE784238632620097E4F1 /* AWSAPIPlugin+Log.swift */,
+				21D7A096237B54D90057D00D /* AWSAPIPlugin+Reset.swift */,
+				21D7A0D0237B54D90057D00D /* AWSAPIPlugin+RESTBehavior.swift */,
+				21D7A0D1237B54D90057D00D /* AWSAPIPlugin+URLSessionBehaviorDelegate.swift */,
+				21D7A09B237B54D90057D00D /* AWSAPIPlugin+URLSessionDelegate.swift */,
 				21D7A093237B54D90057D00D /* Configuration */,
 				21D7A0DE237B54D90057D00D /* Info.plist */,
 				21D7A0D2237B54D90057D00D /* Interceptor */,
@@ -2016,15 +2016,15 @@
 				21D7A101237B54D90057D00D /* OperationTaskMapper.swift in Sources */,
 				21D7A11D237B54D90057D00D /* SubscriptionInterceptable.swift in Sources */,
 				21D7A110237B54D90057D00D /* GraphQLOperationRequestUtils.swift in Sources */,
-				21D7A0E8237B54D90057D00D /* AWSAPICategoryPlugin+Configure.swift in Sources */,
+				21D7A0E8237B54D90057D00D /* AWSAPIPlugin+Configure.swift in Sources */,
 				21D7A0E1237B54D90057D00D /* AWSRESTOperation.swift in Sources */,
 				21D7A10C237B54D90057D00D /* RESTOperationRequest+Validate.swift in Sources */,
-				21D7A0FB237B54D90057D00D /* AWSAPICategoryPlugin+GraphQLBehavior.swift in Sources */,
-				21D7A0E7237B54D90057D00D /* AWSAPICategoryPlugin+Reset.swift in Sources */,
-				21D7A115237B54D90057D00D /* AWSAPICategoryPlugin+RESTBehavior.swift in Sources */,
+				21D7A0FB237B54D90057D00D /* AWSAPIPlugin+GraphQLBehavior.swift in Sources */,
+				21D7A0E7237B54D90057D00D /* AWSAPIPlugin+Reset.swift in Sources */,
+				21D7A115237B54D90057D00D /* AWSAPIPlugin+RESTBehavior.swift in Sources */,
 				21D7A0F9237B54D90057D00D /* SubscriptionConnectionFactory.swift in Sources */,
 				B9521822237D12EC00F53237 /* GraphQLDocument.swift in Sources */,
-				21D7A0EA237B54D90057D00D /* AWSAPICategoryPlugin.swift in Sources */,
+				21D7A0EA237B54D90057D00D /* AWSAPIPlugin.swift in Sources */,
 				21D7A0E2237B54D90057D00D /* AWSAPIOperation+APIOperation.swift in Sources */,
 				21D7A0F3237B54D90057D00D /* AppSyncConnectionProvider.swift in Sources */,
 				B9FB05E823821A7500DE1FD4 /* GraphQLRequest+Model.swift in Sources */,
@@ -2061,15 +2061,15 @@
 				21D7A10A237B54D90057D00D /* SubscriptionItem.swift in Sources */,
 				21D7A103237B54D90057D00D /* URLRequestConstants.swift in Sources */,
 				21D7A118237B54D90057D00D /* APIKeyURLRequestInterceptor.swift in Sources */,
-				21D7A116237B54D90057D00D /* AWSAPICategoryPlugin+URLSessionBehaviorDelegate.swift in Sources */,
+				21D7A116237B54D90057D00D /* AWSAPIPlugin+URLSessionBehaviorDelegate.swift in Sources */,
 				21D7A0E6237B54D90057D00D /* AWSAPICategoryPluginConfiguration+EndpointConfig.swift in Sources */,
 				21D7A0FA237B54D90057D00D /* AWSSubscriptionConnectionFactory.swift in Sources */,
-				21D7A0EB237B54D90057D00D /* AWSAPICategoryPlugin+URLSessionDelegate.swift in Sources */,
+				21D7A0EB237B54D90057D00D /* AWSAPIPlugin+URLSessionDelegate.swift in Sources */,
 				21D7A0ED237B54D90057D00D /* WebsocketProviderResponse.swift in Sources */,
 				21D7A105237B54D90057D00D /* ConnectionProviderError.swift in Sources */,
 				21D7A0DF237B54D90057D00D /* AWSGraphQLOperation.swift in Sources */,
-				21409C5E2384DE2C000A53C9 /* AWSAPICategoryPlugin+GraphQLModelBehavior.swift in Sources */,
-				FA8EE785238632620097E4F1 /* AWSAPICategoryPlugin+Log.swift in Sources */,
+				21409C5E2384DE2C000A53C9 /* AWSAPIPlugin+GraphQLModelBehavior.swift in Sources */,
+				FA8EE785238632620097E4F1 /* AWSAPIPlugin+Log.swift in Sources */,
 				21D7A10F237B54D90057D00D /* RESTOperationRequestUtils+Validator.swift in Sources */,
 				21D7A111237B54D90057D00D /* APIError+DecodingError.swift in Sources */,
 				21409C602384DF17000A53C9 /* RESTOperationRequest+RESTRequest.swift in Sources */,
@@ -2080,7 +2080,7 @@
 				217856B72381F19400A30D19 /* AWSAPICategoryPluginEndpointType.swift in Sources */,
 				21D7A107237B54D90057D00D /* AppSyncMessage+Encodable.swift in Sources */,
 				21D7A108237B54D90057D00D /* AppSyncMessage.swift in Sources */,
-				21D7A0E9237B54D90057D00D /* AWSAPICategoryPlugin+InterceptorBehavior.swift in Sources */,
+				21D7A0E9237B54D90057D00D /* AWSAPIPlugin+InterceptorBehavior.swift in Sources */,
 				21D7A0FE237B54D90057D00D /* URLSessionDataTaskBehavior.swift in Sources */,
 				21D7A0E5237B54D90057D00D /* AWSAPICategoryPluginConfiguration.swift in Sources */,
 			);

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Configure.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Configure.swift
@@ -8,7 +8,7 @@
 import Amplify
 import AWSPluginsCore
 
-public extension AWSAPICategoryPlugin {
+public extension AWSAPIPlugin {
 
     /// Configures AWSAPICategoryPlugin
     ///
@@ -44,7 +44,7 @@ public extension AWSAPICategoryPlugin {
 
 // MARK: Internal
 
-extension AWSAPICategoryPlugin {
+extension AWSAPIPlugin {
 
     /// Internal configure method to set the properties of the plugin
     ///

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+GraphQLBehavior.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+GraphQLBehavior.swift
@@ -7,7 +7,7 @@
 
 import Amplify
 
-public extension AWSAPICategoryPlugin {
+public extension AWSAPIPlugin {
 
     func query<R: Decodable>(request: GraphQLRequest<R>,
                              listener: GraphQLOperation<R>.EventListener?) -> GraphQLOperation<R> {

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+GraphQLModelBehavior.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+GraphQLModelBehavior.swift
@@ -7,7 +7,7 @@
 
 import Amplify
 
-public extension AWSAPICategoryPlugin {
+public extension AWSAPIPlugin {
 
     func query<M: Model>(from modelType: M.Type,
                          byId id: String,

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+InterceptorBehavior.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+InterceptorBehavior.swift
@@ -7,7 +7,7 @@
 
 import Amplify
 
-public extension AWSAPICategoryPlugin {
+public extension AWSAPIPlugin {
     func add(interceptor: URLRequestInterceptor, for apiName: String) throws {
         let endpointOptional = pluginConfig.endpoints[apiName]
 

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Log.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Log.swift
@@ -7,7 +7,7 @@
 
 import Amplify
 
-extension AWSAPICategoryPlugin {
+extension AWSAPIPlugin {
     var log: Logger {
         Amplify.Logging.logger(forCategory: key)
     }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+RESTBehavior.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+RESTBehavior.swift
@@ -8,7 +8,7 @@
 import Amplify
 import Foundation
 
-public extension AWSAPICategoryPlugin {
+public extension AWSAPIPlugin {
 
     func get(request: RESTRequest, listener: RESTOperation.EventListener?) -> RESTOperation {
         let operationRequest = RESTOperationRequest(request: request,

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Reset.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Reset.swift
@@ -8,7 +8,7 @@
 import Amplify
 import Foundation
 
-public extension AWSAPICategoryPlugin {
+public extension AWSAPIPlugin {
     func reset(onComplete: @escaping BasicClosure) {
         mapper.reset()
 

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+URLSessionBehaviorDelegate.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+URLSessionBehaviorDelegate.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-extension AWSAPICategoryPlugin: URLSessionBehaviorDelegate {
+extension AWSAPIPlugin: URLSessionBehaviorDelegate {
     public func urlSessionBehavior(_ session: URLSessionBehavior,
                                    dataTaskBehavior: URLSessionDataTaskBehavior,
                                    didCompleteWithError error: Error?) {

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+URLSessionDelegate.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+URLSessionDelegate.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public typealias AuthChallengeDispositionHandler = (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
 
-extension AWSAPICategoryPlugin: URLSessionDelegate {
+extension AWSAPIPlugin: URLSessionDelegate {
     @objc public func urlSession(_ session: URLSession,
                                  didReceive challenge: URLAuthenticationChallenge,
                                  completionHandler: @escaping AuthChallengeDispositionHandler) {
@@ -17,7 +17,7 @@ extension AWSAPICategoryPlugin: URLSessionDelegate {
     }
 }
 
-extension AWSAPICategoryPlugin: URLSessionTaskDelegate {
+extension AWSAPIPlugin: URLSessionTaskDelegate {
 
     @objc public func urlSession(_ session: URLSession,
                                  task: URLSessionTask,
@@ -37,7 +37,7 @@ extension AWSAPICategoryPlugin: URLSessionTaskDelegate {
 
 }
 
-extension AWSAPICategoryPlugin: URLSessionDataDelegate {
+extension AWSAPIPlugin: URLSessionDataDelegate {
     //    func urlSession(_ session: URLSession,
     //                    dataTask: URLSessionDataTask,
     //                    didReceive response: URLResponse,

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin.swift
@@ -8,7 +8,7 @@
 import Amplify
 import AWSPluginsCore
 
-final public class AWSAPICategoryPlugin: NSObject, APICategoryPlugin {
+final public class AWSAPIPlugin: NSObject, APICategoryPlugin {
 
     /// The unique key of the plugin within the API category.
     public var key: PluginKey {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/APICategoryPluginConcurrencyTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/APICategoryPluginConcurrencyTests.swift
@@ -32,7 +32,7 @@ class APICategoryPluginConcurrencyTests: XCTestCase {
 
         let amplifyConfig = AmplifyConfiguration(api: apiConfig)
         do {
-            try Amplify.add(plugin: AWSAPICategoryPlugin())
+            try Amplify.add(plugin: AWSAPIPlugin())
             try Amplify.configure(amplifyConfig)
         } catch {
             XCTFail("Error during setup: \(error)")

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/AWSAPICategoryPluginGetTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/AWSAPICategoryPluginGetTests.swift
@@ -16,7 +16,7 @@ class AWSAPICategoryPluginGetTests: XCTestCase {
 
     override func setUp() {
         Amplify.reset()
-        let plugin = AWSAPICategoryPlugin()
+        let plugin = AWSAPIPlugin()
 
         let apiConfig = APICategoryConfiguration(plugins: [
             "awsAPIPlugin": [

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/AnyModelIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/AnyModelIntegrationTests.swift
@@ -35,7 +35,7 @@ class AnyModelIntegrationTests: XCTestCase {
 
         let amplifyConfig = AmplifyConfiguration(api: apiConfig)
         do {
-            try Amplify.add(plugin: AWSAPICategoryPlugin())
+            try Amplify.add(plugin: AWSAPIPlugin())
             try Amplify.configure(amplifyConfig)
         } catch {
             XCTFail("Error during setup: \(error)")

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/BlogPostCommentGraphQLWithAPIKeyTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/BlogPostCommentGraphQLWithAPIKeyTests.swift
@@ -35,7 +35,7 @@ class BlogPostCommentGraphQLWithAPIKeyTests: XCTestCase {
 
     override func setUp() {
         Amplify.reset()
-        let plugin = AWSAPICategoryPlugin()
+        let plugin = AWSAPIPlugin()
 
         let apiConfig = APICategoryConfiguration(plugins: [
             "awsAPIPlugin": [

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBasedTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBasedTests.swift
@@ -91,7 +91,7 @@ class GraphQLModelBasedTests: XCTestCase {
 
     override func setUp() {
         Amplify.reset()
-        let plugin = AWSAPICategoryPlugin()
+        let plugin = AWSAPIPlugin()
 
         let apiConfig = APICategoryConfiguration(plugins: [
             "awsAPIPlugin": [

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/TodoGraphQLWithAPIKeyTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/TodoGraphQLWithAPIKeyTests.swift
@@ -45,7 +45,7 @@ class TodoGraphQLWithAPIKeyTests: XCTestCase {
 
     override func setUp() {
         Amplify.reset()
-        let plugin = AWSAPICategoryPlugin()
+        let plugin = AWSAPIPlugin()
 
         let apiConfig = APICategoryConfiguration(plugins: [
             "awsAPIPlugin": [

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithIAMIntegrationTests/GraphQLWithIAMIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithIAMIntegrationTests/GraphQLWithIAMIntegrationTests.swift
@@ -121,7 +121,7 @@ class GraphQLWithIAMIntegrationTests: XCTestCase {
         AuthHelper.initializeMobileClient()
 
         Amplify.reset()
-        let plugin = AWSAPICategoryPlugin()
+        let plugin = AWSAPIPlugin()
 
         let apiConfig = APICategoryConfiguration(plugins: [
             "awsAPIPlugin": [

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/GraphQLWithUserPoolIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/GraphQLWithUserPoolIntegrationTests.swift
@@ -94,7 +94,7 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
         AuthHelper.initializeMobileClient()
 
         Amplify.reset()
-        let plugin = AWSAPICategoryPlugin()
+        let plugin = AWSAPIPlugin()
 
         let apiConfig = APICategoryConfiguration(plugins: [
             "awsAPIPlugin": [

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithIAMIntegrationTests/RESTWithIAMIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithIAMIntegrationTests/RESTWithIAMIntegrationTests.swift
@@ -56,7 +56,7 @@ class RESTWithIAMIntegrationTests: XCTestCase {
         AuthHelper.initializeMobileClient()
 
         Amplify.reset()
-        let plugin = AWSAPICategoryPlugin()
+        let plugin = AWSAPIPlugin()
 
         let amplifyConfig = AmplifyConfiguration(api: RESTWithIAMIntegrationTests.apiConfig)
         do {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ConfigureTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ConfigureTests.swift
@@ -17,7 +17,7 @@ class AWSAPICategoryPluginConfigureTests: AWSAPICategoryPluginTestBase {
     }
 
     func testConfigureSuccess() throws {
-        let apiPlugin = AWSAPICategoryPlugin()
+        let apiPlugin = AWSAPIPlugin()
         let apiPluginConfig: JSONValue = [
             "Test": [
                 "endpoint": "http://www.example.com",

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPluginTestBase.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPluginTestBase.swift
@@ -15,7 +15,7 @@ import AWSPluginsCore
 
 class AWSAPICategoryPluginTestBase: XCTestCase {
 
-    var apiPlugin: AWSAPICategoryPlugin!
+    var apiPlugin: AWSAPIPlugin!
     var authService: MockAWSAuthService!
     var pluginConfig: AWSAPICategoryPluginConfiguration!
 
@@ -30,7 +30,7 @@ class AWSAPICategoryPluginTestBase: XCTestCase {
     let testPath = "testPath"
 
     override func setUp() {
-        apiPlugin = AWSAPICategoryPlugin()
+        apiPlugin = AWSAPIPlugin()
         authService = MockAWSAuthService()
         do {
             let endpointConfig = [apiName: try AWSAPICategoryPluginConfiguration.EndpointConfig(

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSRESTOperationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSRESTOperationTests.swift
@@ -156,12 +156,12 @@ class AWSRESTOperationTests: XCTestCase {
     // MARK: - Utilities
 
     func setUpPlugin(with factory: URLSessionBehaviorFactory? = nil) {
-        let apiPlugin: AWSAPICategoryPlugin
+        let apiPlugin: AWSAPIPlugin
 
         if let factory = factory {
-            apiPlugin = AWSAPICategoryPlugin(sessionFactory: factory)
+            apiPlugin = AWSAPIPlugin(sessionFactory: factory)
         } else {
-            apiPlugin = AWSAPICategoryPlugin()
+            apiPlugin = AWSAPIPlugin()
         }
 
         let apiConfig = APICategoryConfiguration(plugins: [

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/AWSDataStoreCategoryPluginIntegrationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/AWSDataStoreCategoryPluginIntegrationTests.swift
@@ -31,7 +31,7 @@ class AWSDataStoreCategoryPluginIntegrationTests: XCTestCase {
 
         // TODO: Move this to an integ test config file
         let apiConfig = APICategoryConfiguration(plugins: [
-            "awsAPICategoryPlugin": [
+            "awsAPIPlugin": [
                 "Default": [
                     "endpoint": "https://ldm7yqjfjngrjckbziumz5fxbe.appsync-api.us-west-2.amazonaws.com/graphql",
                     "region": "us-west-2",
@@ -49,7 +49,7 @@ class AWSDataStoreCategoryPluginIntegrationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(api: apiConfig, dataStore: dataStoreConfig)
 
         do {
-            try Amplify.add(plugin: AWSAPICategoryPlugin())
+            try Amplify.add(plugin: AWSAPIPlugin())
             try Amplify.add(plugin: AWSDataStoreCategoryPlugin())
             try Amplify.configure(amplifyConfig)
         } catch {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/SubscriptionIntegrationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/SubscriptionIntegrationTests.swift
@@ -35,7 +35,7 @@ class SubscriptionIntegrationTests: XCTestCase {
 
         // TODO: Move this to an integ test config file
         let apiConfig = APICategoryConfiguration(plugins: [
-            "awsAPICategoryPlugin": [
+            "awsAPIPlugin": [
                 "default": [
                     "endpoint": "https://ldm7yqjfjngrjckbziumz5fxbe.appsync-api.us-west-2.amazonaws.com/graphql",
                     "region": "us-west-2",
@@ -53,7 +53,7 @@ class SubscriptionIntegrationTests: XCTestCase {
         amplifyConfig = AmplifyConfiguration(api: apiConfig, dataStore: dataStoreConfig)
 
         do {
-            try Amplify.add(plugin: AWSAPICategoryPlugin())
+            try Amplify.add(plugin: AWSAPIPlugin())
             try Amplify.add(plugin: AWSDataStoreCategoryPlugin())
         } catch {
             XCTFail(String(describing: error))


### PR DESCRIPTION
This renames the class "AWSAPICategoryPlugin" to "AWSAPIPlugin" so when developer instantiates the plugin they can do 
`let apiPlugin = AWSAPIPlugin()`

Functionally this PR does the trick, however there are some folder names that should also be renamed, and will do that as a follow up to prevent unnecessary friction for others when rebasing/merging

### Testing done
I've testing this in sample app to make sure i can install the pod and instantiate the plugin

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
