### PR TITLE
Remote sync dispositon; renamed 'cloud*' to 'remote*' (#211)

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreCategory+HubPayloadEventName.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+HubPayloadEventName.swift
@@ -10,13 +10,13 @@ public extension HubPayload.EventName {
 }
 
 public extension HubPayload.EventName.DataStore {
-    /// Dispatched when DataStore begins syncing to the cloud via the API category
+    /// Dispatched when DataStore begins syncing to the remote API via the API category
     static let syncStarted = "DataStore.syncStarted"
 
-    /// Dispatched when DataStore receives a sync response from the cloud via the API category. This event does not
+    /// Dispatched when DataStore receives a sync response from the remote API via the API category. This event does not
     /// define the source of the event--it could be in response to either a subscription or a locally-sourced mutation.
     /// Regardless of source, incoming sync updates always have the possibility of updating local data, so listeners
     /// who are interested in model updates must be notified in any case of a sync received. The HubPayload will be a
-    /// `MutationEvent` instance containing the newly mutated data from the cloud API.
+    /// `MutationEvent` instance containing the newly mutated data from the remote API.
     static let syncReceived = "DataStore.syncReceived"
 }

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -13,7 +13,7 @@ public typealias DataStoreCategoryBehavior = DataStoreBaseBehavior & DataStoreSu
 
 public protocol DataStoreBaseBehavior {
 
-    /// Saves the model to storage. If sync is enabled, also initiates a sync of the mutation to the cloud API
+    /// Saves the model to storage. If sync is enabled, also initiates a sync of the mutation to the remote API
     func save<M: Model>(_ model: M,
                         completion: @escaping DataStoreCallback<M>)
 

--- a/Amplify/Categories/DataStore/DataStoreConflict.swift
+++ b/Amplify/Categories/DataStore/DataStoreConflict.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-/// Information about a conflict that occurred attempting to sync a local model with a cloud model
+/// Information about a conflict that occurred attempting to sync a local model with a remote model
 public struct DataStoreSyncConflict {
     public let localModel: Model
     public let remoteModel: Model

--- a/Amplify/Categories/DataStore/Model/ModelSchema.swift
+++ b/Amplify/Categories/DataStore/Model/ModelSchema.swift
@@ -21,7 +21,7 @@ public enum ModelAttribute {
     /// TODO: What does this mean?
     case index
 
-    /// Instances of this model are syncable to the cloud via the API category
+    /// Instances of this model are syncable to the remote API via the API category
     case isSyncable
 
     /// This model is used by the Amplify system or a plugin, and should not be used by the app developer

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -10,7 +10,7 @@ import Combine
 import Foundation
 
 @available(iOS 13.0, *)
-class CloudSyncEngine: CloudSyncEngineBehavior {
+class RemoteSyncEngine: RemoteSyncEngineBehavior {
     private weak var storageAdapter: StorageEngineAdapter?
 
     // Assigned at `start`
@@ -202,4 +202,4 @@ final class CancelAwareBlockOperation: Operation {
 }
 
 @available(iOS 13, *)
-extension CloudSyncEngine: DefaultLogger { }
+extension RemoteSyncEngine: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
@@ -8,8 +8,8 @@
 import Amplify
 import Combine
 
-/// Behavior to sync mutation events to the cloud, and to subscribe to mutations from the cloud
-protocol CloudSyncEngineBehavior: class {
+/// Behavior to sync mutation events to the remote API, and to subscribe to mutations from the remote API
+protocol RemoteSyncEngineBehavior: class {
 
     /// Start the sync process with a "delta sync" merge
     ///
@@ -23,7 +23,7 @@ protocol CloudSyncEngineBehavior: class {
     ///    any local callbacks on error if necessary
     func start(api: APICategoryGraphQLBehavior)
 
-    /// Submits a new mutation for synchronization to the cloud. The response will be handled by the appropriate
+    /// Submits a new mutation for synchronization to the remote API. The response will be handled by the appropriate
     /// reconciliation queue
     @available(iOS 13.0, *)
     func submit(_ mutationEvent: MutationEvent) -> Future<MutationEvent, DataStoreError>

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueues.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueues.swift
@@ -87,8 +87,8 @@ final class ReconciliationQueue {
             .publisher
             .sink(receiveCompletion: { [weak self] completion in
                 self?.receiveCompletion(completion)
-                }, receiveValue: { [weak self] cloudModel in
-                    self?.receiveValue(cloudModel)
+                }, receiveValue: { [weak self] remoteModel in
+                    self?.receiveValue(remoteModel)
             })
 
     }
@@ -102,13 +102,13 @@ final class ReconciliationQueue {
         allModels?.cancel()
     }
 
-    private func receiveValue(_ cloudModel: MutationSync<AnyModel>) {
+    private func receiveValue(_ remoteModel: MutationSync<AnyModel>) {
         guard let storageAdapter = storageAdapter else {
             log.error("No storage adapter, cannot save received value")
             return
         }
 
-        let reconcileOp = ReconcileAndLocalSaveOperation(cloudModel: cloudModel,
+        let reconcileOp = ReconcileAndLocalSaveOperation(remoteModel: remoteModel,
                                                          storageAdapter: storageAdapter)
         operationQueue.addOperation(reconcileOp)
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Action.swift
@@ -12,14 +12,29 @@ extension ReconcileAndLocalSaveOperation {
 
     /// Actions are declarative, they say what I just did
     enum Action {
-        case started(CloudModel)
-        case deserialized(CloudModel)
-        case queried(CloudModel, LocalModel?)
-        case reconciled(CloudModel)
-        case cancelled
-        case conflicted(CloudModel, LocalModel)
-        case saved(SavedModel)
+        /// Operation has been started by the queue
+        case started(RemoteModel)
+
+        /// Operation has retrieved RemoteModel's corresponding model data and sync metadata from local database
+        case queried(RemoteModel, LocalModel?)
+
+        /// Operation has reconciled the incoming remote model with local model and sync metadata
+        case reconciled(RemoteSyncReconciler.Disposition)
+
+        /// Operation has applied the incoming RemoteModel to the local database per the reconciled disposition. This
+        /// could result in either a save to the local database, or a delete from the local database.
+        case applied(AppliedModel)
+
+        /// Operation dropped the remote model per the reconciled disposition.
+        case dropped
+
+        /// Operation notified listeners and callbacks of completion
         case notified
+
+        /// Operation has been cancelled by the queue
+        case cancelled
+
+        /// Operation has encountered an error
         case errored(AmplifyError)
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Resolver.swift
@@ -19,19 +19,19 @@ extension ReconcileAndLocalSaveOperation {
         static func resolve(currentState: State, action: Action) -> State {
             switch (currentState, action) {
 
-            case (.waiting, .started(let anyModel)):
-                return .deserializing(anyModel)
+            case (.waiting, .started(let remoteModel)):
+                return .querying(remoteModel)
 
-            case (.deserializing, .deserialized(let model)):
-                return .querying(model)
+            case (.querying, .queried(let remoteModel, let localModel)):
+                return .reconciling(remoteModel, localModel)
 
-            case (.querying, .queried(let cloudModel, let localModel)):
-                return .reconciling(cloudModel, localModel)
+            case (.reconciling, .reconciled(let disposition)):
+                return .executing(disposition)
 
-            case (.reconciling, .reconciled(let cloudModel)):
-                return .saving(cloudModel)
+            case (.executing, .dropped):
+                return .finished
 
-            case (.saving, .saved(let savedModel)):
+            case (.executing, .applied(let savedModel)):
                 return .notifying(savedModel)
 
             case (.notifying, .notified):

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+State.swift
@@ -12,15 +12,25 @@ extension ReconcileAndLocalSaveOperation {
 
     /// States are descriptive, they say what is happening in the system right now
     enum State {
+        /// Waiting to be started by the queue
         case waiting
-        case deserializing(CloudModel)
-        case querying(CloudModel)
-        case reconciling(CloudModel, LocalModel?)
-        case saving(CloudModel)
-        case notifying(SavedModel)
 
-        // Terminal states
+        /// Querying the local database for model data and sync metadata
+        case querying(RemoteModel)
+
+        /// Reconciling incoming remote model with local model and sync metadata
+        case reconciling(RemoteModel, LocalModel?)
+
+        /// Executing the reconciled disposition
+        case executing(RemoteSyncReconciler.Disposition)
+
+        /// Notifying listeners and callbacks of completion
+        case notifying(AppliedModel)
+
+        /// Operation has successfully completed
         case finished
+
+        /// Operation completed with an unexpected error
         case inError(AmplifyError)
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/SyncMetadataTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/SyncMetadataTests.swift
@@ -19,16 +19,16 @@ class SyncMetadataTests: SyncEngineIntegrationTestBase {
 
     /// - Given: An API-connected DataStore
     /// - When:
-    ///    - I sync a new model from the cloud
+    ///    - I sync a new model from the remote API
     /// - Then:
-    ///    - The local model is updated with updated cloud information
+    ///    - The local model is updated with updated remote API information
     func testCreateSyncsCloudToLocal() throws {
         XCTFail("Not yet implemented")
     }
 
     /// - Given: An API-connected DataStore
     /// - When:
-    ///    - I sync a new model from the cloud
+    ///    - I sync a new model from the remote API
     /// - Then:
     ///    - Local sync metadata (e.g., _version) is updated
     func testCreateUpdatesSyncMetadata() throws {
@@ -37,16 +37,16 @@ class SyncMetadataTests: SyncEngineIntegrationTestBase {
 
     /// - Given: An API-connected DataStore
     /// - When:
-    ///    - I sync an updated model from the cloud
+    ///    - I sync an updated model from the remote API
     /// - Then:
-    ///    - The local model is updated with updated cloud information
+    ///    - The local model is updated with updated remote API information
     func testUpdateSyncsCloudToLocal() throws {
         XCTFail("Not yet implemented")
     }
 
     /// - Given: An API-connected DataStore
     /// - When:
-    ///    - I sync an updated model from the cloud
+    ///    - I sync an updated model from the remote API
     /// - Then:
     ///    - Local sync metadata (e.g., _version) is updated
     func testUpdateUpdatesSyncMetadata() throws {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
@@ -67,7 +67,7 @@ extension APICategoryDependencyTests {
         storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
         try storageAdapter.setUp(models: StorageEngine.systemModels)
 
-        let syncEngine = try CloudSyncEngine(storageAdapter: storageAdapter)
+        let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter)
         let storageEngine = StorageEngine(storageAdapter: storageAdapter,
                                           syncEngine: syncEngine,
                                           isSyncEnabled: true)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/AWSMutationEventIngesterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/AWSMutationEventIngesterTests.swift
@@ -37,7 +37,7 @@ class AWSMutationEventIngesterTests: XCTestCase {
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
             try storageAdapter.setUp(models: StorageEngine.systemModels)
 
-            let syncEngine = try CloudSyncEngine(storageAdapter: storageAdapter)
+            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter)
 
             let storageEngine = StorageEngine(storageAdapter: storageAdapter,
                                               syncEngine: syncEngine,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
@@ -13,7 +13,7 @@ import Combine
 @testable import AmplifyTestCommon
 @testable import AWSDataStoreCategoryPlugin
 
-/// Tests behavior of local DataStore subscriptions (as opposed to cloud subscription behaviors)
+/// Tests behavior of local DataStore subscriptions (as opposed to remote API subscription behaviors)
 class LocalSubscriptionTests: XCTestCase {
 
     override func setUp() {
@@ -33,7 +33,7 @@ class LocalSubscriptionTests: XCTestCase {
             let mutationDatabaseAdapter = try AWSMutationDatabaseAdapter(storageAdapter: storageAdapter)
             let awsMutationEventPublisher = AWSMutationEventPublisher(eventSource: mutationDatabaseAdapter)
 
-            let syncEngine = CloudSyncEngine(storageAdapter: storageAdapter,
+            let syncEngine = RemoteSyncEngine(storageAdapter: storageAdapter,
                                              outgoingMutationQueue: outgoingMutationQueue,
                                              mutationEventIngester: mutationDatabaseAdapter,
                                              mutationEventPublisher: awsMutationEventPublisher)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/OutgoingMutationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/OutgoingMutationQueueTests.swift
@@ -55,7 +55,7 @@ class OutgoingMutationQueueTests: XCTestCase {
 
     func setUpDataStore() {
         tryOrFail {
-            let syncEngine = try CloudSyncEngine(storageAdapter: storageAdapter)
+            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter)
             let storageEngine = StorageEngine(storageAdapter: storageAdapter,
                                               syncEngine: syncEngine,
                                               isSyncEnabled: true)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSyncAPIInvocationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSyncAPIInvocationTests.swift
@@ -13,8 +13,8 @@ import Combine
 @testable import AmplifyTestCommon
 @testable import AWSDataStoreCategoryPlugin
 
-/// Tests that DataStore invokes proper API methods to fulfill cloud sync
-class CloudSyncTests: XCTestCase {
+/// Tests that DataStore invokes proper API methods to fulfill remote sync
+class RemoteSyncAPIInvocationTests: XCTestCase {
 
     /// Convenience property to get easy access to the mock API plugin
     var apiPlugin: MockAPICategoryPlugin!
@@ -38,7 +38,7 @@ class CloudSyncTests: XCTestCase {
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
             try storageAdapter.setUp(models: StorageEngine.systemModels)
 
-            let syncEngine = try CloudSyncEngine(storageAdapter: storageAdapter)
+            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter)
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
                                           syncEngine: syncEngine,
                                           isSyncEnabled: true)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
@@ -32,7 +32,7 @@ class BaseDataStoreTests: XCTestCase {
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
             try storageAdapter.setUp(models: StorageEngine.systemModels)
 
-            let syncEngine = try CloudSyncEngine(storageAdapter: storageAdapter)
+            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter)
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
                                           syncEngine: syncEngine,
                                           isSyncEnabled: true)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -59,7 +59,7 @@ class SyncEngineTestBase: XCTestCase {
         let awsMutationEventPublisher = AWSMutationEventPublisher(eventSource: mutationDatabaseAdapter)
         let outgoingMutationQueue = NoOpMutationQueue()
 
-        let syncEngine = CloudSyncEngine(storageAdapter: storageAdapter,
+        let syncEngine = RemoteSyncEngine(storageAdapter: storageAdapter,
                                          outgoingMutationQueue: outgoingMutationQueue,
                                          mutationEventIngester: mutationDatabaseAdapter,
                                          mutationEventPublisher: awsMutationEventPublisher)

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 		2149E5D32388684F00873955 /* Statement+Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5B72388684F00873955 /* Statement+Model.swift */; };
 		2149E5D42388684F00873955 /* DataStorePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5B92388684F00873955 /* DataStorePublisher.swift */; };
 		2149E5D72388684F00873955 /* NetworkReachabilityNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5BD2388684F00873955 /* NetworkReachabilityNotifier.swift */; };
-		2149E5D82388684F00873955 /* CloudSyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5BE2388684F00873955 /* CloudSyncEngine.swift */; };
+		2149E5D82388684F00873955 /* RemoteSyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5BE2388684F00873955 /* RemoteSyncEngine.swift */; };
 		2149E5DB2388684F00873955 /* NetworkReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5C12388684F00873955 /* NetworkReachability.swift */; };
 		2149E5DE2388684F00873955 /* AWSDataStoreCategoryPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5C42388684F00873955 /* AWSDataStoreCategoryPlugin.swift */; };
 		2149E5E82388692E00873955 /* AWSDataStoreCategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2149E59B238867E100873955 /* AWSDataStoreCategoryPlugin.framework */; };
@@ -37,7 +37,7 @@
 		2149E5FB238869CF00873955 /* NetworkReachabilityNotifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5F2238869CF00873955 /* NetworkReachabilityNotifierTests.swift */; };
 		2149E5FC238869CF00873955 /* LocalSubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5F3238869CF00873955 /* LocalSubscriptionTests.swift */; };
 		2149E5FD238869CF00873955 /* OutgoingMutationQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5F4238869CF00873955 /* OutgoingMutationQueueTests.swift */; };
-		2149E5FE238869CF00873955 /* CloudSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5F5238869CF00873955 /* CloudSyncTests.swift */; };
+		2149E5FE238869CF00873955 /* RemoteSyncAPIInvocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5F5238869CF00873955 /* RemoteSyncAPIInvocationTests.swift */; };
 		2149E5FF238869CF00873955 /* SQLStatementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5F6238869CF00873955 /* SQLStatementTests.swift */; };
 		2149E600238869CF00873955 /* SQLiteStorageEngineAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5F7238869CF00873955 /* SQLiteStorageEngineAdapterTests.swift */; };
 		2149E60823886C7B00873955 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E60723886C7B00873955 /* AppDelegate.swift */; };
@@ -101,7 +101,7 @@
 		FAED5742238B52CE008EBED8 /* ModelStorageBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAED5741238B52CE008EBED8 /* ModelStorageBehavior.swift */; };
 		FAF7CEC9238C6A940095547B /* SyncMutationToCloudOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF7CEC8238C6A940095547B /* SyncMutationToCloudOperation.swift */; };
 		FAF7CECB238C72830095547B /* OutgoingMutationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF7CECA238C72830095547B /* OutgoingMutationQueue.swift */; };
-		FAF7CECF238C93A50095547B /* CloudSyncEngineBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF7CECE238C93A50095547B /* CloudSyncEngineBehavior.swift */; };
+		FAF7CECF238C93A50095547B /* RemoteSyncEngineBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF7CECE238C93A50095547B /* RemoteSyncEngineBehavior.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -149,7 +149,7 @@
 		2149E5B72388684F00873955 /* Statement+Model.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Statement+Model.swift"; sourceTree = "<group>"; };
 		2149E5B92388684F00873955 /* DataStorePublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataStorePublisher.swift; sourceTree = "<group>"; };
 		2149E5BD2388684F00873955 /* NetworkReachabilityNotifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachabilityNotifier.swift; sourceTree = "<group>"; };
-		2149E5BE2388684F00873955 /* CloudSyncEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudSyncEngine.swift; sourceTree = "<group>"; };
+		2149E5BE2388684F00873955 /* RemoteSyncEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteSyncEngine.swift; sourceTree = "<group>"; };
 		2149E5C12388684F00873955 /* NetworkReachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachability.swift; sourceTree = "<group>"; };
 		2149E5C32388684F00873955 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2149E5C42388684F00873955 /* AWSDataStoreCategoryPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSDataStoreCategoryPlugin.swift; sourceTree = "<group>"; };
@@ -160,7 +160,7 @@
 		2149E5F2238869CF00873955 /* NetworkReachabilityNotifierTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachabilityNotifierTests.swift; sourceTree = "<group>"; };
 		2149E5F3238869CF00873955 /* LocalSubscriptionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalSubscriptionTests.swift; sourceTree = "<group>"; };
 		2149E5F4238869CF00873955 /* OutgoingMutationQueueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutgoingMutationQueueTests.swift; sourceTree = "<group>"; };
-		2149E5F5238869CF00873955 /* CloudSyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudSyncTests.swift; sourceTree = "<group>"; };
+		2149E5F5238869CF00873955 /* RemoteSyncAPIInvocationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteSyncAPIInvocationTests.swift; sourceTree = "<group>"; };
 		2149E5F6238869CF00873955 /* SQLStatementTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLStatementTests.swift; sourceTree = "<group>"; };
 		2149E5F7238869CF00873955 /* SQLiteStorageEngineAdapterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLiteStorageEngineAdapterTests.swift; sourceTree = "<group>"; };
 		2149E60523886C7B00873955 /* HostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -237,7 +237,7 @@
 		FAED5741238B52CE008EBED8 /* ModelStorageBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelStorageBehavior.swift; sourceTree = "<group>"; };
 		FAF7CEC8238C6A940095547B /* SyncMutationToCloudOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncMutationToCloudOperation.swift; sourceTree = "<group>"; };
 		FAF7CECA238C72830095547B /* OutgoingMutationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingMutationQueue.swift; sourceTree = "<group>"; };
-		FAF7CECE238C93A50095547B /* CloudSyncEngineBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudSyncEngineBehavior.swift; sourceTree = "<group>"; };
+		FAF7CECE238C93A50095547B /* RemoteSyncEngineBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSyncEngineBehavior.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -310,11 +310,11 @@
 		2149E5A62388684F00873955 /* AWSDataStoreCategoryPlugin */ = {
 			isa = PBXGroup;
 			children = (
+				2149E5C32388684F00873955 /* Info.plist */,
 				2149E5C42388684F00873955 /* AWSDataStoreCategoryPlugin.swift */,
 				FACBB2AD238AFAE800C29602 /* AWSDataStoreCategoryPlugin+DataStoreBaseBehavior.swift */,
 				FA5D4CEE238AFCBC00D2F54A /* AWSDataStoreCategoryPlugin+DataStoreSubscribeBehavior.swift */,
 				FA5D4CEC238AFC4D00D2F54A /* AWSDataStoreCategoryPlugin+DefaultLogger.swift */,
-				2149E5C32388684F00873955 /* Info.plist */,
 				2149E5A72388684F00873955 /* Storage */,
 				2149E5B82388684F00873955 /* Subscribe */,
 				2149E5BA2388684F00873955 /* Sync */,
@@ -325,11 +325,11 @@
 		2149E5A72388684F00873955 /* Storage */ = {
 			isa = PBXGroup;
 			children = (
-				2149E5AB2388684F00873955 /* SQLite */,
 				FAED5741238B52CE008EBED8 /* ModelStorageBehavior.swift */,
 				2149E5AA2388684F00873955 /* StorageEngine.swift */,
 				2149E5A92388684F00873955 /* StorageEngineAdapter.swift */,
 				2149E5A82388684F00873955 /* StorageEngineBehavior.swift */,
+				2149E5AB2388684F00873955 /* SQLite */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -366,10 +366,10 @@
 		2149E5BA2388684F00873955 /* Sync */ = {
 			isa = PBXGroup;
 			children = (
-				2149E5BE2388684F00873955 /* CloudSyncEngine.swift */,
-				FAF7CECE238C93A50095547B /* CloudSyncEngineBehavior.swift */,
 				2149E5C12388684F00873955 /* NetworkReachability.swift */,
 				2149E5BD2388684F00873955 /* NetworkReachabilityNotifier.swift */,
+				2149E5BE2388684F00873955 /* RemoteSyncEngine.swift */,
+				FAF7CECE238C93A50095547B /* RemoteSyncEngineBehavior.swift */,
 				FAED5736238B2DFA008EBED8 /* MutationSync */,
 				FAED5735238B2DEC008EBED8 /* SubscriptionSync */,
 				FA8F4D1C2395AF5E00861D91 /* Support */,
@@ -456,9 +456,9 @@
 		FA8F4D1C2395AF5E00861D91 /* Support */ = {
 			isa = PBXGroup;
 			children = (
+				FA8F4D1D2395AF7600861D91 /* DataStoreError+Plugin.swift */,
 				FA8F4D212395B11700861D91 /* MutationEvent+Query.swift */,
 				FA3841E823889D440070AD5B /* StateMachine.swift */,
-				FA8F4D1D2395AF7600861D91 /* DataStoreError+Plugin.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -491,12 +491,12 @@
 			children = (
 				2149E5F1238869CF00873955 /* APICategoryDependencyTests.swift */,
 				FA3B3F08238F39DE002EFDB3 /* AWSMutationEventIngesterTests.swift */,
-				2149E5F5238869CF00873955 /* CloudSyncTests.swift */,
 				2149E5F3238869CF00873955 /* LocalSubscriptionTests.swift */,
 				FA4B8E932391C2CD009FC10F /* MutationIngesterConflictResolutionTests.swift */,
 				2149E5F2238869CF00873955 /* NetworkReachabilityNotifierTests.swift */,
 				2149E5F4238869CF00873955 /* OutgoingMutationQueueTests.swift */,
 				6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */,
+				2149E5F5238869CF00873955 /* RemoteSyncAPIInvocationTests.swift */,
 				FAC010EF2395700B00FCE7BB /* RemoteSyncReconcilerTests.swift */,
 				FA3841EC23889D8F0070AD5B /* StateMachineTests.swift */,
 				2129BE4923948A97006363A1 /* StorageAdapterMutationSyncTests.swift */,
@@ -1013,7 +1013,7 @@
 				FAED573C238B4B03008EBED8 /* Statement+AnyModel.swift in Sources */,
 				2149E5D72388684F00873955 /* NetworkReachabilityNotifier.swift in Sources */,
 				2149E5C52388684F00873955 /* StorageEngineBehavior.swift in Sources */,
-				FAF7CECF238C93A50095547B /* CloudSyncEngineBehavior.swift in Sources */,
+				FAF7CECF238C93A50095547B /* RemoteSyncEngineBehavior.swift in Sources */,
 				2149E5CF2388684F00873955 /* SQLStatement+Delete.swift in Sources */,
 				2149E5C92388684F00873955 /* SQLStatement+Insert.swift in Sources */,
 				2149E5D42388684F00873955 /* DataStorePublisher.swift in Sources */,
@@ -1028,7 +1028,7 @@
 				FAF7CECB238C72830095547B /* OutgoingMutationQueue.swift in Sources */,
 				2149E5CC2388684F00873955 /* SQLStatement+Select.swift in Sources */,
 				FADD7291238B19CB005AA69A /* IncomingAsyncSubscriptionEventToAnyModelMapper.swift in Sources */,
-				2149E5D82388684F00873955 /* CloudSyncEngine.swift in Sources */,
+				2149E5D82388684F00873955 /* RemoteSyncEngine.swift in Sources */,
 				2149E5CB2388684F00873955 /* Model+SQLite.swift in Sources */,
 				FA3B3F03238F22CF002EFDB3 /* OutgoingMutationQueue+State.swift in Sources */,
 				FA5D4CEF238AFCBC00D2F54A /* AWSDataStoreCategoryPlugin+DataStoreSubscribeBehavior.swift in Sources */,
@@ -1070,7 +1070,7 @@
 				2149E5FA238869CF00873955 /* APICategoryDependencyTests.swift in Sources */,
 				FA4B8E942391C2CD009FC10F /* MutationIngesterConflictResolutionTests.swift in Sources */,
 				2149E5FB238869CF00873955 /* NetworkReachabilityNotifierTests.swift in Sources */,
-				2149E5FE238869CF00873955 /* CloudSyncTests.swift in Sources */,
+				2149E5FE238869CF00873955 /* RemoteSyncAPIInvocationTests.swift in Sources */,
 				B9FAA142238C6082009414B4 /* BaseDataStoreTests.swift in Sources */,
 				2149E600238869CF00873955 /* SQLiteStorageEngineAdapterTests.swift in Sources */,
 			);


### PR DESCRIPTION
Rebased from master; changes approved on #211, so merging without explicit approval on this PR


*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
