### PR TITLE
CI pipeline improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,25 @@ jobs:
       - store_test_results:
           path: build/reports
   
+  deploy_unstable:
+    <<: *defaults
+    description: deploy pods to trunk
+    steps: 
+      - *restore_repo
+      - restore_gems
+      - check_bundle
+      - run:
+          # without this step, the pipeline hangs during `pod repo update` after pushing (see Fastfile -> :release_pods)
+          # TODO: look into caching this 
+          name: Clone CocoaPods Repo
+          command: |
+            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+      - run:
+          name: Release pods with unstable tag
+          command: bundle exec fastlane unstable
+      - store_artifacts:
+          path: fastlane/report.xml
+
   deploy:
     <<: *defaults
     description: deploy pods to trunk
@@ -157,13 +176,16 @@ jobs:
       - *restore_repo
       - restore_gems
       - check_bundle
-      # - run:
-      #     name: Bump pod versions
-      #     command: bundle exec fastlane bump_podspecs_patch
+      - run:
+          # without this step, the pipeline hangs during `pod repo update` after pushing (see Fastfile -> :release_pods)
+          name: Clone CocoaPods Repo
+          command: |
+            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
       - run:
           name: Release pods
-          command: bundle exec fastlane release_pods
-
+          command: bundle exec fastlane release
+      - store_artifacts:
+          path: fastlane/report.xml
 
 workflows:
   build_test_deploy:
@@ -217,11 +239,11 @@ workflows:
           scheme: AWSDataStoreCategoryPlugin
           requires:
             - install_gems
-      - deploy:
+      - deploy_unstable:
           filters:
             branches:
               only:
-                - release
+                - master
           requires:
             - build_test_amplify
             - unit_test_api

--- a/AWSPluginsCore.podspec
+++ b/AWSPluginsCore.podspec
@@ -21,11 +21,13 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => s.version}
   
   s.requires_arc = true
+  s.swift_versions = '5.1'
   
+  AMPLIFY_VERSION = '0.9.0'
   AWS_SDK_VERSION = "~> 2.12.2"
 
   s.source_files = 'AmplifyPlugins/Core/AWSPluginsCore/**/*.swift'
-  s.dependency 'Amplify', '0.9.0'
+  s.dependency 'Amplify', AMPLIFY_VERSION
   s.dependency 'AWSMobileClient', AWS_SDK_VERSION
 
 end

--- a/AWSPredictionsPlugin.podspec
+++ b/AWSPredictionsPlugin.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
     s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => s.version}
     
     s.requires_arc = true
+    s.swift_versions = '5.1'
 
     AWS_SDK_VERSION = '~> 2.12.2'
     AMPLIFY_VERSION = '0.9.0'

--- a/AmplifyPlugins.podspec
+++ b/AmplifyPlugins.podspec
@@ -21,6 +21,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => s.version}
   
   s.requires_arc = true 
+  s.swift_versions = '5.1'
 
   AWS_SDK_VERSION = '~> 2.12.2'
   AMPLIFY_VERSION = '0.9.0'

--- a/AmplifyTestCommon.podspec
+++ b/AmplifyTestCommon.podspec
@@ -6,26 +6,29 @@
 #  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
 #
 
-Pod::Spec.new do |spec|
+Pod::Spec.new do |s|
+  s.name         = "AmplifyTestCommon"
+  s.version      = "0.9.0"
+  s.summary      = "Test resources used by different targets"
+  s.description  = "Provides different test resources and mock methods"
 
-  spec.name         = "AmplifyTestCommon"
-  spec.version      = "0.9.0"
-  spec.summary      = "Test resources used by different targets"
-  spec.description  = "Provides different test resources and mock methods"
-
-  spec.homepage     = "https://aws.amazon.com/amplify/"
-  spec.license      = 'Apache License, Version 2.0'
-  spec.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  spec.platform     = :ios, '11.0'
-  spec.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => spec.version}
+  s.homepage     = "https://aws.amazon.com/amplify/"
+  s.license      = 'Apache License, Version 2.0'
+  s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
+  s.platform     = :ios, '11.0'
+  s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => s.version}
   
-  spec.requires_arc = true
+  s.requires_arc   = true
+  s.swift_versions = '5.1'
 
