### PR TITLE
Convert all-at-once publisher to on-demand publisher

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreError.swift
+++ b/Amplify/Categories/DataStore/DataStoreError.swift
@@ -88,7 +88,7 @@ extension DataStoreError: AmplifyError {
     }
 }
 
-extension DataStoreError {
+public extension DataStoreError {
     init(error: Error) {
         if let dataStoreError = error as? DataStoreError {
             self = dataStoreError

--- a/Amplify/Categories/DataStore/Subscribe/MutationEvent+Schema.swift
+++ b/Amplify/Categories/DataStore/Subscribe/MutationEvent+Schema.swift
@@ -15,6 +15,7 @@ extension MutationEvent {
         case mutationType
         case createdAt
         case version
+        case inProcess
     }
 
     public static let keys = CodingKeys.self
@@ -33,7 +34,8 @@ extension MutationEvent {
             .field(mutation.json, is: .required, ofType: .string),
             .field(mutation.mutationType, is: .required, ofType: .string),
             .field(mutation.createdAt, is: .required, ofType: .dateTime),
-            .field(mutation.version, is: .optional, ofType: .int)
+            .field(mutation.version, is: .optional, ofType: .int),
+            .field(mutation.inProcess, is: .optional, ofType: .bool)
         )
     }
 }

--- a/Amplify/Categories/DataStore/Subscribe/MutationEvent.swift
+++ b/Amplify/Categories/DataStore/Subscribe/MutationEvent.swift
@@ -9,24 +9,27 @@ import Foundation
 
 public struct MutationEvent: Model {
     public let id: Identifier
-    public let modelName: String
-    public let json: String
-    public let mutationType: String
-    public let createdAt: Date
-    public let version: Int?
+    public var modelName: String
+    public var json: String
+    public var mutationType: String
+    public var createdAt: Date
+    public var version: Int?
+    public var inProcess: Bool
 
     public init(id: Identifier = UUID().uuidString,
                 modelName: String,
                 data: String,
                 mutationType: MutationType,
                 createdAt: Date = Date(),
-                version: Int? = nil) {
+                version: Int? = nil,
+                inProcess: Bool = false) {
         self.id = id
         self.modelName = modelName
         self.json = data
         self.mutationType = mutationType.rawValue
         self.createdAt = createdAt
         self.version = version
+        self.inProcess = inProcess
     }
 
     public init<M: Model>(model: M,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -113,8 +113,20 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
     func query<M: Model>(_ modelType: M.Type,
                          predicate: QueryPredicate? = nil,
                          completion: DataStoreCallback<[M]>) {
+        query(modelType,
+              predicate: predicate,
+              additionalStatements: nil,
+              completion: completion)
+    }
+
+    func query<M: Model>(_ modelType: M.Type,
+                         predicate: QueryPredicate? = nil,
+                         additionalStatements: String? = nil,
+                         completion: DataStoreCallback<[M]>) {
         do {
-            let statement = SelectStatement(from: modelType, predicate: predicate)
+            let statement = SelectStatement(from: modelType,
+                                            predicate: predicate,
+                                            additionalStatements: additionalStatements)
             let rows = try connection.prepare(statement.stringValue).run(statement.variables)
             let result: [M] = try rows.convert(to: modelType)
             completion(.success(result))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -20,10 +20,10 @@ final class StorageEngine: StorageEngineBehavior {
 
     private weak var api: APICategoryGraphQLBehavior?
 
-    // TODO: Find the right place to do this
     static var systemModels: [Model.Type] {
         return [
-            MutationEvent.self
+            MutationEvent.self,
+            MutationSyncMetadata.self
         ]
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -22,5 +22,10 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
                predicate: QueryPredicate?,
                completion: DataStoreCallback<[Model]>)
 
+    func query<M: Model>(_ modelType: M.Type,
+                         predicate: QueryPredicate?,
+                         additionalStatements: String?,
+                         completion: DataStoreCallback<[M]>)
+
     func queryMutationSync(for models: [Model]) throws -> [MutationSync<AnyModel>]
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEventSource.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEventSource.swift
@@ -1,0 +1,69 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Combine
+
+protocol MutationEventSource: class {
+    /// Gets the next available mutation event, marking it as "inProcess" before delivery
+    func getNextMutationEvent(completion: @escaping DataStoreCallback<MutationEvent>)
+}
+
+@available(iOS 13.0, *)
+extension AWSMutationDatabaseAdapter: MutationEventSource {
+    func getNextMutationEvent(completion: @escaping DataStoreCallback<MutationEvent>) {
+        log.verbose(#function)
+
+        guard let storageAdapter = storageAdapter else {
+            let dataStoreError = DataStoreError.configuration(
+                "storageAdapter is unexpectedly nil in an internal operation",
+                """
+                The reference to storageAdapter has been released while an ongoing mutation was being processed.
+                """
+            )
+            completion(.failure(dataStoreError))
+            return
+        }
+
+        let fields = MutationEvent.keys
+        let predicateFactory: QueryPredicateFactory = {
+            fields.inProcess.ne(nil).or(fields.inProcess.eq(false))
+        }
+
+        let orderAndLimitClause = """
+        ORDER BY \(MutationEvent.keys.createdAt.stringValue) ASC
+        LIMIT 1
+        """
+
+        storageAdapter.query(MutationEvent.self,
+                             predicate: predicateFactory(),
+                             additionalStatements: orderAndLimitClause) { result in
+                                switch result {
+                                case .failure(let dataStoreError):
+                                    completion(.failure(dataStoreError))
+                                case .success(let mutationEvents):
+                                    guard let notInProcessEvent = mutationEvents.first else {
+                                        self.nextEventPromise = completion
+                                        return
+                                    }
+                                    self.markInProcess(mutationEvent: notInProcessEvent,
+                                                       storageAdapter: storageAdapter,
+                                                       completion: completion)
+                                }
+
+        }
+    }
+
+    func markInProcess(mutationEvent: MutationEvent,
+                       storageAdapter: StorageEngineAdapter,
+                       completion: @escaping DataStoreCallback<MutationEvent>) {
+        var inProcessEvent = mutationEvent
+        inProcessEvent.inProcess = true
+        storageAdapter.save(inProcessEvent, completion: completion)
+    }
+
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEventSubscriber.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEventSubscriber.swift
@@ -1,0 +1,38 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Combine
+
+@available(iOS 13.0, *)
+final class MutationEventSubscriber: Subscriber {
+    typealias Input = MutationEvent
+    typealias Failure = DataStoreError
+
+    private let receiveSubscription: (Subscription) -> Void
+    private let receiveInput: (MutationEvent) -> Subscribers.Demand
+    private let receiveCompletion: (Subscribers.Completion<DataStoreError>) -> Void
+
+    init<S>(subscriber: S) where S: Subscriber, Failure == S.Failure, Input == S.Input {
+        self.receiveSubscription = subscriber.receive(subscription:)
+        self.receiveInput = subscriber.receive(_:)
+        self.receiveCompletion = subscriber.receive(completion:)
+    }
+
+    func receive(subscription: Subscription) {
+        receiveSubscription(subscription)
+    }
+
+    func receive(_ input: MutationEvent) -> Subscribers.Demand {
+        receiveInput(input)
+    }
+
+    func receive(completion: Subscribers.Completion<DataStoreError>) {
+        receiveCompletion(completion)
+    }
+
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEventSubscription.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEventSubscription.swift
@@ -1,0 +1,37 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Combine
+
+@available(iOS 13.0, *)
+final class MutationEventSubscription: Subscription {
+
+    private var demand = Subscribers.Demand.none
+    let subscriber: MutationEventSubscriber
+    private weak var publisher: AWSMutationEventPublisher?
+
+    init<S>(subscriber: S,
+            publisher: AWSMutationEventPublisher) where S: Subscriber,
+        S.Failure == DataStoreError,
+        S.Input == MutationEvent {
+            self.subscriber = MutationEventSubscriber(subscriber: subscriber)
+            self.publisher = publisher
+    }
+
+    func cancel() {
+        publisher?.cancel()
+    }
+
+    func request(_ demand: Subscribers.Demand) {
+        self.demand = demand
+        publisher?.request(demand)
+    }
+}
+
+@available(iOS 13.0, *)
+extension MutationEventSubscription: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue.swift
@@ -151,6 +151,8 @@ final class OutgoingMutationQueue {
             SyncMutationToCloudOperation(mutationEvent: mutationEvent, api: api)
 
         operationQueue.addOperation(syncMutationToCloudOperation)
+
+        // TODO: We should only request the next event once the current event has finished
         requestEvent()
     }
 
@@ -159,7 +161,7 @@ final class OutgoingMutationQueue {
 @available(iOS 13.0, *)
 extension OutgoingMutationQueue: Subscriber {
     typealias Input = MutationEvent
-    typealias Failure = Never
+    typealias Failure = DataStoreError
 
     func receive(subscription: Subscription) {
         log.verbose(#function)
@@ -176,7 +178,7 @@ extension OutgoingMutationQueue: Subscriber {
     }
 
     // TODO: Resolve with an appropriate state machine notification
-    func receive(completion: Subscribers.Completion<Never>) {
+    func receive(completion: Subscribers.Completion<DataStoreError>) {
         log.verbose(#function)
         subscription?.cancel()
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/MutationIngesterConflictResolutionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/MutationIngesterConflictResolutionTests.swift
@@ -1,0 +1,148 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import SQLite
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+/// Tests in this class have a naming convention of `test_<existing>_<ingesting>`, which is to say: given that the
+/// mutation queue has an existing record of type `<existing>`, assert the behavior when ingesting a mutation of
+/// type `<ingesting>`.
+class MutationIngesterConflictResolutionTests: XCTestCase {
+
+    /// Mock used to listen for API calls; this is how we assert that syncEngine is delivering events to the API
+    var apiPlugin: MockAPICategoryPlugin!
+
+    /// Used for DB manipulation to mock starting data for tests
+    var storageAdapter: SQLiteStorageEngineAdapter!
+
+    /// Populated during setUp, used in each test during `Amplify.configure()`
+    var amplifyConfig: AmplifyConfiguration!
+
+    override func setUp() {
+        continueAfterFailure = false
+
+        Amplify.reset()
+        Amplify.Logging.logLevel = .verbose
+
+        let apiConfig = APICategoryConfiguration(plugins: [
+            "MockAPICategoryPlugin": true
+        ])
+
+        let dataStoreConfig = DataStoreCategoryConfiguration(plugins: [
+            "awsDataStoreCategoryPlugin": true
+        ])
+
+        amplifyConfig = AmplifyConfiguration(api: apiConfig, dataStore: dataStoreConfig)
+
+        apiPlugin = MockAPICategoryPlugin()
+        tryOrFail {
+            try Amplify.add(plugin: apiPlugin)
+        }
+    }
+
+    /// Sets up a StorageAdapter backed by an in-memory SQLite database
+    func setUpStorageAdapter() {
+        tryOrFail {
+            let connection = try Connection(.inMemory)
+            storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
+            try storageAdapter.setUp(models: StorageEngine.systemModels)
+        }
+    }
+
+    func setUpDataStore() {
+        tryOrFail {
+            let syncEngine = try CloudSyncEngine(storageAdapter: storageAdapter)
+            let storageEngine = StorageEngine(storageAdapter: storageAdapter,
+                                              syncEngine: syncEngine,
+                                              isSyncEnabled: true)
+
+            let publisher = DataStorePublisher()
+            let dataStorePlugin = AWSDataStoreCategoryPlugin(modelRegistration: TestModelRegistration(),
+                                                             storageEngine: storageEngine,
+                                                             dataStorePublisher: publisher)
+
+            try Amplify.add(plugin: dataStorePlugin)
+        }
+    }
+
+    func startAmplify() {
+        tryOrFail {
+            try Amplify.configure(amplifyConfig)
+        }
+    }
+
+    func test_create_create() throws {
+        setUpStorageAdapter()
+
+        let post = Post(id: "post-1",
+                        title: "title",
+                        content: "content",
+                        createdAt: Date())
+        try saveMutationEvent(of: .create, for: post)
+
+        try startAmplifyAndWaitForSync()
+
+        let saveResultReceived = expectation(description: "Save result received")
+        Amplify.DataStore.save(post) { result in
+            switch result {
+            case .failure(let dataStoreError):
+                XCTAssertNotNil(dataStoreError)
+            case .success(let post):
+                XCTAssertNil(post)
+            }
+        }
+
+        wait(for: [saveResultReceived], timeout: 1.0)
+    }
+
+    // MARK: - Helpers
+
+    func saveMutationEvent(of mutationType: MutationEvent.MutationType,
+                           for post: Post,
+                           version: Int? = nil) throws {
+        let mutationEvent = try MutationEvent(modelName: post.modelName,
+                                              data: post.toJSON(),
+                                              mutationType: mutationType,
+                                              createdAt: Date(),
+                                              version: version)
+
+        let mutationEventSaved = expectation(description: "Preloaded mutation event saved")
+        storageAdapter.save(mutationEvent) { result in
+            switch result {
+            case .failure(let dataStoreError):
+                XCTFail(String(describing: dataStoreError))
+            case .success:
+                mutationEventSaved.fulfill()
+            }
+        }
+        wait(for: [mutationEventSaved], timeout: 1.0)
+    }
+
+    func startAmplifyAndWaitForSync() throws {
+        setUpDataStore()
+
+        let syncStarted = expectation(description: "Sync started")
+        let token = Amplify.Hub.listen(to: .dataStore,
+                                       eventName: HubPayload.EventName.DataStore.syncStarted) { _ in
+                                        syncStarted.fulfill()
+        }
+
+        guard try HubListenerTestUtilities.waitForListener(with: token, timeout: 5.0) else {
+            XCTFail("Never registered listener for sync started")
+            return
+        }
+
+        startAmplify()
+
+        wait(for: [syncStarted], timeout: 5.0)
+        Amplify.Hub.removeListener(token)
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/OutgoingMutationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/OutgoingMutationQueueTests.swift
@@ -289,16 +289,3 @@ class OutgoingMutationQueueTests: XCTestCase {
     }
 
 }
-
-// TOOD: Figure out how to move this to AmplifyTestCommon. Last time I tried, I wasn't able to `import XCTest` in the
-// extension file, presumably because AmplifyTestCommon isn't a test target?
-extension XCTestCase {
-    /// Execute `block` inside a do/catch block, and fail the test with an XCTFail if the block throws an error
-    func tryOrFail(block: () throws -> Void) {
-        do {
-            try block()
-        } catch {
-            XCTFail(String(describing: error))
-        }
-    }
-}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/ReconcileAndLocalSaveOperationTests.swift
@@ -346,6 +346,13 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
         let result = resultForQuery ?? .failure(DataStoreError.invalidOperation(causedBy: nil))
         completion(result)
     }
+    func query<M: Model>(_ modelType: M.Type,
+                         predicate: QueryPredicate?,
+                         additionalStatements: String?,
+                         completion: (Result<[M], DataStoreError>) -> Void) {
+        completion(.failure(DataStoreError.invalidOperation(causedBy: nil)))
+    }
+
 }
 class MockStorageEngineBehavior: StorageEngineBehavior {
     func startSync() {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/SQLStatementTests.swift
@@ -43,8 +43,6 @@ class SQLStatementTests: XCTestCase {
         let expectedStatement = """
         create table if not exists Post (
           "id" text primary key not null,
-          "_deleted" integer,
-          "_version" integer,
           "content" text not null,
           "createdAt" text not null,
           "draft" integer,
@@ -136,14 +134,14 @@ class SQLStatementTests: XCTestCase {
         let statement = InsertStatement(model: post)
 
         let expectedStatement = """
-        insert into Post ("id", "_deleted", "_version", "content", "createdAt", "draft", "rating", "title", "updatedAt")
-        values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        insert into Post ("id", "content", "createdAt", "draft", "rating", "title", "updatedAt")
+        values (?, ?, ?, ?, ?, ?, ?)
         """
         XCTAssertEqual(statement.stringValue, expectedStatement)
 
         let variables = statement.variables
-        XCTAssertEqual(variables[3] as? String, "content")
-        XCTAssertEqual(variables[7] as? String, "title")
+        XCTAssertEqual(variables[1] as? String, "content")
+        XCTAssertEqual(variables[5] as? String, "title")
     }
 
     /// - Given: a `Model` instance
@@ -185,8 +183,6 @@ class SQLStatementTests: XCTestCase {
         let expectedStatement = """
         update Post
         set
-          "_deleted" = ?,
-          "_version" = ?,
           "content" = ?,
           "createdAt" = ?,
           "draft" = ?,
@@ -198,9 +194,9 @@ class SQLStatementTests: XCTestCase {
         XCTAssertEqual(statement.stringValue, expectedStatement)
 
         let variables = statement.variables
-        XCTAssertEqual(variables[2] as? String, "content")
-        XCTAssertEqual(variables[6] as? String, "title")
-        XCTAssertEqual(variables[8] as? String, post.id)
+        XCTAssertEqual(variables[0] as? String, "content")
+        XCTAssertEqual(variables[4] as? String, "title")
+        XCTAssertEqual(variables[6] as? String, post.id)
     }
 
     // MARK: - Delete Statements
@@ -237,9 +233,9 @@ class SQLStatementTests: XCTestCase {
         let statement = SelectStatement(from: Post.self)
         let expectedStatement = """
         select
-          "root"."id" as "id", "root"."_deleted" as "_deleted", "root"."_version" as "_version",
-          "root"."content" as "content", "root"."createdAt" as "createdAt", "root"."draft" as "draft",
-          "root"."rating" as "rating", "root"."title" as "title", "root"."updatedAt" as "updatedAt"
+          "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
+          "root"."draft" as "draft", "root"."rating" as "rating", "root"."title" as "title",
+          "root"."updatedAt" as "updatedAt"
         from Post as root
         """
         XCTAssertEqual(statement.stringValue, expectedStatement)
@@ -258,9 +254,9 @@ class SQLStatementTests: XCTestCase {
         let statement = SelectStatement(from: Post.self, predicate: predicate)
         let expectedStatement = """
         select
-          "root"."id" as "id", "root"."_deleted" as "_deleted", "root"."_version" as "_version",
-          "root"."content" as "content", "root"."createdAt" as "createdAt", "root"."draft" as "draft",
-          "root"."rating" as "rating", "root"."title" as "title", "root"."updatedAt" as "updatedAt"
+          "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
+          "root"."draft" as "draft", "root"."rating" as "rating", "root"."title" as "title",
+          "root"."updatedAt" as "updatedAt"
         from Post as root
         where 1 = 1
           and "root"."draft" = ?
@@ -284,10 +280,9 @@ class SQLStatementTests: XCTestCase {
         let expectedStatement = """
         select
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
-          "root"."commentPostId" as "commentPostId", "post"."id" as "post.id", "post"."_deleted" as "post._deleted",
-          "post"."_version" as "post._version", "post"."content" as "post.content", "post"."createdAt" as "post.createdAt",
-          "post"."draft" as "post.draft", "post"."rating" as "post.rating", "post"."title" as "post.title",
-          "post"."updatedAt" as "post.updatedAt"
+          "root"."commentPostId" as "commentPostId", "post"."id" as "post.id", "post"."content" as "post.content",
+          "post"."createdAt" as "post.createdAt", "post"."draft" as "post.draft", "post"."rating" as "post.rating",
+          "post"."title" as "post.title", "post"."updatedAt" as "post.updatedAt"
         from Comment as root
         inner join Post as post
           on "post"."id" = "root"."commentPostId"

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/XCTest+AmplifyExtensions.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/XCTest+AmplifyExtensions.swift
@@ -1,0 +1,21 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+// TOOD: Figure out how to move this to AmplifyTestCommon. Last time I tried, I wasn't able to `import XCTest` in the
+// extension file, presumably because AmplifyTestCommon isn't a test target?
+extension XCTestCase {
+    /// Execute `block` inside a do/catch block, and fail the test with an XCTFail if the block throws an error
+    func tryOrFail(block: () throws -> Void) {
+        do {
+            try block()
+        } catch {
+            XCTFail(String(describing: error))
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -72,6 +72,11 @@
 		FA3B3F05238F22F5002EFDB3 /* OutgoingMutationQueue+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3B3F04238F22F5002EFDB3 /* OutgoingMutationQueue+Action.swift */; };
 		FA3B3F07238F23CA002EFDB3 /* OutgoingMutationQueue+Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3B3F06238F23CA002EFDB3 /* OutgoingMutationQueue+Resolver.swift */; };
 		FA3B3F09238F39DE002EFDB3 /* AWSMutationEventIngesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3B3F08238F39DE002EFDB3 /* AWSMutationEventIngesterTests.swift */; };
+		FA4B8E942391C2CD009FC10F /* MutationIngesterConflictResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4B8E932391C2CD009FC10F /* MutationIngesterConflictResolutionTests.swift */; };
+		FA4B8E962391C609009FC10F /* XCTest+AmplifyExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4B8E952391C609009FC10F /* XCTest+AmplifyExtensions.swift */; };
+		FA55A5492391EA89002AFF2D /* MutationEventSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA55A5482391EA89002AFF2D /* MutationEventSubscription.swift */; };
+		FA55A54B2391EAB5002AFF2D /* MutationEventSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA55A54A2391EAB5002AFF2D /* MutationEventSubscriber.swift */; };
+		FA55A54D2391F96E002AFF2D /* MutationEventSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA55A54C2391F96E002AFF2D /* MutationEventSource.swift */; };
 		FA5D4CED238AFC4D00D2F54A /* AWSDataStoreCategoryPlugin+DefaultLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5D4CEC238AFC4D00D2F54A /* AWSDataStoreCategoryPlugin+DefaultLogger.swift */; };
 		FA5D4CEF238AFCBC00D2F54A /* AWSDataStoreCategoryPlugin+DataStoreSubscribeBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5D4CEE238AFCBC00D2F54A /* AWSDataStoreCategoryPlugin+DataStoreSubscribeBehavior.swift */; };
 		FAAFAF3923905F35002CF932 /* MutationEventPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAFAF3823905F35002CF932 /* MutationEventPublisher.swift */; };
@@ -191,6 +196,11 @@
 		FA3B3F04238F22F5002EFDB3 /* OutgoingMutationQueue+Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OutgoingMutationQueue+Action.swift"; sourceTree = "<group>"; };
 		FA3B3F06238F23CA002EFDB3 /* OutgoingMutationQueue+Resolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OutgoingMutationQueue+Resolver.swift"; sourceTree = "<group>"; };
 		FA3B3F08238F39DE002EFDB3 /* AWSMutationEventIngesterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMutationEventIngesterTests.swift; sourceTree = "<group>"; };
+		FA4B8E932391C2CD009FC10F /* MutationIngesterConflictResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationIngesterConflictResolutionTests.swift; sourceTree = "<group>"; };
+		FA4B8E952391C609009FC10F /* XCTest+AmplifyExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTest+AmplifyExtensions.swift"; sourceTree = "<group>"; };
+		FA55A5482391EA89002AFF2D /* MutationEventSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEventSubscription.swift; sourceTree = "<group>"; };
+		FA55A54A2391EAB5002AFF2D /* MutationEventSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEventSubscriber.swift; sourceTree = "<group>"; };
+		FA55A54C2391F96E002AFF2D /* MutationEventSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEventSource.swift; sourceTree = "<group>"; };
 		FA5D4CEC238AFC4D00D2F54A /* AWSDataStoreCategoryPlugin+DefaultLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSDataStoreCategoryPlugin+DefaultLogger.swift"; sourceTree = "<group>"; };
 		FA5D4CEE238AFCBC00D2F54A /* AWSDataStoreCategoryPlugin+DataStoreSubscribeBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSDataStoreCategoryPlugin+DataStoreSubscribeBehavior.swift"; sourceTree = "<group>"; };
 		FAAFAF3823905F35002CF932 /* MutationEventPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEventPublisher.swift; sourceTree = "<group>"; };
@@ -352,6 +362,7 @@
 				2149E5E72388692E00873955 /* Info.plist */,
 				B9FAA13F238C600A009414B4 /* ListTests.swift */,
 				2149E5F3238869CF00873955 /* LocalSubscriptionTests.swift */,
+				FA4B8E932391C2CD009FC10F /* MutationIngesterConflictResolutionTests.swift */,
 				B9FAA182239030A3009414B4 /* MutationSyncMetadataTests.swift */,
 				2149E5F2238869CF00873955 /* NetworkReachabilityNotifierTests.swift */,
 				2149E5F4238869CF00873955 /* OutgoingMutationQueueTests.swift */,
@@ -369,6 +380,7 @@
 			isa = PBXGroup;
 			children = (
 				B9FAA141238C6082009414B4 /* BaseDataStoreTests.swift */,
+				FA4B8E952391C609009FC10F /* XCTest+AmplifyExtensions.swift */,
 				FA3841EE23889DCC0070AD5B /* MockModels.swift */,
 				B9E010E3239167E000DCE8C8 /* TestModelRegistration.swift */,
 			);
@@ -440,8 +452,8 @@
 		FAED5735238B2DEC008EBED8 /* SubscriptionSync */ = {
 			isa = PBXGroup;
 			children = (
-				FADD7290238B19CB005AA69A /* IncomingAsyncSubscriptionEventToAnyModelMapper.swift */,
 				FADD728E238B0F10005AA69A /* IncomingAsyncSubscriptionEventPublisher.swift */,
+				FADD7290238B19CB005AA69A /* IncomingAsyncSubscriptionEventToAnyModelMapper.swift */,
 				FA3841E423889D280070AD5B /* IncomingEventReconciliationQueues.swift */,
 				FAED5737238B3A2A008EBED8 /* IncomingMutationEventFacade.swift */,
 				FA3841E623889D340070AD5B /* ReconcileAndLocalSaveOperation.swift */,
@@ -454,13 +466,16 @@
 			children = (
 				FA3B3EFE238F13B2002EFDB3 /* MutationEventIngester.swift */,
 				FAAFAF3823905F35002CF932 /* MutationEventPublisher.swift */,
+				FA55A54C2391F96E002AFF2D /* MutationEventSource.swift */,
+				FA55A54A2391EAB5002AFF2D /* MutationEventSubscriber.swift */,
+				FA55A5482391EA89002AFF2D /* MutationEventSubscription.swift */,
 				B9E010DD2390780800DCE8C8 /* MutationSync.swift */,
 				B9E010DF2390780900DCE8C8 /* MutationSyncMetadata.swift */,
 				B9E010DE2390780900DCE8C8 /* MutationSyncMetadata+Schema.swift */,
 				FAF7CECA238C72830095547B /* OutgoingMutationQueue.swift */,
 				FA3B3F04238F22F5002EFDB3 /* OutgoingMutationQueue+Action.swift */,
-				FA3B3F02238F22CF002EFDB3 /* OutgoingMutationQueue+State.swift */,
 				FA3B3F06238F23CA002EFDB3 /* OutgoingMutationQueue+Resolver.swift */,
+				FA3B3F02238F22CF002EFDB3 /* OutgoingMutationQueue+State.swift */,
 				FAF7CEC8238C6A940095547B /* SyncMutationToCloudOperation.swift */,
 			);
 			path = MutationSync;
@@ -912,6 +927,7 @@
 				2149E5CD2388684F00873955 /* SQLStatement+Update.swift in Sources */,
 				FAF7CEC9238C6A940095547B /* SyncMutationToCloudOperation.swift in Sources */,
 				2149E5D02388684F00873955 /* QueryPredicate+SQLite.swift in Sources */,
+				FA55A54B2391EAB5002AFF2D /* MutationEventSubscriber.swift in Sources */,
 				FA3B3F07238F23CA002EFDB3 /* OutgoingMutationQueue+Resolver.swift in Sources */,
 				2149E5D22388684F00873955 /* SQLStatement+Condition.swift in Sources */,
 				FAED573C238B4B03008EBED8 /* Statement+AnyModel.swift in Sources */,
@@ -940,7 +956,9 @@
 				2149E5C82388684F00873955 /* SQLStatement.swift in Sources */,
 				FAED5742238B52CE008EBED8 /* ModelStorageBehavior.swift in Sources */,
 				2149E5C62388684F00873955 /* StorageEngineAdapter.swift in Sources */,
+				FA55A5492391EA89002AFF2D /* MutationEventSubscription.swift in Sources */,
 				FAED5738238B3A2A008EBED8 /* IncomingMutationEventFacade.swift in Sources */,
+				FA55A54D2391F96E002AFF2D /* MutationEventSource.swift in Sources */,
 				2149E5CE2388684F00873955 /* SQLStatement+CreateTable.swift in Sources */,
 				FACBB2AE238AFAE800C29602 /* AWSDataStoreCategoryPlugin+DataStoreBaseBehavior.swift in Sources */,
 				2149E5D32388684F00873955 /* Statement+Model.swift in Sources */,
@@ -960,9 +978,11 @@
 				FA3841EF23889DCC0070AD5B /* MockModels.swift in Sources */,
 				2149E5FF238869CF00873955 /* SQLStatementTests.swift in Sources */,
 				FA3B3F09238F39DE002EFDB3 /* AWSMutationEventIngesterTests.swift in Sources */,
+				FA4B8E962391C609009FC10F /* XCTest+AmplifyExtensions.swift in Sources */,
 				B9FAA140238C600A009414B4 /* ListTests.swift in Sources */,
 				2149E5F9238869CF00873955 /* QueryPredicateTests.swift in Sources */,
 				2149E5FA238869CF00873955 /* APICategoryDependencyTests.swift in Sources */,
+				FA4B8E942391C2CD009FC10F /* MutationIngesterConflictResolutionTests.swift in Sources */,
 				2149E5FB238869CF00873955 /* NetworkReachabilityNotifierTests.swift in Sources */,
 				2149E5FE238869CF00873955 /* CloudSyncTests.swift in Sources */,
 				B9FAA142238C6082009414B4 /* BaseDataStoreTests.swift in Sources */,

--- a/AmplifyTestCommon/Models/Post+Schema.swift
+++ b/AmplifyTestCommon/Models/Post+Schema.swift
@@ -8,8 +8,7 @@
 import Amplify
 import Foundation
 
-// TODO: Remove once we remove _version
-// swiftlint:disable identifier_name
+// swiftlint:disable all
 extension Post {
 
     // MARK: - CodingKeys
@@ -22,8 +21,6 @@ extension Post {
         case rating
         case draft
         case comments
-        case _version
-        case _deleted
     }
 
     public static let keys = CodingKeys.self
@@ -44,10 +41,6 @@ extension Post {
             .field(post.updatedAt, is: .optional, ofType: .dateTime),
             .field(post.rating, is: .optional, ofType: .double),
             .field(post.draft, is: .optional, ofType: .bool),
-
-            // TODO: Remove these once we get sync metadata wired up
-            .field(post._version, is: .optional, ofType: .int),
-            .field(post._deleted, is: .optional, ofType: .bool),
 
             .hasMany(post.comments,
                      ofType: Comment.self,

--- a/AmplifyTestCommon/Models/Post.swift
+++ b/AmplifyTestCommon/Models/Post.swift
@@ -8,8 +8,7 @@
 import Amplify
 import Foundation
 
-// TODO: Remove once we remove _version
-// swiftlint:disable identifier_name
+// swiftlint:disable all
 public struct Post: Model {
 
     public let id: String
@@ -21,10 +20,6 @@ public struct Post: Model {
     public var draft: Bool?
     public var comments: List<Comment>?
 
-    // TODO: Remove these once we get sync metadata wired up
-    public var _version: Int?
-    public var _deleted: Bool?
-
     public init(id: String = UUID().uuidString,
                 title: String,
                 content: String,
@@ -32,8 +27,6 @@ public struct Post: Model {
                 updatedAt: Date? = nil,
                 rating: Double? = nil,
                 draft: Bool? = nil,
-                _version: Int? = nil,
-                _deleted: Bool? = nil,
                 comments: List<Comment> = []) {
         self.id = id
         self.title = title
@@ -43,8 +36,6 @@ public struct Post: Model {
         self.rating = rating
         self.draft = draft
         self.comments = comments
-        self._version = _version
-        self._deleted = _deleted
     }
 
 }


### PR DESCRIPTION
- Marking in-process MutationEvents as in-process
- Renamed AWSMutationEventIngester to AWSMutationDatabaseAdapter since it is now responsible for ingesting events, retrieving them, and re-saving in-process events 
- Stub of `resolveConflicts` on the ingestion flow
- Began to stub conflict resolution unit tests to validate conflict resolution on the ingestion flow
- In order to order and limit results, I had to hack in an "additionalStatement" field into the storage adapter. It's not ideal, but it is limited in scope to the storageAdapter, so it's not available to customers
- Fixed SQL tests that started failing now that Post & Comment no longer have `_version` and `_deleted` fields.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
