### PR TITLE
Update logging to use Amplify.API.log

### DIFF
--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/APIKeyAuthInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/APIKeyAuthInterceptor.swift
@@ -8,6 +8,7 @@
 import Foundation
 import AWSCore
 import AWSPluginsCore
+import Amplify
 
 /// Auth interceptor for API Key based authentication
 class APIKeyAuthInterceptor: AuthInterceptor {
@@ -29,7 +30,7 @@ class APIKeyAuthInterceptor: AuthInterceptor {
     func interceptConnection(_ request: AppSyncConnectionRequest,
                              for url: URL) -> AppSyncConnectionRequest {
         guard let host = url.host else {
-            print("[APIKeyAuthInterceptor] interceptConnection missing host")
+            Amplify.API.log.warn("[APIKeyAuthInterceptor] interceptConnection missing host")
             return request
         }
 
@@ -55,7 +56,7 @@ class APIKeyAuthInterceptor: AuthInterceptor {
 
     func interceptMessage(_ message: AppSyncMessage, for url: URL) -> AppSyncMessage {
         guard let host = url.host else {
-            print("[APIKeyAuthInterceptor] interceptMessage missing host")
+            Amplify.API.log.warn("[APIKeyAuthInterceptor] interceptMessage missing host")
             return message
         }
 
@@ -71,8 +72,7 @@ class APIKeyAuthInterceptor: AuthInterceptor {
                                                type: message.messageType)
             return signedMessage
         default:
-            // TODO: Log.verbose
-            print("Message type does not need signing - \(message.messageType)")
+            Amplify.API.log.verbose("Message type does not need signing - \(message.messageType)")
         }
         return message
     }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/AppSyncSubscriptionInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/AppSyncSubscriptionInterceptor.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Amplify
 
 /// Converts a connection request created with a standard endpoint configuration, to an AppSync Realtime Gateway
 /// request by rewriting the URL.
@@ -14,7 +15,7 @@ class AppSyncSubscriptionInterceptor: ConnectionInterceptor {
     func interceptConnection(_ request: AppSyncConnectionRequest,
                              for url: URL) -> AppSyncConnectionRequest {
         guard let host = url.host else {
-            print("[AppSyncSubscriptionInterceptor] interceptConnection missing host")
+            Amplify.API.log.warn("[AppSyncSubscriptionInterceptor] interceptConnection missing host")
             return request
         }
         guard var urlComponents = URLComponents(url: request.url, resolvingAgainstBaseURL: false) else {

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/CognitoUserPoolsAuthInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/CognitoUserPoolsAuthInterceptor.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import AWSPluginsCore
+import Amplify
 
 class CognitoUserPoolsAuthInterceptor: AuthInterceptor {
 
@@ -18,7 +19,7 @@ class CognitoUserPoolsAuthInterceptor: AuthInterceptor {
 
     func interceptMessage(_ message: AppSyncMessage, for url: URL) -> AppSyncMessage {
         guard let host = url.host else {
-            print("[CognitoUserPoolsAuthInterceptor] interceptMessage missing host")
+            Amplify.API.log.warn("[CognitoUserPoolsAuthInterceptor] interceptMessage missing host")
             return message
         }
 
@@ -40,15 +41,14 @@ class CognitoUserPoolsAuthInterceptor: AuthInterceptor {
                                                type: message.messageType)
             return signedMessage
         default:
-            // TODO: Log.verbose
-            print("Message type does not need signing - \(message.messageType)")
+            Amplify.API.log.verbose("Message type does not need signing - \(message.messageType)")
         }
         return message
     }
 
     func interceptConnection(_ request: AppSyncConnectionRequest, for url: URL) -> AppSyncConnectionRequest {
         guard let host = url.host else {
-            print("[CognitoUserPoolsAuthInterceptor] interceptConnection missing host")
+            Amplify.API.log.warn("[CognitoUserPoolsAuthInterceptor] interceptConnection missing host")
             return request
         }
 

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
@@ -8,6 +8,7 @@
 import Foundation
 import AWSCore
 import AWSPluginsCore
+import Amplify
 
 class IAMAuthInterceptor: AuthInterceptor {
 
@@ -30,8 +31,7 @@ class IAMAuthInterceptor: AuthInterceptor {
                                                type: message.messageType)
             return signedMessage
         default:
-            // TODO: Log.verbose
-            print("Message type does not need signing - \(message.messageType)")
+            Amplify.API.log.verbose("Message type does not need signing - \(message.messageType)")
         }
         return message
     }
@@ -62,7 +62,7 @@ class IAMAuthInterceptor: AuthInterceptor {
 
     final private func getAuthHeader(_ url: URL, with payload: String) -> IAMAuthenticationHeader? {
         guard let host = url.host else {
-            print("[IAMAuthInterceptor] getAuthHeader missing host")
+            Amplify.API.log.warn("[IAMAuthInterceptor] getAuthHeader missing host")
             return nil
         }
         let amzDate =  NSDate.aws_clockSkewFixed() as NSDate

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/ConnectionProvider/AppSyncConnectionProvider+EventHandler.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/ConnectionProvider/AppSyncConnectionProvider+EventHandler.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Amplify
 
 extension AppSyncConnectionProvider {
 
@@ -39,7 +40,7 @@ extension AppSyncConnectionProvider {
         case .data(let websocketResponse):
             handleResponse(websocketResponse)
         case .error(let error):
-            print("Got error bac")
+            Amplify.API.log.error("Websocket Error: \(error)")
         }
     }
 
@@ -61,7 +62,8 @@ extension AppSyncConnectionProvider {
                         self.listener?(.connection(self.state))
                     }
                 case .connected, .disconnected:
-                    print("[AppSyncConnectionProvider] connectionAck recieved while connection is \(state)")
+                    Amplify.API.log.verbose(
+                        "[AppSyncConnectionProvider] connectionAck recieved while connection is \(state)")
             }
 
         case .error:

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/ConnectionProvider/AppSyncConnectionProvider.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/ConnectionProvider/AppSyncConnectionProvider.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Amplify
 
 /// Appsync Real time connection that connects to subscriptions
 /// through websocket.
@@ -69,7 +70,7 @@ class AppSyncConnectionProvider: ConnectionProvider {
     }
 
     func subscribe(_ subscriptionItem: SubscriptionItem) {
-        print("subscribe, sending start subscription message...")
+        Amplify.API.log.verbose("subscribe, sending start subscription message...")
         let payload: AppSyncMessage.Payload
         do {
             payload = try convertToPayload(for: subscriptionItem.requestString,
@@ -92,7 +93,7 @@ class AppSyncConnectionProvider: ConnectionProvider {
     }
 
     func unsubscribe(_ identifier: String) {
-        print("sendStartSubscriptionMessage, sending start subscription message...")
+        Amplify.API.log.verbose("sendStartSubscriptionMessage, sending start subscription message...")
         let message = AppSyncMessage(id: identifier, type: .unsubscribe)
         do {
             try write(message)
@@ -120,7 +121,7 @@ class AppSyncConnectionProvider: ConnectionProvider {
     func sendConnectionInitMessage() {
         switch state {
         case .connecting:
-            print("sendConnectionInitMessage, sending init message...")
+            Amplify.API.log.verbose("sendConnectionInitMessage, sending init message...")
             let message = AppSyncMessage(type: .connectionInit)
             do {
                 try write(message)
@@ -146,7 +147,7 @@ class AppSyncConnectionProvider: ConnectionProvider {
         guard case .connected = state else {
             return
         }
-        print("Validating connection")
+        Amplify.API.log.verbose("Validating connection")
         let staleThreshold = lastKeepAliveTime + staleConnectionTimeout
         let currentTime = DispatchTime.now()
         if staleThreshold < currentTime {
@@ -157,7 +158,7 @@ class AppSyncConnectionProvider: ConnectionProvider {
                 }
                 self.state = .disconnected(error: nil)
                 self.websocketProvider.disconnect()
-                print("Realtime connection is stale, disconnecting.")
+                Amplify.API.log.verbose("Realtime connection is stale, disconnecting.")
                 self.listener?(.connection(self.state))
             }
 
@@ -193,7 +194,7 @@ class AppSyncConnectionProvider: ConnectionProvider {
             let jsonData = try JSONSerialization.data(withJSONObject: dataDict)
             payload.data = String(data: jsonData, encoding: .utf8)
         } catch {
-            print(error)
+            Amplify.API.log.error(error: error)
             let jsonError = ConnectionProviderError.jsonParse(nil, error)
             throw jsonError
         }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/SubscriptionConnection/AppSyncSubscriptionConnection.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/SubscriptionConnection/AppSyncSubscriptionConnection.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Amplify
 
 class AppSyncSubscriptionConnection: SubscriptionConnection, RetryableConnection {
 
@@ -60,7 +61,7 @@ class AppSyncSubscriptionConnection: SubscriptionConnection, RetryableConnection
     }
 
     func unsubscribe(item: SubscriptionItem) {
-        print("Unsubscribe - \(item.identifier)")
+        Amplify.API.log.verbose("Unsubscribe - \(item.identifier)")
         connectionProvider.unsubscribe(item.identifier)
     }
 

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/Websocket/StarscreamWebsocketProvider+WebsocketDelegate.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/Websocket/StarscreamWebsocketProvider+WebsocketDelegate.swift
@@ -7,22 +7,23 @@
 
 import Foundation
 import Starscream
+import Amplify
 
 /// Extension to handle delegate callback from Starscream
 extension StarscreamWebsocketProvider: Starscream.WebSocketDelegate {
 
     func websocketDidConnect(socket: WebSocketClient) {
-        print("WebsocketDidConnect")
+        Amplify.API.log.verbose("WebsocketDidConnect")
         listener?(.connect)
     }
 
     func websocketDidDisconnect(socket: WebSocketClient, error: Error?) {
-        print("WebsocketDidDisconnect - \(error?.localizedDescription ?? "No error")")
+        Amplify.API.log.verbose("WebsocketDidDisconnect - \(error?.localizedDescription ?? "No error")")
         listener?(.disconnect(error: error))
     }
 
     func websocketDidReceiveMessage(socket: WebSocketClient, text: String) {
-        print("WebsocketDidReceiveMessage - \(text)")
+        Amplify.API.log.verbose("WebsocketDidReceiveMessage - \(text)")
         let data = text.data(using: .utf8) ?? Data()
 
         do {
@@ -34,7 +35,7 @@ extension StarscreamWebsocketProvider: Starscream.WebSocketDelegate {
     }
 
     func websocketDidReceiveData(socket: WebSocketClient, data: Data) {
-        print("WebsocketDidReceiveData - \(data)")
+        Amplify.API.log.verbose("WebsocketDidReceiveData - \(data)")
         do {
             let response = try JSONDecoder().decode(WebsocketProviderResponse.self, from: data)
             listener?(.data(response))

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/Websocket/StarscreamWebsocketProvider.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/Websocket/StarscreamWebsocketProvider.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Starscream
+import Amplify
 
 class StarscreamWebsocketProvider: WebsocketProvider {
 
@@ -31,7 +32,7 @@ class StarscreamWebsocketProvider: WebsocketProvider {
     }
 
     func connect() {
-        print("Connecting to url ...")
+        Amplify.API.log.verbose("Connecting to url ...")
         let signedRequest = interceptConnection(request, for: url)
         socket = WebSocket(url: signedRequest.url, protocols: protocols)
         socket?.delegate = self
@@ -43,7 +44,7 @@ class StarscreamWebsocketProvider: WebsocketProvider {
     }
 
     func write(_ message: String) {
-        print("Websocket write - \(message)")
+        Amplify.API.log.verbose("Websocket write - \(message)")
         socket?.write(string: message)
     }
 

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/AppSyncJSONHelper.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/AppSyncJSONHelper.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Amplify
 
 struct AppSyncJSONHelper {
 
@@ -13,10 +14,10 @@ struct AppSyncJSONHelper {
         let jsonEncoder = JSONEncoder()
         do {
             let jsonHeader = try jsonEncoder.encode(header)
-            print("Header - \(String(describing: String(data: jsonHeader, encoding: .utf8)))")
+            Amplify.API.log.verbose("Header - \(String(describing: String(data: jsonHeader, encoding: .utf8)))")
             return jsonHeader.base64EncodedString()
         } catch {
-            print(error)
+            Amplify.API.log.error(error: error)
         }
         return ""
     }


### PR DESCRIPTION
replaces print's with verbose/warn/error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