-  spec.source_files = 'AmplifyTestCommon/**/*.swift'
-  spec.dependency 'Amplify', '0.9.0'
+  AMPLIFY_VERSION = '0.9.0'
+  AMPLIFY_PLUGINS_CORE_VERSION = '0.9.0'
 
-  spec.subspec 'AWSPluginsTestCommon' do |subspec|
-    subspec.source_files = 'AmplifyPlugins/Core/AWSPluginsTestCommon/**/*.swift'
-    spec.dependency 'AWSPluginsCore', '0.9.0'
+  s.source_files = 'AmplifyTestCommon/**/*.swift'
+  s.dependency 'Amplify', AMPLIFY_VERSION
+
+  s.subspec 'AWSPluginsTestCommon' do |ss|
+    ss.source_files = 'AmplifyPlugins/Core/AWSPluginsTestCommon/**/*.swift'
+    s.dependency 'AWSPluginsCore', AMPLIFY_PLUGINS_CORE_VERSION
   end
 end

--- a/CoreMLPredictionsPlugin.podspec
+++ b/CoreMLPredictionsPlugin.podspec
@@ -12,9 +12,13 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '13.0'
   s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => s.version}
   
-  s.requires_arc = true
+  s.requires_arc   = true
+  s.swift_versions = '5.1'
+
+  AMPLIFY_VERSION = '0.9.0'
+
   s.source_files = 'AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/**/*.swift'
-  s.dependency 'Amplify', '0.9.0'
+  s.dependency 'Amplify', AMPLIFY_VERSION
 
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,31 +13,108 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
-opt_out_usage
+require_relative './amplify_pods.rb'
 
+opt_out_usage
 default_platform(:ios)
 
-pods = [
-  # "Amplify.podspec",
-  # "AWSPluginsCore.podspec",
-  # "CoreMLPredictionsPlugin.podspec",
-  "AWSPredictionsPlugin.podspec",
-  "AmplifyPlugins.podspec"
-]
+plist_key = "CFBundleShortVersionString"
 
+# This file also contains a version. Should it be incremented as well?
+# AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Constants/URLRequestConstants.swift
+
+# .jazzy.yaml ?
+
+# Unstable - release with unstable tag but don't commit/push version changes
 platform :ios do
-  desc "Bump pod versions"
-  lane :bump_podspecs_patch do
+  desc "Unstable"
+  lane :unstable do 
+    tag_prefix = '*'
 
-    pods.each { |pod| version_bump_podspec(path: pod, bump_type: "patch") }
+    analyze_commits_canary(match: tag_prefix, canary: true, preid: 'unstable')
 
+    # Increment all specs and plists
+    increment_versions()
+
+    # Create tag and push to origin
+    add_tag()
+
+    # Push pods
+    release_pods()
+  end
+
+  # Stable - commit, tag, and push to origin
+  desc "Release"
+  lane :release do
+    tag_prefix = '*'
+    
+    analyze_commits_canary(match: tag_prefix, canary: true, preid: 'unstable')
+
+    # Increment all specs and plists
+    increment_versions()
+
+    # TODO: Generate changelog
+
+    # Commit and push
+    release_commit()
+
+    # Create tag and push to origin
+    add_tag()
+
+    # Push pods
+    release_pods()
+  end
+
+  desc "Increment versions"
+  private_lane :increment_versions do |options|
+    AmplifyPods.pods.each { |pod| increment_pod(pod) }
+  end
+  
+  desc "Increment versions for pod"
+  private_lane :increment_pod do |options|
+    spec, push, constants, plist_paths = options.values
+    next_version = lane_context[SharedValues::RELEASE_NEXT_VERSION]
+
+    version_bump_podspec(path: spec, version_number: next_version)
+
+    constants.each { |constant| podspec_constant_versioning(podspec: spec, constant: constant, value: next_version) }
+    
+    plist_paths.each { |plist| set_info_plist_value(path: plist, key: plist_key, value: next_version) }
+  end
+
+  desc "Commit and push"
+  private_lane :release_commit do
+    next_version = lane_context[SharedValues::RELEASE_NEXT_VERSION]
+
+    sh("git config --global user.email $GITHUB_EMAIL")
+    sh("git config --global user.name $GITHUB_USER")
+
+    # We don't want this commit to trigger another build
+    commit_message = "chore(release): #{next_version} [skip ci]"
+    sh("git commit -am '#{commit_message}'")
+    sh("git push origin")
+  end
+
+  desc "Tag in git"
+  private_lane :add_tag do
+    next_version = lane_context[SharedValues::RELEASE_NEXT_VERSION]
+
+    add_git_tag(tag: next_version)
+    push_git_tags(tag: next_version)
   end
 
   desc "Release pods"
