### PR TITLE
Fix for configuration in predictions

### DIFF
--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Configuration/ConvertConfiguration.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Configuration/ConvertConfiguration.swift
@@ -80,8 +80,8 @@ extension ConvertConfiguration: Decodable {
 extension TranslateTextConfiguration: Decodable {
 
     enum CodingKeys: String, CodingKey {
-        case sourceLanguage
-        case targetLanguage
+        case sourceLanguage = "sourceLang"
+        case targetLanguage = "targetLang"
     }
 
     public init(from decoder: Decoder) throws {
@@ -95,7 +95,7 @@ extension LanguageType: Decodable {}
 
 extension SpeechGeneratorConfiguration: Decodable {
     enum CodingKeys: String, CodingKey {
-        case voiceID = "voiceId"
+        case voiceID = "voice"
     }
 
     public init(from decoder: Decoder) throws {

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Configuration/IdentifyConfiguration.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Configuration/IdentifyConfiguration.swift
@@ -33,7 +33,7 @@ public struct IdentifyTextConfiguration {
 
 public struct IdentifyEntitiesConfiguration {
     public let collectionId: String?
-    public let maxEntities: Int?
+    public let maxEntities: String?
 }
 
 extension IdentifyConfiguration: Decodable {

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Rekognition.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Rekognition.swift
@@ -200,7 +200,8 @@ extension AWSPredictionsService: AWSRekognitionServiceBehavior {
         rekognitionImage.bytes = imageData
         request.image = rekognitionImage
         request.collectionId = collectionId
-        request.maxFaces = predictionsConfig.identify.identifyEntities?.maxEntities as NSNumber?
+        let maxEntities = Int(predictionsConfig.identify.identifyEntities?.maxEntities ?? "50") ?? 50
+        request.maxFaces = NSNumber(value: maxEntities)
 
         awsRekognition.detectFacesFromCollection(request: request).continueWith { (task) -> Any? in
             guard task.error == nil else {

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
@@ -25,13 +25,16 @@ class PredictionsPluginConfigurationTests: XCTestCase {
         "defaultRegion": "us-west-2",
         "convert": {
             "translateText": {
-                "region": "us-west-2",
-                "sourceLanguage": "en",
-                "targetLanguage": "it"
+                "targetLang": "nl",
+                "sourceLang": "fi",
+                "region": "us-east-1",
+                "defaultNetworkPolicy": "auto"
             },
             "speechGenerator": {
+                "voice": "Justin",
+                "language": "en-US",
                 "region": "us-west-2",
-                "voiceId": "Justin"
+                "defaultNetworkPolicy": "auto"
             }
         },
         "interpret": {
@@ -47,6 +50,13 @@ class PredictionsPluginConfigurationTests: XCTestCase {
             "identifyText": {
                 "region": "us-west-2",
                 "format": "ALL"
+            },
+            "identifyEntities": {
+                "maxEntities": "50",
+                "celebrityDetectionEnabled": "true",
+                "region": "us-east-1",
+                "collectionId": "identifyEntities7561c236-beta",
+                "defaultNetworkPolicy": "auto"
             }
         }
         }
@@ -56,6 +66,10 @@ class PredictionsPluginConfigurationTests: XCTestCase {
             XCTAssertNotNil(configuration, "Configuration should not be nil")
             XCTAssertEqual(configuration.defaultRegion, .USWest2, "Default value should be equal to the input")
             XCTAssertEqual(configuration.identify.identifyLabels?.type, LabelType.labels, "Label type should match")
+
+            XCTAssertEqual(configuration.convert.translateText?.sourceLanguage, LanguageType.finnish)
+            XCTAssertEqual(configuration.convert.translateText?.targetLanguage, LanguageType.dutch)
+            XCTAssertEqual(Int((configuration.identify.identifyEntities?.maxEntities)!), 50)
         } catch {
             XCTFail("Decoding the json data should not produce any error \(error)")
         }
@@ -76,12 +90,12 @@ class PredictionsPluginConfigurationTests: XCTestCase {
         "convert": {
             "translateText": {
                 "region": "us-west-2",
-                "sourceLanguage": "en",
-                "targetLanguage": "it"
+                "sourceLang": "en",
+                "targetLang": "it"
             },
             "speechGenerator": {
                 "region": "us-west-2",
-                "voiceId": "Justin"
+                "voice": "Justin"
             }
         }
         }


### PR DESCRIPTION
Changed the maxEntities to String.
Fixed key values for sourceLanguage and targetLanguage
Fixed voiceId.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
