### PR TITLE
Make predicate optional for query

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
@@ -17,7 +17,7 @@ extension DataStoreCategory: DataStoreBaseBehavior {
     }
 
     public func query<M: Model>(_ modelType: M.Type,
-                                where predicate: QueryPredicateFactory?,
+                                where predicate: QueryPredicateFactory? = nil,
                                 completion: DataStoreCallback<[M]>) {
         plugin.query(modelType, where: predicate, completion: completion)
     }


### PR DESCRIPTION
Allows for invocations like `Amplify.DataStore.query(Post.self) { _ in }`

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