-  lane :release_pods do
+  private_lane :release_pods do
 
-    pods.each { |pod| pod_push(path: pod, allow_warnings: true, swift_version: "5.1") }
+    AmplifyPods.pods.each { 
+      |pod|
 
+        if !pod[:push]
+          next
+        end
+        
+        pod_push(path: pod[:spec], allow_warnings: true)
+        Actions.sh('pod repo update')
+    }
   end
-
 end

--- a/fastlane/actions/analyze_commits_canary.rb
+++ b/fastlane/actions/analyze_commits_canary.rb
@@ -1,0 +1,399 @@
+require_relative '../helper/semantic_release_helper'
+
+# Matches any valid semver with optional v at the beginning e.g. 1.2.3, v1.2.3, 1.2.3-alpha.0, etc
+SEMVER_REGEX = /^v?(?'MAJOR'0|[1-9]\d*)\.(?'MINOR'0|[1-9]\d*)\.(?'PATCH'0|[1-9]\d*)(?:-(?'PRE_RELEASE'(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?'BUILD'[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+# Matches semver prerelease, e.g. alpha.0
+PRERELEASE_REGEX = /^(?'PREID'\w+)\.(?'PREVERSION'\d+)/
+# Matches git describe suffix, e.g. 1-g93c6f0b
+GITHASH_REGEX = /^\d+\-g[0-9a-f]{7}/
+
+module Fastlane
+  module Actions
+    module SharedValues
+      RELEASE_ANALYZED = :RELEASE_ANALYZED
+      RELEASE_IS_NEXT_VERSION_HIGHER = :RELEASE_IS_NEXT_VERSION_HIGHER
+      RELEASE_LAST_TAG_HASH = :RELEASE_LAST_TAG_HASH
+      RELEASE_LAST_VERSION = :RELEASE_LAST_VERSION
+      RELEASE_NEXT_MAJOR_VERSION = :RELEASE_NEXT_MAJOR_VERSION
+      RELEASE_NEXT_MINOR_VERSION = :RELEASE_NEXT_MINOR_VERSION
+      RELEASE_NEXT_PATCH_VERSION = :RELEASE_NEXT_PATCH_VERSION
+      RELEASE_NEXT_VERSION = :RELEASE_NEXT_VERSION
+      RELEASE_NEXT_PRERELEASE_VERSION = :RELEASE_NEXT_PRERELEASE_VERSION
+      RELEASE_LAST_INCOMPATIBLE_CODEPUSH_VERSION = :RELEASE_LAST_INCOMPATIBLE_CODEPUSH_VERSION
+    end
+
+    class AnalyzeCommitsCanaryAction < Action
+      def self.get_last_tag(params)
+        # Try to find the tag
+        command = "git describe --tags --match=#{params[:match]}"
+        Actions.sh(command, log: false)
+      rescue
+        UI.message("Tag was not found for match pattern - #{params[:match]}")
+        ''
+      end
+
+      def self.get_last_tag_hash(params)
+        command = "git rev-list -n 1 refs/tags/#{params[:tag_name]}"
+        Actions.sh(command, log: false).chomp
+      end
+
+      def self.get_commits_from_hash(params)
+        commits = Helper::SemanticReleaseHelper.git_log('%s|%b|>', params[:hash])
+        commits.split("|>")
+      end
+
+      def self.break_apart_tag(params)
+        tagmatch = params[:tag].match(SEMVER_REGEX)
+
+        if !tagmatch
+          UI.user_error!("The last tag is not semver")
+        end
+
+        major, minor, patch, preandgit = tagmatch.captures
+      
+        returnObj = {
+          'major': major.to_i,
+          'minor': minor.to_i,
+          'patch': patch.to_i
+        }
+      
+        prerelease_match = preandgit.match(PRERELEASE_REGEX)
+      
+        if prerelease_match
+          preid, pre_ver = prerelease_match.captures
+      
+          returnObj['preid'] = preid
+          returnObj['pre_ver'] = pre_ver.to_i
+        end
+      
+        returnObj
+      end
+
+      # TODO: this method needs to utilize break apart tag similarly to the _canary method
+      # Fix before using the stable release lane
+      def self.is_releasable(params)
+        # Hash of the commit where is the last version
+        # If the tag is not found we are taking HEAD as reference
+        hash = 'HEAD'
+        # Default last version
+        version = '0.0.0'
+
+        tag = get_last_tag(match: params[:match])
+
+        if tag.empty?
+          UI.message("First commit of the branch is taken as a begining of next release")
+          # If there is no tag found we taking the first commit of current branch
+          hash = Actions.sh('git rev-list --max-parents=0 HEAD', log: false).chomp
+        else
+          # Tag's format is v2.3.4-5-g7685948
+          # See git describe man page for more info
+          tag_name = tag.split('-')[0].strip
+          parsed_version = tag_name.match(params[:tag_version_match])
+
+          if parsed_version.nil?
+            UI.user_error!("Error while parsing version from tag #{tag_name} by using tag_version_match - #{params[:tag_version_match]}. Please check if the tag contains version as you expect and if you are using single brackets for tag_version_match parameter.")
+          end
+
+          version = parsed_version[0]
+          # Get a hash of last version tag
+          # pass the whole tag with canary version
+          hash = get_last_tag_hash(tag_name: tag_name)
+
+          UI.message("Found a tag #{tag_name} associated with version #{version}")
+        end
+
+        # converts last version string to the int numbers
+        next_major = (version.split('.')[0] || 0).to_i
+        next_minor = (version.split('.')[1] || 0).to_i
+        next_patch = (version.split('.')[2] || 0).to_i
+
+        # Get commits log between last version and head
+        splitted = get_commits_from_hash(hash: hash)
+
+        UI.message("Found #{splitted.length} commits since last release")
+        releases = params[:releases]
+
+        splitted.each do |line|
+          # conventional commits are in format
+          # type: subject (fix: app crash - for example)
+          commit = Helper::SemanticReleaseHelper.parse_commit(
+            commit_subject: line.split("|")[0],
+            commit_body: line.split("|")[1],
+            releases: releases
+          )
+
+          unless commit[:scope].nil?
+            # if this commit has a scope, then we need to inspect to see if that is one of the scopes we're trying to exclude
+            scope = commit[:scope]
+            scopes_to_ignore = params[:ignore_scopes]
+            # if it is, we'll skip this commit when bumping versions
+            next if scopes_to_ignore.include?(scope) #=> true
+          end
+
+          if commit[:release] == "major" || commit[:is_breaking_change]
+            next_major += 1
+            next_minor = 0
+            next_patch = 0
+          elsif commit[:release] == "minor"
+            next_minor += 1
+            next_patch = 0
+          elsif commit[:release] == "patch"
+            next_patch += 1
+          end
+
+          next_version = "#{next_major}.#{next_minor}.#{next_patch}"
+          UI.message("#{next_version}: #{line}")
+        end
+
+        next_version = "#{next_major}.#{next_minor}.#{next_patch}"
+
+        is_next_version_releasable = Helper::SemanticReleaseHelper.semver_gt(next_version, version)
+
+        Actions.lane_context[SharedValues::RELEASE_ANALYZED] = true
+        Actions.lane_context[SharedValues::RELEASE_IS_NEXT_VERSION_HIGHER] = is_next_version_releasable
+        # Last release analysis
+        Actions.lane_context[SharedValues::RELEASE_LAST_TAG_HASH] = hash
+        Actions.lane_context[SharedValues::RELEASE_LAST_VERSION] = version
+        # Next release analysis
+        Actions.lane_context[SharedValues::RELEASE_NEXT_MAJOR_VERSION] = next_major
+        Actions.lane_context[SharedValues::RELEASE_NEXT_MINOR_VERSION] = next_minor
+        Actions.lane_context[SharedValues::RELEASE_NEXT_PATCH_VERSION] = next_patch
+        Actions.lane_context[SharedValues::RELEASE_NEXT_VERSION] = next_version
+
+        success_message = "Next version (#{next_version}) is higher than last version (#{version}). This version should be released."
+        UI.success(success_message) if is_next_version_releasable
+
+        is_next_version_releasable
+      end
+
+      def self.is_releasable_canary(params)
+        # Hash of the commit where is the last version
+        # If the tag is not found we are taking HEAD as reference
+        hash = 'HEAD'
+        # Default last version
+        version = '0.1.0'
+
+        # Tag's format is 2.3.4-alpha.0-5-g7685948
+        # See git describe man page for more info
+        tag = get_last_tag(match: params[:match])
+
+        if tag.empty?
+          UI.message("First commit of the branch is taken as a begining of next release")
+          # If there is no tag found we taking the first commit of current branch
+          hash = Actions.sh('git rev-list --max-parents=0 HEAD', log: false).chomp
+        else
+          major, minor, patch, preid, pre_ver = break_apart_tag(tag: tag).values
+
+          tag_name = "#{major}.#{minor}.#{patch}"
+
+          if !preid.nil?
+            tag_name += "-#{preid}.#{pre_ver}"
+          end
+
+          parsed_version = tag_name.match(params[:tag_version_match])
+
+          if parsed_version.nil?
+            UI.user_error!("Error while parsing version from tag #{tag_name} by using tag_version_match - #{params[:tag_version_match]}. Please check if the tag contains version as you expect and if you are using single brackets for tag_version_match parameter.")
+          end
+
+          # Get a hash of last version tag
+          hash = get_last_tag_hash(tag_name: tag_name)
+
+          UI.message("Found a tag #{tag} associated with version #{tag_name}")
+        end
+
+        version = tag_name
+
+        next_major = major
+        next_minor = minor
+        next_patch = patch
+
+        if preid.nil?
+          next_patch += 1
+          next_preid = params[:preid]
+          next_pre_ver = 0
+        else
+          # different preid exists on tag than the one that was passed in
+          if preid != params[:preid]
+            next_preid = params[:preid]
+            next_pre_ver = 0
+          else
+            # if preid exists and matches the one that was passed in, increment the prerelease version
+            next_preid = preid
+            next_pre_ver = pre_ver + 1
+          end
+        end
+
+        next_version = "#{next_major}.#{next_minor}.#{next_patch}-#{next_preid}.#{next_pre_ver}"
+
+        is_next_version_releasable = true
+
+        Actions.lane_context[SharedValues::RELEASE_ANALYZED] = true
+        Actions.lane_context[SharedValues::RELEASE_IS_NEXT_VERSION_HIGHER] = is_next_version_releasable
+        # Last release analysis
+        Actions.lane_context[SharedValues::RELEASE_LAST_TAG_HASH] = hash
+        Actions.lane_context[SharedValues::RELEASE_LAST_VERSION] = version
+        # Next release analysis
+        Actions.lane_context[SharedValues::RELEASE_NEXT_MAJOR_VERSION] = next_major
+        Actions.lane_context[SharedValues::RELEASE_NEXT_MINOR_VERSION] = next_minor
+        Actions.lane_context[SharedValues::RELEASE_NEXT_PATCH_VERSION] = next_patch
+        Actions.lane_context[SharedValues::RELEASE_NEXT_VERSION] = next_version
+        Actions.lane_context[SharedValues::RELEASE_NEXT_PRERELEASE_VERSION] = "#{next_preid}.#{next_pre_ver}"
+
+        success_message = "Next version (#{next_version}) is higher than last version (#{version}). This version should be released."
+        UI.success(success_message) if is_next_version_releasable
+
+        is_next_version_releasable
+      end
+
+      def self.is_codepush_friendly(params)
+        # Begining of the branch is taken for codepush analysis
+        hash = Actions.sh('git rev-list --max-parents=0 HEAD', log: false).chomp
+        next_major = 0
+        next_minor = 0
+        next_patch = 0
+        last_incompatible_codepush_version = '0.0.0'
+
+        # Get commits log between last version and head
+        splitted = get_commits_from_hash(hash: hash)
+        releases = params[:releases]
+        codepush_friendly = params[:codepush_friendly]
+
+        splitted.each do |line|
+          # conventional commits are in format
+          # type: subject (fix: app crash - for example)
+          commit = Helper::SemanticReleaseHelper.parse_commit(
+            commit_subject: line.split("|")[0],
+            commit_body: line.split("|")[1],
+            releases: releases,
+            codepush_friendly: codepush_friendly
+          )
+
+          if commit[:release] == "major" || commit[:is_breaking_change]
+            next_major += 1
+            next_minor = 0
+            next_patch = 0
+          elsif commit[:release] == "minor"
+            next_minor += 1
+            next_patch = 0
+          elsif commit[:release] == "patch"
+            next_patch += 1
+          end
+
+          unless commit[:is_codepush_friendly]
+            last_incompatible_codepush_version = "#{next_major}.#{next_minor}.#{next_patch}"
+          end
+        end
+
+        Actions.lane_context[SharedValues::RELEASE_LAST_INCOMPATIBLE_CODEPUSH_VERSION] = last_incompatible_codepush_version
+      end
+
+      def self.run(params)
+        if params[:canary]
+          is_next_version_releasable = is_releasable_canary(params)
+          return is_next_version_releasable
+        end
+          
+        is_next_version_releasable = is_releasable(params)
+        is_codepush_friendly(params)
+        is_next_version_releasable
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Finds a tag of last release and determinates version of next release"
+      end
+
+      def self.details
+        "This action will find a last release tag and analyze all commits since the tag. It uses conventional commits. Every time when commit is marked as fix or feat it will increase patch or minor number (you can setup this default behaviour). After all it will suggest if the version should be released or not."
+      end
+
+      def self.available_options
+        # Define all options your action supports.
+
+        # Below a few examples
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :match,
+            description: "Match parameter of git describe. See man page of git describe for more info",
+            verify_block: proc do |value|
+              UI.user_error!("No match for analyze_commits action given, pass using `match: 'expr'`") unless value && !value.empty?
+            end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :releases,
+            description: "Map types of commit to release (major, minor, patch)",
+            default_value: { fix: "patch", feat: "minor" },
+            type: Hash
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :codepush_friendly,
+            description: "These types are consider as codepush friendly automatically",
+            default_value: ["chore", "test", "docs"],
+            type: Array,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :tag_version_match,
+            description: "To parse version number from tag name",
+            default_value: '\d+\.\d+\.\d+'
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :ignore_scopes,
+            description: "To ignore certain scopes when calculating releases",
+            default_value: [],
+            type: Array,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :canary,
+            description: "Canary deployment",
+            type: Boolean,
+            default_value: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :preid,
+            description: "Canary pre-release id",
+            type: String,
+            default_value: "alpha"
+          )
+        ]
+      end
+
+      def self.output
+        # Define the shared values you are going to provide
+        # Example
+        [
+          ['RELEASE_ANALYZED', 'True if commits were analyzed.'],
+          ['RELEASE_IS_NEXT_VERSION_HIGHER', 'True if next version is higher then last version'],
+          ['RELEASE_LAST_TAG_HASH', 'Hash of commit that is tagged as a last version'],
+          ['RELEASE_LAST_VERSION', 'Last version number - parsed from last tag.'],
+          ['RELEASE_NEXT_MAJOR_VERSION', 'Major number of the next version'],
+          ['RELEASE_NEXT_MINOR_VERSION', 'Minor number of the next version'],
+          ['RELEASE_NEXT_PATCH_VERSION', 'Patch number of the next version'],
+          ['RELEASE_NEXT_VERSION', 'Next version string in format (major.minor.patch)'],
+          ['RELEASE_NEXT_PRERELEASE_VERSION', 'Next prerelease version string in format (preid.pre_ver)'],
+          ['RELEASE_LAST_INCOMPATIBLE_CODEPUSH_VERSION', 'Last commit without codepush']
+        ]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+        "Returns true if the next version is higher then the last version"
+      end
+
+      def self.authors
+        # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+        ["xotahal"]
+      end
+
+      def self.is_supported?(platform)
+        # you can do things like
+        true
+      end
+    end
+  end
+end

--- a/fastlane/actions/podspec_constant_versioning.rb
+++ b/fastlane/actions/podspec_constant_versioning.rb
@@ -1,0 +1,78 @@
+module Fastlane
+  module Actions
+    class PodspecConstantVersioningAction < Action
+      def self.run(params)
+        podspec = params[:podspec]
+        constant = params[:constant]
+        value = params[:value]
+        
+        podspec_contents = File.read(podspec)
+
+        # TODO: improve RegEx
+        if !podspec_contents.match(/(?<=#{constant})(\s*=\s*["'].*)/)
+          UI.error("#{constant} not present or doesn't have an explicit value in #{podspec}")
+          return
+        end
+
+        new_value = " = '#{value}'"
+        
+        podspec_new_contents = podspec_contents.gsub(/(?<=#{constant})(\s*=\s*["'].*)/, new_value)
+
+        File.open(podspec, "w") { |file| file.puts podspec_new_contents }
+        UI.success("successfully modified #{constant} to value #{value} in #{podspec}")
+            
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "This action will modify the value of a constant in your podspec."
+      end
+
+      def self.available_options
+        [
+            FastlaneCore::ConfigItem.new(
+                key: :podspec,
+                env_name: "PODSPEC_PATH",
+                description: "The path of the podspec you wish to modify",
+                optional: false,
+                type: String
+            ),
+            FastlaneCore::ConfigItem.new(
+                key: :constant,
+                env_name: "CONSTANT_NAME",
+                description: "The constant you wish to modify",
+                optional: false,
+                type: String
+            ),
+            FastlaneCore::ConfigItem.new(
+                key: :value,
+                env_name: "CONSTANT_VALUE",
+                description: "The new value to assign to the constant",
+                optional: false,
+                type: String
+            )
+        ]
+      end
+
+      def self.authors
+        ["iartemiev"]
+      end
+
+      def self.is_supported?(platform)
+        # you can do things like
+        # 
+        #  true
+        # 
+        #  platform == :ios
+        # 
+        #  [:ios, :mac].include?(platform)
+        # 
+
+        platform == :ios
+      end
+    end
+  end
+end

--- a/fastlane/amplify_pods.rb
+++ b/fastlane/amplify_pods.rb
@@ -1,0 +1,63 @@
+module AmplifyPods
+  @@pods = [
+    {
+      spec: "Amplify.podspec",
+      push: true,
+      constants: [],
+      plist_paths: [
+        "Amplify/Info.plist",
+        "AmplifyTests/Info.plist",
+        "AmplifyFunctionalTests/Info.plist",
+        "AmplifyTestApp/Info.plist",
+        "AmplifyTestCommon/Info.plist"
+      ]
+    },
+    {
+      spec: "AWSPluginsCore.podspec",
+      push: true,
+      constants: ['AMPLIFY_VERSION'],
+      plist_paths: [
+        "AmplifyPlugins/Core/AWSPluginsCore/Info.plist",
+        "AmplifyPlugins/Core/AWSPluginsCoreTests/Info.plist",
+        "AmplifyPlugins/Core/AWSPluginsTestCommon/Info.plist"
+      ]
+    },
+    {
+      spec: "CoreMLPredictionsPlugin.podspec",
+      push: true,
+      constants: ['AMPLIFY_VERSION'],
+      plist_paths: [
+        "AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Resources/Info.plist"
+      ]
+    },
+    {
+      spec: "AWSPredictionsPlugin.podspec",
+      push: true,
+      constants: ['AMPLIFY_VERSION'],
+      plist_paths: [
+        "AmplifyPlugins/Predictions/AWSPredictionsPlugin/Resources/Info.plist"
+      ]
+    },
+    {
+      spec: "AmplifyPlugins.podspec",
+      push: true,
+      constants: ['AMPLIFY_VERSION'],
+      plist_paths: [
+        "AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Resources/Info.plist",
+        "AmplifyPlugins/API/AWSAPICategoryPlugin/Info.plist",
+        "AmplifyPlugins/Storage/AWSS3StoragePlugin/Resources/Info.plist"
+      ]
+    },
+    {
+      spec: "AmplifyTestCommon.podspec",
+      push: false,
+      constants: ['AMPLIFY_VERSION', 'AMPLIFY_PLUGINS_CORE_VERSION'],
+      plist_paths: [
+        "AmplifyTestCommon/Info.plist"
+      ]
+    }
+  ]
+  def self.pods
+    @@pods
+  end
+end

--- a/fastlane/helper/semantic_release_helper.rb
+++ b/fastlane/helper/semantic_release_helper.rb
@@ -1,0 +1,97 @@
+require 'fastlane_core/ui/ui'
+
+module Fastlane
+  UI = FastlaneCore::UI unless Fastlane.const_defined?("UI")
+
+  module Helper
+    class SemanticReleaseHelper
+      # class methods that you define here become available in your action
+      # as `Helper::SemanticReleaseHelper.your_method`
+      #
+      def self.git_log(pretty, start)
+        command = "git log --pretty='#{pretty}' --reverse #{start}..HEAD"
+        Actions.sh(command, log: false).chomp
+      end
+
+      def self.parse_commit(params)
+        commit_subject = params[:commit_subject].strip
+        commit_body = params[:commit_body]
+        releases = params[:releases]
+        codepush_friendly = params[:codepush_friendly]
+        pattern = /^(docs|fix|feat|chore|style|refactor|perf|test)(\((.*)\))?(!?)\: (.*)/
+        breaking_change_pattern = /BREAKING CHANGES?: (.*)/
+        codepush_pattern = /codepush?: (.*)/
+
+        matched = commit_subject.match(pattern)
+        result = {
+          is_valid: false,
+          subject: commit_subject,
+          is_merge: !(commit_subject =~ /^Merge/).nil?,
+          type: 'no_type'
+        }
+
+        unless matched.nil?
+          type = matched[1]
+          scope = matched[3]
+
+          result[:is_valid] = true
+          result[:type] = type
+          result[:scope] = scope
+          result[:has_exclamation_mark] = matched[4] == '!'
+          result[:subject] = matched[5]
+
+          unless releases.nil?
+            result[:release] = releases[type.to_sym]
+          end
+          unless codepush_friendly.nil?
+            result[:is_codepush_friendly] = codepush_friendly.include?(type)
+          end
+
+          unless commit_body.nil?
+            breaking_change_matched = commit_body.match(breaking_change_pattern)
+            codepush_matched = commit_body.match(codepush_pattern)
+
+            unless breaking_change_matched.nil?
+              result[:is_breaking_change] = true
+              result[:breaking_change] = breaking_change_matched[1]
+            end
+            unless codepush_matched.nil?
+              result[:is_codepush_friendly] = codepush_matched[1] == 'ok'
+            end
+          end
+        end
+
+        result
+      end
+
+      def self.semver_gt(first, second)
+        first_major = (first.split('.')[0] || 0).to_i
+        first_minor = (first.split('.')[1] || 0).to_i
+        first_patch = (first.split('.')[2] || 0).to_i
+
+        second_major = (second.split('.')[0] || 0).to_i
+        second_minor = (second.split('.')[1] || 0).to_i
+        second_patch = (second.split('.')[2] || 0).to_i
+
+        # Check if next version is higher then last version
+        if first_major > second_major
+          return true
+        elsif first_major == second_major
+          if first_minor > second_minor
+            return true
+          elsif first_minor == second_minor
+            if first_patch > second_patch
+              return true
+            end
+          end
+        end
+
+        return false
+      end
+
+      def self.semver_lt(first, second)
+        return !semver_gt(first, second)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a fully functional unstable release pipeline. 
Stable still needs some minor tweaks that will be added in a later PR.

I have tested this extensively using a private clone of amplify-ios and a private spec repo. Happy to grant anyone access to these if they want to try it out before merging.

I will create a Quip doc detailing the process. 

Here's an overview:

* When a PR is merged into master the pipeline will release it to CocoaPods trunk under an `unstable` prerelease tag that conforms to https://semver.org/#spec-item-9

* Once deployed, customers will be able to install the latest unstable version by specifying e.g. `pod 'Amplify', '~> 0.9.1-unstable'` in their Podfile

* Versioning example: if the latest "stable" tag is `0.9.0`, the next prerelease will be `0.9.1-unstable.0`, followed by `0.9.1-unstable.1`. The following "stable" version will be `0.9.1` or `0.10.0` or `1.0.0` depending on the analysis of commit messages using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec.

* If Conventional Commits are not followed, version is bumped to patch by default

* The pipeline uses [fastlane](https://fastlane.tools/) to automate versioning and releasing pods to CocoaPods Trunk. Utilizing a combination of built-in fastlane actions and custom functionality.

* Each version creates a corresponding git tag. This is necessary for CocoaPods to be able to reference the source code. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
