### PR TITLE
Remove dependency on ModelRegistry for syncability of models

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		21D79FDA237617C60057D00D /* SubscriptionEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D79FD9237617C60057D00D /* SubscriptionEvent.swift */; };
 		21D79FE12377BF4B0057D00D /* AuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D79FE02377BF4B0057D00D /* AuthProvider.swift */; };
 		21D79FE32377F4120057D00D /* SubscriptionConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D79FE22377F4120057D00D /* SubscriptionConnectionState.swift */; };
+		21F40A3223A160FC0074678E /* GraphQLDocument+DeleteSyncMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F40A3123A160FC0074678E /* GraphQLDocument+DeleteSyncMutation.swift */; };
 		21FFF988230B7B2C005878EA /* AsychronousOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFF986230B7A5D005878EA /* AsychronousOperation.swift */; };
 		21FFF98E230C81E6005878EA /* StorageAccessLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFF98D230C81E6005878EA /* StorageAccessLevel.swift */; };
 		21FFF994230C96CB005878EA /* StorageUploadDataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFF98F230C96CA005878EA /* StorageUploadDataOperation.swift */; };
@@ -582,6 +583,7 @@
 		21D79FD9237617C60057D00D /* SubscriptionEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionEvent.swift; sourceTree = "<group>"; };
 		21D79FE02377BF4B0057D00D /* AuthProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthProvider.swift; sourceTree = "<group>"; };
 		21D79FE22377F4120057D00D /* SubscriptionConnectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionConnectionState.swift; sourceTree = "<group>"; };
+		21F40A3123A160FC0074678E /* GraphQLDocument+DeleteSyncMutation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQLDocument+DeleteSyncMutation.swift"; sourceTree = "<group>"; };
 		21FFF986230B7A5D005878EA /* AsychronousOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsychronousOperation.swift; sourceTree = "<group>"; };
 		21FFF98D230C81E6005878EA /* StorageAccessLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAccessLevel.swift; sourceTree = "<group>"; };
 		21FFF98F230C96CA005878EA /* StorageUploadDataOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageUploadDataOperation.swift; sourceTree = "<group>"; };
@@ -1161,13 +1163,14 @@
 		2129BE0523948005006363A1 /* GraphQLDocument */ = {
 			isa = PBXGroup;
 			children = (
-				2129BE0623948005006363A1 /* GraphQLDocument+Subscription.swift */,
-				2129BE0723948005006363A1 /* GraphQLDocument+SyncMutation.swift */,
 				2129BE0823948005006363A1 /* GraphQLDocument.swift */,
-				2129BE0923948005006363A1 /* GraphQLDocument+SyncQuery.swift */,
+				21F40A3123A160FC0074678E /* GraphQLDocument+DeleteSyncMutation.swift */,
 				2129BE0A23948005006363A1 /* GraphQLDocument+GetQuery.swift */,
 				2129BE0B23948005006363A1 /* GraphQLDocument+ListQuery.swift */,
 				2129BE0C23948005006363A1 /* GraphQLDocument+Mutation.swift */,
+				2129BE0623948005006363A1 /* GraphQLDocument+Subscription.swift */,
+				2129BE0723948005006363A1 /* GraphQLDocument+SyncMutation.swift */,
+				2129BE0923948005006363A1 /* GraphQLDocument+SyncQuery.swift */,
 			);
 			path = GraphQLDocument;
 			sourceTree = "<group>";
@@ -3348,6 +3351,7 @@
 				21420A98237222A900FA140C /* AuthTokenProvider.swift in Sources */,
 				21420A91237222A900FA140C /* AWSAuthorizationConfiguration.swift in Sources */,
 				21420A97237222A900FA140C /* IAMCredentialProvider.swift in Sources */,
+				21F40A3223A160FC0074678E /* GraphQLDocument+DeleteSyncMutation.swift in Sources */,
 				21420A99237222A900FA140C /* APIKeyProvider.swift in Sources */,
 				21420A90237222A900FA140C /* APIKeyConfiguration.swift in Sources */,
 				2129BE552395CAEF006363A1 /* PaginatedList.swift in Sources */,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLDocument+DeleteSyncMutation.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLDocument+DeleteSyncMutation.swift
@@ -6,11 +6,10 @@
 //
 
 import Amplify
-import AWSPluginsCore
 import Foundation
 
 /// A convenience implementation of `GraphQLDocument` that represents a delete operation, requiring no model data
-public class MinimalGraphQLDeleteMutation: GraphQLDocument {
+public class GraphQLDeleteSyncMutation: GraphQLDocument {
     public let documentType = GraphQLDocumentType.mutation
     public let mutationType = GraphQLMutationType.delete
 
@@ -36,6 +35,10 @@ public class MinimalGraphQLDeleteMutation: GraphQLDocument {
 
     public var decodePath: String {
         name
+    }
+
+    public var hasSyncableModels: Bool {
+        true
     }
 
     public var stringValue: String {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLDocument+GetQuery.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLDocument+GetQuery.swift
@@ -16,11 +16,14 @@ public struct GraphQLGetQuery: GraphQLDocument {
     public let documentType = GraphQLDocumentType.query
     public let modelType: Model.Type
     public let id: String
+    public let syncEnabled: Bool
 
     public init(from modelType: Model.Type,
-                id: String) {
+                id: String,
+                syncEnabled: Bool = false) {
         self.modelType = modelType
         self.id = id
+        self.syncEnabled = syncEnabled
     }
 
     public var name: String {
@@ -29,6 +32,10 @@ public struct GraphQLGetQuery: GraphQLDocument {
 
     public var decodePath: String {
         return name
+    }
+
+    public var hasSyncableModels: Bool {
+        return syncEnabled
     }
 
     public var stringValue: String {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLDocument+ListQuery.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLDocument+ListQuery.swift
@@ -16,11 +16,20 @@ public class GraphQLListQuery: GraphQLDocument {
     public let documentType = GraphQLDocumentType.query
     public let modelType: Model.Type
     public let predicate: QueryPredicate?
+    public let limit: Int?
+    public let nextToken: String?
+    public let syncEnabled: Bool
 
     public init(from modelType: Model.Type,
-                predicate: QueryPredicate? = nil) {
+                predicate: QueryPredicate? = nil,
+                limit: Int? = nil,
+                nextToken: String? = nil,
+                syncEnabled: Bool = false) {
         self.modelType = modelType
         self.predicate = predicate
+        self.limit = limit
+        self.nextToken = nextToken
+        self.syncEnabled = syncEnabled
     }
 
     public var name: String {
@@ -29,6 +38,10 @@ public class GraphQLListQuery: GraphQLDocument {
 
     public var decodePath: String {
         return name + ".items"
+    }
+
+    public var hasSyncableModels: Bool {
+        return syncEnabled
     }
 
     public var stringValue: String {
@@ -65,8 +78,16 @@ public class GraphQLListQuery: GraphQLDocument {
             variables.updateValue(predicate.graphQLFilterVariables, forKey: "filter")
         }
 
-        // TODO: Remove this once we support limit and nextToken passed in from the developer
-        variables.updateValue(1_000, forKey: "limit")
+        if let limit = limit {
+            variables.updateValue(limit, forKey: "limit")
+        } else {
+            // TODO: Remove this once we support limit and nextToken passed in from the developer
+            variables.updateValue(1_000, forKey: "limit")
+        }
+
+        if let nextToken = nextToken {
+            variables.updateValue(nextToken, forKey: "nextToken")
+        }
 
         return variables
     }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLDocument+Mutation.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLDocument+Mutation.swift
@@ -23,7 +23,8 @@ public class GraphQLMutation: GraphQLDocument {
     public let modelType: Model.Type
     public let mutationType: GraphQLMutationType
 
-    public init(of model: Model, type mutationType: GraphQLMutationType) {
+    public init(of model: Model,
+                type mutationType: GraphQLMutationType) {
         self.model = model
         self.modelType = ModelRegistry.modelType(from: model.modelName) ?? Swift.type(of: model)
         self.mutationType = mutationType
@@ -35,6 +36,10 @@ public class GraphQLMutation: GraphQLDocument {
 
     public var decodePath: String {
         name
+    }
+
+    public var hasSyncableModels: Bool {
+        false
     }
 
     public var stringValue: String {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLDocument+Subscription.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLDocument+Subscription.swift
@@ -16,11 +16,14 @@ public struct GraphQLSubscription: GraphQLDocument {
     public let documentType = GraphQLDocumentType.subscription
     public let modelType: Model.Type
     public let subscriptionType: GraphQLSubscriptionType
+    public let syncEnabled: Bool
 
     public init(of modelType: Model.Type,
-                type subscriptionType: GraphQLSubscriptionType) {
+                type subscriptionType: GraphQLSubscriptionType,
+                syncEnabled: Bool = false) {
         self.modelType = modelType
         self.subscriptionType = subscriptionType
+        self.syncEnabled = syncEnabled
     }
 
     public var name: String {
@@ -29,6 +32,10 @@ public struct GraphQLSubscription: GraphQLDocument {
 
     public var decodePath: String {
         name
+    }
+
+    public var hasSyncableModels: Bool {
+        return syncEnabled
     }
 
     public var stringValue: String {
@@ -44,5 +51,4 @@ public struct GraphQLSubscription: GraphQLDocument {
 
         return document
     }
-
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLDocument+SyncMutation.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLDocument+SyncMutation.swift
@@ -17,6 +17,10 @@ public class GraphQLSyncMutation: GraphQLMutation {
         super.init(of: model, type: mutationType)
     }
 
+    public override var hasSyncableModels: Bool {
+        return true
+    }
+
     public override var variables: [String: Any] {
 
         if mutationType == .delete {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLDocument+SyncQuery.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLDocument+SyncQuery.swift
@@ -9,8 +9,7 @@ import Amplify
 import Foundation
 
 public class GraphQLSyncQuery: GraphQLListQuery {
-    public let limit: Int?
-    public let nextToken: String?
+
     public let lastSync: Int?
 
     public init(from modelType: Model.Type,
@@ -18,10 +17,11 @@ public class GraphQLSyncQuery: GraphQLListQuery {
                 limit: Int? = nil,
                 nextToken: String? = nil,
                 lastSync: Int? = nil) {
-        self.limit = limit
-        self.nextToken = nextToken
         self.lastSync = lastSync
-        super.init(from: modelType, predicate: predicate)
+        super.init(from: modelType,
+                   predicate: predicate,
+                   limit: limit,
+                   nextToken: nextToken)
     }
 
     public override var name: String {
@@ -36,6 +36,10 @@ public class GraphQLSyncQuery: GraphQLListQuery {
 
     public override var decodePath: String {
         return name
+    }
+
+    public override var hasSyncableModels: Bool {
+        true
     }
 
     public override var stringValue: String {
@@ -70,18 +74,7 @@ public class GraphQLSyncQuery: GraphQLListQuery {
     }
 
     public override var variables: [String: Any] {
-        var variables = [String: Any]()
-        if let predicate = predicate {
-            variables.updateValue(predicate.graphQLFilterVariables, forKey: "filter")
-        }
-
-        if let limit = limit {
-            variables.updateValue(limit, forKey: "limit")
-        }
-
-        if let nextToken = nextToken {
-            variables.updateValue(nextToken, forKey: "nextToken")
-        }
+        var variables = super.variables
 
         if let lastSync = lastSync {
             variables.updateValue(lastSync, forKey: "lastSync")

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLDocument.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLDocument.swift
@@ -29,6 +29,9 @@ public protocol GraphQLDocument: DataStoreStatement where Variables == [String: 
     /// The name of the document. This is useful to inspect the response, since it will
     /// contain the name of the document as the key to the response value.
     var name: String { get }
+
+    /// The state of the model's backend provisioning, whether it is provisioned with conflict resolution or not.
+    var hasSyncableModels: Bool { get }
 }
 
 extension GraphQLDocument {
@@ -66,7 +69,7 @@ extension GraphQLDocument {
                 }
             }
             fieldSet.append(indent + "__typename")
-            if ModelRegistry.hasSyncableModels {
+            if hasSyncableModels {
                 fieldSet.append(indent + "_version")
                 fieldSet.append(indent + "_deleted")
                 fieldSet.append(indent + "_lastChangedAt")

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDocumentTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDocumentTests.swift
@@ -12,25 +12,31 @@ import XCTest
 
 class GraphQLDocumentTests: XCTestCase {
 
+    override func setUp() {
+         ModelRegistry.register(modelType: Comment.self)
+         ModelRegistry.register(modelType: Post.self)
+    }
+
     override func tearDown() {
         ModelRegistry.reset()
     }
 
     func testSelectionSetFieldsForNotSyncableModels() {
-        ModelRegistry.register(modelType: MockUnsynced.self)
-
-        let document = GraphQLGetQuery(from: MockUnsynced.self, id: "id")
+        let document = GraphQLGetQuery(from: Post.self, id: "id", syncEnabled: false)
         let expectedSelectionSet = ["id",
+                                    "content",
+                                    "createdAt",
+                                    "draft",
+                                    "rating",
+                                    "title",
+                                    "updatedAt",
                                     "__typename"]
 
         XCTAssertEqual(document.selectionSetFields, expectedSelectionSet)
     }
 
     func testSelectionSetFieldsForSyncableModels() {
-        ModelRegistry.register(modelType: Comment.self)
-        ModelRegistry.register(modelType: Post.self)
-
-        let document = GraphQLGetQuery(from: Post.self, id: "id")
+        let document = GraphQLGetQuery(from: Post.self, id: "id", syncEnabled: true)
         let expectedSelectionSet = ["id",
                                     "content",
                                     "createdAt",

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLGetQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLGetQueryTests.swift
@@ -30,7 +30,7 @@ class GraphQLGetQueryTests: XCTestCase {
     ///     - it has a list of fields with no nested models
     ///     - it has variables containing `id`
     func testGetGraphQLQueryFromSimpleModel() {
-        let document = GraphQLGetQuery(from: Post.self, id: "id")
+        let document = GraphQLGetQuery(from: Post.self, id: "id", syncEnabled: true)
         let expectedQueryDocument = """
         query GetPost($id: ID!) {
           getPost(id: $id) {
@@ -65,7 +65,7 @@ class GraphQLGetQueryTests: XCTestCase {
     ///     - it is named `getComment`
     ///     - it has a list of fields with a nested `post`
     func testGetGraphQLQueryFromModelWithAssociation() {
-        let document = GraphQLGetQuery(from: Comment.self, id: "id")
+        let document = GraphQLGetQuery(from: Comment.self, id: "id", syncEnabled: true)
         let expectedQueryDocument = """
         query GetComment($id: ID!) {
           getComment(id: $id) {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLListQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLListQueryTests.swift
@@ -36,7 +36,7 @@ class GraphQLListQueryTests: XCTestCase {
     func testListGraphQLQueryFromSimpleModel() {
         let post = Post.keys
         let predicate = post.id.eq("id") && (post.title.beginsWith("Title") || post.content.contains("content"))
-        let document = GraphQLListQuery(from: Post.self, predicate: predicate)
+        let document = GraphQLListQuery(from: Post.self, predicate: predicate, syncEnabled: true)
         let expectedQueryDocument = """
         query ListPosts($filter: ModelPostFilterInput, $limit: Int, $nextToken: String) {
           listPosts(filter: $filter, limit: $limit, nextToken: $nextToken) {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLMutationTests.swift
@@ -46,9 +46,6 @@ class GraphQLMutationTests: XCTestCase {
             title
             updatedAt
             __typename
-            _version
-            _deleted
-            _lastChangedAt
           }
         }
         """
@@ -94,14 +91,8 @@ class GraphQLMutationTests: XCTestCase {
               title
               updatedAt
               __typename
-              _version
-              _deleted
-              _lastChangedAt
             }
             __typename
-            _version
-            _deleted
-            _lastChangedAt
           }
         }
         """
@@ -140,9 +131,6 @@ class GraphQLMutationTests: XCTestCase {
             title
             updatedAt
             __typename
-            _version
-            _deleted
-            _lastChangedAt
           }
         }
         """
@@ -183,9 +171,6 @@ class GraphQLMutationTests: XCTestCase {
             title
             updatedAt
             __typename
-            _version
-            _deleted
-            _lastChangedAt
           }
         }
         """

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSubscriptionTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSubscriptionTests.swift
@@ -32,7 +32,7 @@ class GraphQLSubscriptionTests: XCTestCase {
     ///   - check if the generated GraphQL document is a valid subscription
     ///     - it has a list of fields with no nested models
     func testOnCreateGraphQLSubscriptionFromSimpleModel() {
-        let document = GraphQLSubscription(of: Post.self, type: .onCreate)
+        let document = GraphQLSubscription(of: Post.self, type: .onCreate, syncEnabled: true)
         let expectedQueryDocument = """
         subscription OnCreatePost {
           onCreatePost {
@@ -66,7 +66,7 @@ class GraphQLSubscriptionTests: XCTestCase {
     ///   - check if the generated GraphQL document is a valid subscription
     ///     - it has a list of fields with no nested models
     func testOnCreateGraphQLSubscriptionFromModelWithAssociation() {
-        let document = GraphQLSubscription(of: Comment.self, type: .onCreate)
+        let document = GraphQLSubscription(of: Comment.self, type: .onCreate, syncEnabled: true)
         let expectedQueryDocument = """
         subscription OnCreateComment {
           onCreateComment {
@@ -107,7 +107,7 @@ class GraphQLSubscriptionTests: XCTestCase {
     ///   - check if the generated GraphQL document is a valid subscription
     ///     - it has a list of fields with no nested models
     func testOnUpdateGraphQLSubscriptionFromSimpleModel() {
-        let document = GraphQLSubscription(of: Post.self, type: .onUpdate)
+        let document = GraphQLSubscription(of: Post.self, type: .onUpdate, syncEnabled: true)
         let expectedQueryDocument = """
         subscription OnUpdatePost {
           onUpdatePost {
@@ -139,7 +139,7 @@ class GraphQLSubscriptionTests: XCTestCase {
     ///   - check if the generated GraphQL document is a valid subscription
     ///     - it has a list of fields with no nested models
     func testOnDeleteGraphQLSubscriptionFromSimpleModel() {
-        let document = GraphQLSubscription(of: Post.self, type: .onDelete)
+        let document = GraphQLSubscription(of: Post.self, type: .onDelete, syncEnabled: true)
         let expectedQueryDocument = """
         subscription OnDeletePost {
           onDeletePost {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
@@ -94,9 +94,9 @@ class SyncMutationToCloudOperation: Operation {
 
     private func deleteRequest(for mutationEvent: MutationEvent)
         throws -> GraphQLRequest<MutationSync<AnyModel>> {
-            let document = try MinimalGraphQLDeleteMutation(of: mutationEvent.modelName,
-                                                            id: mutationEvent.modelId,
-                                                            version: mutationEvent.version)
+            let document = try GraphQLDeleteSyncMutation(of: mutationEvent.modelName,
+                                                         id: mutationEvent.modelId,
+                                                         version: mutationEvent.version)
             let request = GraphQLRequest(document: document.stringValue,
                                          variables: document.variables,
                                          responseType: MutationSync<AnyModel>.self,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -77,7 +77,9 @@ final class IncomingAsyncSubscriptionEventPublisher {
                                 api: APICategoryGraphQLBehavior,
                                 listener: @escaping GraphQLSubscriptionOperation<Payload>.EventListener)
         -> GraphQLSubscriptionOperation<Payload> {
-            let document = GraphQLSubscription(of: modelType, type: subscriptionType)
+            let document = GraphQLSubscription(of: modelType,
+                                               type: subscriptionType,
+                                               syncEnabled: true)
 
             let request = GraphQLRequest(document: document.stringValue,
                                          variables: document.variables,

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -82,7 +82,6 @@
 		FA4A955D239AD810008E876E /* MockSQLiteStorageEngineAdapterResponders.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4A955C239AD810008E876E /* MockSQLiteStorageEngineAdapterResponders.swift */; };
 		FA4B8E942391C2CD009FC10F /* MutationIngesterConflictResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4B8E932391C2CD009FC10F /* MutationIngesterConflictResolutionTests.swift */; };
 		FA4B8E962391C609009FC10F /* XCTest+AmplifyExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4B8E952391C609009FC10F /* XCTest+AmplifyExtensions.swift */; };
-		FA4FB5B42396034000FC0462 /* MinimalGraphQLDeleteMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4FB5B32396034000FC0462 /* MinimalGraphQLDeleteMutation.swift */; };
 		FA4FF13C239B218000056633 /* SortByDependencyOrderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4FF13B239B218000056633 /* SortByDependencyOrderTests.swift */; };
 		FA55A5492391EA89002AFF2D /* MutationEventSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA55A5482391EA89002AFF2D /* MutationEventSubscription.swift */; };
 		FA55A54B2391EAB5002AFF2D /* MutationEventSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA55A54A2391EAB5002AFF2D /* MutationEventSubscriber.swift */; };
@@ -243,7 +242,6 @@
 		FA4A955C239AD810008E876E /* MockSQLiteStorageEngineAdapterResponders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSQLiteStorageEngineAdapterResponders.swift; sourceTree = "<group>"; };
 		FA4B8E932391C2CD009FC10F /* MutationIngesterConflictResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationIngesterConflictResolutionTests.swift; sourceTree = "<group>"; };
 		FA4B8E952391C609009FC10F /* XCTest+AmplifyExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTest+AmplifyExtensions.swift"; sourceTree = "<group>"; };
-		FA4FB5B32396034000FC0462 /* MinimalGraphQLDeleteMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimalGraphQLDeleteMutation.swift; sourceTree = "<group>"; };
 		FA4FF13B239B218000056633 /* SortByDependencyOrderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortByDependencyOrderTests.swift; sourceTree = "<group>"; };
 		FA55A5482391EA89002AFF2D /* MutationEventSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEventSubscription.swift; sourceTree = "<group>"; };
 		FA55A54A2391EAB5002AFF2D /* MutationEventSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEventSubscriber.swift; sourceTree = "<group>"; };
@@ -516,7 +514,6 @@
 		FA6C3FEF2398942500A73110 /* OutgoingMutationQueue */ = {
 			isa = PBXGroup;
 			children = (
-				FA4FB5B32396034000FC0462 /* MinimalGraphQLDeleteMutation.swift */,
 				FAF7CECA238C72830095547B /* OutgoingMutationQueue.swift */,
 				FA3B3F04238F22F5002EFDB3 /* OutgoingMutationQueue+Action.swift */,
 				FA3B3F06238F23CA002EFDB3 /* OutgoingMutationQueue+Resolver.swift */,
@@ -1211,7 +1208,6 @@
 				FA5D76AB2394752900489864 /* AWSMutationDatabaseAdapter+MutationEventIngester.swift in Sources */,
 				FA0427CA2396C35500D25AB0 /* InitialSyncOrchestrator.swift in Sources */,
 				FAED5738238B3A2A008EBED8 /* AWSIncomingSubscriptionEventPublisher.swift in Sources */,
-				FA4FB5B42396034000FC0462 /* MinimalGraphQLDeleteMutation.swift in Sources */,
 				FACBA78F23949C75006349C8 /* AWSMutationDatabaseAdapter.swift in Sources */,
 				FA55A54D2391F96E002AFF2D /* AWSMutationDatabaseAdapter+MutationEventSource.swift in Sources */,
 				2149E5CE2388684F00873955 /* SQLStatement+CreateTable.swift in Sources */,


### PR DESCRIPTION
### Major changes
This introduces a flag for whether a GraphQLDocument helper method should contain the sync-able fields. Methods like GraphQLSyncQuery by default will be true, and methods like GraphQLGetQuery can be used with syncEnabled parameter.

### Minor changes
- Moved MinimalGraphQLDeleteMutation over to PluginsCore as GraphQLDeleteSyncMutation
- Updated GraphQLListQuery to include limit and nextToken, in anticipation for ModelBased List query to allow limit/nextToken.

### Testing done
- Ensured the Sync provisioned backend in API integration tests is working as expected, and so went to datastore plugin and updated the calls where necessary, like
```
let document = GraphQLSubscription(of: modelType,
                                   type: subscriptionType,
                                   syncEnabled: true)
// adding syncEnabled true parameter
```
- Ensure Model based APIs are working. by default the models are not syncable until specified to be syncable. since Model based API's should never be used with sync and developer should use DataStore if using sync provisioned backend

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
