### PR TITLE
Update AmplifyPlugins.podspec ios platform to 11

### DIFF
--- a/AmplifyPlugins.podspec
+++ b/AmplifyPlugins.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '13.0'
+  s.platform     = :ios, '11.0'
   s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => s.version}
   
   s.requires_arc = true 

--- a/AmplifyPlugins/DataStore/Podfile
+++ b/AmplifyPlugins/DataStore/Podfile
@@ -33,6 +33,6 @@ target "HostApp" do
   target "AWSDataStoreCategoryPluginIntegrationTests" do
     inherit! :complete
 
-    pod 'AmplifyPlugins/AWSAPICategoryPlugin', :path => '../../'
+    pod 'AmplifyPlugins/AWSAPIPlugin', :path => '../../'
   end
 end


### PR DESCRIPTION
### Major changes
Update AmplifyPlugins.podspec ios platform to 11

### Minor changes
Podfile for DataStore was referencing old AWSAPICategoryPlugin instead of renamed AWSAPIPlugin

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
