### PR TITLE
Adding amplify specific user agent, revival of PR#166 (271)

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -98,6 +98,8 @@
 		2CFB61C7E80D065C0A885A2F /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsTestCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5363CAF9EFAA822FED56808 /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsTestCommon.framework */; };
 		3263D332138415AF42E64FF7 /* Pods_AmplifyTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC7F1C368154B364CB74742 /* Pods_AmplifyTestApp.framework */; };
 		6BB7441023A9954900B0EB6C /* DispatchSource+MakeOneOff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB7440F23A9954900B0EB6C /* DispatchSource+MakeOneOff.swift */; };
+		6BBECD7123ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BBECD7023ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift */; };
+		6BBECD7423ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BBECD7323ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift */; };
 		7D5ED6C78E25246DDAF2F2EC /* Pods_Amplify.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84F3A76FB68CEFA45F4BB1BB /* Pods_Amplify.framework */; platformFilter = ios; };
 		7F27B1DCE59C1E674172CCD6 /* Pods_Amplify_AmplifyTestConfigs_AmplifyTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 976D972EC2BBCAAD023694EB /* Pods_Amplify_AmplifyTestConfigs_AmplifyTests.framework */; };
 		881246F5DCC59436DC932469 /* Pods_Amplify_AWSPluginsCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35D92182B8445C8F9B0FAE94 /* Pods_Amplify_AWSPluginsCore.framework */; };
@@ -652,6 +654,8 @@
 		6AF0E4775809F0866F9C44D9 /* Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig"; path = "Target Support Files/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6BAC32194A15ACB56F07DC87 /* Pods-AWSS3StoragePlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSS3StoragePlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSS3StoragePlugin/Pods-AWSS3StoragePlugin.debug.xcconfig"; sourceTree = "<group>"; };
 		6BB7440F23A9954900B0EB6C /* DispatchSource+MakeOneOff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchSource+MakeOneOff.swift"; sourceTree = "<group>"; };
+		6BBECD7023ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplifyAWSServiceConfiguration.swift; sourceTree = "<group>"; };
+		6BBECD7323ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplifyAWSServiceConfigurationTests.swift; sourceTree = "<group>"; };
 		6C41D3730B7ED4FD62A43E40 /* Pods-Amplify-AmplifyAWSPlugins-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AmplifyAWSPlugins-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AmplifyAWSPlugins-AWSAPICategoryPlugin-AWSAPICategoryPluginTests/Pods-Amplify-AmplifyAWSPlugins-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6D51240C78418B733FFA6829 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSDataStoreCategoryPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSDataStoreCategoryPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSDataStoreCategoryPluginTests/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSDataStoreCategoryPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6D62C9C57736C3BEADEB1E30 /* Pods-AWSPinpointAnalyticsPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSPinpointAnalyticsPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSPinpointAnalyticsPlugin/Pods-AWSPinpointAnalyticsPlugin.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1510,6 +1514,22 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		6BBECD6F23ADA7C100C8DFBE /* ServiceConfiguration */ = {
+			isa = PBXGroup;
+			children = (
+				6BBECD7023ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift */,
+			);
+			path = ServiceConfiguration;
+			sourceTree = "<group>";
+		};
+		6BBECD7223ADA9B400C8DFBE /* ServiceConfiguration */ = {
+			isa = PBXGroup;
+			children = (
+				6BBECD7323ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift */,
+			);
+			path = ServiceConfiguration;
+			sourceTree = "<group>";
+		};
 		95DAAB00237E63370028544F /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -1859,6 +1879,7 @@
 				FA131AAD2360FE070008381C /* Info.plist */,
 				FA131ACB2360FE470008381C /* Auth */,
 				2129BE0223947FA3006363A1 /* Model */,
+				6BBECD6F23ADA7C100C8DFBE /* ServiceConfiguration */,
 				2129BE3F23948909006363A1 /* Sync */,
 			);
 			path = AWSPluginsCore;
@@ -1870,6 +1891,7 @@
 				FA131ABB2360FE070008381C /* Info.plist */,
 				2129BE2223948085006363A1 /* Model */,
 				2129BE4523948975006363A1 /* Sync */,
+				6BBECD7223ADA9B400C8DFBE /* ServiceConfiguration */,
 			);
 			path = AWSPluginsCoreTests;
 			sourceTree = "<group>";
@@ -3368,6 +3390,7 @@
 				21420A97237222A900FA140C /* IAMCredentialProvider.swift in Sources */,
 				21F40A3223A160FC0074678E /* GraphQLDocument+DeleteSyncMutation.swift in Sources */,
 				21420A99237222A900FA140C /* APIKeyProvider.swift in Sources */,
+				6BBECD7123ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift in Sources */,
 				21420A90237222A900FA140C /* APIKeyConfiguration.swift in Sources */,
 				2129BE552395CAEF006363A1 /* PaginatedList.swift in Sources */,
 				2129BE212394806B006363A1 /* ModelSchema+GraphQL.swift in Sources */,
@@ -3390,6 +3413,7 @@
 				2129BE3B2394828B006363A1 /* GraphQLRequestAnyModelTests.swift in Sources */,
 				2129BE562395CAF9006363A1 /* PaginatedListTests.swift in Sources */,
 				2129BE372394828B006363A1 /* GraphQLSyncQueryTests.swift in Sources */,
+				6BBECD7423ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift in Sources */,
 				2129BE342394828B006363A1 /* GraphQLMutationTests.swift in Sources */,
 				2129BE392394828B006363A1 /* GraphQLSyncMutationTests.swift in Sources */,
 				2129BE332394828B006363A1 /* GraphQLSubscriptionTests.swift in Sources */,

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/APIKeyURLRequestInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/APIKeyURLRequestInterceptor.swift
@@ -21,7 +21,10 @@ struct APIKeyURLRequestInterceptor: URLRequestInterceptor {
         var modifiedRequest = request
         let apiKey = apiKeyProvider.getAPIKey()
         modifiedRequest.addValue(apiKey,
-                                 forHTTPHeaderField: URLRequestContants.Header.xApiKey)
+                                 forHTTPHeaderField: URLRequestConstants.Header.xApiKey)
+        modifiedRequest.setValue(AmplifyAWSServiceConfiguration.baseUserAgent(),
+                                 forHTTPHeaderField: URLRequestConstants.Header.userAgent)
+
         return modifiedRequest
     }
 

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/IAMURLRequestInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/IAMURLRequestInterceptor.swift
@@ -29,19 +29,20 @@ struct IAMURLRequestInterceptor: URLRequestInterceptor {
         guard let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
             throw APIError.unknown("Could not get mutable request", "")
         }
-
         mutableRequest.setValue(NSDate().aws_stringValue(AWSDateISO8601DateFormat2),
-                                forHTTPHeaderField: URLRequestContants.Header.xAmzDate)
-        mutableRequest.setValue(URLRequestContants.ContentType.applicationJson,
-                                forHTTPHeaderField: URLRequestContants.Header.contentType)
-        mutableRequest.setValue(URLRequestContants.UserAgent.amplify,
-                                forHTTPHeaderField: URLRequestContants.Header.userAgent)
+                                forHTTPHeaderField: URLRequestConstants.Header.xAmzDate)
+        mutableRequest.setValue(URLRequestConstants.ContentType.applicationJson,
+                                forHTTPHeaderField: URLRequestConstants.Header.contentType)
+        let serviceConfiguration = AmplifyAWSServiceConfiguration(region: region,
+                                                                  credentialsProvider: iamCredentialsProvider.getCredentialsProvider())
+        mutableRequest.setValue(serviceConfiguration.userAgent,
+                                forHTTPHeaderField: URLRequestConstants.Header.userAgent)
 
         let endpoint: AWSEndpoint
         switch endpointType {
         case .graphQL:
             endpoint = AWSEndpoint(region: region,
-                                   serviceName: URLRequestContants.appSyncServiceName,
+                                   serviceName: URLRequestConstants.appSyncServiceName,
                                    url: mutableRequest.url)
         case .rest:
             endpoint = AWSEndpoint(region: region,

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/UserPoolRequestInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/UserPoolRequestInterceptor.swift
@@ -24,13 +24,12 @@ struct UserPoolURLRequestInterceptor: URLRequestInterceptor {
         guard let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
             throw APIError.unknown("Could not get mutable request", "")
         }
-
         mutableRequest.setValue(NSDate().aws_stringValue(AWSDateISO8601DateFormat2),
-                                forHTTPHeaderField: URLRequestContants.Header.xAmzDate)
-        mutableRequest.setValue(URLRequestContants.ContentType.applicationJson,
-                                forHTTPHeaderField: URLRequestContants.Header.contentType)
-        mutableRequest.setValue(URLRequestContants.UserAgent.amplify,
-                                forHTTPHeaderField: URLRequestContants.Header.userAgent)
+                                forHTTPHeaderField: URLRequestConstants.Header.xAmzDate)
+        mutableRequest.setValue(URLRequestConstants.ContentType.applicationJson,
+                                forHTTPHeaderField: URLRequestConstants.Header.contentType)
+        mutableRequest.setValue(AmplifyAWSServiceConfiguration.baseUserAgent(),
+                                forHTTPHeaderField: URLRequestConstants.Header.userAgent)
 
         let tokenResult = userPoolTokenProvider.getToken()
         guard case let .success(token) = tokenResult else {

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Constants/URLRequestConstants.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Constants/URLRequestConstants.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 // TODO: remove this https://github.com/aws-amplify/amplify-ios/issues/75
-struct URLRequestContants {
+struct URLRequestConstants {
     static let appSyncServiceName = "appsync"
 
     struct Header {
@@ -20,9 +20,5 @@ struct URLRequestContants {
 
     struct ContentType {
         static let applicationJson = "application/json"
-    }
-
-    struct UserAgent {
-        static let amplify = "amplify-ios/0.9.0 Amplify"
     }
 }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAdapter.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAdapter.swift
@@ -9,6 +9,7 @@ import Foundation
 import Amplify
 import AWSPinpoint
 import AWSMobileClient
+import AWSPluginsCore
 
 /// Conforms to `AWSPinpointBehavior` by storing an instance of the `AWSPinpoint` to expose AWS Pinpoint functionality
 class AWSPinpointAdapter: AWSPinpointBehavior {
@@ -22,22 +23,10 @@ class AWSPinpointAdapter: AWSPinpointBehavior {
                      cognitoCredentialsProvider: AWSCognitoCredentialsProvider) throws {
 
         let pinpointConfiguration = AWSPinpointConfiguration(appId: pinpointAnalyticsAppId, launchOptions: nil)
-
-        guard let serviceConfiguration = AWSServiceConfiguration(region: pinpointAnalyticsRegion,
-                                                                 credentialsProvider: cognitoCredentialsProvider) else {
-            throw PluginError.pluginConfigurationError(
-                AnalyticsPluginErrorConstant.pinpointAnalyticsServiceConfigurationError.errorDescription,
-                AnalyticsPluginErrorConstant.pinpointAnalyticsServiceConfigurationError.recoverySuggestion)
-        }
-
-        guard let targetingServiceConfiguration =
-            AWSServiceConfiguration(region: pinpointTargetingRegion,
-                                    credentialsProvider: cognitoCredentialsProvider) else {
-
-            throw PluginError.pluginConfigurationError(
-                AnalyticsPluginErrorConstant.pinpointTargetingServiceConfigurationError.errorDescription,
-                AnalyticsPluginErrorConstant.pinpointTargetingServiceConfigurationError.recoverySuggestion)
-        }
+        let serviceConfiguration = AmplifyAWSServiceConfiguration(region: pinpointAnalyticsRegion,
+                                                                  credentialsProvider: cognitoCredentialsProvider)
+        let targetingServiceConfiguration = AmplifyAWSServiceConfiguration(region: pinpointTargetingRegion,
+                                                                           credentialsProvider: cognitoCredentialsProvider)
 
         pinpointConfiguration.serviceConfiguration = serviceConfiguration
         pinpointConfiguration.targetingServiceConfiguration = targetingServiceConfiguration

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -1,0 +1,39 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import AWSCore
+
+public class AmplifyAWSServiceConfiguration: AWSServiceConfiguration {
+    override public class func baseUserAgent() -> String! {
+        //TODO: Retrieve this version from a centralized location:
+        //https://github.com/aws-amplify/amplify-ios/issues/276
+        let version = "0.9.0"
+        let sdkName = "amplify-iOS"
+        let systemName = UIDevice.current.systemName.replacingOccurrences(of: " ", with: "-")
+        let systemVersion = UIDevice.current.systemVersion
+        let localeIdentifier = Locale.current.identifier
+        return "\(sdkName)/\(version) \(systemName)/\(systemVersion) \(localeIdentifier)"
+    }
+
+    override public var userAgent: String {
+        return AmplifyAWSServiceConfiguration.baseUserAgent()
+    }
+
+    override public func copy(with zone: NSZone? = nil) -> Any {
+        return super.copy(with: zone)
+    }
+
+    override init() {
+        super.init(region: .Unknown, credentialsProvider: nil)
+    }
+
+    override public init(region regionType: AWSRegionType,
+                         credentialsProvider: AWSCredentialsProvider) {
+        super.init(region: regionType, credentialsProvider: credentialsProvider)
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
@@ -1,0 +1,29 @@
+//
+// Copyright 2018-2019 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import AWSPluginsCore
+
+class AmplifyAWSServiceConfigurationTests: XCTestCase {
+    let credentialProvider = AWSAuthService().getCognitoCredentialsProvider()
+    func testInstantiation() {
+        let currentSystemName = UIDevice.current.systemName.replacingOccurrences(of: " ", with: "-")
+        let currentSystemVersion = UIDevice.current.systemVersion
+        let expectedLocale = Locale.current.identifier
+        let expectedSystem = "\(currentSystemName)/\(currentSystemVersion)"
+
+        let configuration = AmplifyAWSServiceConfiguration(region: .USEast1,
+                                                           credentialsProvider: credentialProvider)
+
+        XCTAssertNotNil(configuration.userAgent)
+        let userAgentParts = configuration.userAgent.components(separatedBy: " ")
+        XCTAssertEqual(3, userAgentParts.count)
+        XCTAssert(userAgentParts[0].starts(with: "amplify-iOS/"))
+        XCTAssertEqual(expectedSystem, userAgentParts[1])
+        XCTAssertEqual(expectedLocale, userAgentParts[2])
+    }
+}

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin+Configure.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin+Configure.swift
@@ -32,8 +32,8 @@ extension AWSPredictionsPlugin {
                                                                 from: configurationData)
         let authService = AWSAuthService()
         let cognitoCredentialsProvider = authService.getCognitoCredentialsProvider()
-        let coremlService = try CoreMLPredictionService(config: configuration)
-        let predictionsService = try AWSPredictionsService(config: predictionsConfiguration,
+        let coremlService = try CoreMLPredictionService(configuration: configuration)
+        let predictionsService = try AWSPredictionsService(configuration: predictionsConfiguration,
                                                            cognitoCredentialsProvider: cognitoCredentialsProvider,
                                                            identifier: key)
         configure(predictionsService: predictionsService,

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/CoreML/CoreMLPredictionService.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/CoreML/CoreMLPredictionService.swift
@@ -13,9 +13,9 @@ class CoreMLPredictionService: CoreMLPredictionBehavior {
 
     let coreMLPlugin: CoreMLPredictionsPlugin
 
-    init(config: Any) throws {
+    init(configuration: Any) throws {
         self.coreMLPlugin = CoreMLPredictionsPlugin()
-        try coreMLPlugin.configure(using: config)
+        try coreMLPlugin.configure(using: configuration)
     }
 
     func comprehend(text: String, onEvent: @escaping InterpretTextEventHandler) {

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceComprehendTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceComprehendTests.swift
@@ -32,7 +32,7 @@ class PredictionsServiceComprehendTests: XCTestCase {
                                                        awsTextract: MockTextractBehavior(),
                                                        awsComprehend: mockComprehend,
                                                        awsPolly: MockPollyBehavior(),
-                                                       config: mockConfiguration)
+                                                       configuration: mockConfiguration)
         } catch {
             XCTFail("Initialization of the text failed")
         }

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceRekognitionTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceRekognitionTests.swift
@@ -53,7 +53,7 @@ class PredictionsServiceRekognitionTests: XCTestCase {
                                                        awsTextract: MockTextractBehavior(),
                                                        awsComprehend: MockComprehendBehavior(),
                                                        awsPolly: MockPollyBehavior(),
-                                                       config: mockConfiguration)
+                                                       configuration: mockConfiguration)
         } catch {
             print(error)
             XCTFail("Initialization of the text failed")

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceTextractTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceTextractTests.swift
@@ -31,7 +31,7 @@ class PredictionsServiceTextractTests: XCTest {
                                                        awsTextract: mockTextract,
                                                        awsComprehend: MockComprehendBehavior(),
                                                        awsPolly: MockPollyBehavior(),
-                                                       config: mockConfiguration)
+                                                       configuration: mockConfiguration)
         } catch {
             XCTFail("Initialization of the text failed")
         }

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceTranslateTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceTranslateTests.swift
@@ -30,7 +30,7 @@ class PredictionsServiceTranslateTests: XCTestCase {
                                                        awsTextract: MockTextractBehavior(),
                                                        awsComprehend: MockComprehendBehavior(),
                                                        awsPolly: MockPollyBehavior(),
-                                                       config: mockConfiguration)
+                                                       configuration: mockConfiguration)
         } catch {
             XCTFail("Initialization of the text failed")
         }
@@ -122,7 +122,7 @@ class PredictionsServiceTranslateTests: XCTestCase {
                                             awsTextract: MockTextractBehavior(),
                                             awsComprehend: MockComprehendBehavior(),
                                             awsPolly: MockPollyBehavior(),
-                                            config: mockConfiguration)
+                                            configuration: mockConfiguration)
         } catch {
             XCTFail("Initialization of the text failed. \(error)")
         }

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
@@ -9,6 +9,7 @@ import Foundation
 import AWSS3
 import Amplify
 import AWSMobileClient
+import AWSPluginsCore
 
 class AWSS3StorageService: AWSS3StorageServiceBehaviour {
 
@@ -22,14 +23,8 @@ class AWSS3StorageService: AWSS3StorageServiceBehaviour {
                      bucket: String,
                      cognitoCredentialsProvider: AWSCognitoCredentialsProvider,
                      identifier: String) throws {
-        let serviceConfigurationOptional = AWSServiceConfiguration(region: region,
-                                                                   credentialsProvider: cognitoCredentialsProvider)
-
-        guard let serviceConfiguration = serviceConfigurationOptional else {
-            throw PluginError.pluginConfigurationError(
-                PluginErrorConstants.serviceConfigurationInitializationError.errorDescription,
-                PluginErrorConstants.serviceConfigurationInitializationError.recoverySuggestion)
-        }
+        let serviceConfiguration = AmplifyAWSServiceConfiguration(region: region,
+                                                                  credentialsProvider: cognitoCredentialsProvider)
 
         AWSS3TransferUtility.register(with: serviceConfiguration, forKey: identifier)
         AWSS3PreSignedURLBuilder.register(with: serviceConfiguration, forKey: identifier)

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,7 +23,7 @@ DEPENDENCIES:
   - SwiftLint
 
 SPEC REPOS:
-  https://cdn.cocoapods.org/:
+  trunk:
     - AWSAuthCore
     - AWSCognitoIdentityProvider
     - AWSCognitoIdentityProviderASF

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -23,7 +23,7 @@ DEPENDENCIES:
   - SwiftLint
 
 SPEC REPOS:
-  https://cdn.cocoapods.org/:
+  trunk:
     - AWSAuthCore
     - AWSCognitoIdentityProvider
     - AWSCognitoIdentityProviderASF

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -28,290 +28,296 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		004DE85F3AE8FFE0816925652FFFBB75 /* AWSCognitoCredentialsProvider+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 953E533AB3626686BC0DCFEE4DCDBCC9 /* AWSCognitoCredentialsProvider+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		00F52188FE076B3977A110330D3A48C7 /* AWSCognitoIdentityProviderResources.h in Headers */ = {isa = PBXBuildFile; fileRef = 77BAFF4FE895704E891DA828C3F2CA60 /* AWSCognitoIdentityProviderResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		01A5950E9EFD7E3A5B723870607D30BA /* AWSService.h in Headers */ = {isa = PBXBuildFile; fileRef = 760FEF898396FB1D507B4561369EC431 /* AWSService.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		02AB04EAA02008DCACB322A63238278A /* AWSCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = B0C4B1EB0A6EE847AB190230311FEDD2 /* AWSCategory.m */; };
-		0500B5952A472F8A25D1B1FC9347F745 /* AWSAuthCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C49CC694143B932ACAEDAB2B998DE32A /* AWSAuthCore.framework */; };
-		067065D83D1701E8457EFF708593E7CF /* AWSDDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = F6F2FC19E23CBF1C81BE3432A3164D83 /* AWSDDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		06FCF9F78279F32E1AD8A412C1C22847 /* AWSDDOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = AFB26DF1FE16A5A49EE8FE0638EDE5C8 /* AWSDDOSLogger.m */; };
-		07B59E01154974D12F41F89734C12541 /* AWSSTS.h in Headers */ = {isa = PBXBuildFile; fileRef = 989EDB692EAD309BA42690776AF9415E /* AWSSTS.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		07E00EE1AEB8DB9013DC357339E01573 /* AWSJKBigInteger.h in Headers */ = {isa = PBXBuildFile; fileRef = CEBD24D90E4FFBE94B3CE017E20BBC63 /* AWSJKBigInteger.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		0987A78DE6F0F75CAFBE9B683D640A02 /* JSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D51F01A2CCD2C6FB8821C4F7CC4507 /* JSONHelper.swift */; };
-		09D0000737838FD4D8234BBE7B52BCE7 /* AWSMTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 97E93588591EFDC4639A147B175BCCDD /* AWSMTLJSONAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		00245045D5E45577751253E413EB5A41 /* AWSCancellationToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B78D374D0A051D9C447BCFAE475F4E2 /* AWSCancellationToken.m */; };
+		00F52188FE076B3977A110330D3A48C7 /* AWSCognitoIdentityProviderResources.h in Headers */ = {isa = PBXBuildFile; fileRef = FABA1EBEF087305EAED9649E53354E5E /* AWSCognitoIdentityProviderResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		014D5B8A4928C9A387534875206E8AFE /* AWSDDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = F512671A8CA89ACEF7575B062F6AD0DC /* AWSDDASLLogCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		016F99722715BF88A9636B87434EA4F8 /* AWSSignature.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C401F43F3647CFB1A04369928781E0E /* AWSSignature.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		06286FFF5F9A837D882033756A51BA6F /* AWSCognitoCredentialsProvider+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = B785B0927F487DA24F8777BAA7C3FD3E /* AWSCognitoCredentialsProvider+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		06920E9A30F8C694426F31326AEC669F /* AWSDDOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 0831B18334CCA361EBE774FCE1C79065 /* AWSDDOSLogger.m */; };
+		07C22CB8F0D5D1D155E99E7FAA03E922 /* AWSSTSService.h in Headers */ = {isa = PBXBuildFile; fileRef = 009CACF5738D03F5B64F3EF3C99FB61E /* AWSSTSService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		07E00EE1AEB8DB9013DC357339E01573 /* AWSJKBigInteger.h in Headers */ = {isa = PBXBuildFile; fileRef = CEAA8CF19472EC4ACF9D738F775FC832 /* AWSJKBigInteger.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		080A963CA88B480650FFE9DA4C1FB652 /* AWSCognitoAuth_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 57E610DB1C9834B93B86B32AE203D34B /* AWSCognitoAuth_Internal.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		090E87DED2A7E745AB4B80D9D40A3B0F /* Fabric+FABKits.h in Headers */ = {isa = PBXBuildFile; fileRef = ACCDDF8A621C80784B35192C5C55D9ED /* Fabric+FABKits.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0B2EFA3514269B1827188E84004105AD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
 		0BE7171684CA5D10C9831EC4DFF28406 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		0CE4D459B21390FBAA64FDB4213E6FAB /* AWSMTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F400E46236066397175BEF33AB11D46 /* AWSMTLModel+NSCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0D9F55C573A165D3B7437DEE8F91BFFD /* AWSXMLDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B3F626DDF47B7A62A8143255FA2E51A /* AWSXMLDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0DA5E07E1BA323EEA73D7E1675363EA2 /* AWSCognitoIdentityUserPool.h in Headers */ = {isa = PBXBuildFile; fileRef = 66EE313AB25CB9F796B40540A13890D7 /* AWSCognitoIdentityUserPool.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0E8089A141DC626BC0673739E4005994 /* AWSCognitoAuthUICKeyChainStore.h in Headers */ = {isa = PBXBuildFile; fileRef = B225D9D4836594D19B6CBD2FF5D85D31 /* AWSCognitoAuthUICKeyChainStore.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		0E8BDDEF31A17BB3E2D73F7A6812E1C1 /* AWSCognitoIdentity+Fabric.m in Sources */ = {isa = PBXBuildFile; fileRef = 65BB125D267BA4B1D4FA8A28C9727E9F /* AWSCognitoIdentity+Fabric.m */; };
-		0F5FE030071823DFE9F130C40B19BEC0 /* AWSIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A4364EE7C5AC1D626C2EC5F6473A9A7 /* AWSIdentityProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F7ABBD637E331A9CA9F514904C5EF64 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7829B6EBCFB30A013745B15EA9035B94 /* CwlCatchBadInstruction.swift */; };
-		0F8A8555DB78C4DCE2A50E397F9B292F /* AWSAuthCore-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 79641B7E0DED5BBD74610BDBF3C5B665 /* AWSAuthCore-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0FDB6FCA2363C99C65277783725A2856 /* AWSMTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = A7744B1868C57C4A60A47A7ED5DD0800 /* AWSMTLValueTransformer.m */; };
-		1228FA123FF29FBB8C673ABB8693B9B5 /* AWSNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = A4CEFBF2F47127AB8796BFEB091E3927 /* AWSNetworking.m */; };
-		13E1E9094F5329494002200340B1AF65 /* NSData+AWSCognitoIdentityProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = B7614A9E198573F33364E08A44D191A2 /* NSData+AWSCognitoIdentityProvider.m */; };
-		1443F4986172D7C166827E3E8CDAA21D /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847C7997045CF6766083BAB662053174 /* CwlDarwinDefinitions.swift */; };
-		164E856DD6E9D75266BD63DBE756E8D5 /* AWSCognitoIdentity+Fabric.h in Headers */ = {isa = PBXBuildFile; fileRef = 023B6B51414D71AD0293B95B3B78DBB1 /* AWSCognitoIdentity+Fabric.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		165E2ECAD0CBD103023BCA5CC87D3EE3 /* NSObject+AWSMTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DA59FBF1D71A43520DFAEECD69EC2AB /* NSObject+AWSMTLComparisonAdditions.m */; };
-		171EDC862D3E1A2CB45F12DE4BEBE706 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
+		0D975819F09C9DCD588638EC7D2C3C91 /* AWSIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = ED595581B874044815E93AAC0D4FB3A4 /* AWSIdentityProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0DA5E07E1BA323EEA73D7E1675363EA2 /* AWSCognitoIdentityUserPool.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B5D74163C65BA45F129C2F75A244A26 /* AWSCognitoIdentityUserPool.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0DC60DC3F6A7EDA73648721C422359A7 /* AWSCognitoAuth+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = AFE6CA3E54E94B93879D0415A2FA535C /* AWSCognitoAuth+Extensions.m */; };
+		0F7ABBD637E331A9CA9F514904C5EF64 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983EDE1A47AA1B93CFCC5C3B7E1E5678 /* CwlCatchBadInstruction.swift */; };
+		1060FCAC1ACCA3BA3F7B2B266177E21D /* AWSDDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 1853077C437335F8E40E76858B148CE5 /* AWSDDLog.m */; };
+		11D1DF9ADBCB93C6643F9C14E8E5ABF6 /* AWSCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 99B54D708FFA50347BEFA9AD8730A8AA /* AWSCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		11E98BE334C469A1C9694F6891B2119D /* AWSDDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 98015366A1F6CDB77D29D5B2458E7056 /* AWSDDDispatchQueueLogFormatter.m */; };
+		121B62241BE1752EA25A5BA6E017616A /* AWSFMDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = F3CB9777F44C0BDB4C2F7226731D7A17 /* AWSFMDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		13603B0B004ADA8FA4C6A29F8C255F00 /* AWSEXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = D30FB1471BD4A7F0CE23217C25A286D6 /* AWSEXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		13E1E9094F5329494002200340B1AF65 /* NSData+AWSCognitoIdentityProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F45A88D28CED0D57D7F1D7138D0CDFF /* NSData+AWSCognitoIdentityProvider.m */; };
+		1443F4986172D7C166827E3E8CDAA21D /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76183A993DAA4D030DEB79B1EE231C3C /* CwlDarwinDefinitions.swift */; };
+		14BB10E6F64439F078229540A0807EE6 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8DB7849FE18394F4C1421ABE0CEA2E /* Security.framework */; };
+		15558E6E6B5B340AE9A56594910085DC /* AWSCancellationTokenRegistration.m in Sources */ = {isa = PBXBuildFile; fileRef = 281AC237A5385219FDCE6717E9C69709 /* AWSCancellationTokenRegistration.m */; };
 		176EE1FC318E9CD5AA1E79B1A79070D7 /* CwlCatchException.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E95AAB996428D7874DB2E4B93260F35 /* CwlCatchException.framework */; };
-		177AF0BB8CCB1E9F6E3B59C63653D6BF /* AWSNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 18D74676CDF8DA9E34ACD1D1FB077F8D /* AWSNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1826140B28141D15526A6496F027EEA2 /* AWSServiceEnum.h in Headers */ = {isa = PBXBuildFile; fileRef = 887EDB2AF4A6615AB0046559981DDC4A /* AWSServiceEnum.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1912D9BBE939D40B7F1D5D5006671F32 /* AWSCognitoIdentityProvider-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 998EE64602226D70380E0CEB420DE53C /* AWSCognitoIdentityProvider-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		19CE9907C75259C041A78F894689E189 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = C668F5F5F1FCA13477AEA34A9A87FB75 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1A02B3201A7036F4A28FD76E097B654B /* AWSBolts.m in Sources */ = {isa = PBXBuildFile; fileRef = 954C6F2887E29DB41520A7D369558C27 /* AWSBolts.m */; };
-		1B792DF647AA6A2BE2F0DCF2706ED403 /* AWSSTSService.h in Headers */ = {isa = PBXBuildFile; fileRef = 302410B8A963352D5D9582F1052A757E /* AWSSTSService.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1BB794FB213EC4CA73B3C8BC4D05C3A5 /* CwlCatchException-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CF91665F677AFEFDDEBA8528174E0846 /* CwlCatchException-dummy.m */; };
-		1C3989F261B6DEB7427157E58FFAF18E /* AWSCognitoIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 09CF2AF892B02F271301BDC969A95E14 /* AWSCognitoIdentityProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1CFD278435B7BB1D3F2F37EEB5B75E23 /* AWSSignature.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A78B2CC4203D1B81AC6F03B00947583 /* AWSSignature.m */; };
-		1D9A5130624A73FF361E1E21F4FD6EFC /* AWSURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 2331E13421EDE769751BEB53A865341B /* AWSURLResponseSerialization.m */; };
-		1DF599F2B8BF8C21CC90E0EBC96FEA09 /* AWSGeneric.h in Headers */ = {isa = PBXBuildFile; fileRef = 619965D8A2E8B9EBD1D1D6AD46124CF8 /* AWSGeneric.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1E650874FB9DB87F5841D5B9A2F316C9 /* AWSSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = C1B8B4FEACAF1420B0B96475BE90AD87 /* AWSSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1FEDF05177016B30BEE6388DE35BCDE8 /* AWSDDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = E93B01FE03FA51348290E064579C896C /* AWSDDTTYLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		204CE0D1375D7D27DB6707826EE0BB17 /* AWSTMDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 6ADEE001834A1EB63E83AD9FF5E2E657 /* AWSTMDiskCache.m */; };
-		20B984C335C8FC46AB2E1F2EE8804028 /* AWSDDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 550678CEB07A27206F9F706AC35ECB8E /* AWSDDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		189C52695A137B58704DF3C5BD57BCA7 /* AWSDDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E02F91D7B07EC8FC39A4CAF40D39746 /* AWSDDTTYLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1912D9BBE939D40B7F1D5D5006671F32 /* AWSCognitoIdentityProvider-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 82AE0D4FE2C5DA296BA6072367A2F9F6 /* AWSCognitoIdentityProvider-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1A39D1693474EB62977EF09A9433600E /* AWSTaskCompletionSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 30642F131CF85895AB20D4764112A7B1 /* AWSTaskCompletionSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1B3F193F03EA731E027EB54639B9AFAE /* AWSDDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A425EA2780C3972162FA364B8134591 /* AWSDDLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1B4699D8D8A9FA361461FA0918FB1BBD /* AWSDDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 076B6FA2F32A84341788F1C2E42A79CA /* AWSDDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1B607F8C305C2DDE2170D517993A0542 /* AWSClientContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 11981CE8441163483F737D85DE32B1CE /* AWSClientContext.m */; };
+		1BB794FB213EC4CA73B3C8BC4D05C3A5 /* CwlCatchException-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FFCB4AAE367BAD78D9C6A46083E63014 /* CwlCatchException-dummy.m */; };
+		1C3989F261B6DEB7427157E58FFAF18E /* AWSCognitoIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = DADB698FF6F0FE317C721CB8277E3306 /* AWSCognitoIdentityProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1C458B6D3529A73474CA7ED48C718CEA /* AWSIdentityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 3844849C30D28B47FF9C3DD61529455D /* AWSIdentityManager.m */; };
+		1CEC54C8680C61BAE07A09608EE075A1 /* AWSDDOSLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 745068DD32DDB8617322A32B3A678DDD /* AWSDDOSLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		20D58851C6F80D8EC03E236B6066D2E4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		20F5B6668A2D5C62774918E1554E7B1D /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B74700571E45B4B8084C2CF6DC7122A /* CwlBadInstructionException.swift */; };
-		2145910BF9E8293B01895487859507A7 /* tommath.c in Sources */ = {isa = PBXBuildFile; fileRef = 6D6EE3BB562D22B7BDBB0E108ACA5649 /* tommath.c */; };
-		21603C2FBCE8E5F81B367775FEC1CC3B /* AWSCognitoAuth.m in Sources */ = {isa = PBXBuildFile; fileRef = 330803FE2581778D386F729BF4845395 /* AWSCognitoAuth.m */; };
-		219CB19925CD761730E5AFC746D07A33 /* AWSKSReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 27FD7CAF337CC5B059781204CD63D3F8 /* AWSKSReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		224E2C74968842E2CB20C0E708373B39 /* AWSCognitoIdentityProviderModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E1EE4E86046CCC1C42AD5EFC671D6A3 /* AWSCognitoIdentityProviderModel.m */; };
-		236F8B8D6AC456B756907BB2304A845C /* AWSCognitoIdentityModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DE0E318F8B727F880BE50269334A1FB /* AWSCognitoIdentityModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		20DE217DA9E41A2BFD1E4A71C564929B /* AWSSTSResources.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A3B34FAA9B84A5377B2D5C709DA6B92 /* AWSSTSResources.m */; };
+		20F5B6668A2D5C62774918E1554E7B1D /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B52AFD8824D96B30C353421A67E04F /* CwlBadInstructionException.swift */; };
+		2145910BF9E8293B01895487859507A7 /* tommath.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F18885B0C226C01535E4BC473565790 /* tommath.c */; };
+		221795EAC91598916CB8F66DAEEB2AE1 /* AWSCognitoIdentityModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E57BA4A95EE17DEB99ECB5EBFC44EA9 /* AWSCognitoIdentityModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		224E2C74968842E2CB20C0E708373B39 /* AWSCognitoIdentityProviderModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 557CB74CF255046C393A564440AE135F /* AWSCognitoIdentityProviderModel.m */; };
 		23B8ECAE96DAB3886CCE1CE90B8277F9 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 03D039338D77A6CA524CBC57DE6E2BCF /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-dummy.m */; };
-		248189324987696703F2538E3505E96E /* FABKitProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D63B32CF1F9ED5B8E6C8305468A8484 /* FABKitProtocol.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		253D4842116A87463AE2FE2E6F22C11E /* AWSMobileOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAA1591C171FABA209F8DD8CBDD9474 /* AWSMobileOptions.swift */; };
-		2663B6509C0E948A2AB8F026F958C991 /* AWSEXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = A8408C93D1D7483BF3AF2267895FB47A /* AWSEXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		2777406E199904C8BA33A1B3D608EE75 /* AWSMobileClientUserDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD4A5C49B68FFDF313E84752A7A8C833 /* AWSMobileClientUserDetails.swift */; };
-		283D6D2E0D6D3C28C6111AE57D50F9DC /* AWSDDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = BCE30B479D2F9EEE3D3AC4ECDC256CD2 /* AWSDDDispatchQueueLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2918ACDE197F4019785CDAAD6EE91694 /* AWSDDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 00A9F9D487F770ACF4AE33F74AB275D3 /* AWSDDLog.m */; };
-		29A30DF1ED433FF2CF086D2CD5FDE391 /* aws_tommath_superclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C05D3E8BB489B73FDF8C5A2F0993DC1 /* aws_tommath_superclass.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		2A306E0FAEC68DCFD212A47F58E4C992 /* AWSMobileResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AB238158A3FCE734364EDE3C8F998A /* AWSMobileResults.swift */; };
-		2A87B8AEB95293084FE0C7EBC1232791 /* AWSCancellationToken.m in Sources */ = {isa = PBXBuildFile; fileRef = E7B6AAB2A324861F81A30FFE86E53DF5 /* AWSCancellationToken.m */; };
-		2AAB30EBA4663ED5F7D8753356C26F2E /* AWSDDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = EDAF6B48646B5CF2EC92CB5195E0F966 /* AWSDDFileLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2B798A8D55F738CB910A57B79A33156D /* AWSCognitoAuth+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = C21BE7FA37988912443776169E6B9145 /* AWSCognitoAuth+Extensions.m */; };
+		248507F49B3F12E442FE6AC425DD398B /* AWSIdentityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = C5C34C491A183A09D49EF0138F8202FE /* AWSIdentityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		264783C2F064A47445C5894BC568C1EB /* AWSNetworkingHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 285440696A5920B5E6B03DE8351989B8 /* AWSNetworkingHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2757F826A5D3164D7FF294C3C0D2DA44 /* AWSDDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = FF9CFC24BCA0B14493B8518376969BEC /* AWSDDFileLogger.m */; };
+		2814D4D361A4E86079D72A04F0AB30D5 /* AWSCognitoIdentityModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 91C2094C059BAFFFFBC229AC5C0F9CEF /* AWSCognitoIdentityModel.m */; };
+		292DFC7361D422AB72038DBEA947ECEC /* Fabric.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CEEBBC83FB1A93562327EAFF615AA6B /* Fabric.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		295FA629B96FCE0C14815243AF6F4DA6 /* AWSmetamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B69116025E7AE4E03FD9CB6AE7D4A79 /* AWSmetamacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		29A30DF1ED433FF2CF086D2CD5FDE391 /* aws_tommath_superclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DD919F5D40936CBB175BC18C0CC012A /* aws_tommath_superclass.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		2A45D2B2E9015B55E07DD13D43E1A197 /* AWSModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FCBEE62A3337BC2F65D83AF4E6B900F /* AWSModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A7389B92220C12253767AA85D2B23AB /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 13A27886A2A2BD9BDC18D4AA06E0BE8D /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2BCA4C45CE7BE68A677F5B3042BC4BD7 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 70EF68EF61C4587DEC5119A866265B57 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-dummy.m */; };
-		2C2E4BD9840B2B646A8FF31C7B5D221B /* AWSCognitoIdentityModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 535C83A91CC020AFB7530E10C8EEF27F /* AWSCognitoIdentityModel.m */; };
-		2C4C1A6C7BED9A111DA724CAB2AB778C /* AWSCognitoIdentityProviderASF-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0310E0B59C9259ADAB4636C5A7010C7E /* AWSCognitoIdentityProviderASF-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2D1078002F1C28A0C300A25FE1D56F6A /* AWSTMMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = E98868DF74CFC121476E71CAF5D5B917 /* AWSTMMemoryCache.m */; };
-		2D43D835AE1B1C72D2F8663693B99E55 /* AWSFMResultSet.m in Sources */ = {isa = PBXBuildFile; fileRef = CD01F6BEAD7597F2BE12DF5DEAD8EFCE /* AWSFMResultSet.m */; };
-		2D60A8250C636D5DA78E1A8214DE3E00 /* AWSMTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B50B70E9AB640910D0909A9A6D00D10 /* AWSMTLJSONAdapter.m */; };
-		2EA2267D6B555455AD9F617935CD1F16 /* AWSURLRequestRetryHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 46E25C0067451C42478D6F8D0E2D0BB4 /* AWSURLRequestRetryHandler.m */; };
-		30069C4206C76CA80F829F9E30AD8846 /* AWSFMDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 52E2C3D83CDE56B97DAB55CAA571A422 /* AWSFMDatabase.m */; };
-		30426E1360A92453C47781E08C3C6719 /* AWSCognitoAuth_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 167AA0AB77323674B63505B4C320DE54 /* AWSCognitoAuth_Internal.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		33438D6A7B769D16F1D528B0ADC783C6 /* AWSCognitoIdentityASF.h in Headers */ = {isa = PBXBuildFile; fileRef = DA1C66EA6864356E4922848C7144C4DF /* AWSCognitoIdentityASF.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		35439200B23D406C07D5161DAEB9F046 /* AWSCognitoIdentityUser_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5471E69EB7F11DB1920AFA5EFA4CFF00 /* AWSCognitoIdentityUser_Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		369225211AFC463F2090CEE05DC5A97E /* AWSTMMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 29C1909F8CEAA8A3BD1A7E3D3B2094E9 /* AWSTMMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		369BCA5193B509F7ED9C4510C0B854C4 /* _AWSMobileClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 8319645FEC9FDF368C1C182C318B5C74 /* _AWSMobileClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		37220D2A3B31AF9959B09420F265BD8B /* AWSEXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 1210644233B0F05F9A3BF152ADCAF1AF /* AWSEXTScope.m */; };
-		37CF2468721210240B585FC038355BAD /* AWSJKBigDecimal.m in Sources */ = {isa = PBXBuildFile; fileRef = FD8ABFA6F971C7126B39B12AED1B60B8 /* AWSJKBigDecimal.m */; };
-		3800CA780F69128004ED8D8477F8387A /* AWSEXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 05C3FADC70C4131D4CE2CA995C9B4732 /* AWSEXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		383EC2E1434114137D1F92B759289079 /* _AWSMobileClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 24D7C4A40FE6A6E8B9A1408D69A1312E /* _AWSMobileClient.m */; };
-		3AA24C39040281FDD5BA57C431899954 /* AWSCancellationTokenRegistration.h in Headers */ = {isa = PBXBuildFile; fileRef = BF574DD5F235DC4861034E0CA2A88D7F /* AWSCancellationTokenRegistration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2C4C1A6C7BED9A111DA724CAB2AB778C /* AWSCognitoIdentityProviderASF-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DAF63CB3927C45D2346F11705E3AFA7 /* AWSCognitoIdentityProviderASF-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D0A57953832EF83AD2FA1511820B602 /* AWSMobileClient.h in Headers */ = {isa = PBXBuildFile; fileRef = CA9BF82B9D49B3E34E31C82200838ACE /* AWSMobileClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D7804C365C5B74B4CFCE9DCDB990FDA /* AWSXMLDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 0ADFD7E42BE139F259349496AA57A0A2 /* AWSXMLDictionary.m */; };
+		3037B29B6276CF8FE3546D3E977DD84A /* AWSFMDatabasePool.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D18BB847E2E5CA341022508986C0EA8 /* AWSFMDatabasePool.m */; };
+		3140BF9E55F36B4CE5E2FAC0317FBE58 /* NSDictionary+AWSMTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 52E8B5E00968480B2775F83181520231 /* NSDictionary+AWSMTLManipulationAdditions.m */; };
+		327212D4B1210D85CEBFEE82E654D5A8 /* AWSFMDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 07ECE90907BE180F6A539BF08715EDE3 /* AWSFMDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		33438D6A7B769D16F1D528B0ADC783C6 /* AWSCognitoIdentityASF.h in Headers */ = {isa = PBXBuildFile; fileRef = EAB2EC18E32F6E2FCA424AE80D8412DB /* AWSCognitoIdentityASF.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		339FA6343AC88EB9B429322BAF8FF915 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1073C3EE5CBDD8387A3FB523E790C5CA /* SystemConfiguration.framework */; };
+		33AB80FF79E9E8922EB6414ECA6D13F4 /* AWSCognitoIdentityResources.h in Headers */ = {isa = PBXBuildFile; fileRef = B2DB7B9AA67A4C2901A501179E35FDC8 /* AWSCognitoIdentityResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34D02615F8968D64CC0F5B2F1CFB6CFD /* AWSSynchronizedMutableDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 26844A716609D618B953ADCC3477A9C2 /* AWSSynchronizedMutableDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34D0E0F7CFB4DFE1D93A31A57C6D97AD /* AWSMTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = F739532763F64777B91327F4DD6E9AB0 /* AWSMTLValueTransformer.m */; };
+		35439200B23D406C07D5161DAEB9F046 /* AWSCognitoIdentityUser_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = E7EC8830B686D3AA9F8A5EC5559D133E /* AWSCognitoIdentityUser_Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		35A9EDB5F19A0AA37CFAC061744C58A4 /* DeviceOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B1415B741EF9175334EEB8D7110C62F /* DeviceOperations.swift */; };
+		36793D105BE701C00338BDF313AB6C46 /* AWSDDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E93344537320B3C5EB8604688C8560C /* AWSDDContextFilterLogFormatter.m */; };
+		36F73E51FDF6AD36471B99E64C4A7730 /* NSObject+AWSMTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B0F9182481E43628F757BAFB64AD0B54 /* NSObject+AWSMTLComparisonAdditions.m */; };
+		37899F8A7B0ED0B72C99334BAA54CEAB /* AWSMobileClient-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A7521733F008AF096D52D74AF5F36981 /* AWSMobileClient-dummy.m */; };
+		37CF2468721210240B585FC038355BAD /* AWSJKBigDecimal.m in Sources */ = {isa = PBXBuildFile; fileRef = 85B16C1BEED6DAD6A2AB160002933CDA /* AWSJKBigDecimal.m */; };
+		37E3C990B6B94ED3A68546B534D113F7 /* AWSDDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 86BE6A81DB57EC1FEA08B44FDD69B10E /* AWSDDMultiFormatter.m */; };
+		39182F41F7B148E56863FD6A48300A15 /* AWSAuthCore-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AEEFB1F4D4875A426FBE8C5C6D76AB1 /* AWSAuthCore-dummy.m */; };
+		39678AF6674F85C354F294BE9F490B2F /* AWSExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = D3E5DF2CC49F1C2A673519ADB5D725BE /* AWSExecutor.m */; };
+		3979D282ECA583525A2099DDA11E1EBD /* AWSXMLWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = 40D3E2ACC250193E898393BB5E5B0FAD /* AWSXMLWriter.m */; };
+		3A211A601A173429FC164E21BFBD925C /* AWSCognitoIdentityResources.m in Sources */ = {isa = PBXBuildFile; fileRef = 185F0DC6368FA1D4547527B451DB8EB9 /* AWSCognitoIdentityResources.m */; };
+		3A7F8C983F3205D2586B913580D7818D /* AWSSignInManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 13F6EC075EF080997FC5EAA557A51049 /* AWSSignInManager.m */; };
+		3B0F330CAAE0F4DF8D362E5C00EF3715 /* AWSKSReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D58BF63FD36A36860F5EB44E38DD099 /* AWSKSReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3B9FFB26452B15D69C725846E481624F /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8DB7849FE18394F4C1421ABE0CEA2E /* Security.framework */; };
-		3BCC2938CD89D34C6D4CBF06C215B8A5 /* AWSMobileClient-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 71D1F9D0DBC89FD691F685E6A5AA15AE /* AWSMobileClient-dummy.m */; };
+		3C295496C91AFABA2DA6D3202C7C482B /* AWSUICKeyChainStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 73D6A1A96394F99C88C2D192F6EE2472 /* AWSUICKeyChainStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C5CF7D00A143641F05F9B6BC1C1FEB1 /* Pods-Amplify-AWSPluginsCore-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B350FFEF637C6AF934EE101CD54DCE5 /* Pods-Amplify-AWSPluginsCore-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3CA3FA796B4F76092847C7CE45C7B2B0 /* AWSCognitoIdentityProviderASF-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DDEFE9EFCE6276D0B23D56F4DCED501B /* AWSCognitoIdentityProviderASF-dummy.m */; };
-		3CD5E4A964E12AA39B1C5BF153CD3E27 /* AWSURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 29D585CE1EF74476EE6E9FC8653F1186 /* AWSURLSessionManager.m */; };
-		3D99527A2F315AB5E526327D7CE1FA8C /* AWSCancellationToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 84274CDFE4A91976E91F70B196DB5FE3 /* AWSCancellationToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3CA3FA796B4F76092847C7CE45C7B2B0 /* AWSCognitoIdentityProviderASF-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FC3DCF579216C793C1D5986A399A2417 /* AWSCognitoIdentityProviderASF-dummy.m */; };
+		3CA6B00BEC52629874A59C4425B040FF /* _AWSMobileClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 0CACEC397330066C8C398ECECCE8BD5F /* _AWSMobileClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3D20174EDA7E54ACF0B3FA03BC9BAF4F /* AWSDDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 390C1B329BDBA41B75D7590CFC85F033 /* AWSDDContextFilterLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3E7788CD8A9220F214923E66A480F5E7 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = EFD2AEC8F92F60614948319DA39DDA2C /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-dummy.m */; };
 		3EBD1DFC7072E4D27E1C6EE9BCF7A5EC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		40BE279FC7854E78878AF51B3C577357 /* AWSDDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 272846E6C6A1F75201AEF412E1F113E6 /* AWSDDDispatchQueueLogFormatter.m */; };
-		4454CCAB09AB97EC1F396D37DFF469ED /* AWSMTLReflection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AAB32D7539E8EDCE5671C5EF2B2C202 /* AWSMTLReflection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		45A742EBBE1D814917D2F4F44E48B9B7 /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = CE892E9AE80BCC61D0650AB6C6E4906B /* mach_excServer.c */; };
-		45A7F1B5826DB4453A9221390FDB4283 /* AWSSignature.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D320BB78515CC43BFB72D75526267FD /* AWSSignature.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		45C54CF80A7289E3B8EAC70A5C8CDBAE /* AWSSignInManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4ED297B820F96D037627E4109EDBEF25 /* AWSSignInManager.m */; };
-		46A2EC60005AE658F6582003385B0AEE /* NSValueTransformer+AWSMTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CE0CC5FA3F31C10F3B50A8AE74853213 /* NSValueTransformer+AWSMTLInversionAdditions.m */; };
-		47330E097ADC7F4D604B2D1E95959D17 /* AWSUIConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = CA682CBF0E44BDD635C0FBB679D6C5EC /* AWSUIConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3EE59D51700D3E008C115C34DDC73403 /* AWSDDASLLogCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = C212D282C3A3524B1011E30E0E313E1C /* AWSDDASLLogCapture.m */; };
+		41427B4C2C98D529E00FDDEEEAB32D0D /* AWSTMMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 94701E2D8BEB1ECDDF758D0719854FAF /* AWSTMMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4169B42294AE9AB96766A16B1293ED08 /* FABAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AF033D372099B17E4AD1ECEF2388C74 /* FABAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		416B3D71CD66C2F82429B252EDC0C4A7 /* AWSAuthUIHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 00ED9F12F787409584FD64E63CB00BFA /* AWSAuthUIHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		440B8ECC492853A954F9EF74E134A1A9 /* AWSEXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AB1A2F26FDFD8E1CCDB36F0FFD0FDA0 /* AWSEXTScope.m */; };
+		45036FC7C954DBE6E733CB429174B2EA /* AWSEXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 94327DFA9363831CE32D78455D699B69 /* AWSEXTScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		452B95EB46C02DE66D5E2F415EAD1F85 /* AWSCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = E128D8EF93BA4D893F0117811A205D83 /* AWSCategory.m */; };
+		45A742EBBE1D814917D2F4F44E48B9B7 /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = 8A5462580CC9DC68AF7075ACA8844031 /* mach_excServer.c */; };
+		45AFA12190BAF394C1B57536268CBD8D /* AWSSTSModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 70B3F537BC06A2190DBA5545CA3BC9D1 /* AWSSTSModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		46239FCB5AA1A9C393996E3975E4AB72 /* AWSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 115578294D5785F67A4164B425F3D299 /* AWSModel.m */; };
+		466CB5C4FE8DD7AA3EE53FE3D1E728E1 /* AWSMTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 679BE254CFCDEE26015A8539E066D54F /* AWSMTLModel+NSCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		46818E554C7902ABE93D24966BB50EE3 /* AWSAuthCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C49CC694143B932ACAEDAB2B998DE32A /* AWSAuthCore.framework */; };
+		4724A9B83CF9F3763A6C9B7AB185F780 /* AWSSignInProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 316D632308F1EFBC2C0DF047773030DF /* AWSSignInProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4746D2E0317722A3DED3470DB2DBFCD7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		4894E3D5FE3088AB3E36EF52ACE38761 /* Fabric.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E45C810F244B77A58178FD3D2B7BB80 /* Fabric.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		499E5B186AB37B5EAE9524B3F6A1543C /* AWSUICKeyChainStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 1857920E16FDBE7B45549583A1E0F961 /* AWSUICKeyChainStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		49BFAFCF8CD24786DBEE0DB525590378 /* AWSCognitoIdentityUserPool.m in Sources */ = {isa = PBXBuildFile; fileRef = 754CA60E9D4F3F509CD3D0CD69803593 /* AWSCognitoIdentityUserPool.m */; };
-		49FB3545535B5BA67CAC16F4ADEC0D39 /* CwlPreconditionTesting-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 02E17769E68C64E4ED79B645F74F2E65 /* CwlPreconditionTesting-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4A1EC2418BCB3DAF31BCF0D2E53972B7 /* AWSTaskCompletionSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 19893BD9311EEA1ED479F6A2BC5C66A1 /* AWSTaskCompletionSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4A8E2E181E0171FDE012F1B5765BD726 /* AWSGZIP.h in Headers */ = {isa = PBXBuildFile; fileRef = 0576434B9FA7F8432DB8317EFE254CE6 /* AWSGZIP.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4BDF2CD9D7938D71F3DEDE57E5A4DA20 /* AWSXMLWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = AE67B5FC8A1D844635C8C85C6836466D /* AWSXMLWriter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4851DF7728E1A4D83BEBD0259F55894A /* AWSValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = AD1FFEF90711E0EC311224E066703638 /* AWSValidation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		49BFAFCF8CD24786DBEE0DB525590378 /* AWSCognitoIdentityUserPool.m in Sources */ = {isa = PBXBuildFile; fileRef = A1163FE82E3D89D2C4D5F59685F700D0 /* AWSCognitoIdentityUserPool.m */; };
+		49FB3545535B5BA67CAC16F4ADEC0D39 /* CwlPreconditionTesting-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D7E8BDCF5CB5DF64785E0DE7EDD5371A /* CwlPreconditionTesting-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4B0A6C1C5E40CA5991F72FE870380789 /* AWSCognitoIdentityUserPool+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D3E0FBF0A1B96D9B0A1670BC8C4117E /* AWSCognitoIdentityUserPool+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CAC8656530CBAB205D1B329885B2420 /* AWSFMDB+AWSHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 38C24E5DB4B1C541A80CDFF1952C4545 /* AWSFMDB+AWSHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4D6195524E59D17144D2463C2245ACAC /* AWSGeneric.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CB773EA726322B9A2CD42FF90D4DD17 /* AWSGeneric.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4D68B5FF0FDD5D66EC75E01E4E55E881 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A7F5959C56A2F6E93DDA0D9EB3274DE /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-dummy.m */; };
-		4E12FAB55DF8FEBBECCDAAD2EEF41A6D /* AWSSTSResources.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E21FE623B6D96ED3B851CE8586FD882 /* AWSSTSResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4F775EE0184C10B66E9DCFC15493E1A3 /* AWSCognitoIdentityProviderSrpHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 2116F89D162EED1D1AF6937894DFAADE /* AWSCognitoIdentityProviderSrpHelper.m */; };
-		4FDF5A63D4580132177948D42603FB35 /* AWSCognitoIdentityProviderResources.m in Sources */ = {isa = PBXBuildFile; fileRef = EA658D78FC406AFA945D31B0D046AB03 /* AWSCognitoIdentityProviderResources.m */; };
-		500E1A7931E8A0AE6D2700B384B00653 /* NSObject+AWSMTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = AB024C083DC49727FA7E4F405892ED3A /* NSObject+AWSMTLComparisonAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		508AEBB842172D9A8A8E6F868E533147 /* AWSMobileClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1DAC56F84465C1D97C25BC1495B7607 /* AWSMobileClient.swift */; };
-		50C0FACEDA7EAF330865E3ABCF646734 /* CwlPreconditionTesting-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0276AA0305ACFA3EEB7AC9822B834C03 /* CwlPreconditionTesting-dummy.m */; };
-		51A2C93AC4E003767439629FCDB9CD03 /* AWSCognitoIdentity.h in Headers */ = {isa = PBXBuildFile; fileRef = B39F1BB26E3CFBE20F7F3FE417B47FD8 /* AWSCognitoIdentity.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4DF330318C6863C9A9457AB6A0D931AC /* AWSCognitoAuth.h in Headers */ = {isa = PBXBuildFile; fileRef = 04498D780108D3EBDF53FD76FB42D380 /* AWSCognitoAuth.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E7A6FAE1EDFAEECBB22F317BB0A5619 /* NSArray+AWSMTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C69D27D99AAF70EBC5392FB14C7B7DA /* NSArray+AWSMTLManipulationAdditions.m */; };
+		4EA7E8C75835B7707BCC449C87AE56B8 /* AWSMTLManagedObjectAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = BD6402601C3C46495B29A0B51C537439 /* AWSMTLManagedObjectAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4F775EE0184C10B66E9DCFC15493E1A3 /* AWSCognitoIdentityProviderSrpHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = C751FB32301C38302A2EC137BA70D3EC /* AWSCognitoIdentityProviderSrpHelper.m */; };
+		4FDF5A63D4580132177948D42603FB35 /* AWSCognitoIdentityProviderResources.m in Sources */ = {isa = PBXBuildFile; fileRef = DA93AD0D291E93447CCCCCEFD85708BB /* AWSCognitoIdentityProviderResources.m */; };
+		4FF58842A18EEBA4291A5A9BC8DBA9D3 /* AWSTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D2101718310C6801E3A00062C07C39C /* AWSTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		50C0FACEDA7EAF330865E3ABCF646734 /* CwlPreconditionTesting-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F14752C7AAF0C272D64F8DB9DB35D1FB /* CwlPreconditionTesting-dummy.m */; };
+		51250616CA565F13AACEBE3D53B538A9 /* AWSMobileClient-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B3AE5FD3791D0D949459393DD40CD3DF /* AWSMobileClient-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		51BB5558A79C35EFC02ED63C95726B97 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E7D5AC68E43CA3768505A58681304E1 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5296910C64F9CFF68149C484D4FCB927 /* AWSCognitoAuthUICKeyChainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = E8D2519C6A2A39EC2767637F8B899FDB /* AWSCognitoAuthUICKeyChainStore.m */; };
 		52CE898391D84D10885B9453ADF3335F /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47D46D2BEC1D90EDAE4F1B547348EEFB /* AWSCore.framework */; };
-		531404E8A2ABACA0EFACCD951A7222EE /* AWSSTSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 58C2F31559199BF7D5D53164AA6F019A /* AWSSTSModel.m */; };
-		5357D2210C2C37C547AAFB35C2685C7B /* AWSFMDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = C5492BB52A5B3D8B009B9878B5E25987 /* AWSFMDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5387F4AAAA5B69E24747A06DD2DEC19A /* AWSDDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F101994E77186A9F9F09402BFC3E1CB /* AWSDDFileLogger.m */; };
-		5440C426F9AD47F83C786597EED5074B /* AWSMobileClient-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BF16544386127F9C6E26486D1BBA0C5 /* AWSMobileClient-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		54D748980BE1085042B7CA495973F34E /* AWSDDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 22630171D3A1BBBCC8F31BCF32D10570 /* AWSDDMultiFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		551C054C3C2762ED76904044493A3649 /* AWSCognitoIdentityProviderService.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EB91CF25CF930E29224C18C6BCC4E20 /* AWSCognitoIdentityProviderService.m */; };
-		55D2EA9F7607F558A25F4E1AB80F23E8 /* AWSKSReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = CD9D5488378B8834D5DAE698D0FBE073 /* AWSKSReachability.m */; };
-		55F93CF763DD2623520A0B800B7B58D2 /* NSError+AWSMTLModelException.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D2C28D5E7E89A421341AEDF1725E85 /* NSError+AWSMTLModelException.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		569E588EB848786109C851253D8FD05F /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9000133D745E33FE1ED02390F5F7E717 /* CoreGraphics.framework */; };
-		56A4293D4326B2AD8C75AE6363CAFE6A /* AWSEXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 9869A18656334720E2709AB030CED186 /* AWSEXTScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		56DF8DBA0E60DE0E0B74FA839E59480B /* AWSMTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350CDE7B953DE51333978AFC91C00FD /* AWSMTLModel+NSCoding.m */; };
-		58BD66C69F22A39246C34EF273B1F368 /* aws_tommath.h in Headers */ = {isa = PBXBuildFile; fileRef = EAE123BA511E10D801798B996DBA65A2 /* aws_tommath.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		53BB8CAB8C037542DF1E4D61B141C140 /* AWSXMLWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = CAB31BB0CB1979BC02AE603D4C767273 /* AWSXMLWriter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		551C054C3C2762ED76904044493A3649 /* AWSCognitoIdentityProviderService.m in Sources */ = {isa = PBXBuildFile; fileRef = 27556645674390E079A50FAE1D38FFF1 /* AWSCognitoIdentityProviderService.m */; };
+		55B7F2064D84D89F672A51C07FAF3F25 /* AWSAuthCore-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B4E599012C75D7A133B5D77EB7591134 /* AWSAuthCore-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		565F48D47A3D4B7210AD3710A6D5DC31 /* AWSDDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FB6BA58A3DC5A5334029E7C6BBF6990 /* AWSDDLog+LOGV.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		585B8C3A6DD4AF9F63247DAEE3950B55 /* AWSGZIP.h in Headers */ = {isa = PBXBuildFile; fileRef = 59A459A5BE87F0DADD67EBB169FFF49A /* AWSGZIP.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5881547D10D0115CB765498C4DD879C5 /* AWSMantle.h in Headers */ = {isa = PBXBuildFile; fileRef = B11D75C0DCD9FF11DB626B078823A733 /* AWSMantle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		58BD66C69F22A39246C34EF273B1F368 /* aws_tommath.h in Headers */ = {isa = PBXBuildFile; fileRef = 2791EB61C4AFF9075545494144A5BD95 /* aws_tommath.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		58F04275CDDD17740755E139361A104A /* AWSCancellationTokenSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 12D212D94038E4481D8C3C8043590F7C /* AWSCancellationTokenSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		590D69E6710099A3290F2650B7FB5BB5 /* Pods-AmplifyTestApp-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D7E43FB42F81273FADA2B41F8A59397E /* Pods-AmplifyTestApp-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5948FB5077F766182F92BD1A5A9D7D79 /* AWSURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 12F91AD721DA3E5AEAEDF9C4C2D5F9B6 /* AWSURLRequestSerialization.m */; };
-		5997B9CD7C53755E5280D4C388059906 /* AWSJKBigDecimal.h in Headers */ = {isa = PBXBuildFile; fileRef = BFDD9C67B3B6CB96B20718D49380ECE9 /* AWSJKBigDecimal.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		59ED9B8BC229B43BC758FE771D7ACAFD /* AWSDDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 03CADE1D8C5CA75A636F2DE98BF8FC26 /* AWSDDContextFilterLogFormatter.m */; };
-		5A41DCFDD03C1FDF56839D98E31941EB /* AWSCognitoIdentityProviderSrpHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 4847747404AB74113FFD8EC4DA63AA4E /* AWSCognitoIdentityProviderSrpHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		62BFE5376C245EAA54F1F93E7B335459 /* AWSLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 285C6FD84C4982A2B5F25DABB08C7897 /* AWSLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		64FB0F82B4B57ACAB52BC6917BBA1972 /* AWSAuthCore.h in Headers */ = {isa = PBXBuildFile; fileRef = EFFCCAE331008549C9E453221F29B95B /* AWSAuthCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6748B3A09288B9405215998F2284851F /* AWSSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = E4CC35AA518D998C368B3FE4C929B95A /* AWSSerialization.m */; };
-		69426D3130E20C2B3A6679390F539131 /* AWSCognitoIdentityProvider-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 448B7D6B55A4A3F3BCE22250E82D5EB5 /* AWSCognitoIdentityProvider-dummy.m */; };
-		6B1C83D7CC83EE2DAA018496423257C2 /* AWSSignInButtonView.h in Headers */ = {isa = PBXBuildFile; fileRef = B8E90544C20A9FE810B7903869974FD1 /* AWSSignInButtonView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6C1438AA5192213903C163AAA8810952 /* NSDictionary+AWSMTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A099F78198AE7CBE498B4173A29059 /* NSDictionary+AWSMTLManipulationAdditions.m */; };
+		5997B9CD7C53755E5280D4C388059906 /* AWSJKBigDecimal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CDCA759E2B524AD0D5B0529F695A28C /* AWSJKBigDecimal.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		5A41DCFDD03C1FDF56839D98E31941EB /* AWSCognitoIdentityProviderSrpHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B531E9546AD9DB8A58EDF26D38A9FE1 /* AWSCognitoIdentityProviderSrpHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5C6F85ECFE37588A579291C57BA28E44 /* NSArray+AWSMTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A075F8FA03A8A6E504C77FC33DE7E6D /* NSArray+AWSMTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5D1E1ED20C02309D4897C489A4FF1385 /* AWSCognitoAuth+Extensions.h in Headers */ = {isa = PBXBuildFile; fileRef = DBF4A88D5942D7C441128C119BAF0999 /* AWSCognitoAuth+Extensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5D97CDAB82AF5231ACF2D62F75FB4F55 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
+		5E0032B52DC5BB5FB3CA69F45D484781 /* AWSFMDatabaseQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 81685F61C04386054C6EB486CE045EB4 /* AWSFMDatabaseQueue.m */; };
+		5EB28630A9CC30863DE4382D0A18BB38 /* AWSSTSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C7EFC1FA0A94BB3040D38C1BBFCF76E /* AWSSTSModel.m */; };
+		5FE479276304FDA83745E989DA2F79DF /* AWSDDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 5410D8EAB2C72480C6D03EAC64799186 /* AWSDDASLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		600A24E9D61C48AE2664008652AF340C /* AWSURLRequestRetryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = F7BD476B02A70C2CA36E64D4DDF32DAD /* AWSURLRequestRetryHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6026B603F1245AD52915F34CA6A83CC5 /* AWSCognitoAuth.m in Sources */ = {isa = PBXBuildFile; fileRef = F271D7B7BA1C38C1E117F07AA0BB9E42 /* AWSCognitoAuth.m */; };
+		617A71B50115147C51AD0C6D00BFCCCF /* AWSMTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D02469A819F1238BA748181F1265632 /* AWSMTLJSONAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		61B1A698911FFEDAC3E17424104462CF /* AWSKSReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FF7C8B2AC413711B14A91BC15CD8431 /* AWSKSReachability.m */; };
+		623B9A6697A87E1F42B847CA8F2FE28B /* AWSURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 168E7EDD61CE770FCEEFF271776BDD39 /* AWSURLRequestSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		62D392DC89FC9697970873E8455C503E /* AWSTMCache.m in Sources */ = {isa = PBXBuildFile; fileRef = AE43657F8C0C1405A6F48A02C31C2CF5 /* AWSTMCache.m */; };
+		657547730A8E5358B795A62B0A80137A /* AWSURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = C0B03B2C8F2862CAF77DEFE91DF50641 /* AWSURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		67D8229426E3B531C446102C3F290D63 /* AWSMobileClientUserDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E046FABC7AEB1DDEAF83E80E8A23E5 /* AWSMobileClientUserDetails.swift */; };
+		69426D3130E20C2B3A6679390F539131 /* AWSCognitoIdentityProvider-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A077A3D16945E07EBB64DF9B37B77A62 /* AWSCognitoIdentityProvider-dummy.m */; };
+		6A6F7F27DCCF6D5F73EA43FCCA1DAB92 /* _AWSMobileClient.m in Sources */ = {isa = PBXBuildFile; fileRef = F5DABEBB1A7AE30FC002FA9F7D7C32BC /* _AWSMobileClient.m */; };
 		6CC5A1D52EF2B655C4F784DDF05E6570 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		6D47C12FB2A3F1A9975FD8A4F26DF5EE /* AWSFMDatabaseQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = F6B703033BBE0A61D18CA101C30E1AC6 /* AWSFMDatabaseQueue.m */; };
-		6EC58DAF1B0A34FD2313DA6C441B0D8A /* AWSLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 35E60246C30F13E28F5682FD4ADA6C01 /* AWSLogging.m */; };
-		71320470245F75D31B044D2124F50B4D /* AWSDDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = ED153D8760D84C9A9D3C2419AFEA1E27 /* AWSDDAbstractDatabaseLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6D4394F1745698365A9C40BB0A7A7AD2 /* AWSMTLModel.h in Headers */ = {isa = PBXBuildFile; fileRef = F9E0D46A0F53CEF014CB608689479F5A /* AWSMTLModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6E4FD2AB420D24BA1FE7D53D4CABEAC8 /* AWSSignInButtonView.h in Headers */ = {isa = PBXBuildFile; fileRef = EA5ACF18886A4FF581354E7504E25CCD /* AWSSignInButtonView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		719C0EFB3578E7E5303BDE1B25596ABD /* Pods-Amplify-AWSPluginsCore-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DEC3E3C3510C8A55F95F909E0207C7DD /* Pods-Amplify-AWSPluginsCore-dummy.m */; };
 		7220D03973258EA8DE357E18142CFBCE /* Pods-Amplify-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 64802F2E333FD29A93B939784FB965FE /* Pods-Amplify-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		737BF3747D1EA411B13BAFDBD564288C /* AWSSynchronizedMutableDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C7AF41AC3469F6AA08497AB92DED4F /* AWSSynchronizedMutableDictionary.m */; };
-		73A9A7C30E71B2ADA50DDC2A8132C4DC /* AWSSTSResources.m in Sources */ = {isa = PBXBuildFile; fileRef = F8C0DA431C7BEEB8C8DBDC93FC331138 /* AWSSTSResources.m */; };
-		76C2EE375F6E45975723188B609D8CFC /* NSDictionary+AWSMTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = AB74DE22440765B4DB2FA75152FCDB4E /* NSDictionary+AWSMTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		78BEB096DCE534C58CDB8F3F30E7DCEC /* AWSEXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A611C30E177DDD6F14CECE647238E0F /* AWSEXTRuntimeExtensions.m */; };
-		7A055B5CFE741CF5E8D86258EA7B1332 /* AWSCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = 72A71B300822301B02175A776829FDD5 /* AWSCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7A56A77E670018AD7C96B575EDD2F2D8 /* AWSExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = 027E6E6E1397ECEC532588E2FEA6CF38 /* AWSExecutor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7A91CEDA043B8B5257FD9D1EAA5614A7 /* AWSJKBigInteger.m in Sources */ = {isa = PBXBuildFile; fileRef = 986C98B931A676FC118C9E1BBD676265 /* AWSJKBigInteger.m */; };
-		7AAEE9E9F355EFB9B22A47AC3E2D8BA1 /* AWSCognitoAuth+Extensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 37306661AA76074040E8089831654A0E /* AWSCognitoAuth+Extensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7B05CC1AF6780F68F1FF089B48652318 /* AWSFMDatabaseAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C87FDEBC481B70900979EF90CF27CFF /* AWSFMDatabaseAdditions.m */; };
-		7B81C22E00652B512C92118BE69467EE /* AWSCognitoIdentityProviderASF.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D79EA8A0193479BD7F7E122F9C1E9C0 /* AWSCognitoIdentityProviderASF.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		781205D14C8BB2089F3A5EACB8D848CC /* AWSFMDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D814B6AF5A67FF1828ECF314845D1BD /* AWSFMDatabase.m */; };
+		7823E936D9B566B90F997812337AFF6D /* AWSTMDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = C163507295304A519E85051ED74A6209 /* AWSTMDiskCache.m */; };
+		786A00B206FE67A484E80BB4F52C65D5 /* AWSXMLDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 49C1DACDE13725ACAFADE7825739F218 /* AWSXMLDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		788692E6436FAA77FB4106A8A43A6D43 /* AWSFMDB+AWSHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = A52145D6322955C0D6C6F09871F24741 /* AWSFMDB+AWSHelpers.m */; };
+		7A91CEDA043B8B5257FD9D1EAA5614A7 /* AWSJKBigInteger.m in Sources */ = {isa = PBXBuildFile; fileRef = 856B9460EE390E948E972BC937AD38F4 /* AWSJKBigInteger.m */; };
+		7AD034A4C74DD3FAC09164FF4462B682 /* AWSFMDatabaseQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 41F1BA5E8793C8CC6222D85413CE4C4A /* AWSFMDatabaseQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7B81C22E00652B512C92118BE69467EE /* AWSCognitoIdentityProviderASF.h in Headers */ = {isa = PBXBuildFile; fileRef = CDA38353C499EAFBF0C7F4C481DB06D1 /* AWSCognitoIdentityProviderASF.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BA450B429AD6BFB0CD6903F48A3A73A /* AWSAuthCore.h in Headers */ = {isa = PBXBuildFile; fileRef = A46B3233721574887E89B7E89E73CB49 /* AWSAuthCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7C54E87DA0FEDA01C2E6466361F2E915 /* NSError+AWSMTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = C9022B2A001A348E8DEDD1296B5E0716 /* NSError+AWSMTLModelException.m */; };
 		7E563800D6BC72004F79096CF284A320 /* Pods-Amplify-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B8A667E74EC0A8A4EDFB8F2D2364FC92 /* Pods-Amplify-dummy.m */; };
-		8005CFE2A71D0D93FB37D9D0D0FEC5D1 /* AWSSTSService.m in Sources */ = {isa = PBXBuildFile; fileRef = D4E14945D602237E27049F763EA18FBE /* AWSSTSService.m */; };
-		8125C10721A3639BD9ACF9335897111A /* Fabric+FABKits.h in Headers */ = {isa = PBXBuildFile; fileRef = FA186FC8E0A7DA8AD1832D28E0F1230D /* Fabric+FABKits.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		812E6FE7C800C026A4C38E2C51290A85 /* AWSCredentialsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = BEBAB3C7809690613DC9CAFA944D8EDA /* AWSCredentialsProvider.m */; };
-		82B1792780A182252D1634A1684CB898 /* AWSMTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = FB3FB11FF4A8D28C1128AB30C30C71AA /* AWSMTLReflection.m */; };
-		82BFAD55E61B70C232D78AED3AA10431 /* AWSSignInProviderApplicationIntercept.h in Headers */ = {isa = PBXBuildFile; fileRef = 44B546B0A6D74703ADCFBD38A0D6EABE /* AWSSignInProviderApplicationIntercept.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		84C888AA44AC965AA122EFDC5E9DFA33 /* AWSmetamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E81A98248D90B4D4CBA3247B45A6DAC /* AWSmetamacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		84F1B973AFBCCC12088C40C41A9AAD0E /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 16D16C7F3CC2A777770BD46E5A36DAB9 /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		86EB3D9547E5B06DE5C12D144139C578 /* AWSUICKeyChainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D5E9435E602D6E154E08200A3D0499A /* AWSUICKeyChainStore.m */; };
-		8768FC3B9795070C95E616AD2F604712 /* AWSMTLModel.h in Headers */ = {isa = PBXBuildFile; fileRef = AB361E23A65D4E6BD16AF9720259A168 /* AWSMTLModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		896DAD7E4351CB1280A69219F2F87A66 /* AWSDDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BCA6DA44439111C917017DE70D65CAB /* AWSDDASLLogger.m */; };
-		8B674E154C488891F92084314F681415 /* AWSCognitoIdentityProviderService.h in Headers */ = {isa = PBXBuildFile; fileRef = E88BE96FAF2EA8862751E14F4E1E1260 /* AWSCognitoIdentityProviderService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7E72445D57E2B1377BB8C31D0D45F583 /* AWSDDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F3CA727772902D38F633984F132084D /* AWSDDAbstractDatabaseLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7FAAD3074FCCD0FB5F7DC085A79F1352 /* AWSMTLManagedObjectAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E3D65FEA8DF69AB59F24058F42DCED6 /* AWSMTLManagedObjectAdapter.m */; };
+		82B604223403F2D8913736CDBCBD3421 /* AWSTMCacheBackgroundTaskManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B105C48272F594AC5233F7320470A5B7 /* AWSTMCacheBackgroundTaskManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		84F1B973AFBCCC12088C40C41A9AAD0E /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 98EBAF29DC4D794957822E239F9C944B /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		858196891699CB779D9415EE462CD40B /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D98814487113FC0451682BF2CA928D0 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */; };
+		85DF3750F9FDC7219E7E1BF6F9194D4D /* AWSTMDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = DAA8BB0506C2E9D42D5AED09D74156A6 /* AWSTMDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		865DC647D80B2C560666A8BC90753092 /* AWSSTS.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E8F49480EF8060BB37B26F5BC5DF99 /* AWSSTS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		867F53F6C252DB86B6980B38127D670A /* AWSFMResultSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A8546CE0DBDFE5D38B2046606E4B7CE /* AWSFMResultSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B56F42D143D78C6F5BD42A941106BA9 /* AWSService.m in Sources */ = {isa = PBXBuildFile; fileRef = 65A25F6FD0D61706F9535950AFC406E4 /* AWSService.m */; };
+		8B674E154C488891F92084314F681415 /* AWSCognitoIdentityProviderService.h in Headers */ = {isa = PBXBuildFile; fileRef = 58C89AD838EDC38CC8C7DBB462B82E56 /* AWSCognitoIdentityProviderService.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8C3D6083788CFA96F014554916B47E96 /* Pods-AmplifyTestApp-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CC60529D233360B1F356DC750E15164 /* Pods-AmplifyTestApp-dummy.m */; };
-		8C779BB6EEC04BE3152B057CD6695282 /* AWSMTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = A6E435979BE405717E44EA6820003765 /* AWSMTLModel.m */; };
-		8E17B1081D3CEBCA661AF6EF03AA9B91 /* AWSCognitoIdentityProviderASF.m in Sources */ = {isa = PBXBuildFile; fileRef = C2DAAF70CB9E19EA4D2313D99B529CBA /* AWSCognitoIdentityProviderASF.m */; };
-		8F6A4531EC93144BE668A81137B2DF44 /* AWSDDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 470DACED7FA482EE4F2D2F781A78EB9B /* AWSDDAbstractDatabaseLogger.m */; };
-		938E74E70E290A74DF2953430022C5F1 /* AWSCognitoIdentityProvider.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 897BE0E1152364146DF9E84966A20D23 /* AWSCognitoIdentityProvider.framework */; };
-		94DF5723F5F4F98EED3FAF91CA73F685 /* AWSUserPoolOperationsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACEAA077B4DC5FF33706180C515F269 /* AWSUserPoolOperationsHandler.swift */; };
-		95C3EDA1C39362E679186B1905041F62 /* AWSFMDatabase+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 9ECDF6559A006DFA06D0518D79726410 /* AWSFMDatabase+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		970F0A8B1FBD05F16DAC6BE24F2E2AA9 /* NSValueTransformer+AWSMTLInversionAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 372F6716342DA6EE1616FE8E41DCF50F /* NSValueTransformer+AWSMTLInversionAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		994AD321CFD65367815ACF04BAB369AA /* AWSFMDB+AWSHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 95EE31B5AE458FE53DD0805178E1CD88 /* AWSFMDB+AWSHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9A4979568AB7A750A8303BDD21E1F230 /* AWSClientContext.m in Sources */ = {isa = PBXBuildFile; fileRef = B6678B3BFB137395C6BFB6442F592DAF /* AWSClientContext.m */; };
-		9AEAF6CAD298F286AE1BC32B731A99FF /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47D46D2BEC1D90EDAE4F1B547348EEFB /* AWSCore.framework */; };
-		9B33FC6B8FDB513847D980A15669BB87 /* AWSDDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 597F1FBC284F71F3B4FA26BA2D7073CF /* AWSDDLegacyMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9BB751C6E1D43B8323EFC34DCB0A39EB /* AWSService.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EAB57F27B14013C8DD9ACC0853D0832 /* AWSService.m */; };
-		9BF996D39A3A712D2A41F03F493B708D /* AWSDDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = C542DA5A0D1AC50D6BBE628AD7322953 /* AWSDDTTYLogger.m */; };
-		9C29016A79E85593D4903D4AC0EE9795 /* AWSCancellationTokenSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 7615572287FFAD3ADADE3696B49FBEA0 /* AWSCancellationTokenSource.m */; };
-		9CE73F8C8F261B13AF986C3A19ADD23C /* FABAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = F48C0396440C39938B23C0BD6D7F0102 /* FABAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		8C4F65C6BCEB1D62FD195E15403F01F9 /* AWSGZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DB0C0B9E1C812A42914C8AA7BF1A8D /* AWSGZIP.m */; };
+		8DE2768806CC526886BF6D06E8E83C1D /* AWSInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C5FAED483BFCC2F6ED318BFC0A89612 /* AWSInfo.m */; };
+		8E17B1081D3CEBCA661AF6EF03AA9B91 /* AWSCognitoIdentityProviderASF.m in Sources */ = {isa = PBXBuildFile; fileRef = 4108872B2D9F35982F849D20935EFE58 /* AWSCognitoIdentityProviderASF.m */; };
+		92944936808E537A51D7FB76879573B0 /* AWSFMDatabasePool.h in Headers */ = {isa = PBXBuildFile; fileRef = CD9504574C2BEA74886D0BA7A7E51BE6 /* AWSFMDatabasePool.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9330A6BAFFA518B4BECBFAD3412BF162 /* AWSSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = B8785DC9A87864D9C1FDCB43C2469B74 /* AWSSerialization.m */; };
+		9343EE314C0B2A5126CC43BA07AC6001 /* AWSUIConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = EB037FE1BB0944A9A0396B42155C798B /* AWSUIConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94E032B726F3F3D2425C5803AA3905E5 /* AWSCore-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 017996FA9F98A7E1AC8B1FB672D4E557 /* AWSCore-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		95465C26DCAF34829BEDF0B2873E5D22 /* AWSSynchronizedMutableDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 11EDEFEDFA365D9648D81979FF0CF2BA /* AWSSynchronizedMutableDictionary.m */; };
+		960B8E71E94DFFC52104B7D2A005F701 /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47D46D2BEC1D90EDAE4F1B547348EEFB /* AWSCore.framework */; };
+		96D71A9A27A288204F9C2C6FB0938075 /* AWSCancellationTokenSource.m in Sources */ = {isa = PBXBuildFile; fileRef = D29FE4BBF56788C9AC325256DFB9A156 /* AWSCancellationTokenSource.m */; };
+		96D859318FE7B536D841C4B7ED8915B9 /* AWSTMCache.h in Headers */ = {isa = PBXBuildFile; fileRef = DE52C631AAD1F37EC85940B309484450 /* AWSTMCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		97C52BFCC42E09EEE37E0F079375C892 /* JSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAC8F37FB83D9A1FAE60863BAE22A2 /* JSONHelper.swift */; };
+		98E684975408A0A06FE6BCE1431F686A /* AWSLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 722FB0BF2F494C956CD49C0C75A2FDC0 /* AWSLogging.m */; };
+		99D77CDBCF4C3CF91116F5E54921F181 /* NSError+AWSMTLModelException.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CAB3BD92207D2E252347FD79A669516 /* NSError+AWSMTLModelException.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C348F0554641CE5E4D400226C483C84 /* AWSSignature.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B109D739CFC883289A6548766B8B7DD /* AWSSignature.m */; };
+		9C756224993E158189C803D1CF6DB659 /* AWSMobileClientExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE13CC64B7D51AA8D246157E67E7DDB0 /* AWSMobileClientExtensions.swift */; };
 		9D914E2C5BB01F438CE2CEFAF3518D6F /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C6DDDDA1D966AED315AB70664004815 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9F031D2C1D45AF3F7F9F802CD43F4CB4 /* AWSURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 5658CFB1EE58DB90BACB45071B93D3FA /* AWSURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9F35EB8A76445B4265DBD4D0C1D81CDC /* AWSDDASLLogCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = B17B2529C82595074FBB5299CA4C33F4 /* AWSDDASLLogCapture.m */; };
-		9F8E4A338D88949F73048DC5C6BCA831 /* AWSSTSModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 58CAF26D90978B1CEF93B2CE577F090E /* AWSSTSModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A1B8BC6F446260D9062F08EE602A11BB /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D7C69697E9FEB677A5FD0883D9E63DE /* CwlMachBadInstructionHandler.m */; };
-		A2C6D38BF055B80D1E379AC093FC07E6 /* AWSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FA8ED3AD37F037DC824A5F6E91A7405 /* AWSModel.m */; };
-		A2FF0AACA73E0D90A8E4E4B4E92F64E0 /* AWSDDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = EDE386C04D660CD52D88BD3C45334C9D /* AWSDDLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A4C8EAA5B9CFA9409292F5A4632B5383 /* AWSMantle.h in Headers */ = {isa = PBXBuildFile; fileRef = 799B96796EC00C7068F5E7BBAB3EC905 /* AWSMantle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A5C6D3348F0648627589AF623D7EFDC5 /* AWSCognitoIdentityResources.h in Headers */ = {isa = PBXBuildFile; fileRef = 7EF841B46EC42CD1F560B98CD32D7CEE /* AWSCognitoIdentityResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A694F17C4E57537B8C1F4BC122E5F725 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1073C3EE5CBDD8387A3FB523E790C5CA /* SystemConfiguration.framework */; };
-		A6A9848E773D9E5E0AB1550639A9D748 /* AWSDDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = 2133A4C34B9432D76D7E52785CF5DFA3 /* AWSDDLog+LOGV.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A713621EF397D381EE3C41219649F48D /* AWSValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = BAACC47EBE7463E76E1A7A527FEFD7E2 /* AWSValidation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A77676E23AADF400ACFEFDC714FE69B4 /* AWSURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 4309152BC40096DDD5A7CD143D059A18 /* AWSURLResponseSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A81152A334E18EC67B13C8DE062572C9 /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7CA64F79A273DFB20A0536914C253F /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A835CA432F8492BBFBBDDBA98F66D1BE /* AWSCancellationTokenSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C8A48FB23DA4C723054237DD88FF8627 /* AWSCancellationTokenSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9E6E606BC775C9D70B5F73B75F6466D7 /* AWSCognitoIdentityService.h in Headers */ = {isa = PBXBuildFile; fileRef = 7771C2DFE4AD99CD3A269C7ADB017DAA /* AWSCognitoIdentityService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F178FED04D876360188F685980EC42B /* AWSSignInManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F94581174EDFD77DD77D64E573D786 /* AWSSignInManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A1B8BC6F446260D9062F08EE602A11BB /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 63558BCBF0A625B52BCB547CD0DFB1BA /* CwlMachBadInstructionHandler.m */; };
+		A26278DDB3EBC5C5A65C4C86382B0AF8 /* NSObject+AWSMTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0CF40D7AF9CA3F2F9A410759AE391171 /* NSObject+AWSMTLComparisonAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A26C2FD9F3C6A6D8C8859C915163A0B6 /* AWSCognitoIdentity+Fabric.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CACA599E066FECF7765E60FB671E1A8 /* AWSCognitoIdentity+Fabric.m */; };
+		A325BDDE98FB22C8DCB42AFCA0A0A1A1 /* AWSFMResultSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 9176A30EF537A984349EF0941C29042B /* AWSFMResultSet.m */; };
+		A3E2BFD1F35BCE94C2023D88AA5BC579 /* AWSDDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 92A43858635F9C27ED94A05763E2521E /* AWSDDASLLogger.m */; };
+		A6598CE3C61D646FEB39A1CC9AC3BA6F /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9000133D745E33FE1ED02390F5F7E717 /* CoreGraphics.framework */; };
+		A81152A334E18EC67B13C8DE062572C9 /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = E727F698E5184B8A8F0AEF9CAF632FA8 /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A9E6B3F4412CAA30168D675A302122E9 /* AWSNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E2AEE92884E8A3660E2A5C368A9D134 /* AWSNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA518F23ECB9642D933EEB2D112C00FB /* AWSCognitoIdentityProviderASF.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4144DE60EA249CC4A98549069F402FB /* AWSCognitoIdentityProviderASF.framework */; };
 		AA66B7FEEAF81CA08B1515A1BDFA8511 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		AB958B4B2C4703DFEB18B8142B688E64 /* AWSTask.m in Sources */ = {isa = PBXBuildFile; fileRef = DC69A6FCA7057AAD299BDF046A8E8253 /* AWSTask.m */; };
-		AC78540F570C892CFB0617CC99A6D87A /* NSArray+AWSMTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 50D64E42E6221E8FF4AB21C399E7EFA7 /* NSArray+AWSMTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ACAA7A9F47BA86060AD4D4F320D3FBA1 /* AWSValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = FABED7D2E0EDD2DB1CD3929AC70D4B1D /* AWSValidation.m */; };
-		AE1D3AE6FC610797CA01072C4C81D9BD /* AWSTaskCompletionSource.m in Sources */ = {isa = PBXBuildFile; fileRef = B662F5F03B62A30404A4A72883EF2BBD /* AWSTaskCompletionSource.m */; };
-		AF0DFE57311A572448946175FA8ABAA2 /* AWSURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = B65C31B8D395F09A9D5F06EC043B14E2 /* AWSURLRequestSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AF66AF015E286081DB48279E84D00286 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DF90D7DF6E0AB0C6DAD5ACD71EE5837 /* CwlCatchException.m */; };
-		B05C34E599B60EE6147198C28771EA0E /* AWSSignInProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = E27B6AFE92FC2D4B1D7D6617EFEDACE0 /* AWSSignInProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B0F30D051C98A799C09BA355E5A4D7DF /* AWSTMCache.m in Sources */ = {isa = PBXBuildFile; fileRef = F3C8CC46B2D8F801024481E5D2D742FA /* AWSTMCache.m */; };
-		B2055B59F47FA0688CF56E1959CF9703 /* AWSDDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 42D1C9714D461A6FEBFA26A038D4F780 /* AWSDDContextFilterLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B249CEEC9F02F95B0382FFF224AC495C /* AWSCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 1385AC19B182894FE81125DDCE8C5F06 /* AWSCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B4103ECBACFEA13A55407D22F3E56A33 /* AWSInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 480BAF4B1C5C9B17EC75A49C9A44BE85 /* AWSInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ABC164C2B5402553E19E1CE32AE65E14 /* AWSCredentialsProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 13A6AC4F2598B540AB29DEA12B8DA004 /* AWSCredentialsProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AC0913A1E4C9CDEC5699AD154BA254A1 /* AWSCognitoIdentityService.m in Sources */ = {isa = PBXBuildFile; fileRef = DCE1BA35810587B99C58F0FED53ABAC3 /* AWSCognitoIdentityService.m */; };
+		AD223728D8DFA18B28E0340459453763 /* AWSCognitoIdentityProvider.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 897BE0E1152364146DF9E84966A20D23 /* AWSCognitoIdentityProvider.framework */; };
+		AE2C16CE9FB6CCEC0BAE444DEBD69234 /* AWSDDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 98FCA979D8A8822E734476B6E58B8ED4 /* AWSDDFileLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AF66AF015E286081DB48279E84D00286 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 673FC21F904E05922260C6F6C1055044 /* CwlCatchException.m */; };
+		AF8EBCA0F90060448E15E47025733327 /* AWSCancellationToken.h in Headers */ = {isa = PBXBuildFile; fileRef = E1EC8C3E16C71BF25AA7F00CDEF6C1DE /* AWSCancellationToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AFD9EAAB3DD21504017BEA68684667AD /* AWSFMDatabaseAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 810E6C0AEAF81CEF142AD224BC9FA4D7 /* AWSFMDatabaseAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B12C8A1CC225C17AFCA43D4BAF707E7B /* AWSCocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = 9348F3E0355579436D403C96DB0D7EF4 /* AWSCocoaLumberjack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B496D83E23179346F1978A44D72C8CA5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		B4E9077F189C342F80BADA5A2CE1A110 /* AWSURLRequestRetryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F02B57322A914C3ABD0AEC8402B3EE6 /* AWSURLRequestRetryHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B5AFCE15B9D849BD84A6D6E46C144F16 /* AWSSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = F2F95957A8A28F91A1A0FE2164F2234D /* AWSSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5F01854ADFAC527435AAC6D505D9A46 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 11618E052B1995FC3B058B8E47104CFA /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-dummy.m */; };
-		B6BBFC993B975EE185C9ADD4C5D2420B /* AWSExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = 35EBDFBE4DD338E13AE38E0D38C691A3 /* AWSExecutor.m */; };
-		B79F025D9EF7BB4E4860A39308B967B1 /* AWSCognitoIdentityUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B2CEB7C609DE754234286DB0B2099D2 /* AWSCognitoIdentityUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B924412F3326FD285D0DF5145D1AFF3E /* AWSMTLManagedObjectAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 17BE1A5690F7F5D226BB85EE0C715F82 /* AWSMTLManagedObjectAdapter.m */; };
-		BAF1E92557EF7F7F16BEBAB2E1A512A7 /* CwlPreconditionTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = C57087617E12CE6B735EB2F37693BF70 /* CwlPreconditionTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BAFF65E2953B8E9393F1294F1D380458 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DCEB76D109419AFAE5EF55575C9F69EE /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */; };
-		BC816D50344B3DD5EBBEB5357A59C346 /* AWSBolts.h in Headers */ = {isa = PBXBuildFile; fileRef = C53B9703FFDCF5CAC036A262B1D4F62C /* AWSBolts.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B67CE9FC51F77CC591562D2BF2CA3EA2 /* AWSSTSResources.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6AB7B64F3EA49D82336E6F2342E8F4 /* AWSSTSResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B79F025D9EF7BB4E4860A39308B967B1 /* AWSCognitoIdentityUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 506993FFD5E43321C8EE111378E6B6C5 /* AWSCognitoIdentityUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BA498D6F2E108FF6A250EF156FB199CA /* AWSCognitoIdentity.h in Headers */ = {isa = PBXBuildFile; fileRef = 66B10363FF226628014BC9AA0109E500 /* AWSCognitoIdentity.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BAC85A39D3808CE79873936E4231A6DA /* AWSURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 79F8F7318B8DE19209DA9DDF5193FC01 /* AWSURLRequestSerialization.m */; };
+		BAF1E92557EF7F7F16BEBAB2E1A512A7 /* CwlPreconditionTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 12163530DDDEF249BE3C311D0ED23327 /* CwlPreconditionTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BDAFBC302AFBD0169D63A493EF24F019 /* AWSEXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 16A649B28EBAF292512D8F10FD00EEC0 /* AWSEXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BE6A0ECFE8619D15EF84F45C240644F5 /* AWSMTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 18F8E4C791238DE2BC89F84EF383A00D /* AWSMTLModel.m */; };
+		BE7ADABCCDB533FDC0433D0D631EF85E /* AWSMobileOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F0A6A210EDEAFCB636DEF2E8E2C143 /* AWSMobileOptions.swift */; };
+		BE8ABD8C2F11BF351AEC13B6FFFDF99A /* NSValueTransformer+AWSMTLInversionAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F427531291DB1D1C9D8F6A709F1BBD2A /* NSValueTransformer+AWSMTLInversionAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BEA4DBC17C6B9BCE2C41179ECC3DAA1D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		BEB73441F0DAC067FDACBDFA540901CD /* AWSDDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 3020E70B872491E1D6E28FD21ECC2157 /* AWSDDASLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF35E2B9FF252642569E97E514E203E4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		C04F7B51A7AD38D0055EA82A0176EED1 /* AWSFMResultSet.h in Headers */ = {isa = PBXBuildFile; fileRef = F8C53AA0E9793A1A70374EAB2FD6FB99 /* AWSFMResultSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C146BB6121D1E7BB4B9C7DA7770086E6 /* AWSCognitoAuth.h in Headers */ = {isa = PBXBuildFile; fileRef = 188F37DEE01522564894F2F82EDD1EF6 /* AWSCognitoAuth.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C20E9D9EF169BFD9A31A364683D3ECAF /* AWSAuthCore-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E630833E85807E70FC177062E5C07B8 /* AWSAuthCore-dummy.m */; };
-		C2CD857BBF59B9B268148536E01E9EB9 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8DB7849FE18394F4C1421ABE0CEA2E /* Security.framework */; };
-		C46FEE5166870EAC61B19C9EDB7AADC3 /* AWSCognitoIdentityProviderHKDF.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E7C334C7718E548C12E9BD587E2E334 /* AWSCognitoIdentityProviderHKDF.m */; };
-		C493C5E2602242F0F5DDECCFCF9D1AFA /* AWSFMDB.h in Headers */ = {isa = PBXBuildFile; fileRef = B7B517F0B29949FB45D5A65D1D283A0A /* AWSFMDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C4D4135EC7E448AF8291FD16971D51BF /* AWSDDOSLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 67CD77FFD4E62B560C010929AFDF8FC8 /* AWSDDOSLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C4EAE6EC8670168F0EF052C269AA4E71 /* AWSFMDatabasePool.m in Sources */ = {isa = PBXBuildFile; fileRef = 264C21DDA41C552389D593887842E2E5 /* AWSFMDatabasePool.m */; };
+		BEEC4A944FADA30EC4B4A113212AEEE5 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE49F6473631850D3EC76C328D5772CB /* UIKit.framework */; };
+		C2A8E95E1378D95C29118217596E5EEA /* AWSDDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = A30C60B5CD0C127A0F791708CFE9B42D /* AWSDDDispatchQueueLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C3525FB9301A85B4E55C6F01D3BBDD5A /* AWSMTLReflection.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A60E93D25B2C3C212B4679F93F75755 /* AWSMTLReflection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C35B120FF2B1D18672753CF6EC0985DD /* AWSCore-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 51F546FB05338188F9D16DCA20239565 /* AWSCore-dummy.m */; };
+		C3E5346133EC63B83B5B163399B39A1B /* AWSURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C738EC7E8D4A0BF95B09336DEDB98B1 /* AWSURLSessionManager.m */; };
+		C46FEE5166870EAC61B19C9EDB7AADC3 /* AWSCognitoIdentityProviderHKDF.m in Sources */ = {isa = PBXBuildFile; fileRef = A1D9BE851096D333C6BCF3DCC3CB8685 /* AWSCognitoIdentityProviderHKDF.m */; };
 		C4F5A55C56D472D4F7D140D0950B6E97 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 189C8021820D164FA9236F1D27850C3F /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C64E8C289FE51FD28664A25A6AF7B95C /* AWSIdentityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = A91CA38278370894947C0EE0FBEC9746 /* AWSIdentityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C671EBBDB2A304FE606E2A7689AC44B4 /* AWSMTLManagedObjectAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 18A3E400D3F817D016218A417D6F7D3D /* AWSMTLManagedObjectAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C74236311AEE52428383FCD4820606C4 /* AWSIdentityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = D445676006ADD383CA026790E342881A /* AWSIdentityManager.m */; };
-		CA46FB0B92B5831CD73B49D188549037 /* aws_tommath_class.h in Headers */ = {isa = PBXBuildFile; fileRef = F0E0AE0D981A07A94FB82B3749ED4294 /* aws_tommath_class.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		CAD5041B5768C4F6E0EE0C3D3EA1C439 /* AWSCognitoIdentityProviderHKDF.h in Headers */ = {isa = PBXBuildFile; fileRef = 2671FF7E927AEACE1D57CD183C23B33A /* AWSCognitoIdentityProviderHKDF.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBDA1AF9C1C14DFCC8FB3F54C2602EFA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		CBFC476A9C141CA0FA835A672F10BD62 /* AWSFMDatabaseQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AD3460A804CAD6E3F709F0BBC359B7F /* AWSFMDatabaseQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C61912BA5E6897BB6DF7A83C5114AC61 /* AWSAuthUIHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D7AD3753C2B976519ABD2B870B1AAF5 /* AWSAuthUIHelper.m */; };
+		C682CF45DC1BE3A1391C38D98B23178D /* AWSTask.m in Sources */ = {isa = PBXBuildFile; fileRef = B22773A61D27574942BD3C76F4C90814 /* AWSTask.m */; };
+		C6E6CC33D0DC9F7F706B5BEECD5C5A75 /* AWSDDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = AF9B52768BC4CE65526EAB63E2E75880 /* AWSDDTTYLogger.m */; };
+		C7BB5752DCF16A55A09916C85EB64EA1 /* AWSTMMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 60F4BE632949FAE284F63F70D7952C60 /* AWSTMMemoryCache.m */; };
+		CA226D1FC3EC02847A70C9DC565362CC /* AWSTaskCompletionSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 25B48B5E2F240D5C178AEC37739F47BD /* AWSTaskCompletionSource.m */; };
+		CA46FB0B92B5831CD73B49D188549037 /* aws_tommath_class.h in Headers */ = {isa = PBXBuildFile; fileRef = 388680EB7CAF4AB53E3DD89E2CC90F2E /* aws_tommath_class.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		CA8CAC4B7D5CEA18AEC162BE523E3368 /* AWSServiceEnum.h in Headers */ = {isa = PBXBuildFile; fileRef = D0E94613A5F8B0E8267BE68F25F2F8CD /* AWSServiceEnum.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CAC63FC5740B67E322F64FA92C51BE29 /* AWSBolts.h in Headers */ = {isa = PBXBuildFile; fileRef = B6F8E974D59BB2C71C3998C162816143 /* AWSBolts.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CAD5041B5768C4F6E0EE0C3D3EA1C439 /* AWSCognitoIdentityProviderHKDF.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B0AAF84EC698F11CC63045004A9ED58 /* AWSCognitoIdentityProviderHKDF.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CBFDA937C68D277582439A7F827791FA /* AWSBolts.m in Sources */ = {isa = PBXBuildFile; fileRef = D87BBA54881BE0850CBFFDC4D8114FCA /* AWSBolts.m */; };
 		CC3489D3AE121850205206C8DA3AC9BB /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 71803B908C82923324FBC55B50603420 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CE5D986CDF7DBEF4F11DCC9EA3B5B929 /* DeviceOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0FC39EDE37B13F74EFD7D11094F05E /* DeviceOperations.swift */; };
-		CF78E377AE49A86D20A00D51793979C9 /* AWSCancellationTokenRegistration.m in Sources */ = {isa = PBXBuildFile; fileRef = CB96EAB0130FC52A057E49780D95D87B /* AWSCancellationTokenRegistration.m */; };
-		D1BEC8D155F8C308122CDE89D5E8BD64 /* AWSCognitoIdentityResources.m in Sources */ = {isa = PBXBuildFile; fileRef = AEF6FE2870E54B10EF30BE095D07ADE5 /* AWSCognitoIdentityResources.m */; };
-		D3F34BB211709B19D794F38CAE744DCF /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEDCAB69641F21BD95E3D9568D7CBF2 /* CwlCatchException.swift */; };
-		D57941F71569BF2BD17F084BA72A870B /* NSArray+AWSMTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = AF646CD18863080860DF747A69722D6B /* NSArray+AWSMTLManipulationAdditions.m */; };
+		CCF3D812222A96CB42B542F4D68A6B3F /* AWSUserPoolOperationsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA5040145A5FC42FC743FA56514940 /* AWSUserPoolOperationsHandler.swift */; };
+		CD670349157D1CC299C595DBC118D553 /* AWSMobileResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8E1C643E55898382E15AC05AA7365E /* AWSMobileResults.swift */; };
+		CD9C8503D19F1E4D26A2D1705B7C922C /* AWSURLRequestRetryHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EDE3BF19468DE4E9605AD1B08021DF4 /* AWSURLRequestRetryHandler.m */; };
+		CEAD5A825A2B2228733F1F745D85024D /* AWSSignInProviderApplicationIntercept.h in Headers */ = {isa = PBXBuildFile; fileRef = F752DCF3576E6E8F2191593BA7C6F05A /* AWSSignInProviderApplicationIntercept.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D0008DB1D694408559F50AD06E9DCF00 /* AWSUserPoolCustomAuthHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D4071126A64D42B2F302F608505CE9 /* AWSUserPoolCustomAuthHandler.swift */; };
+		D3C7CEE1ABDD4DB9F318808066874630 /* AWSInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = A160B41090A56C0EFD3C4DF8921A1539 /* AWSInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D3F34BB211709B19D794F38CAE744DCF /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = F917BC5B219C19085ED19ED90CB19D15 /* CwlCatchException.swift */; };
+		D448DBF68ABFA8F084BE3AAE05171D4C /* AWSClientContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A3C4EF0A54DFF8F64748AB9A6E364E0 /* AWSClientContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D4F6F977E4D77F9982B1AF5B6ABBDC46 /* AWSFMDatabase+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E8B5FDB178DA118BA766982955206D30 /* AWSFMDatabase+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D50A080B30C8131DB858F71727E0B271 /* AWSMTLValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = D7E963C4F0D7D073D7546DDC482E53FD /* AWSMTLValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D5C3DC01A7E8D3CA0C9F9E2A09D56C86 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE49F6473631850D3EC76C328D5772CB /* UIKit.framework */; };
-		D68A1087FDAFC7AFDA9E7EDEEAC760BC /* AWSModel.h in Headers */ = {isa = PBXBuildFile; fileRef = F0572A28051693DA8F8FEFDD2D1AB217 /* AWSModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D6B6F05BD0397853158A47B854089582 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		D73D19AACFA1A61E7C5B338298ABFA74 /* AWSFMDatabasePool.h in Headers */ = {isa = PBXBuildFile; fileRef = 191511A3810F3B192E24B321C4589C46 /* AWSFMDatabasePool.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D749F6C4A5B21788FB368EFFA00196F1 /* AWSSynchronizedMutableDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 776091FCE4C283ABB38949973F5703CD /* AWSSynchronizedMutableDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D76CECDB2FAB94F3D8DD51B54EA7F510 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		D7DB71375E75568144A6F44787C896AE /* AWSXMLWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = ED507E39D0E6A513CFA5C09ADDBBE7F7 /* AWSXMLWriter.m */; };
-		DA8E7AD70C4E70661341B17628B98B9D /* CwlCatchException-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 22BE5BDD8BEA74A45AE7BA7B7E27C2CA /* CwlCatchException-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DABD5E5E42113F1287706F95ED57787F /* AWSCognitoIdentityService.m in Sources */ = {isa = PBXBuildFile; fileRef = 526789E47E87CD57DC238155C82E851D /* AWSCognitoIdentityService.m */; };
-		DDA5DD81D769898BD292F0B182859EFE /* AWSCredentialsProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B77ED9825E341DEF2A12FAE12D669D2 /* AWSCredentialsProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E2E307C6CB768DB60D6FE577A8492AEF /* AWSCognitoIdentityService.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AD77E92817948CBE257C0921A8168E1 /* AWSCognitoIdentityService.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E55CFDBB36EBDE881066C3DBF58B8DAC /* AWSDDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 18239979C2E3508F26FBE3C76EBAB6F9 /* AWSDDASLLogCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E561099206E38F18CF7EBEB5B1B78E80 /* AWSCocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = C60A8B140370A37C7542F37266CDA34A /* AWSCocoaLumberjack.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E590C90C490A4CB76A59FC13589FB166 /* AWSFMDB+AWSHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 643A75097C14026359E5647074040E50 /* AWSFMDB+AWSHelpers.m */; };
-		E5F9A1CF6A4BE96B761B733635FFA377 /* AWSInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = E167A6671830F3708A2B1FB69032281F /* AWSInfo.m */; };
-		E65A2AD89A723E22FF8244A0CC487318 /* NSError+AWSMTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = A95E336C4D29585F2AD392A2F8D10FFC /* NSError+AWSMTLModelException.m */; };
+		D995F1889A0498202C5B04A04ED81688 /* NSDictionary+AWSMTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F110F53CAAF1AB03CE1CA851F85859F /* NSDictionary+AWSMTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9A075C15C47BC77535148A5A2D2C468 /* AWSDDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 13A70D9A2492A9A41C2BC8FDDE0C6707 /* AWSDDAbstractDatabaseLogger.m */; };
+		DA8E7AD70C4E70661341B17628B98B9D /* CwlCatchException-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 66D34A65BD719CA839A366AED5ACE1F2 /* CwlCatchException-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DABA700D6E837C34EA646731E2426132 /* AWSDDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3965E8754824714C58065089218E87C4 /* AWSDDMultiFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBCA55BB7256CF0FCC1535AB9B0D3550 /* AWSURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A0ADFA07325170FDC5BB0CE2DB1EBA9 /* AWSURLResponseSerialization.m */; };
+		DBF5AAEC5F1978380EC14D82EDF31054 /* AWSLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = BFCEEE328F910F62BBDE90665F16FD72 /* AWSLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DEFC6955484751C28D36B1126354830B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
+		E14859804FDF14B09F1DDF7C2E3404E4 /* AWSFMDatabaseAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = F95F5D2719024ECC7BF03F6832F6944E /* AWSFMDatabaseAdditions.m */; };
+		E1702B4EF8EC1AB6F934AC3BC6600A6F /* AWSMTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = F170E6A7DDECEFE5838C092C79B21FDA /* AWSMTLReflection.m */; };
+		E2121B84A87B54637022A745BA905991 /* AWSCognitoIdentity+Fabric.h in Headers */ = {isa = PBXBuildFile; fileRef = 8712DFDF41458E13CDE557E792397356 /* AWSCognitoIdentity+Fabric.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E67AC75CF625D30A349F06B872AD7DC7 /* FABKitProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 920863BE9A25A6D24A89E4889EE0A014 /* FABKitProtocol.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E70FC945E697C5DB7BEB83F5DDA67DA4 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 16B0120C1306E487433FCA2B1B0D2673 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E929D0F5359AE8857624AA8CDEACD8AB /* AWSClientContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 6075D205854C3273C42D6872BB69588E /* AWSClientContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EA97672CE9D5E84D129FBFA113A74D18 /* AWSMobileClientExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FDA22EA479098F4BD726442ADB34A1 /* AWSMobileClientExtensions.swift */; };
-		EBA1D2EEAF45E71A8E2079605D3746E2 /* AWSGZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E0D15EADD3AADC19B695054A1D13C64 /* AWSGZIP.m */; };
-		EC025F0FE35A6932FAE9C9A66EFFBF91 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE49F6473631850D3EC76C328D5772CB /* UIKit.framework */; };
+		E93E93B977E8B8E4C067729097481601 /* AWSEXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = E946D357D1B824535DF21C71A74F7306 /* AWSEXTRuntimeExtensions.m */; };
+		EBB5629A5A587AB94332D976DE76116B /* NSValueTransformer+AWSMTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3802AAD88A0ED5ABF4155747E2EC95BC /* NSValueTransformer+AWSMTLInversionAdditions.m */; };
+		EBDCAD5D12AE793D0A153530B8461492 /* AWSURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = CB5F5DD200C1796E0CD90E3B92A8DB28 /* AWSURLResponseSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EC2BC6AB009C3407813297E7660041CD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		EE24CB2671D97C781BA65442CA43DB00 /* AWSCognitoIdentityUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D48C5F3D2DEEE640B846066CB4126EA /* AWSCognitoIdentityUser.m */; };
-		EE8E9629C3ACB289EDC89260B539BD41 /* AWSCore-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A961C296142A0DF7ECC521DE76D4B01 /* AWSCore-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EF34D0B237DCB7D3209E3489B5568CE9 /* AWSTMDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D0D8DBA1E4C65DC5ABCA805122C1EAB /* AWSTMDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EF48789F2529FBABFC8032DD7CD2C023 /* AWSTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 166566D85854749EA3E2EA5703125695 /* AWSTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F06C38ADE5EBE33DB5A49FB236597552 /* AWSTMCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 165FBC6E04E5ACC477E3062D62C32B2E /* AWSTMCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F1958DDD97662963D1D386A7274A4C3B /* AWSFMDatabaseAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A2E468F0E0CED3E36EB9CB4C868FEB9 /* AWSFMDatabaseAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F234C9C6995F787397767C99BAE466FE /* AWSDDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4536DFB3A87AAD633645038FAD6A82FC /* AWSDDMultiFormatter.m */; };
-		F3909ADAF51026D1484701DFCB9F515D /* NSData+AWSCognitoIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 79D06071864E7D2C2A583BA20A80FE96 /* NSData+AWSCognitoIdentityProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F3F88A9F3028498A198989B1AACCC93A /* AWSSignInManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 94AD95A8DB82AF9AD0B9B7C124E6109E /* AWSSignInManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F5BCDBEEE390E1ED42E433E015CF3265 /* AWSCore-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B135F6001AFFAF6D2C0B9753AFD9497 /* AWSCore-dummy.m */; };
-		F785DACA06792679253D0114D2B1B1C1 /* AWSCognitoIdentityProviderModel.h in Headers */ = {isa = PBXBuildFile; fileRef = FA45D1A07F3B26B40BCAE39A6FC72003 /* AWSCognitoIdentityProviderModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F7ECDD7582930DBC43027FF5FBF8E44F /* AWSTMCacheBackgroundTaskManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B61A4055F0155D4A7FAEE9EA54CB4A60 /* AWSTMCacheBackgroundTaskManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F96D20AF94D29F7EF73DD8CD5F3197E0 /* AWSCognitoIdentityUserPool_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = E0C152ACE24CF32262809F5D86181BBF /* AWSCognitoIdentityUserPool_Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FB1F231D217D2914C4C03FE5B66F6301 /* AWSCognitoAuthUICKeyChainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 689C85B7A1BA6D62F0D490ABAD8A14D0 /* AWSCognitoAuthUICKeyChainStore.m */; };
-		FB8B41B95B8FCACA60CD482A37357212 /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 849F64B469D3BB22311DDDB52E8CDF2D /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FC1BFF263F28DF45B48C6088192D5479 /* AWSXMLDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 1493B5FD643C880E892290EEFF76F37A /* AWSXMLDictionary.m */; };
-		FCAB654F98D73A6F5EFE4EA356EF600D /* AWSIdentityProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 6964272CECA346AC5ED20E7B33457069 /* AWSIdentityProvider.m */; };
-		FD85A372868510FDFD6534963B952E71 /* AWSMobileClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 559ED735E06A51AB1E085F76D239ECE2 /* AWSMobileClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FEBE606A0C5598ACFD3AB28694B62852 /* AWSMTLValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B83B37411DCD7F7FA695BF3ADFB3477 /* AWSMTLValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC8750873DB5F6265E48BA9315A7B2F5 /* AWSMTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 12B99B810FB2E25531E1E4F2CAF6AABD /* AWSMTLJSONAdapter.m */; };
+		ED85DB4CE570B57E433BCFB56BBCBF04 /* AWSCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = EFEA0F24602DFAEAAC189215C3C59E39 /* AWSCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EE24CB2671D97C781BA65442CA43DB00 /* AWSCognitoIdentityUser.m in Sources */ = {isa = PBXBuildFile; fileRef = ACA1E3EBBEA1F5D3160841769800B0DC /* AWSCognitoIdentityUser.m */; };
+		F091C99F7BB142D1DB6152C7E144B9D2 /* AWSNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 46873E29496F81BE8EB8FC668D31C366 /* AWSNetworking.m */; };
+		F0C669060B8BFEF00131CC06B6995586 /* AWSExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = 7281DA57E485275E8A49803FCDED939E /* AWSExecutor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F3909ADAF51026D1484701DFCB9F515D /* NSData+AWSCognitoIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 906357A4C1AA3FE5689B0E940D3D91F2 /* NSData+AWSCognitoIdentityProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F57674F250149BF452F8E2CD1CFACB13 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
+		F5EFC3BA946FAB0C653C0EFB9187348D /* AWSUICKeyChainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 12DBB62EC989FA364779063935663723 /* AWSUICKeyChainStore.m */; };
+		F785DACA06792679253D0114D2B1B1C1 /* AWSCognitoIdentityProviderModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 64477AF05BB569C283F8CA75DC186B39 /* AWSCognitoIdentityProviderModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F96D20AF94D29F7EF73DD8CD5F3197E0 /* AWSCognitoIdentityUserPool_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B9A3E48A5EBDD64DAE2ECD9EE0D19659 /* AWSCognitoIdentityUserPool_Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FA1F41CB174865C3ABAA696511940338 /* AWSSTSService.m in Sources */ = {isa = PBXBuildFile; fileRef = BC78A1BE3112CD63FB79FC0D632C08AD /* AWSSTSService.m */; };
+		FA57383E56731300CB3E661B5BEF21DE /* AWSIdentityProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A1CD521E28948276DB6DF5C1CEBC2C1 /* AWSIdentityProvider.m */; };
+		FB8B41B95B8FCACA60CD482A37357212 /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BD2BB7E9FDBD0CD5EBDDACD4E5589AF /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FC0DF3B29BF928EB487F36248496068F /* AWSDDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 72AF9BE763154EB3F8872F62553004E1 /* AWSDDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FCB0E2F79322AAE4808375602EE9E27C /* AWSService.h in Headers */ = {isa = PBXBuildFile; fileRef = CF52B59CF212AEF5EF49ED0B7A9E02C1 /* AWSService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FCCD667C2ECB8F6AB815CFBE869B7BAE /* AWSValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = EB3B13702A64602EEE8777F3A9C91B70 /* AWSValidation.m */; };
+		FCF5EF0D7D0E39CEF61A1F8E7029923A /* AWSCredentialsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CC392531C7DC92AB41B16939E55FBAC /* AWSCredentialsProvider.m */; };
+		FDBB04B8FC16CF6EAD1AAC14B5E7B978 /* AWSDDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = BB55B2CB2AA26552F0C51813928696F6 /* AWSDDLegacyMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FDCCAC00A99C74E2BE6C3FD070D45C3D /* AWSCancellationTokenRegistration.h in Headers */ = {isa = PBXBuildFile; fileRef = 9109D53E30C8C4C64FBC39ECF60C179E /* AWSCancellationTokenRegistration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FEBDB02A795559B8678FF609BD63DC5D /* AWSMobileClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB67317B1299EE3D2F425CDDD6AFEEC0 /* AWSMobileClient.swift */; };
+		FF2758D837FB5A2D465659698E8D095F /* AWSMTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = BC067900E6CC27C9DAEE297A89AD2D0F /* AWSMTLModel+NSCoding.m */; };
+		FF35610D44E99E6782EF579730D183DF /* AWSNetworkingHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 42BB3C6979837861377DA5A89549AE64 /* AWSNetworkingHelpers.m */; };
+		FF5A3D0068C906E484D9FB5CC613556E /* AWSCognitoAuthUICKeyChainStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B7083ED686E473C67DDF5D1E86E724C /* AWSCognitoAuthUICKeyChainStore.h */; settings = {ATTRIBUTES = (Project, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -364,6 +370,13 @@
 			remoteGlobalIDString = BBF90BA4F6EC5653945C7B0FFD9128D2;
 			remoteInfo = AWSCognitoIdentityProviderASF;
 		};
+		198F4C9BE19725A59DDC93CD8A13CAE0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9B172FACE90046AA5E100E650B6109DD;
+			remoteInfo = AWSCore;
+		};
 		22894B8B0CF18BB08D17EF1249EAE641 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
@@ -385,26 +398,12 @@
 			remoteGlobalIDString = 29212B2F049288E035AB98405A23E41E;
 			remoteInfo = AWSCognitoIdentityProvider;
 		};
-		30894E0F73D05EABEF118596786A61A7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 9B172FACE90046AA5E100E650B6109DD;
-			remoteInfo = AWSCore;
-		};
 		36CF06C3E14C7BBA38DC5D502E356CA0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 29212B2F049288E035AB98405A23E41E;
 			remoteInfo = AWSCognitoIdentityProvider;
-		};
-		380E6810679FD8527F8690183215C99C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8042F2B0721B13AEDEB81F058C2B2125;
-			remoteInfo = AWSAuthCore;
 		};
 		3A9920B76D2D0C7A97C61BDC011F6E04 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -546,6 +545,13 @@
 			remoteGlobalIDString = 308B5C440C446909122081D367A27A8F;
 			remoteInfo = CwlCatchException;
 		};
+		808E02155DEA9FFFA7AB26A41DE112FA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 29212B2F049288E035AB98405A23E41E;
+			remoteInfo = AWSCognitoIdentityProvider;
+		};
 		823ACA39C425FB28F6D8371F2DAAC525 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
@@ -616,6 +622,13 @@
 			remoteGlobalIDString = 29212B2F049288E035AB98405A23E41E;
 			remoteInfo = AWSCognitoIdentityProvider;
 		};
+		ABF241B4BEC3E8ADB5E0B8D8BB34B97C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8042F2B0721B13AEDEB81F058C2B2125;
+			remoteInfo = AWSAuthCore;
+		};
 		ACA985698F78CE51CD54B4CC2C26CF5A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
@@ -650,13 +663,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 9B172FACE90046AA5E100E650B6109DD;
 			remoteInfo = AWSCore;
-		};
-		BE94540EF0C0E21FBAB6B1151DB42390 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 29212B2F049288E035AB98405A23E41E;
-			remoteInfo = AWSCognitoIdentityProvider;
 		};
 		C11EDAD6A1504B19CF07D09E6310F723 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -801,375 +807,393 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		00A9F9D487F770ACF4AE33F74AB275D3 /* AWSDDLog.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDLog.m; path = AWSCore/Logging/AWSDDLog.m; sourceTree = "<group>"; };
+		009CACF5738D03F5B64F3EF3C99FB61E /* AWSSTSService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSService.h; path = AWSCore/STS/AWSSTSService.h; sourceTree = "<group>"; };
+		00ED9F12F787409584FD64E63CB00BFA /* AWSAuthUIHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSAuthUIHelper.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.h; sourceTree = "<group>"; };
+		017996FA9F98A7E1AC8B1FB672D4E557 /* AWSCore-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCore-umbrella.h"; sourceTree = "<group>"; };
 		01CEDC80C5B028F2AE09C4BECC2F076B /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsCoreTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsCoreTests.framework; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		023B6B51414D71AD0293B95B3B78DBB1 /* AWSCognitoIdentity+Fabric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoIdentity+Fabric.h"; path = "AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.h"; sourceTree = "<group>"; };
-		0276AA0305ACFA3EEB7AC9822B834C03 /* CwlPreconditionTesting-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CwlPreconditionTesting-dummy.m"; sourceTree = "<group>"; };
-		027E6E6E1397ECEC532588E2FEA6CF38 /* AWSExecutor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSExecutor.h; path = AWSCore/Bolts/AWSExecutor.h; sourceTree = "<group>"; };
-		02E17769E68C64E4ED79B645F74F2E65 /* CwlPreconditionTesting-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlPreconditionTesting-umbrella.h"; sourceTree = "<group>"; };
-		0310E0B59C9259ADAB4636C5A7010C7E /* AWSCognitoIdentityProviderASF-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProviderASF-umbrella.h"; sourceTree = "<group>"; };
-		03CADE1D8C5CA75A636F2DE98BF8FC26 /* AWSDDContextFilterLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDContextFilterLogFormatter.m; path = AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter.m; sourceTree = "<group>"; };
 		03D039338D77A6CA524CBC57DE6E2BCF /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-dummy.m"; sourceTree = "<group>"; };
+		04498D780108D3EBDF53FD76FB42D380 /* AWSCognitoAuth.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuth.h; path = AWSCognitoAuth/AWSCognitoAuth.h; sourceTree = "<group>"; };
+		04F94581174EDFD77DD77D64E573D786 /* AWSSignInManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInManager.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInManager.h; sourceTree = "<group>"; };
 		055A209829E9548F5285CA89F94E6CC2 /* Pods-Amplify-AWSPluginsCore.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AWSPluginsCore.modulemap"; sourceTree = "<group>"; };
-		0576434B9FA7F8432DB8317EFE254CE6 /* AWSGZIP.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSGZIP.h; path = AWSCore/GZIP/AWSGZIP.h; sourceTree = "<group>"; };
-		05C0F4E4C138B9133220D879EB6297D0 /* AWSAuthCore-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSAuthCore-prefix.pch"; sourceTree = "<group>"; };
-		05C3FADC70C4131D4CE2CA995C9B4732 /* AWSEXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTRuntimeExtensions.h; path = AWSCore/Mantle/extobjc/AWSEXTRuntimeExtensions.h; sourceTree = "<group>"; };
-		0669AB8647FCA850A2FAD6F35CAB9B21 /* AWSCognitoIdentityProvider.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCognitoIdentityProvider.xcconfig; sourceTree = "<group>"; };
-		09CF2AF892B02F271301BDC969A95E14 /* AWSCognitoIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProvider.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityProvider.h; sourceTree = "<group>"; };
+		05F0A6A210EDEAFCB636DEF2E8E2C143 /* AWSMobileOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileOptions.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileOptions.swift; sourceTree = "<group>"; };
+		076B6FA2F32A84341788F1C2E42A79CA /* AWSDDLogMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLogMacros.h; path = AWSCore/Logging/AWSDDLogMacros.h; sourceTree = "<group>"; };
+		07ECE90907BE180F6A539BF08715EDE3 /* AWSFMDB.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDB.h; path = AWSCore/FMDB/AWSFMDB.h; sourceTree = "<group>"; };
+		0831B18334CCA361EBE774FCE1C79065 /* AWSDDOSLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDOSLogger.m; path = AWSCore/Logging/AWSDDOSLogger.m; sourceTree = "<group>"; };
+		0A075F8FA03A8A6E504C77FC33DE7E6D /* NSArray+AWSMTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+AWSMTLManipulationAdditions.h"; path = "AWSCore/Mantle/NSArray+AWSMTLManipulationAdditions.h"; sourceTree = "<group>"; };
+		0A1CD521E28948276DB6DF5C1CEBC2C1 /* AWSIdentityProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSIdentityProvider.m; path = AWSCore/Authentication/AWSIdentityProvider.m; sourceTree = "<group>"; };
+		0A3B34FAA9B84A5377B2D5C709DA6B92 /* AWSSTSResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSResources.m; path = AWSCore/STS/AWSSTSResources.m; sourceTree = "<group>"; };
+		0ADFD7E42BE139F259349496AA57A0A2 /* AWSXMLDictionary.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSXMLDictionary.m; path = AWSCore/XMLDictionary/AWSXMLDictionary.m; sourceTree = "<group>"; };
+		0AEEFB1F4D4875A426FBE8C5C6D76AB1 /* AWSAuthCore-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSAuthCore-dummy.m"; sourceTree = "<group>"; };
 		0B350FFEF637C6AF934EE101CD54DCE5 /* Pods-Amplify-AWSPluginsCore-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AWSPluginsCore-umbrella.h"; sourceTree = "<group>"; };
 		0B8DB7849FE18394F4C1421ABE0CEA2E /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
-		0C05D3E8BB489B73FDF8C5A2F0993DC1 /* aws_tommath_superclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath_superclass.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath_superclass.h; sourceTree = "<group>"; };
-		0C261BF596A4C5600D2FC1674D411BD9 /* CwlCatchException-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "CwlCatchException-Info.plist"; sourceTree = "<group>"; };
+		0C7EFC1FA0A94BB3040D38C1BBFCF76E /* AWSSTSModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSModel.m; path = AWSCore/STS/AWSSTSModel.m; sourceTree = "<group>"; };
+		0CACEC397330066C8C398ECECCE8BD5F /* _AWSMobileClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = _AWSMobileClient.h; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.h; sourceTree = "<group>"; };
+		0CF40D7AF9CA3F2F9A410759AE391171 /* NSObject+AWSMTLComparisonAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+AWSMTLComparisonAdditions.h"; path = "AWSCore/Mantle/NSObject+AWSMTLComparisonAdditions.h"; sourceTree = "<group>"; };
+		0D58BF63FD36A36860F5EB44E38DD099 /* AWSKSReachability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSKSReachability.h; path = AWSCore/KSReachability/AWSKSReachability.h; sourceTree = "<group>"; };
+		0D9574530C129769D1D1F03203C85D7C /* AWSCore-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCore-Info.plist"; sourceTree = "<group>"; };
+		0E02F91D7B07EC8FC39A4CAF40D39746 /* AWSDDTTYLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDTTYLogger.h; path = AWSCore/Logging/AWSDDTTYLogger.h; sourceTree = "<group>"; };
+		0E3D65FEA8DF69AB59F24058F42DCED6 /* AWSMTLManagedObjectAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLManagedObjectAdapter.m; path = AWSCore/Mantle/AWSMTLManagedObjectAdapter.m; sourceTree = "<group>"; };
+		0E4D66772DCE19A7404EF983F3D98759 /* CwlPreconditionTesting.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CwlPreconditionTesting.xcconfig; sourceTree = "<group>"; };
+		0F18885B0C226C01535E4BC473565790 /* tommath.c */ = {isa = PBXFileReference; includeInIndex = 1; name = tommath.c; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/tommath.c; sourceTree = "<group>"; };
 		0F1DEDC150BBA9D337427317717EC680 /* Pods_AmplifyTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_AmplifyTestApp.framework; path = "Pods-AmplifyTestApp.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1073C3EE5CBDD8387A3FB523E790C5CA /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
+		115578294D5785F67A4164B425F3D299 /* AWSModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSModel.m; path = AWSCore/Utility/AWSModel.m; sourceTree = "<group>"; };
 		11618E052B1995FC3B058B8E47104CFA /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-dummy.m"; sourceTree = "<group>"; };
-		1210644233B0F05F9A3BF152ADCAF1AF /* AWSEXTScope.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSEXTScope.m; path = AWSCore/Mantle/extobjc/AWSEXTScope.m; sourceTree = "<group>"; };
-		12F91AD721DA3E5AEAEDF9C4C2D5F9B6 /* AWSURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLRequestSerialization.m; path = AWSCore/Serialization/AWSURLRequestSerialization.m; sourceTree = "<group>"; };
-		1385AC19B182894FE81125DDCE8C5F06 /* AWSCore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCore.h; path = AWSCore/AWSCore.h; sourceTree = "<group>"; };
+		11981CE8441163483F737D85DE32B1CE /* AWSClientContext.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSClientContext.m; path = AWSCore/Service/AWSClientContext.m; sourceTree = "<group>"; };
+		11EDEFEDFA365D9648D81979FF0CF2BA /* AWSSynchronizedMutableDictionary.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSynchronizedMutableDictionary.m; path = AWSCore/Utility/AWSSynchronizedMutableDictionary.m; sourceTree = "<group>"; };
+		12163530DDDEF249BE3C311D0ED23327 /* CwlPreconditionTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlPreconditionTesting.h; path = Sources/CwlPreconditionTesting/include/CwlPreconditionTesting.h; sourceTree = "<group>"; };
+		12B99B810FB2E25531E1E4F2CAF6AABD /* AWSMTLJSONAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLJSONAdapter.m; path = AWSCore/Mantle/AWSMTLJSONAdapter.m; sourceTree = "<group>"; };
+		12D212D94038E4481D8C3C8043590F7C /* AWSCancellationTokenSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationTokenSource.h; path = AWSCore/Bolts/AWSCancellationTokenSource.h; sourceTree = "<group>"; };
+		12DBB62EC989FA364779063935663723 /* AWSUICKeyChainStore.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSUICKeyChainStore.m; path = AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m; sourceTree = "<group>"; };
+		13A27886A2A2BD9BDC18D4AA06E0BE8D /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h"; sourceTree = "<group>"; };
+		13A6AC4F2598B540AB29DEA12B8DA004 /* AWSCredentialsProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCredentialsProvider.h; path = AWSCore/Authentication/AWSCredentialsProvider.h; sourceTree = "<group>"; };
+		13A70D9A2492A9A41C2BC8FDDE0C6707 /* AWSDDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDAbstractDatabaseLogger.m; path = AWSCore/Logging/AWSDDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
+		13F6EC075EF080997FC5EAA557A51049 /* AWSSignInManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSignInManager.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInManager.m; sourceTree = "<group>"; };
 		14469F121FFD84334E39499AEA8DBAE8 /* Pods-AmplifyTestApp-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-AmplifyTestApp-frameworks.sh"; sourceTree = "<group>"; };
-		1493B5FD643C880E892290EEFF76F37A /* AWSXMLDictionary.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSXMLDictionary.m; path = AWSCore/XMLDictionary/AWSXMLDictionary.m; sourceTree = "<group>"; };
-		165FBC6E04E5ACC477E3062D62C32B2E /* AWSTMCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMCache.h; path = AWSCore/TMCache/AWSTMCache.h; sourceTree = "<group>"; };
-		166566D85854749EA3E2EA5703125695 /* AWSTask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTask.h; path = AWSCore/Bolts/AWSTask.h; sourceTree = "<group>"; };
 		1668BE896BD53109C08AF7DC22CF4EB7 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		167AA0AB77323674B63505B4C320DE54 /* AWSCognitoAuth_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuth_Internal.h; path = AWSCognitoAuth/Internal/AWSCognitoAuth_Internal.h; sourceTree = "<group>"; };
+		168E7EDD61CE770FCEEFF271776BDD39 /* AWSURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLRequestSerialization.h; path = AWSCore/Serialization/AWSURLRequestSerialization.h; sourceTree = "<group>"; };
+		16A649B28EBAF292512D8F10FD00EEC0 /* AWSEXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTKeyPathCoding.h; path = AWSCore/Mantle/extobjc/AWSEXTKeyPathCoding.h; sourceTree = "<group>"; };
 		16B0120C1306E487433FCA2B1B0D2673 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-umbrella.h"; sourceTree = "<group>"; };
-		16D16C7F3CC2A777770BD46E5A36DAB9 /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
-		17BE1A5690F7F5D226BB85EE0C715F82 /* AWSMTLManagedObjectAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLManagedObjectAdapter.m; path = AWSCore/Mantle/AWSMTLManagedObjectAdapter.m; sourceTree = "<group>"; };
 		17C7782F05A2504AD7615DC3ECD11FE5 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.debug.xcconfig"; sourceTree = "<group>"; };
-		18239979C2E3508F26FBE3C76EBAB6F9 /* AWSDDASLLogCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDASLLogCapture.h; path = AWSCore/Logging/AWSDDASLLogCapture.h; sourceTree = "<group>"; };
-		1857920E16FDBE7B45549583A1E0F961 /* AWSUICKeyChainStore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSUICKeyChainStore.h; path = AWSCore/UICKeyChainStore/AWSUICKeyChainStore.h; sourceTree = "<group>"; };
-		188D37813096871738338C0AE719885C /* SwiftFormat.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftFormat.xcconfig; sourceTree = "<group>"; };
-		188F37DEE01522564894F2F82EDD1EF6 /* AWSCognitoAuth.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuth.h; path = AWSCognitoAuth/AWSCognitoAuth.h; sourceTree = "<group>"; };
+		1853077C437335F8E40E76858B148CE5 /* AWSDDLog.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDLog.m; path = AWSCore/Logging/AWSDDLog.m; sourceTree = "<group>"; };
+		185F0DC6368FA1D4547527B451DB8EB9 /* AWSCognitoIdentityResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityResources.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityResources.m; sourceTree = "<group>"; };
 		189C8021820D164FA9236F1D27850C3F /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-umbrella.h"; sourceTree = "<group>"; };
-		18A3E400D3F817D016218A417D6F7D3D /* AWSMTLManagedObjectAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLManagedObjectAdapter.h; path = AWSCore/Mantle/AWSMTLManagedObjectAdapter.h; sourceTree = "<group>"; };
-		18D74676CDF8DA9E34ACD1D1FB077F8D /* AWSNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSNetworking.h; path = AWSCore/Networking/AWSNetworking.h; sourceTree = "<group>"; };
-		191511A3810F3B192E24B321C4589C46 /* AWSFMDatabasePool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabasePool.h; path = AWSCore/FMDB/AWSFMDatabasePool.h; sourceTree = "<group>"; };
-		19893BD9311EEA1ED479F6A2BC5C66A1 /* AWSTaskCompletionSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTaskCompletionSource.h; path = AWSCore/Bolts/AWSTaskCompletionSource.h; sourceTree = "<group>"; };
-		1A4792CC29627D2983F897C3A17E2818 /* AWSMobileClient-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSMobileClient-prefix.pch"; sourceTree = "<group>"; };
+		18F8E4C791238DE2BC89F84EF383A00D /* AWSMTLModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLModel.m; path = AWSCore/Mantle/AWSMTLModel.m; sourceTree = "<group>"; };
+		1A60E93D25B2C3C212B4679F93F75755 /* AWSMTLReflection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLReflection.h; path = AWSCore/Mantle/AWSMTLReflection.h; sourceTree = "<group>"; };
+		1B0AAF84EC698F11CC63045004A9ED58 /* AWSCognitoIdentityProviderHKDF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderHKDF.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderHKDF.h; sourceTree = "<group>"; };
+		1B1415B741EF9175334EEB8D7110C62F /* DeviceOperations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeviceOperations.swift; path = AWSAuthSDK/Sources/AWSMobileClient/DeviceOperations.swift; sourceTree = "<group>"; };
+		1B7083ED686E473C67DDF5D1E86E724C /* AWSCognitoAuthUICKeyChainStore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuthUICKeyChainStore.h; path = AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.h; sourceTree = "<group>"; };
 		1BB9D281CBBD8B4517D1F76CCC30FC7B /* Pods-AmplifyTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-AmplifyTestApp.debug.xcconfig"; sourceTree = "<group>"; };
+		1CB773EA726322B9A2CD42FF90D4DD17 /* AWSGeneric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSGeneric.h; path = AWSCore/Bolts/AWSGeneric.h; sourceTree = "<group>"; };
 		1D87F3274BC9EDCF528FEDC7945B146C /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-Info.plist"; sourceTree = "<group>"; };
-		1DA59FBF1D71A43520DFAEECD69EC2AB /* NSObject+AWSMTLComparisonAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+AWSMTLComparisonAdditions.m"; path = "AWSCore/Mantle/NSObject+AWSMTLComparisonAdditions.m"; sourceTree = "<group>"; };
-		1DD1F0DAB474DC311D2AD49F5739648D /* libAWSCognitoIdentityProviderASFBinary.a */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = archive.ar; name = libAWSCognitoIdentityProviderASFBinary.a; path = AWSCognitoIdentityProviderASF/Internal/libAWSCognitoIdentityProviderASFBinary.a; sourceTree = "<group>"; };
-		1E45C810F244B77A58178FD3D2B7BB80 /* Fabric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Fabric.h; path = AWSCore/Fabric/Fabric.h; sourceTree = "<group>"; };
-		1F400E46236066397175BEF33AB11D46 /* AWSMTLModel+NSCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSMTLModel+NSCoding.h"; path = "AWSCore/Mantle/AWSMTLModel+NSCoding.h"; sourceTree = "<group>"; };
-		2116F89D162EED1D1AF6937894DFAADE /* AWSCognitoIdentityProviderSrpHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderSrpHelper.m; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderSrpHelper.m; sourceTree = "<group>"; };
-		2133A4C34B9432D76D7E52785CF5DFA3 /* AWSDDLog+LOGV.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSDDLog+LOGV.h"; path = "AWSCore/Logging/AWSDDLog+LOGV.h"; sourceTree = "<group>"; };
-		22630171D3A1BBBCC8F31BCF32D10570 /* AWSDDMultiFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDMultiFormatter.h; path = AWSCore/Logging/Extensions/AWSDDMultiFormatter.h; sourceTree = "<group>"; };
-		22BE5BDD8BEA74A45AE7BA7B7E27C2CA /* CwlCatchException-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlCatchException-umbrella.h"; sourceTree = "<group>"; };
-		2331E13421EDE769751BEB53A865341B /* AWSURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLResponseSerialization.m; path = AWSCore/Serialization/AWSURLResponseSerialization.m; sourceTree = "<group>"; };
-		233BEDEACBE0EC3689AAAAC21BF3F84B /* AWSCognitoIdentityProviderASF-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCognitoIdentityProviderASF-Info.plist"; sourceTree = "<group>"; };
-		24D7C4A40FE6A6E8B9A1408D69A1312E /* _AWSMobileClient.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = _AWSMobileClient.m; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.m; sourceTree = "<group>"; };
+		1E2AEE92884E8A3660E2A5C368A9D134 /* AWSNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSNetworking.h; path = AWSCore/Networking/AWSNetworking.h; sourceTree = "<group>"; };
+		1E93344537320B3C5EB8604688C8560C /* AWSDDContextFilterLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDContextFilterLogFormatter.m; path = AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter.m; sourceTree = "<group>"; };
+		1EEAEFF4390C69F3ED0B2E72D09E4966 /* AWSCognitoIdentityProviderASF.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCognitoIdentityProviderASF.xcconfig; sourceTree = "<group>"; };
+		25B48B5E2F240D5C178AEC37739F47BD /* AWSTaskCompletionSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTaskCompletionSource.m; path = AWSCore/Bolts/AWSTaskCompletionSource.m; sourceTree = "<group>"; };
+		25DFBB76C1BF492E05A46B34178281AD /* AWSAuthCore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSAuthCore.xcconfig; sourceTree = "<group>"; };
 		2610F9ADBE599E1ACDCAC688B21F3A61 /* Pods-Amplify-AWSPluginsCore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore.release.xcconfig"; sourceTree = "<group>"; };
-		264C21DDA41C552389D593887842E2E5 /* AWSFMDatabasePool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabasePool.m; path = AWSCore/FMDB/AWSFMDatabasePool.m; sourceTree = "<group>"; };
-		2671FF7E927AEACE1D57CD183C23B33A /* AWSCognitoIdentityProviderHKDF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderHKDF.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderHKDF.h; sourceTree = "<group>"; };
-		272846E6C6A1F75201AEF412E1F113E6 /* AWSDDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDDispatchQueueLogFormatter.m; path = AWSCore/Logging/Extensions/AWSDDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
-		27FD7CAF337CC5B059781204CD63D3F8 /* AWSKSReachability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSKSReachability.h; path = AWSCore/KSReachability/AWSKSReachability.h; sourceTree = "<group>"; };
-		285C6FD84C4982A2B5F25DABB08C7897 /* AWSLogging.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSLogging.h; path = AWSCore/Utility/AWSLogging.h; sourceTree = "<group>"; };
-		29C1909F8CEAA8A3BD1A7E3D3B2094E9 /* AWSTMMemoryCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMMemoryCache.h; path = AWSCore/TMCache/AWSTMMemoryCache.h; sourceTree = "<group>"; };
-		29D585CE1EF74476EE6E9FC8653F1186 /* AWSURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLSessionManager.m; path = AWSCore/Networking/AWSURLSessionManager.m; sourceTree = "<group>"; };
-		2A4364EE7C5AC1D626C2EC5F6473A9A7 /* AWSIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSIdentityProvider.h; path = AWSCore/Authentication/AWSIdentityProvider.h; sourceTree = "<group>"; };
-		2A78B2CC4203D1B81AC6F03B00947583 /* AWSSignature.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSignature.m; path = AWSCore/Authentication/AWSSignature.m; sourceTree = "<group>"; };
-		2A961C296142A0DF7ECC521DE76D4B01 /* AWSCore-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCore-umbrella.h"; sourceTree = "<group>"; };
-		2B2CEB7C609DE754234286DB0B2099D2 /* AWSCognitoIdentityUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUser.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h; sourceTree = "<group>"; };
-		2B50B70E9AB640910D0909A9A6D00D10 /* AWSMTLJSONAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLJSONAdapter.m; path = AWSCore/Mantle/AWSMTLJSONAdapter.m; sourceTree = "<group>"; };
-		2DF90D7DF6E0AB0C6DAD5ACD71EE5837 /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
-		2E0FC39EDE37B13F74EFD7D11094F05E /* DeviceOperations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeviceOperations.swift; path = AWSAuthSDK/Sources/AWSMobileClient/DeviceOperations.swift; sourceTree = "<group>"; };
+		26844A716609D618B953ADCC3477A9C2 /* AWSSynchronizedMutableDictionary.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSynchronizedMutableDictionary.h; path = AWSCore/Utility/AWSSynchronizedMutableDictionary.h; sourceTree = "<group>"; };
+		27556645674390E079A50FAE1D38FFF1 /* AWSCognitoIdentityProviderService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderService.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderService.m; sourceTree = "<group>"; };
+		2791EB61C4AFF9075545494144A5BD95 /* aws_tommath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath.h; sourceTree = "<group>"; };
+		281AC237A5385219FDCE6717E9C69709 /* AWSCancellationTokenRegistration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationTokenRegistration.m; path = AWSCore/Bolts/AWSCancellationTokenRegistration.m; sourceTree = "<group>"; };
+		285440696A5920B5E6B03DE8351989B8 /* AWSNetworkingHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSNetworkingHelpers.h; path = AWSCore/Networking/AWSNetworkingHelpers.h; sourceTree = "<group>"; };
+		2B531E9546AD9DB8A58EDF26D38A9FE1 /* AWSCognitoIdentityProviderSrpHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderSrpHelper.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderSrpHelper.h; sourceTree = "<group>"; };
+		2C5FAED483BFCC2F6ED318BFC0A89612 /* AWSInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSInfo.m; path = AWSCore/Service/AWSInfo.m; sourceTree = "<group>"; };
+		2C69D27D99AAF70EBC5392FB14C7B7DA /* NSArray+AWSMTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+AWSMTLManipulationAdditions.m"; path = "AWSCore/Mantle/NSArray+AWSMTLManipulationAdditions.m"; sourceTree = "<group>"; };
+		2EDE3BF19468DE4E9605AD1B08021DF4 /* AWSURLRequestRetryHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLRequestRetryHandler.m; path = AWSCore/Serialization/AWSURLRequestRetryHandler.m; sourceTree = "<group>"; };
+		2F6A9E75313D30A2B28F68110FF230A2 /* CwlCatchException-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlCatchException-prefix.pch"; sourceTree = "<group>"; };
+		2F8E1C643E55898382E15AC05AA7365E /* AWSMobileResults.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileResults.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileResults.swift; sourceTree = "<group>"; };
 		2F99AE9B0E76188538C212C2BB77D456 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-Info.plist"; sourceTree = "<group>"; };
-		301896368726EDD96867206BBDD39070 /* SwiftLint.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLint.xcconfig; sourceTree = "<group>"; };
-		3020E70B872491E1D6E28FD21ECC2157 /* AWSDDASLLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDASLLogger.h; path = AWSCore/Logging/AWSDDASLLogger.h; sourceTree = "<group>"; };
-		302410B8A963352D5D9582F1052A757E /* AWSSTSService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSService.h; path = AWSCore/STS/AWSSTSService.h; sourceTree = "<group>"; };
+		30642F131CF85895AB20D4764112A7B1 /* AWSTaskCompletionSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTaskCompletionSource.h; path = AWSCore/Bolts/AWSTaskCompletionSource.h; sourceTree = "<group>"; };
+		316D632308F1EFBC2C0DF047773030DF /* AWSSignInProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInProvider.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInProvider.h; sourceTree = "<group>"; };
 		31ACD2A46D4B2806FEF94323C827E97C /* Pods-AmplifyTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-AmplifyTestApp.release.xcconfig"; sourceTree = "<group>"; };
-		330803FE2581778D386F729BF4845395 /* AWSCognitoAuth.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoAuth.m; path = AWSCognitoAuth/AWSCognitoAuth.m; sourceTree = "<group>"; };
 		356316C4DFEB6875A03C1B1AC2F84026 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-frameworks.sh"; sourceTree = "<group>"; };
-		35E60246C30F13E28F5682FD4ADA6C01 /* AWSLogging.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSLogging.m; path = AWSCore/Utility/AWSLogging.m; sourceTree = "<group>"; };
-		35EBDFBE4DD338E13AE38E0D38C691A3 /* AWSExecutor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSExecutor.m; path = AWSCore/Bolts/AWSExecutor.m; sourceTree = "<group>"; };
 		36BDAD0F29489ADEBD0B1E3648F2A317 /* Pods-Amplify-AWSPluginsCore-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AWSPluginsCore-acknowledgements.markdown"; sourceTree = "<group>"; };
-		372F6716342DA6EE1616FE8E41DCF50F /* NSValueTransformer+AWSMTLInversionAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+AWSMTLInversionAdditions.h"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLInversionAdditions.h"; sourceTree = "<group>"; };
-		37306661AA76074040E8089831654A0E /* AWSCognitoAuth+Extensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoAuth+Extensions.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h"; sourceTree = "<group>"; };
+		37E8F49480EF8060BB37B26F5BC5DF99 /* AWSSTS.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTS.h; path = AWSCore/STS/AWSSTS.h; sourceTree = "<group>"; };
+		3802AAD88A0ED5ABF4155747E2EC95BC /* NSValueTransformer+AWSMTLInversionAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+AWSMTLInversionAdditions.m"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLInversionAdditions.m"; sourceTree = "<group>"; };
+		3844849C30D28B47FF9C3DD61529455D /* AWSIdentityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSIdentityManager.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSIdentityManager.m; sourceTree = "<group>"; };
+		388680EB7CAF4AB53E3DD89E2CC90F2E /* aws_tommath_class.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath_class.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath_class.h; sourceTree = "<group>"; };
+		38B52AFD8824D96B30C353421A67E04F /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
+		38C24E5DB4B1C541A80CDFF1952C4545 /* AWSFMDB+AWSHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSFMDB+AWSHelpers.h"; path = "AWSCore/FMDB/AWSFMDB+AWSHelpers.h"; sourceTree = "<group>"; };
 		38C6AD3DCE09BA628BA94A834905BFA2 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.release.xcconfig"; sourceTree = "<group>"; };
 		38FF9DA450E0F55F72749EB00C3E4C06 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.release.xcconfig"; sourceTree = "<group>"; };
-		390C1C9CA7BE32F1E916129268C583BB /* AWSCognitoIdentityProvider-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProvider-prefix.pch"; sourceTree = "<group>"; };
-		3A611C30E177DDD6F14CECE647238E0F /* AWSEXTRuntimeExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSEXTRuntimeExtensions.m; path = AWSCore/Mantle/extobjc/AWSEXTRuntimeExtensions.m; sourceTree = "<group>"; };
+		390C1B329BDBA41B75D7590CFC85F033 /* AWSDDContextFilterLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDContextFilterLogFormatter.h; path = AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter.h; sourceTree = "<group>"; };
+		3965E8754824714C58065089218E87C4 /* AWSDDMultiFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDMultiFormatter.h; path = AWSCore/Logging/Extensions/AWSDDMultiFormatter.h; sourceTree = "<group>"; };
+		3A3C4EF0A54DFF8F64748AB9A6E364E0 /* AWSClientContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSClientContext.h; path = AWSCore/Service/AWSClientContext.h; sourceTree = "<group>"; };
 		3A7A8A66EAE3CF28E4545528AD125CFC /* Pods-Amplify.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify.release.xcconfig"; sourceTree = "<group>"; };
-		3B74700571E45B4B8084C2CF6DC7122A /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
+		3A9A9123BBE11A58771EB87A087316B6 /* CwlCatchException.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CwlCatchException.modulemap; sourceTree = "<group>"; };
+		3B109D739CFC883289A6548766B8B7DD /* AWSSignature.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSignature.m; path = AWSCore/Authentication/AWSSignature.m; sourceTree = "<group>"; };
 		3BF5B6D3E0339165EB3C15592888ACB3 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.debug.xcconfig"; sourceTree = "<group>"; };
-		3D320BB78515CC43BFB72D75526267FD /* AWSSignature.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignature.h; path = AWSCore/Authentication/AWSSignature.h; sourceTree = "<group>"; };
+		3CE55D53ECA949420B445EF748A6B476 /* SwiftLint.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLint.xcconfig; sourceTree = "<group>"; };
+		3D02469A819F1238BA748181F1265632 /* AWSMTLJSONAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLJSONAdapter.h; path = AWSCore/Mantle/AWSMTLJSONAdapter.h; sourceTree = "<group>"; };
+		3D7AD3753C2B976519ABD2B870B1AAF5 /* AWSAuthUIHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSAuthUIHelper.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.m; sourceTree = "<group>"; };
+		3D98814487113FC0451682BF2CA928D0 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m"; sourceTree = "<group>"; };
 		3E93CB74B9F5DE129151102493A989CB /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsTestCommon.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsTestCommon.framework; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3F3CA727772902D38F633984F132084D /* AWSDDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDAbstractDatabaseLogger.h; path = AWSCore/Logging/AWSDDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
 		3F8DD9A4C98BD4C5E30943C049E35926 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		3FB6BA58A3DC5A5334029E7C6BBF6990 /* AWSDDLog+LOGV.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSDDLog+LOGV.h"; path = "AWSCore/Logging/AWSDDLog+LOGV.h"; sourceTree = "<group>"; };
 		40363564952E7B989CC8FD137DFC0347 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-Info.plist"; sourceTree = "<group>"; };
-		42D1C9714D461A6FEBFA26A038D4F780 /* AWSDDContextFilterLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDContextFilterLogFormatter.h; path = AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter.h; sourceTree = "<group>"; };
+		40D3E2ACC250193E898393BB5E5B0FAD /* AWSXMLWriter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSXMLWriter.m; path = AWSCore/XMLWriter/AWSXMLWriter.m; sourceTree = "<group>"; };
+		4108872B2D9F35982F849D20935EFE58 /* AWSCognitoIdentityProviderASF.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderASF.m; path = AWSCognitoIdentityProviderASF/AWSCognitoIdentityProviderASF.m; sourceTree = "<group>"; };
+		41F1BA5E8793C8CC6222D85413CE4C4A /* AWSFMDatabaseQueue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabaseQueue.h; path = AWSCore/FMDB/AWSFMDatabaseQueue.h; sourceTree = "<group>"; };
+		42BB3C6979837861377DA5A89549AE64 /* AWSNetworkingHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSNetworkingHelpers.m; path = AWSCore/Networking/AWSNetworkingHelpers.m; sourceTree = "<group>"; };
 		42F9974C1E644CB8D99A4CE7C7E2CA56 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-acknowledgements.markdown"; sourceTree = "<group>"; };
 		430811562C2E438327AA9EA8436484D5 /* Pods-AmplifyTestApp-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-AmplifyTestApp-Info.plist"; sourceTree = "<group>"; };
-		4309152BC40096DDD5A7CD143D059A18 /* AWSURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLResponseSerialization.h; path = AWSCore/Serialization/AWSURLResponseSerialization.h; sourceTree = "<group>"; };
-		448B7D6B55A4A3F3BCE22250E82D5EB5 /* AWSCognitoIdentityProvider-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCognitoIdentityProvider-dummy.m"; sourceTree = "<group>"; };
-		44B546B0A6D74703ADCFBD38A0D6EABE /* AWSSignInProviderApplicationIntercept.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInProviderApplicationIntercept.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInProviderApplicationIntercept.h; sourceTree = "<group>"; };
-		4536DFB3A87AAD633645038FAD6A82FC /* AWSDDMultiFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDMultiFormatter.m; path = AWSCore/Logging/AWSDDMultiFormatter.m; sourceTree = "<group>"; };
-		46AAC543E8596322357324D02944C052 /* CwlPreconditionTesting.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CwlPreconditionTesting.modulemap; sourceTree = "<group>"; };
-		46E25C0067451C42478D6F8D0E2D0BB4 /* AWSURLRequestRetryHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLRequestRetryHandler.m; path = AWSCore/Serialization/AWSURLRequestRetryHandler.m; sourceTree = "<group>"; };
-		470DACED7FA482EE4F2D2F781A78EB9B /* AWSDDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDAbstractDatabaseLogger.m; path = AWSCore/Logging/AWSDDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
+		46873E29496F81BE8EB8FC668D31C366 /* AWSNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSNetworking.m; path = AWSCore/Networking/AWSNetworking.m; sourceTree = "<group>"; };
 		47D46D2BEC1D90EDAE4F1B547348EEFB /* AWSCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		480BAF4B1C5C9B17EC75A49C9A44BE85 /* AWSInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSInfo.h; path = AWSCore/Service/AWSInfo.h; sourceTree = "<group>"; };
-		4847747404AB74113FFD8EC4DA63AA4E /* AWSCognitoIdentityProviderSrpHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderSrpHelper.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderSrpHelper.h; sourceTree = "<group>"; };
 		48B10C571F93314CED282170847D63D8 /* Pods-AmplifyTestApp.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-AmplifyTestApp.modulemap"; sourceTree = "<group>"; };
-		498D20AA560AEC314E9573CE635D2DE5 /* AWSMobileClient.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSMobileClient.xcconfig; sourceTree = "<group>"; };
-		4A2E468F0E0CED3E36EB9CB4C868FEB9 /* AWSFMDatabaseAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabaseAdditions.h; path = AWSCore/FMDB/AWSFMDatabaseAdditions.h; sourceTree = "<group>"; };
-		4AD77E92817948CBE257C0921A8168E1 /* AWSCognitoIdentityService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityService.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityService.h; sourceTree = "<group>"; };
-		4AEDCAB69641F21BD95E3D9568D7CBF2 /* CwlCatchException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchException.swift; path = Sources/CwlCatchException/CwlCatchException.swift; sourceTree = "<group>"; };
-		4BCA6DA44439111C917017DE70D65CAB /* AWSDDASLLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDASLLogger.m; path = AWSCore/Logging/AWSDDASLLogger.m; sourceTree = "<group>"; };
-		4D79EA8A0193479BD7F7E122F9C1E9C0 /* AWSCognitoIdentityProviderASF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderASF.h; path = AWSCognitoIdentityProviderASF/AWSCognitoIdentityProviderASF.h; sourceTree = "<group>"; };
-		4DDAA621C1CDBD9DFFD60CDC770E0102 /* AWSCognitoIdentityProvider.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCognitoIdentityProvider.modulemap; sourceTree = "<group>"; };
-		4E7C334C7718E548C12E9BD587E2E334 /* AWSCognitoIdentityProviderHKDF.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderHKDF.m; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderHKDF.m; sourceTree = "<group>"; };
-		4ED297B820F96D037627E4109EDBEF25 /* AWSSignInManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSignInManager.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInManager.m; sourceTree = "<group>"; };
-		50D64E42E6221E8FF4AB21C399E7EFA7 /* NSArray+AWSMTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+AWSMTLManipulationAdditions.h"; path = "AWSCore/Mantle/NSArray+AWSMTLManipulationAdditions.h"; sourceTree = "<group>"; };
-		51D2C28D5E7E89A421341AEDF1725E85 /* NSError+AWSMTLModelException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSError+AWSMTLModelException.h"; path = "AWSCore/Mantle/NSError+AWSMTLModelException.h"; sourceTree = "<group>"; };
-		524A30EDB9EFE391117EA5798D76BCCE /* AWSCognitoIdentityProvider-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCognitoIdentityProvider-Info.plist"; sourceTree = "<group>"; };
-		526789E47E87CD57DC238155C82E851D /* AWSCognitoIdentityService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityService.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityService.m; sourceTree = "<group>"; };
-		52E2C3D83CDE56B97DAB55CAA571A422 /* AWSFMDatabase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabase.m; path = AWSCore/FMDB/AWSFMDatabase.m; sourceTree = "<group>"; };
-		5350CDE7B953DE51333978AFC91C00FD /* AWSMTLModel+NSCoding.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSMTLModel+NSCoding.m"; path = "AWSCore/Mantle/AWSMTLModel+NSCoding.m"; sourceTree = "<group>"; };
-		535C83A91CC020AFB7530E10C8EEF27F /* AWSCognitoIdentityModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityModel.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityModel.m; sourceTree = "<group>"; };
-		53FDA22EA479098F4BD726442ADB34A1 /* AWSMobileClientExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClientExtensions.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift; sourceTree = "<group>"; };
+		49C1DACDE13725ACAFADE7825739F218 /* AWSXMLDictionary.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSXMLDictionary.h; path = AWSCore/XMLDictionary/AWSXMLDictionary.h; sourceTree = "<group>"; };
+		4BD2BB7E9FDBD0CD5EBDDACD4E5589AF /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
+		4D18BB847E2E5CA341022508986C0EA8 /* AWSFMDatabasePool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabasePool.m; path = AWSCore/FMDB/AWSFMDatabasePool.m; sourceTree = "<group>"; };
+		4D3E0FBF0A1B96D9B0A1670BC8C4117E /* AWSCognitoIdentityUserPool+Extension.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoIdentityUserPool+Extension.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoIdentityUserPool+Extension.h"; sourceTree = "<group>"; };
+		4E04EDF5782C184E748B3557700E2640 /* AWSCognitoIdentityProviderASF.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCognitoIdentityProviderASF.modulemap; sourceTree = "<group>"; };
+		4E57BA4A95EE17DEB99ECB5EBFC44EA9 /* AWSCognitoIdentityModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityModel.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityModel.h; sourceTree = "<group>"; };
+		506993FFD5E43321C8EE111378E6B6C5 /* AWSCognitoIdentityUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUser.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h; sourceTree = "<group>"; };
+		5085A6145D46202038A579642BB3B761 /* libAWSCognitoIdentityProviderASFBinary.a */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = archive.ar; name = libAWSCognitoIdentityProviderASFBinary.a; path = AWSCognitoIdentityProviderASF/Internal/libAWSCognitoIdentityProviderASFBinary.a; sourceTree = "<group>"; };
+		51F546FB05338188F9D16DCA20239565 /* AWSCore-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCore-dummy.m"; sourceTree = "<group>"; };
+		5292499829C37C41F261711AC72F7168 /* CwlCatchException.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CwlCatchException.xcconfig; sourceTree = "<group>"; };
+		52E8B5E00968480B2775F83181520231 /* NSDictionary+AWSMTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+AWSMTLManipulationAdditions.m"; path = "AWSCore/Mantle/NSDictionary+AWSMTLManipulationAdditions.m"; sourceTree = "<group>"; };
 		540B0D26F5B613408E8F5D94A66B5C28 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-acknowledgements.markdown"; sourceTree = "<group>"; };
-		5458CB47C2EF22CEE66D77C5DEB15466 /* AWSCognitoIdentityProviderASF-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProviderASF-prefix.pch"; sourceTree = "<group>"; };
-		5471E69EB7F11DB1920AFA5EFA4CFF00 /* AWSCognitoIdentityUser_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUser_Internal.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityUser_Internal.h; sourceTree = "<group>"; };
-		550678CEB07A27206F9F706AC35ECB8E /* AWSDDLogMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLogMacros.h; path = AWSCore/Logging/AWSDDLogMacros.h; sourceTree = "<group>"; };
-		559ED735E06A51AB1E085F76D239ECE2 /* AWSMobileClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMobileClient.h; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.h; sourceTree = "<group>"; };
+		5410D8EAB2C72480C6D03EAC64799186 /* AWSDDASLLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDASLLogger.h; path = AWSCore/Logging/AWSDDASLLogger.h; sourceTree = "<group>"; };
+		557CB74CF255046C393A564440AE135F /* AWSCognitoIdentityProviderModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderModel.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderModel.m; sourceTree = "<group>"; };
 		5609021041C2F48853430E0091C5BB5A /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-Info.plist"; sourceTree = "<group>"; };
-		5658CFB1EE58DB90BACB45071B93D3FA /* AWSURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLSessionManager.h; path = AWSCore/Networking/AWSURLSessionManager.h; sourceTree = "<group>"; };
 		5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		58C2F31559199BF7D5D53164AA6F019A /* AWSSTSModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSModel.m; path = AWSCore/STS/AWSSTSModel.m; sourceTree = "<group>"; };
-		58CAF26D90978B1CEF93B2CE577F090E /* AWSSTSModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSModel.h; path = AWSCore/STS/AWSSTSModel.h; sourceTree = "<group>"; };
+		57E610DB1C9834B93B86B32AE203D34B /* AWSCognitoAuth_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuth_Internal.h; path = AWSCognitoAuth/Internal/AWSCognitoAuth_Internal.h; sourceTree = "<group>"; };
+		58C89AD838EDC38CC8C7DBB462B82E56 /* AWSCognitoIdentityProviderService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderService.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderService.h; sourceTree = "<group>"; };
 		592313CB94B49286EEF277EA91D3D95A /* AWSCognitoIdentityProviderASF.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AWSCognitoIdentityProviderASF.framework; path = AWSCognitoIdentityProviderASF.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		597F1FBC284F71F3B4FA26BA2D7073CF /* AWSDDLegacyMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLegacyMacros.h; path = AWSCore/Logging/AWSDDLegacyMacros.h; sourceTree = "<group>"; };
+		59A459A5BE87F0DADD67EBB169FFF49A /* AWSGZIP.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSGZIP.h; path = AWSCore/GZIP/AWSGZIP.h; sourceTree = "<group>"; };
 		59AD6B8077039CA78508DA2892FE480F /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.modulemap"; sourceTree = "<group>"; };
-		5ACEAA077B4DC5FF33706180C515F269 /* AWSUserPoolOperationsHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSUserPoolOperationsHandler.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift; sourceTree = "<group>"; };
-		5B135F6001AFFAF6D2C0B9753AFD9497 /* AWSCore-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCore-dummy.m"; sourceTree = "<group>"; };
-		5BAA1591C171FABA209F8DD8CBDD9474 /* AWSMobileOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileOptions.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileOptions.swift; sourceTree = "<group>"; };
-		5BF16544386127F9C6E26486D1BBA0C5 /* AWSMobileClient-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSMobileClient-umbrella.h"; sourceTree = "<group>"; };
+		5AF033D372099B17E4AD1ECEF2388C74 /* FABAttributes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FABAttributes.h; path = AWSCore/Fabric/FABAttributes.h; sourceTree = "<group>"; };
 		5C6DDDDA1D966AED315AB70664004815 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-umbrella.h"; sourceTree = "<group>"; };
-		5C87FDEBC481B70900979EF90CF27CFF /* AWSFMDatabaseAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabaseAdditions.m; path = AWSCore/FMDB/AWSFMDatabaseAdditions.m; sourceTree = "<group>"; };
 		5CC60529D233360B1F356DC750E15164 /* Pods-AmplifyTestApp-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-AmplifyTestApp-dummy.m"; sourceTree = "<group>"; };
+		5CDCA759E2B524AD0D5B0529F695A28C /* AWSJKBigDecimal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSJKBigDecimal.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigDecimal.h; sourceTree = "<group>"; };
 		5E7D5AC68E43CA3768505A58681304E1 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-umbrella.h"; sourceTree = "<group>"; };
-		5EAB57F27B14013C8DD9ACC0853D0832 /* AWSService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSService.m; path = AWSCore/Service/AWSService.m; sourceTree = "<group>"; };
+		5EDFE115C3392FB9863659189DFA9FD0 /* AWSCognitoIdentityProvider.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCognitoIdentityProvider.xcconfig; sourceTree = "<group>"; };
 		5FA201FD7F04844F9B9C1F2974AD9B46 /* AWSCognitoIdentityProvider.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AWSCognitoIdentityProvider.framework; path = AWSCognitoIdentityProvider.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6075D205854C3273C42D6872BB69588E /* AWSClientContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSClientContext.h; path = AWSCore/Service/AWSClientContext.h; sourceTree = "<group>"; };
-		619965D8A2E8B9EBD1D1D6AD46124CF8 /* AWSGeneric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSGeneric.h; path = AWSCore/Bolts/AWSGeneric.h; sourceTree = "<group>"; };
-		61A099F78198AE7CBE498B4173A29059 /* NSDictionary+AWSMTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+AWSMTLManipulationAdditions.m"; path = "AWSCore/Mantle/NSDictionary+AWSMTLManipulationAdditions.m"; sourceTree = "<group>"; };
+		60F4BE632949FAE284F63F70D7952C60 /* AWSTMMemoryCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMMemoryCache.m; path = AWSCore/TMCache/AWSTMMemoryCache.m; sourceTree = "<group>"; };
+		63558BCBF0A625B52BCB547CD0DFB1BA /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
 		636498E92402BEB2BB38D02D7EC74238 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-acknowledgements.plist"; sourceTree = "<group>"; };
-		643A75097C14026359E5647074040E50 /* AWSFMDB+AWSHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSFMDB+AWSHelpers.m"; path = "AWSCore/FMDB/AWSFMDB+AWSHelpers.m"; sourceTree = "<group>"; };
+		64477AF05BB569C283F8CA75DC186B39 /* AWSCognitoIdentityProviderModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderModel.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderModel.h; sourceTree = "<group>"; };
 		64802F2E333FD29A93B939784FB965FE /* Pods-Amplify-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-umbrella.h"; sourceTree = "<group>"; };
-		65BB125D267BA4B1D4FA8A28C9727E9F /* AWSCognitoIdentity+Fabric.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSCognitoIdentity+Fabric.m"; path = "AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.m"; sourceTree = "<group>"; };
+		65A25F6FD0D61706F9535950AFC406E4 /* AWSService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSService.m; path = AWSCore/Service/AWSService.m; sourceTree = "<group>"; };
 		66112A1C75E7120538B03A9B1914DB4A /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-Info.plist"; sourceTree = "<group>"; };
-		66EE313AB25CB9F796B40540A13890D7 /* AWSCognitoIdentityUserPool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUserPool.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h; sourceTree = "<group>"; };
-		67CD77FFD4E62B560C010929AFDF8FC8 /* AWSDDOSLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDOSLogger.h; path = AWSCore/Logging/AWSDDOSLogger.h; sourceTree = "<group>"; };
-		682069AC7E59C138843C82C76D694A59 /* AWSCognitoIdentityProviderASF.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCognitoIdentityProviderASF.modulemap; sourceTree = "<group>"; };
-		68745D588A16410345510D25D11B08F5 /* CwlCatchException.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CwlCatchException.xcconfig; sourceTree = "<group>"; };
-		689C85B7A1BA6D62F0D490ABAD8A14D0 /* AWSCognitoAuthUICKeyChainStore.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoAuthUICKeyChainStore.m; path = AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.m; sourceTree = "<group>"; };
-		6964272CECA346AC5ED20E7B33457069 /* AWSIdentityProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSIdentityProvider.m; path = AWSCore/Authentication/AWSIdentityProvider.m; sourceTree = "<group>"; };
-		6AAB32D7539E8EDCE5671C5EF2B2C202 /* AWSMTLReflection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLReflection.h; path = AWSCore/Mantle/AWSMTLReflection.h; sourceTree = "<group>"; };
-		6AD3460A804CAD6E3F709F0BBC359B7F /* AWSFMDatabaseQueue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabaseQueue.h; path = AWSCore/FMDB/AWSFMDatabaseQueue.h; sourceTree = "<group>"; };
-		6ADEE001834A1EB63E83AD9FF5E2E657 /* AWSTMDiskCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMDiskCache.m; path = AWSCore/TMCache/AWSTMDiskCache.m; sourceTree = "<group>"; };
+		66931E8F9AFA69143E52E4F621951059 /* AWSCore.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCore.modulemap; sourceTree = "<group>"; };
+		66B10363FF226628014BC9AA0109E500 /* AWSCognitoIdentity.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentity.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentity.h; sourceTree = "<group>"; };
+		66D34A65BD719CA839A366AED5ACE1F2 /* CwlCatchException-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlCatchException-umbrella.h"; sourceTree = "<group>"; };
+		673FC21F904E05922260C6F6C1055044 /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
+		679BE254CFCDEE26015A8539E066D54F /* AWSMTLModel+NSCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSMTLModel+NSCoding.h"; path = "AWSCore/Mantle/AWSMTLModel+NSCoding.h"; sourceTree = "<group>"; };
+		6A425EA2780C3972162FA364B8134591 /* AWSDDLog.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLog.h; path = AWSCore/Logging/AWSDDLog.h; sourceTree = "<group>"; };
+		6B78D374D0A051D9C447BCFAE475F4E2 /* AWSCancellationToken.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationToken.m; path = AWSCore/Bolts/AWSCancellationToken.m; sourceTree = "<group>"; };
+		6BCC572FE610F38AA38FE89EDDD3EDEE /* AWSCore-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCore-prefix.pch"; sourceTree = "<group>"; };
+		6C401F43F3647CFB1A04369928781E0E /* AWSSignature.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignature.h; path = AWSCore/Authentication/AWSSignature.h; sourceTree = "<group>"; };
 		6C5ECBC402A49A42921C8BA77F0A19C5 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-acknowledgements.plist"; sourceTree = "<group>"; };
 		6C81CC0258D4E4C6230E583C79613573 /* AWSAuthCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AWSAuthCore.framework; path = AWSAuthCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C836C6AB96168F166B40979832ABA3F /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-frameworks.sh"; sourceTree = "<group>"; };
-		6D0D8DBA1E4C65DC5ABCA805122C1EAB /* AWSTMDiskCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMDiskCache.h; path = AWSCore/TMCache/AWSTMDiskCache.h; sourceTree = "<group>"; };
-		6D6EE3BB562D22B7BDBB0E108ACA5649 /* tommath.c */ = {isa = PBXFileReference; includeInIndex = 1; name = tommath.c; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/tommath.c; sourceTree = "<group>"; };
-		6E21FE623B6D96ED3B851CE8586FD882 /* AWSSTSResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSResources.h; path = AWSCore/STS/AWSSTSResources.h; sourceTree = "<group>"; };
-		6FA8ED3AD37F037DC824A5F6E91A7405 /* AWSModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSModel.m; path = AWSCore/Utility/AWSModel.m; sourceTree = "<group>"; };
-		6FEDCA780BD39F32B34903769AA07865 /* CwlPreconditionTesting-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlPreconditionTesting-prefix.pch"; sourceTree = "<group>"; };
+		6D2101718310C6801E3A00062C07C39C /* AWSTask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTask.h; path = AWSCore/Bolts/AWSTask.h; sourceTree = "<group>"; };
+		70B3F537BC06A2190DBA5545CA3BC9D1 /* AWSSTSModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSModel.h; path = AWSCore/STS/AWSSTSModel.h; sourceTree = "<group>"; };
+		70BCFF3866799D2A76B86625EB6F94A7 /* CwlPreconditionTesting-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlPreconditionTesting-prefix.pch"; sourceTree = "<group>"; };
 		70EF68EF61C4587DEC5119A866265B57 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-dummy.m"; sourceTree = "<group>"; };
 		71803B908C82923324FBC55B50603420 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-umbrella.h"; sourceTree = "<group>"; };
-		71D1F9D0DBC89FD691F685E6A5AA15AE /* AWSMobileClient-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSMobileClient-dummy.m"; sourceTree = "<group>"; };
-		72A71B300822301B02175A776829FDD5 /* AWSCategory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCategory.h; path = AWSCore/Utility/AWSCategory.h; sourceTree = "<group>"; };
-		736ED39179608901F09197369E221D00 /* CwlCatchException.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CwlCatchException.modulemap; sourceTree = "<group>"; };
-		754CA60E9D4F3F509CD3D0CD69803593 /* AWSCognitoIdentityUserPool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityUserPool.m; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m; sourceTree = "<group>"; };
-		760FEF898396FB1D507B4561369EC431 /* AWSService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSService.h; path = AWSCore/Service/AWSService.h; sourceTree = "<group>"; };
-		7615572287FFAD3ADADE3696B49FBEA0 /* AWSCancellationTokenSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationTokenSource.m; path = AWSCore/Bolts/AWSCancellationTokenSource.m; sourceTree = "<group>"; };
+		722FB0BF2F494C956CD49C0C75A2FDC0 /* AWSLogging.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSLogging.m; path = AWSCore/Utility/AWSLogging.m; sourceTree = "<group>"; };
+		7257E001ABB1CC1EF9EE34046FC8BCD2 /* AWSCognitoIdentityProvider.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCognitoIdentityProvider.modulemap; sourceTree = "<group>"; };
+		7281DA57E485275E8A49803FCDED939E /* AWSExecutor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSExecutor.h; path = AWSCore/Bolts/AWSExecutor.h; sourceTree = "<group>"; };
+		72AF9BE763154EB3F8872F62553004E1 /* AWSDDAssertMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDAssertMacros.h; path = AWSCore/Logging/AWSDDAssertMacros.h; sourceTree = "<group>"; };
+		73D6A1A96394F99C88C2D192F6EE2472 /* AWSUICKeyChainStore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSUICKeyChainStore.h; path = AWSCore/UICKeyChainStore/AWSUICKeyChainStore.h; sourceTree = "<group>"; };
+		745068DD32DDB8617322A32B3A678DDD /* AWSDDOSLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDOSLogger.h; path = AWSCore/Logging/AWSDDOSLogger.h; sourceTree = "<group>"; };
+		76183A993DAA4D030DEB79B1EE231C3C /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
 		77145BB1E378943FCB981368F4B9E771 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests.release.xcconfig"; sourceTree = "<group>"; };
-		7715655789C4DEFA42CCEDADF986EB1A /* AWSAuthCore.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSAuthCore.modulemap; sourceTree = "<group>"; };
-		776091FCE4C283ABB38949973F5703CD /* AWSSynchronizedMutableDictionary.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSynchronizedMutableDictionary.h; path = AWSCore/Utility/AWSSynchronizedMutableDictionary.h; sourceTree = "<group>"; };
-		77BAFF4FE895704E891DA828C3F2CA60 /* AWSCognitoIdentityProviderResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderResources.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderResources.h; sourceTree = "<group>"; };
-		7829B6EBCFB30A013745B15EA9035B94 /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
-		79641B7E0DED5BBD74610BDBF3C5B665 /* AWSAuthCore-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSAuthCore-umbrella.h"; sourceTree = "<group>"; };
-		799B96796EC00C7068F5E7BBAB3EC905 /* AWSMantle.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMantle.h; path = AWSCore/Mantle/AWSMantle.h; sourceTree = "<group>"; };
-		79D06071864E7D2C2A583BA20A80FE96 /* NSData+AWSCognitoIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+AWSCognitoIdentityProvider.h"; path = "AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.h"; sourceTree = "<group>"; };
-		7B3F626DDF47B7A62A8143255FA2E51A /* AWSXMLDictionary.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSXMLDictionary.h; path = AWSCore/XMLDictionary/AWSXMLDictionary.h; sourceTree = "<group>"; };
-		7B77ED9825E341DEF2A12FAE12D669D2 /* AWSCredentialsProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCredentialsProvider.h; path = AWSCore/Authentication/AWSCredentialsProvider.h; sourceTree = "<group>"; };
-		7B83B37411DCD7F7FA695BF3ADFB3477 /* AWSMTLValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLValueTransformer.h; path = AWSCore/Mantle/AWSMTLValueTransformer.h; sourceTree = "<group>"; };
-		7D5E9435E602D6E154E08200A3D0499A /* AWSUICKeyChainStore.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSUICKeyChainStore.m; path = AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m; sourceTree = "<group>"; };
-		7D63B32CF1F9ED5B8E6C8305468A8484 /* FABKitProtocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FABKitProtocol.h; path = AWSCore/Fabric/FABKitProtocol.h; sourceTree = "<group>"; };
+		7771C2DFE4AD99CD3A269C7ADB017DAA /* AWSCognitoIdentityService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityService.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityService.h; sourceTree = "<group>"; };
+		795169AE5537F5799BCDE954951A68F6 /* AWSCognitoIdentityProviderASF-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProviderASF-prefix.pch"; sourceTree = "<group>"; };
+		79F8F7318B8DE19209DA9DDF5193FC01 /* AWSURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLRequestSerialization.m; path = AWSCore/Serialization/AWSURLRequestSerialization.m; sourceTree = "<group>"; };
+		7A8546CE0DBDFE5D38B2046606E4B7CE /* AWSFMResultSet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMResultSet.h; path = AWSCore/FMDB/AWSFMResultSet.h; sourceTree = "<group>"; };
+		7AA514D521D364F474E1B819D72E6CA6 /* CwlPreconditionTesting-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "CwlPreconditionTesting-Info.plist"; sourceTree = "<group>"; };
+		7AB1A2F26FDFD8E1CCDB36F0FFD0FDA0 /* AWSEXTScope.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSEXTScope.m; path = AWSCore/Mantle/extobjc/AWSEXTScope.m; sourceTree = "<group>"; };
+		7B5D74163C65BA45F129C2F75A244A26 /* AWSCognitoIdentityUserPool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUserPool.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h; sourceTree = "<group>"; };
+		7B69116025E7AE4E03FD9CB6AE7D4A79 /* AWSmetamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSmetamacros.h; path = AWSCore/Mantle/extobjc/AWSmetamacros.h; sourceTree = "<group>"; };
 		7E95AAB996428D7874DB2E4B93260F35 /* CwlCatchException.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CwlCatchException.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		7EF841B46EC42CD1F560B98CD32D7CEE /* AWSCognitoIdentityResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityResources.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityResources.h; sourceTree = "<group>"; };
-		7F5E975E46445A4810198027571DB7D7 /* CwlCatchException-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlCatchException-prefix.pch"; sourceTree = "<group>"; };
-		7F749536B6554065641E229399AE2E2D /* CwlPreconditionTesting-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "CwlPreconditionTesting-Info.plist"; sourceTree = "<group>"; };
+		80C849937AD2C88BA17636FFE3EEE60C /* AWSCore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCore.xcconfig; sourceTree = "<group>"; };
 		80DF1944FBE1C02C0D19FA556279CF7A /* Pods_Amplify.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify.framework; path = "Pods-Amplify.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		82AB238158A3FCE734364EDE3C8F998A /* AWSMobileResults.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileResults.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileResults.swift; sourceTree = "<group>"; };
-		82ED6B642009AEBCB14888FADDD771DF /* AWSCore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCore.xcconfig; sourceTree = "<group>"; };
-		8319645FEC9FDF368C1C182C318B5C74 /* _AWSMobileClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = _AWSMobileClient.h; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.h; sourceTree = "<group>"; };
-		84274CDFE4A91976E91F70B196DB5FE3 /* AWSCancellationToken.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationToken.h; path = AWSCore/Bolts/AWSCancellationToken.h; sourceTree = "<group>"; };
-		847C7997045CF6766083BAB662053174 /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
-		849F64B469D3BB22311DDDB52E8CDF2D /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
+		810E6C0AEAF81CEF142AD224BC9FA4D7 /* AWSFMDatabaseAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabaseAdditions.h; path = AWSCore/FMDB/AWSFMDatabaseAdditions.h; sourceTree = "<group>"; };
+		81685F61C04386054C6EB486CE045EB4 /* AWSFMDatabaseQueue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabaseQueue.m; path = AWSCore/FMDB/AWSFMDatabaseQueue.m; sourceTree = "<group>"; };
+		82AE0D4FE2C5DA296BA6072367A2F9F6 /* AWSCognitoIdentityProvider-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProvider-umbrella.h"; sourceTree = "<group>"; };
+		856B9460EE390E948E972BC937AD38F4 /* AWSJKBigInteger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSJKBigInteger.m; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.m; sourceTree = "<group>"; };
+		85B16C1BEED6DAD6A2AB160002933CDA /* AWSJKBigDecimal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSJKBigDecimal.m; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigDecimal.m; sourceTree = "<group>"; };
+		86BE6A81DB57EC1FEA08B44FDD69B10E /* AWSDDMultiFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDMultiFormatter.m; path = AWSCore/Logging/AWSDDMultiFormatter.m; sourceTree = "<group>"; };
+		8712DFDF41458E13CDE557E792397356 /* AWSCognitoIdentity+Fabric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoIdentity+Fabric.h"; path = "AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.h"; sourceTree = "<group>"; };
 		8866A6188CF9937D30E31F9C3AF4744D /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests.modulemap"; sourceTree = "<group>"; };
-		887EDB2AF4A6615AB0046559981DDC4A /* AWSServiceEnum.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSServiceEnum.h; path = AWSCore/Service/AWSServiceEnum.h; sourceTree = "<group>"; };
 		88B5B053284A3CD214CB2345BB04C33F /* AWSMobileClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AWSMobileClient.framework; path = AWSMobileClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		897BE0E1152364146DF9E84966A20D23 /* AWSCognitoIdentityProvider.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSCognitoIdentityProvider.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A0ADFA07325170FDC5BB0CE2DB1EBA9 /* AWSURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLResponseSerialization.m; path = AWSCore/Serialization/AWSURLResponseSerialization.m; sourceTree = "<group>"; };
+		8A5462580CC9DC68AF7075ACA8844031 /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
+		8A6AB7B64F3EA49D82336E6F2342E8F4 /* AWSSTSResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSResources.h; path = AWSCore/STS/AWSSTSResources.h; sourceTree = "<group>"; };
 		8A7F5959C56A2F6E93DDA0D9EB3274DE /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-dummy.m"; sourceTree = "<group>"; };
 		8B37EE7562B33B09D027EE4A0B32AA75 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.release.xcconfig"; sourceTree = "<group>"; };
-		8D7C69697E9FEB677A5FD0883D9E63DE /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
-		8E1EE4E86046CCC1C42AD5EFC671D6A3 /* AWSCognitoIdentityProviderModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderModel.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderModel.m; sourceTree = "<group>"; };
-		8F02B57322A914C3ABD0AEC8402B3EE6 /* AWSURLRequestRetryHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLRequestRetryHandler.h; path = AWSCore/Serialization/AWSURLRequestRetryHandler.h; sourceTree = "<group>"; };
-		8F101994E77186A9F9F09402BFC3E1CB /* AWSDDFileLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDFileLogger.m; path = AWSCore/Logging/AWSDDFileLogger.m; sourceTree = "<group>"; };
+		8CAB3BD92207D2E252347FD79A669516 /* NSError+AWSMTLModelException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSError+AWSMTLModelException.h"; path = "AWSCore/Mantle/NSError+AWSMTLModelException.h"; sourceTree = "<group>"; };
+		8CEEBBC83FB1A93562327EAFF615AA6B /* Fabric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Fabric.h; path = AWSCore/Fabric/Fabric.h; sourceTree = "<group>"; };
 		9000133D745E33FE1ED02390F5F7E717 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
 		9022B9B1EE62A9406A47544AF1A9A60A /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		94AD95A8DB82AF9AD0B9B7C124E6109E /* AWSSignInManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInManager.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInManager.h; sourceTree = "<group>"; };
-		953E533AB3626686BC0DCFEE4DCDBCC9 /* AWSCognitoCredentialsProvider+Extension.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoCredentialsProvider+Extension.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoCredentialsProvider+Extension.h"; sourceTree = "<group>"; };
-		954C6F2887E29DB41520A7D369558C27 /* AWSBolts.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSBolts.m; path = AWSCore/Bolts/AWSBolts.m; sourceTree = "<group>"; };
-		95EE31B5AE458FE53DD0805178E1CD88 /* AWSFMDB+AWSHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSFMDB+AWSHelpers.h"; path = "AWSCore/FMDB/AWSFMDB+AWSHelpers.h"; sourceTree = "<group>"; };
-		97E93588591EFDC4639A147B175BCCDD /* AWSMTLJSONAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLJSONAdapter.h; path = AWSCore/Mantle/AWSMTLJSONAdapter.h; sourceTree = "<group>"; };
-		9869A18656334720E2709AB030CED186 /* AWSEXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTScope.h; path = AWSCore/Mantle/extobjc/AWSEXTScope.h; sourceTree = "<group>"; };
-		986C98B931A676FC118C9E1BBD676265 /* AWSJKBigInteger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSJKBigInteger.m; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.m; sourceTree = "<group>"; };
-		989EDB692EAD309BA42690776AF9415E /* AWSSTS.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTS.h; path = AWSCore/STS/AWSSTS.h; sourceTree = "<group>"; };
-		998EE64602226D70380E0CEB420DE53C /* AWSCognitoIdentityProvider-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProvider-umbrella.h"; sourceTree = "<group>"; };
-		9D48C5F3D2DEEE640B846066CB4126EA /* AWSCognitoIdentityUser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityUser.m; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m; sourceTree = "<group>"; };
+		906357A4C1AA3FE5689B0E940D3D91F2 /* NSData+AWSCognitoIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+AWSCognitoIdentityProvider.h"; path = "AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.h"; sourceTree = "<group>"; };
+		9109D53E30C8C4C64FBC39ECF60C179E /* AWSCancellationTokenRegistration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationTokenRegistration.h; path = AWSCore/Bolts/AWSCancellationTokenRegistration.h; sourceTree = "<group>"; };
+		9176A30EF537A984349EF0941C29042B /* AWSFMResultSet.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMResultSet.m; path = AWSCore/FMDB/AWSFMResultSet.m; sourceTree = "<group>"; };
+		91C2094C059BAFFFFBC229AC5C0F9CEF /* AWSCognitoIdentityModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityModel.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityModel.m; sourceTree = "<group>"; };
+		920863BE9A25A6D24A89E4889EE0A014 /* FABKitProtocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FABKitProtocol.h; path = AWSCore/Fabric/FABKitProtocol.h; sourceTree = "<group>"; };
+		92A43858635F9C27ED94A05763E2521E /* AWSDDASLLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDASLLogger.m; path = AWSCore/Logging/AWSDDASLLogger.m; sourceTree = "<group>"; };
+		9348F3E0355579436D403C96DB0D7EF4 /* AWSCocoaLumberjack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCocoaLumberjack.h; path = AWSCore/Logging/AWSCocoaLumberjack.h; sourceTree = "<group>"; };
+		94327DFA9363831CE32D78455D699B69 /* AWSEXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTScope.h; path = AWSCore/Mantle/extobjc/AWSEXTScope.h; sourceTree = "<group>"; };
+		94701E2D8BEB1ECDDF758D0719854FAF /* AWSTMMemoryCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMMemoryCache.h; path = AWSCore/TMCache/AWSTMMemoryCache.h; sourceTree = "<group>"; };
+		96A2D651BCE8019612EBFDAB5CBD48F2 /* AWSAuthCore-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSAuthCore-prefix.pch"; sourceTree = "<group>"; };
+		98015366A1F6CDB77D29D5B2458E7056 /* AWSDDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDDispatchQueueLogFormatter.m; path = AWSCore/Logging/Extensions/AWSDDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
+		983EDE1A47AA1B93CFCC5C3B7E1E5678 /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
+		98EBAF29DC4D794957822E239F9C944B /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
+		98FCA979D8A8822E734476B6E58B8ED4 /* AWSDDFileLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDFileLogger.h; path = AWSCore/Logging/AWSDDFileLogger.h; sourceTree = "<group>"; };
+		99B54D708FFA50347BEFA9AD8730A8AA /* AWSCore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCore.h; path = AWSCore/AWSCore.h; sourceTree = "<group>"; };
+		9ADAC8F37FB83D9A1FAE60863BAE22A2 /* JSONHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JSONHelper.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/JSONHelper.swift; sourceTree = "<group>"; };
+		9C738EC7E8D4A0BF95B09336DEDB98B1 /* AWSURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLSessionManager.m; path = AWSCore/Networking/AWSURLSessionManager.m; sourceTree = "<group>"; };
+		9CACA599E066FECF7765E60FB671E1A8 /* AWSCognitoIdentity+Fabric.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSCognitoIdentity+Fabric.m"; path = "AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.m"; sourceTree = "<group>"; };
+		9CC392531C7DC92AB41B16939E55FBAC /* AWSCredentialsProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCredentialsProvider.m; path = AWSCore/Authentication/AWSCredentialsProvider.m; sourceTree = "<group>"; };
+		9D814B6AF5A67FF1828ECF314845D1BD /* AWSFMDatabase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabase.m; path = AWSCore/FMDB/AWSFMDatabase.m; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		9DE0E318F8B727F880BE50269334A1FB /* AWSCognitoIdentityModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityModel.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityModel.h; sourceTree = "<group>"; };
-		9E0D15EADD3AADC19B695054A1D13C64 /* AWSGZIP.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSGZIP.m; path = AWSCore/GZIP/AWSGZIP.m; sourceTree = "<group>"; };
-		9E630833E85807E70FC177062E5C07B8 /* AWSAuthCore-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSAuthCore-dummy.m"; sourceTree = "<group>"; };
-		9E81A98248D90B4D4CBA3247B45A6DAC /* AWSmetamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSmetamacros.h; path = AWSCore/Mantle/extobjc/AWSmetamacros.h; sourceTree = "<group>"; };
-		9EB91CF25CF930E29224C18C6BCC4E20 /* AWSCognitoIdentityProviderService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderService.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderService.m; sourceTree = "<group>"; };
-		9ECDF6559A006DFA06D0518D79726410 /* AWSFMDatabase+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSFMDatabase+Private.h"; path = "AWSCore/FMDB/AWSFMDatabase+Private.h"; sourceTree = "<group>"; };
-		A0E6E441D5D233E13E9794788839B361 /* AWSCognitoIdentityProviderASF.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCognitoIdentityProviderASF.xcconfig; sourceTree = "<group>"; };
-		A1DAC56F84465C1D97C25BC1495B7607 /* AWSMobileClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClient.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift; sourceTree = "<group>"; };
+		9DAF63CB3927C45D2346F11705E3AFA7 /* AWSCognitoIdentityProviderASF-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProviderASF-umbrella.h"; sourceTree = "<group>"; };
+		9DD919F5D40936CBB175BC18C0CC012A /* aws_tommath_superclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath_superclass.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath_superclass.h; sourceTree = "<group>"; };
+		9F110F53CAAF1AB03CE1CA851F85859F /* NSDictionary+AWSMTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+AWSMTLManipulationAdditions.h"; path = "AWSCore/Mantle/NSDictionary+AWSMTLManipulationAdditions.h"; sourceTree = "<group>"; };
+		9F45A88D28CED0D57D7F1D7138D0CDFF /* NSData+AWSCognitoIdentityProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+AWSCognitoIdentityProvider.m"; path = "AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.m"; sourceTree = "<group>"; };
+		9FCBEE62A3337BC2F65D83AF4E6B900F /* AWSModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSModel.h; path = AWSCore/Utility/AWSModel.h; sourceTree = "<group>"; };
+		9FEEDF39BB2522F1F1564847E3D9021A /* AWSMobileClient.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSMobileClient.modulemap; sourceTree = "<group>"; };
+		9FF7C8B2AC413711B14A91BC15CD8431 /* AWSKSReachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSKSReachability.m; path = AWSCore/KSReachability/AWSKSReachability.m; sourceTree = "<group>"; };
+		A077A3D16945E07EBB64DF9B37B77A62 /* AWSCognitoIdentityProvider-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCognitoIdentityProvider-dummy.m"; sourceTree = "<group>"; };
+		A1163FE82E3D89D2C4D5F59685F700D0 /* AWSCognitoIdentityUserPool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityUserPool.m; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m; sourceTree = "<group>"; };
+		A160B41090A56C0EFD3C4DF8921A1539 /* AWSInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSInfo.h; path = AWSCore/Service/AWSInfo.h; sourceTree = "<group>"; };
+		A1D9BE851096D333C6BCF3DCC3CB8685 /* AWSCognitoIdentityProviderHKDF.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderHKDF.m; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderHKDF.m; sourceTree = "<group>"; };
+		A30C60B5CD0C127A0F791708CFE9B42D /* AWSDDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDDispatchQueueLogFormatter.h; path = AWSCore/Logging/Extensions/AWSDDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
+		A46B3233721574887E89B7E89E73CB49 /* AWSAuthCore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSAuthCore.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSAuthCore.h; sourceTree = "<group>"; };
 		A483C9091059B80817F2F1D6E7F4ADC0 /* Pods-Amplify-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-acknowledgements.markdown"; sourceTree = "<group>"; };
 		A4B8551213E176E1C8DC109BF5957DD3 /* Pods_Amplify_AmplifyTestConfigs_AmplifyTestCommon.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AmplifyTestConfigs_AmplifyTestCommon.framework; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		A4CEFBF2F47127AB8796BFEB091E3927 /* AWSNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSNetworking.m; path = AWSCore/Networking/AWSNetworking.m; sourceTree = "<group>"; };
-		A4D68A02BDE42E83CFD7E214A90E94F9 /* AWSCore-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCore-Info.plist"; sourceTree = "<group>"; };
-		A6E435979BE405717E44EA6820003765 /* AWSMTLModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLModel.m; path = AWSCore/Mantle/AWSMTLModel.m; sourceTree = "<group>"; };
+		A4F18ECC77B90BCC7C16CD58FFCA677C /* SwiftFormat.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftFormat.xcconfig; sourceTree = "<group>"; };
+		A52145D6322955C0D6C6F09871F24741 /* AWSFMDB+AWSHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSFMDB+AWSHelpers.m"; path = "AWSCore/FMDB/AWSFMDB+AWSHelpers.m"; sourceTree = "<group>"; };
 		A70C7A2407B818ECD1C5D3D6EF9E6781 /* Pods-Amplify-AWSPluginsCore-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-Info.plist"; sourceTree = "<group>"; };
-		A729E887BEFAE11B8E6585C54E3C94B5 /* AWSMobileClient.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSMobileClient.modulemap; sourceTree = "<group>"; };
-		A7744B1868C57C4A60A47A7ED5DD0800 /* AWSMTLValueTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLValueTransformer.m; path = AWSCore/Mantle/AWSMTLValueTransformer.m; sourceTree = "<group>"; };
-		A8408C93D1D7483BF3AF2267895FB47A /* AWSEXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTKeyPathCoding.h; path = AWSCore/Mantle/extobjc/AWSEXTKeyPathCoding.h; sourceTree = "<group>"; };
-		A91CA38278370894947C0EE0FBEC9746 /* AWSIdentityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSIdentityManager.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSIdentityManager.h; sourceTree = "<group>"; };
-		A95E336C4D29585F2AD392A2F8D10FFC /* NSError+AWSMTLModelException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSError+AWSMTLModelException.m"; path = "AWSCore/Mantle/NSError+AWSMTLModelException.m"; sourceTree = "<group>"; };
-		AA7CA64F79A273DFB20A0536914C253F /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
-		AB024C083DC49727FA7E4F405892ED3A /* NSObject+AWSMTLComparisonAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+AWSMTLComparisonAdditions.h"; path = "AWSCore/Mantle/NSObject+AWSMTLComparisonAdditions.h"; sourceTree = "<group>"; };
-		AB361E23A65D4E6BD16AF9720259A168 /* AWSMTLModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLModel.h; path = AWSCore/Mantle/AWSMTLModel.h; sourceTree = "<group>"; };
-		AB74DE22440765B4DB2FA75152FCDB4E /* NSDictionary+AWSMTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+AWSMTLManipulationAdditions.h"; path = "AWSCore/Mantle/NSDictionary+AWSMTLManipulationAdditions.h"; sourceTree = "<group>"; };
-		AE67B5FC8A1D844635C8C85C6836466D /* AWSXMLWriter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSXMLWriter.h; path = AWSCore/XMLWriter/AWSXMLWriter.h; sourceTree = "<group>"; };
-		AEF6FE2870E54B10EF30BE095D07ADE5 /* AWSCognitoIdentityResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityResources.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityResources.m; sourceTree = "<group>"; };
-		AF646CD18863080860DF747A69722D6B /* NSArray+AWSMTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+AWSMTLManipulationAdditions.m"; path = "AWSCore/Mantle/NSArray+AWSMTLManipulationAdditions.m"; sourceTree = "<group>"; };
+		A7521733F008AF096D52D74AF5F36981 /* AWSMobileClient-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSMobileClient-dummy.m"; sourceTree = "<group>"; };
+		ACA1E3EBBEA1F5D3160841769800B0DC /* AWSCognitoIdentityUser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityUser.m; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m; sourceTree = "<group>"; };
+		ACCDCDE3D9BB24C9A28284F325A016D5 /* AWSAuthCore.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSAuthCore.modulemap; sourceTree = "<group>"; };
+		ACCDDF8A621C80784B35192C5C55D9ED /* Fabric+FABKits.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Fabric+FABKits.h"; path = "AWSCore/Fabric/Fabric+FABKits.h"; sourceTree = "<group>"; };
+		AD1FFEF90711E0EC311224E066703638 /* AWSValidation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSValidation.h; path = AWSCore/Serialization/AWSValidation.h; sourceTree = "<group>"; };
+		AE43657F8C0C1405A6F48A02C31C2CF5 /* AWSTMCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMCache.m; path = AWSCore/TMCache/AWSTMCache.m; sourceTree = "<group>"; };
 		AF9100203F45E4A2CE2EE987A561A14F /* Pods-AmplifyTestApp-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-AmplifyTestApp-acknowledgements.plist"; sourceTree = "<group>"; };
-		AFB26DF1FE16A5A49EE8FE0638EDE5C8 /* AWSDDOSLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDOSLogger.m; path = AWSCore/Logging/AWSDDOSLogger.m; sourceTree = "<group>"; };
-		B0C4B1EB0A6EE847AB190230311FEDD2 /* AWSCategory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCategory.m; path = AWSCore/Utility/AWSCategory.m; sourceTree = "<group>"; };
-		B17B2529C82595074FBB5299CA4C33F4 /* AWSDDASLLogCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDASLLogCapture.m; path = AWSCore/Logging/AWSDDASLLogCapture.m; sourceTree = "<group>"; };
-		B20B01BB89E1F1933267835A149A1CE2 /* AWSAuthCore-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSAuthCore-Info.plist"; sourceTree = "<group>"; };
-		B225D9D4836594D19B6CBD2FF5D85D31 /* AWSCognitoAuthUICKeyChainStore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuthUICKeyChainStore.h; path = AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.h; sourceTree = "<group>"; };
+		AF9B52768BC4CE65526EAB63E2E75880 /* AWSDDTTYLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDTTYLogger.m; path = AWSCore/Logging/AWSDDTTYLogger.m; sourceTree = "<group>"; };
+		AFE6CA3E54E94B93879D0415A2FA535C /* AWSCognitoAuth+Extensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSCognitoAuth+Extensions.m"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.m"; sourceTree = "<group>"; };
+		B0F9182481E43628F757BAFB64AD0B54 /* NSObject+AWSMTLComparisonAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+AWSMTLComparisonAdditions.m"; path = "AWSCore/Mantle/NSObject+AWSMTLComparisonAdditions.m"; sourceTree = "<group>"; };
+		B105C48272F594AC5233F7320470A5B7 /* AWSTMCacheBackgroundTaskManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMCacheBackgroundTaskManager.h; path = AWSCore/TMCache/AWSTMCacheBackgroundTaskManager.h; sourceTree = "<group>"; };
+		B11D75C0DCD9FF11DB626B078823A733 /* AWSMantle.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMantle.h; path = AWSCore/Mantle/AWSMantle.h; sourceTree = "<group>"; };
+		B1E046FABC7AEB1DDEAF83E80E8A23E5 /* AWSMobileClientUserDetails.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClientUserDetails.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSMobileClientUserDetails.swift; sourceTree = "<group>"; };
+		B22773A61D27574942BD3C76F4C90814 /* AWSTask.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTask.m; path = AWSCore/Bolts/AWSTask.m; sourceTree = "<group>"; };
 		B270484543DC97A2E5759EB4E30E0E90 /* Pods_Amplify_AmplifyTestConfigs_AmplifyTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AmplifyTestConfigs_AmplifyTests.framework; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		B2C7AF41AC3469F6AA08497AB92DED4F /* AWSSynchronizedMutableDictionary.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSynchronizedMutableDictionary.m; path = AWSCore/Utility/AWSSynchronizedMutableDictionary.m; sourceTree = "<group>"; };
-		B39F1BB26E3CFBE20F7F3FE417B47FD8 /* AWSCognitoIdentity.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentity.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentity.h; sourceTree = "<group>"; };
+		B2DB7B9AA67A4C2901A501179E35FDC8 /* AWSCognitoIdentityResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityResources.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityResources.h; sourceTree = "<group>"; };
+		B3AE5FD3791D0D949459393DD40CD3DF /* AWSMobileClient-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSMobileClient-umbrella.h"; sourceTree = "<group>"; };
 		B4144DE60EA249CC4A98549069F402FB /* AWSCognitoIdentityProviderASF.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSCognitoIdentityProviderASF.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B61A4055F0155D4A7FAEE9EA54CB4A60 /* AWSTMCacheBackgroundTaskManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMCacheBackgroundTaskManager.h; path = AWSCore/TMCache/AWSTMCacheBackgroundTaskManager.h; sourceTree = "<group>"; };
-		B65C31B8D395F09A9D5F06EC043B14E2 /* AWSURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLRequestSerialization.h; path = AWSCore/Serialization/AWSURLRequestSerialization.h; sourceTree = "<group>"; };
-		B662F5F03B62A30404A4A72883EF2BBD /* AWSTaskCompletionSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTaskCompletionSource.m; path = AWSCore/Bolts/AWSTaskCompletionSource.m; sourceTree = "<group>"; };
-		B6678B3BFB137395C6BFB6442F592DAF /* AWSClientContext.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSClientContext.m; path = AWSCore/Service/AWSClientContext.m; sourceTree = "<group>"; };
-		B73BB8777F0FF75A2C999665718D660C /* AWSAuthCore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSAuthCore.xcconfig; sourceTree = "<group>"; };
-		B7614A9E198573F33364E08A44D191A2 /* NSData+AWSCognitoIdentityProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+AWSCognitoIdentityProvider.m"; path = "AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.m"; sourceTree = "<group>"; };
-		B7B517F0B29949FB45D5A65D1D283A0A /* AWSFMDB.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDB.h; path = AWSCore/FMDB/AWSFMDB.h; sourceTree = "<group>"; };
+		B4E599012C75D7A133B5D77EB7591134 /* AWSAuthCore-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSAuthCore-umbrella.h"; sourceTree = "<group>"; };
+		B5FA5040145A5FC42FC743FA56514940 /* AWSUserPoolOperationsHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSUserPoolOperationsHandler.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift; sourceTree = "<group>"; };
+		B6F8E974D59BB2C71C3998C162816143 /* AWSBolts.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSBolts.h; path = AWSCore/Bolts/AWSBolts.h; sourceTree = "<group>"; };
+		B785B0927F487DA24F8777BAA7C3FD3E /* AWSCognitoCredentialsProvider+Extension.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoCredentialsProvider+Extension.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoCredentialsProvider+Extension.h"; sourceTree = "<group>"; };
+		B8785DC9A87864D9C1FDCB43C2469B74 /* AWSSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSerialization.m; path = AWSCore/Serialization/AWSSerialization.m; sourceTree = "<group>"; };
 		B8A667E74EC0A8A4EDFB8F2D2364FC92 /* Pods-Amplify-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-dummy.m"; sourceTree = "<group>"; };
-		B8E90544C20A9FE810B7903869974FD1 /* AWSSignInButtonView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInButtonView.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInButtonView.h; sourceTree = "<group>"; };
-		BAACC47EBE7463E76E1A7A527FEFD7E2 /* AWSValidation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSValidation.h; path = AWSCore/Serialization/AWSValidation.h; sourceTree = "<group>"; };
+		B9A3E48A5EBDD64DAE2ECD9EE0D19659 /* AWSCognitoIdentityUserPool_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUserPool_Internal.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityUserPool_Internal.h; sourceTree = "<group>"; };
+		BB402C47244C897CE7236FE13AD98752 /* AWSMobileClient-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSMobileClient-Info.plist"; sourceTree = "<group>"; };
+		BB55B2CB2AA26552F0C51813928696F6 /* AWSDDLegacyMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLegacyMacros.h; path = AWSCore/Logging/AWSDDLegacyMacros.h; sourceTree = "<group>"; };
 		BBCCE722E2FD574C72320E1D0DFA805A /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-acknowledgements.plist"; sourceTree = "<group>"; };
+		BC067900E6CC27C9DAEE297A89AD2D0F /* AWSMTLModel+NSCoding.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSMTLModel+NSCoding.m"; path = "AWSCore/Mantle/AWSMTLModel+NSCoding.m"; sourceTree = "<group>"; };
 		BC0AAAB222E3424AB42C3968AE2DD9F7 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests.debug.xcconfig"; sourceTree = "<group>"; };
-		BCE30B479D2F9EEE3D3AC4ECDC256CD2 /* AWSDDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDDispatchQueueLogFormatter.h; path = AWSCore/Logging/Extensions/AWSDDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
+		BC78A1BE3112CD63FB79FC0D632C08AD /* AWSSTSService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSService.m; path = AWSCore/STS/AWSSTSService.m; sourceTree = "<group>"; };
+		BD6402601C3C46495B29A0B51C537439 /* AWSMTLManagedObjectAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLManagedObjectAdapter.h; path = AWSCore/Mantle/AWSMTLManagedObjectAdapter.h; sourceTree = "<group>"; };
 		BDE3D242E320015920FF9968B3B82469 /* Pods-Amplify-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-Info.plist"; sourceTree = "<group>"; };
 		BE3DBB67EEF91BEAEEF0780F753CCB8E /* Pods-Amplify-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-acknowledgements.plist"; sourceTree = "<group>"; };
-		BEBAB3C7809690613DC9CAFA944D8EDA /* AWSCredentialsProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCredentialsProvider.m; path = AWSCore/Authentication/AWSCredentialsProvider.m; sourceTree = "<group>"; };
+		BE4816820DBD8AD200627DBCE6504789 /* AWSMobileClient-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSMobileClient-prefix.pch"; sourceTree = "<group>"; };
 		BF3EC1DB119CD6294BF8B76C95215B6E /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.modulemap"; sourceTree = "<group>"; };
-		BF574DD5F235DC4861034E0CA2A88D7F /* AWSCancellationTokenRegistration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationTokenRegistration.h; path = AWSCore/Bolts/AWSCancellationTokenRegistration.h; sourceTree = "<group>"; };
-		BFDD9C67B3B6CB96B20718D49380ECE9 /* AWSJKBigDecimal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSJKBigDecimal.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigDecimal.h; sourceTree = "<group>"; };
+		BFCEEE328F910F62BBDE90665F16FD72 /* AWSLogging.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSLogging.h; path = AWSCore/Utility/AWSLogging.h; sourceTree = "<group>"; };
 		C0764D426402BEC77DB42BBD5102F91F /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-acknowledgements.plist"; sourceTree = "<group>"; };
-		C1B8B4FEACAF1420B0B96475BE90AD87 /* AWSSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSerialization.h; path = AWSCore/Serialization/AWSSerialization.h; sourceTree = "<group>"; };
-		C21BE7FA37988912443776169E6B9145 /* AWSCognitoAuth+Extensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSCognitoAuth+Extensions.m"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.m"; sourceTree = "<group>"; };
-		C2DAAF70CB9E19EA4D2313D99B529CBA /* AWSCognitoIdentityProviderASF.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderASF.m; path = AWSCognitoIdentityProviderASF/AWSCognitoIdentityProviderASF.m; sourceTree = "<group>"; };
+		C0B03B2C8F2862CAF77DEFE91DF50641 /* AWSURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLSessionManager.h; path = AWSCore/Networking/AWSURLSessionManager.h; sourceTree = "<group>"; };
+		C0DB0C0B9E1C812A42914C8AA7BF1A8D /* AWSGZIP.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSGZIP.m; path = AWSCore/GZIP/AWSGZIP.m; sourceTree = "<group>"; };
+		C163507295304A519E85051ED74A6209 /* AWSTMDiskCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMDiskCache.m; path = AWSCore/TMCache/AWSTMDiskCache.m; sourceTree = "<group>"; };
+		C212D282C3A3524B1011E30E0E313E1C /* AWSDDASLLogCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDASLLogCapture.m; path = AWSCore/Logging/AWSDDASLLogCapture.m; sourceTree = "<group>"; };
 		C49CC694143B932ACAEDAB2B998DE32A /* AWSAuthCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSAuthCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C53B9703FFDCF5CAC036A262B1D4F62C /* AWSBolts.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSBolts.h; path = AWSCore/Bolts/AWSBolts.h; sourceTree = "<group>"; };
-		C542DA5A0D1AC50D6BBE628AD7322953 /* AWSDDTTYLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDTTYLogger.m; path = AWSCore/Logging/AWSDDTTYLogger.m; sourceTree = "<group>"; };
-		C5492BB52A5B3D8B009B9878B5E25987 /* AWSFMDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabase.h; path = AWSCore/FMDB/AWSFMDatabase.h; sourceTree = "<group>"; };
-		C57087617E12CE6B735EB2F37693BF70 /* CwlPreconditionTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlPreconditionTesting.h; path = Sources/CwlPreconditionTesting/include/CwlPreconditionTesting.h; sourceTree = "<group>"; };
-		C60A8B140370A37C7542F37266CDA34A /* AWSCocoaLumberjack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCocoaLumberjack.h; path = AWSCore/Logging/AWSCocoaLumberjack.h; sourceTree = "<group>"; };
-		C668F5F5F1FCA13477AEA34A9A87FB75 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h"; sourceTree = "<group>"; };
-		C8A48FB23DA4C723054237DD88FF8627 /* AWSCancellationTokenSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationTokenSource.h; path = AWSCore/Bolts/AWSCancellationTokenSource.h; sourceTree = "<group>"; };
+		C5C34C491A183A09D49EF0138F8202FE /* AWSIdentityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSIdentityManager.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSIdentityManager.h; sourceTree = "<group>"; };
+		C6FB30955DA68107EDEF56A9A1344D17 /* AWSMobileClient.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSMobileClient.xcconfig; sourceTree = "<group>"; };
+		C751FB32301C38302A2EC137BA70D3EC /* AWSCognitoIdentityProviderSrpHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderSrpHelper.m; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderSrpHelper.m; sourceTree = "<group>"; };
 		C8D22E6E639FD8B2AA18F007DEDB51F7 /* Pods-Amplify.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify.debug.xcconfig"; sourceTree = "<group>"; };
-		CA682CBF0E44BDD635C0FBB679D6C5EC /* AWSUIConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSUIConfiguration.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSUIConfiguration.h; sourceTree = "<group>"; };
+		C9022B2A001A348E8DEDD1296B5E0716 /* NSError+AWSMTLModelException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSError+AWSMTLModelException.m"; path = "AWSCore/Mantle/NSError+AWSMTLModelException.m"; sourceTree = "<group>"; };
+		CA7B6E7179083414E201D1859C9528EB /* AWSCognitoIdentityProvider-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProvider-prefix.pch"; sourceTree = "<group>"; };
+		CA847668DCC864011A6F5E61B5B8F788 /* AWSCognitoIdentityProvider-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCognitoIdentityProvider-Info.plist"; sourceTree = "<group>"; };
+		CA9BF82B9D49B3E34E31C82200838ACE /* AWSMobileClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMobileClient.h; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.h; sourceTree = "<group>"; };
 		CAB297499AF600870ECB83BC5970DED8 /* Pods-AmplifyTestApp-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-AmplifyTestApp-acknowledgements.markdown"; sourceTree = "<group>"; };
-		CB96EAB0130FC52A057E49780D95D87B /* AWSCancellationTokenRegistration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationTokenRegistration.m; path = AWSCore/Bolts/AWSCancellationTokenRegistration.m; sourceTree = "<group>"; };
+		CAB31BB0CB1979BC02AE603D4C767273 /* AWSXMLWriter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSXMLWriter.h; path = AWSCore/XMLWriter/AWSXMLWriter.h; sourceTree = "<group>"; };
+		CB5F5DD200C1796E0CD90E3B92A8DB28 /* AWSURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLResponseSerialization.h; path = AWSCore/Serialization/AWSURLResponseSerialization.h; sourceTree = "<group>"; };
 		CBED44CF131280494DBEBD7CF2B56150 /* Pods_Amplify_AWSPluginsCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AWSPluginsCore.framework; path = "Pods-Amplify-AWSPluginsCore.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC46A423E858362387E2F494BE58A39B /* Pods-Amplify.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify.modulemap"; sourceTree = "<group>"; };
 		CC56497384E780278F916D6C57EA4951 /* CwlPreconditionTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = CwlPreconditionTesting.framework; path = CwlPreconditionTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCFB8F03867DB892EFC47B53186590C4 /* AWSCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AWSCore.framework; path = AWSCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CD01F6BEAD7597F2BE12DF5DEAD8EFCE /* AWSFMResultSet.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMResultSet.m; path = AWSCore/FMDB/AWSFMResultSet.m; sourceTree = "<group>"; };
-		CD9D5488378B8834D5DAE698D0FBE073 /* AWSKSReachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSKSReachability.m; path = AWSCore/KSReachability/AWSKSReachability.m; sourceTree = "<group>"; };
-		CE0CC5FA3F31C10F3B50A8AE74853213 /* NSValueTransformer+AWSMTLInversionAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+AWSMTLInversionAdditions.m"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLInversionAdditions.m"; sourceTree = "<group>"; };
-		CE892E9AE80BCC61D0650AB6C6E4906B /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
-		CEBD24D90E4FFBE94B3CE017E20BBC63 /* AWSJKBigInteger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSJKBigInteger.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.h; sourceTree = "<group>"; };
-		CF91665F677AFEFDDEBA8528174E0846 /* CwlCatchException-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CwlCatchException-dummy.m"; sourceTree = "<group>"; };
-		CFB22AC768E6929AE82F7D73FDC64B65 /* AWSCore.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCore.modulemap; sourceTree = "<group>"; };
+		CD4393963F8EEB81AD47AEF6938B3646 /* CwlPreconditionTesting.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CwlPreconditionTesting.modulemap; sourceTree = "<group>"; };
+		CD9504574C2BEA74886D0BA7A7E51BE6 /* AWSFMDatabasePool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabasePool.h; path = AWSCore/FMDB/AWSFMDatabasePool.h; sourceTree = "<group>"; };
+		CDA38353C499EAFBF0C7F4C481DB06D1 /* AWSCognitoIdentityProviderASF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderASF.h; path = AWSCognitoIdentityProviderASF/AWSCognitoIdentityProviderASF.h; sourceTree = "<group>"; };
+		CEAA8CF19472EC4ACF9D738F775FC832 /* AWSJKBigInteger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSJKBigInteger.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.h; sourceTree = "<group>"; };
+		CF52B59CF212AEF5EF49ED0B7A9E02C1 /* AWSService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSService.h; path = AWSCore/Service/AWSService.h; sourceTree = "<group>"; };
+		D0E94613A5F8B0E8267BE68F25F2F8CD /* AWSServiceEnum.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSServiceEnum.h; path = AWSCore/Service/AWSServiceEnum.h; sourceTree = "<group>"; };
 		D278F5748D57849269D3BC19FE845B99 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.release.xcconfig"; sourceTree = "<group>"; };
+		D29FE4BBF56788C9AC325256DFB9A156 /* AWSCancellationTokenSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationTokenSource.m; path = AWSCore/Bolts/AWSCancellationTokenSource.m; sourceTree = "<group>"; };
 		D2FC9F4ECE3B1251F36F9AC548B8969B /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.modulemap"; sourceTree = "<group>"; };
-		D445676006ADD383CA026790E342881A /* AWSIdentityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSIdentityManager.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSIdentityManager.m; sourceTree = "<group>"; };
-		D4E14945D602237E27049F763EA18FBE /* AWSSTSService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSService.m; path = AWSCore/STS/AWSSTSService.m; sourceTree = "<group>"; };
+		D30FB1471BD4A7F0CE23217C25A286D6 /* AWSEXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTRuntimeExtensions.h; path = AWSCore/Mantle/extobjc/AWSEXTRuntimeExtensions.h; sourceTree = "<group>"; };
+		D3E5DF2CC49F1C2A673519ADB5D725BE /* AWSExecutor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSExecutor.m; path = AWSCore/Bolts/AWSExecutor.m; sourceTree = "<group>"; };
 		D745E2A5C3D7BB82BB00BA0C3CD9A56C /* Pods_Amplify_AmplifyTestConfigs_AmplifyFunctionalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AmplifyTestConfigs_AmplifyFunctionalTests.framework; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D7E43FB42F81273FADA2B41F8A59397E /* Pods-AmplifyTestApp-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-AmplifyTestApp-umbrella.h"; sourceTree = "<group>"; };
-		D97F2B1789651B25F7979DA0F52D0067 /* AWSMobileClient-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSMobileClient-Info.plist"; sourceTree = "<group>"; };
+		D7E8BDCF5CB5DF64785E0DE7EDD5371A /* CwlPreconditionTesting-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlPreconditionTesting-umbrella.h"; sourceTree = "<group>"; };
+		D7E963C4F0D7D073D7546DDC482E53FD /* AWSMTLValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLValueTransformer.h; path = AWSCore/Mantle/AWSMTLValueTransformer.h; sourceTree = "<group>"; };
+		D87BBA54881BE0850CBFFDC4D8114FCA /* AWSBolts.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSBolts.m; path = AWSCore/Bolts/AWSBolts.m; sourceTree = "<group>"; };
 		D9D21961D651909C5E5D1161C7FF4859 /* Pods-Amplify-AWSPluginsCore-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-acknowledgements.plist"; sourceTree = "<group>"; };
-		DA1C66EA6864356E4922848C7144C4DF /* AWSCognitoIdentityASF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityASF.h; path = AWSCognitoIdentityProviderASF/Internal/AWSCognitoIdentityASF.h; sourceTree = "<group>"; };
-		DC69A6FCA7057AAD299BDF046A8E8253 /* AWSTask.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTask.m; path = AWSCore/Bolts/AWSTask.m; sourceTree = "<group>"; };
-		DCEB76D109419AFAE5EF55575C9F69EE /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m"; sourceTree = "<group>"; };
-		DDEFE9EFCE6276D0B23D56F4DCED501B /* AWSCognitoIdentityProviderASF-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCognitoIdentityProviderASF-dummy.m"; sourceTree = "<group>"; };
+		DA93AD0D291E93447CCCCCEFD85708BB /* AWSCognitoIdentityProviderResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderResources.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderResources.m; sourceTree = "<group>"; };
+		DAA8BB0506C2E9D42D5AED09D74156A6 /* AWSTMDiskCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMDiskCache.h; path = AWSCore/TMCache/AWSTMDiskCache.h; sourceTree = "<group>"; };
+		DAD1437F5D9BFFE96ADE2AC63A18703F /* AWSAuthCore-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSAuthCore-Info.plist"; sourceTree = "<group>"; };
+		DADB698FF6F0FE317C721CB8277E3306 /* AWSCognitoIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProvider.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityProvider.h; sourceTree = "<group>"; };
+		DBF4A88D5942D7C441128C119BAF0999 /* AWSCognitoAuth+Extensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoAuth+Extensions.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h"; sourceTree = "<group>"; };
+		DCE1BA35810587B99C58F0FED53ABAC3 /* AWSCognitoIdentityService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityService.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityService.m; sourceTree = "<group>"; };
+		DD0529F2FD94E94EE9F9F9EA3B418E22 /* AWSCognitoIdentityProviderASF-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCognitoIdentityProviderASF-Info.plist"; sourceTree = "<group>"; };
+		DE52C631AAD1F37EC85940B309484450 /* AWSTMCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMCache.h; path = AWSCore/TMCache/AWSTMCache.h; sourceTree = "<group>"; };
 		DEC3E3C3510C8A55F95F909E0207C7DD /* Pods-Amplify-AWSPluginsCore-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AWSPluginsCore-dummy.m"; sourceTree = "<group>"; };
-		DF631E62A7EE783A0B2B9A5796CDE669 /* CwlPreconditionTesting.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CwlPreconditionTesting.xcconfig; sourceTree = "<group>"; };
 		E0BC8BB0FE4725CF87EB0A9F5D400FD6 /* CwlCatchException.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = CwlCatchException.framework; path = CwlCatchException.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E0C152ACE24CF32262809F5D86181BBF /* AWSCognitoIdentityUserPool_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUserPool_Internal.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityUserPool_Internal.h; sourceTree = "<group>"; };
-		E0D51F01A2CCD2C6FB8821C4F7CC4507 /* JSONHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JSONHelper.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/JSONHelper.swift; sourceTree = "<group>"; };
-		E167A6671830F3708A2B1FB69032281F /* AWSInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSInfo.m; path = AWSCore/Service/AWSInfo.m; sourceTree = "<group>"; };
-		E27B6AFE92FC2D4B1D7D6617EFEDACE0 /* AWSSignInProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInProvider.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInProvider.h; sourceTree = "<group>"; };
-		E4CC35AA518D998C368B3FE4C929B95A /* AWSSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSerialization.m; path = AWSCore/Serialization/AWSSerialization.m; sourceTree = "<group>"; };
-		E7B6AAB2A324861F81A30FFE86E53DF5 /* AWSCancellationToken.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationToken.m; path = AWSCore/Bolts/AWSCancellationToken.m; sourceTree = "<group>"; };
-		E88BE96FAF2EA8862751E14F4E1E1260 /* AWSCognitoIdentityProviderService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderService.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderService.h; sourceTree = "<group>"; };
-		E93B01FE03FA51348290E064579C896C /* AWSDDTTYLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDTTYLogger.h; path = AWSCore/Logging/AWSDDTTYLogger.h; sourceTree = "<group>"; };
-		E98868DF74CFC121476E71CAF5D5B917 /* AWSTMMemoryCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMMemoryCache.m; path = AWSCore/TMCache/AWSTMMemoryCache.m; sourceTree = "<group>"; };
-		EA658D78FC406AFA945D31B0D046AB03 /* AWSCognitoIdentityProviderResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderResources.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderResources.m; sourceTree = "<group>"; };
-		EAE123BA511E10D801798B996DBA65A2 /* aws_tommath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath.h; sourceTree = "<group>"; };
-		ED153D8760D84C9A9D3C2419AFEA1E27 /* AWSDDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDAbstractDatabaseLogger.h; path = AWSCore/Logging/AWSDDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
-		ED507E39D0E6A513CFA5C09ADDBBE7F7 /* AWSXMLWriter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSXMLWriter.m; path = AWSCore/XMLWriter/AWSXMLWriter.m; sourceTree = "<group>"; };
-		EDAF6B48646B5CF2EC92CB5195E0F966 /* AWSDDFileLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDFileLogger.h; path = AWSCore/Logging/AWSDDFileLogger.h; sourceTree = "<group>"; };
-		EDE386C04D660CD52D88BD3C45334C9D /* AWSDDLog.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLog.h; path = AWSCore/Logging/AWSDDLog.h; sourceTree = "<group>"; };
+		E128D8EF93BA4D893F0117811A205D83 /* AWSCategory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCategory.m; path = AWSCore/Utility/AWSCategory.m; sourceTree = "<group>"; };
+		E1EC8C3E16C71BF25AA7F00CDEF6C1DE /* AWSCancellationToken.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationToken.h; path = AWSCore/Bolts/AWSCancellationToken.h; sourceTree = "<group>"; };
+		E727F698E5184B8A8F0AEF9CAF632FA8 /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
+		E7EC8830B686D3AA9F8A5EC5559D133E /* AWSCognitoIdentityUser_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUser_Internal.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityUser_Internal.h; sourceTree = "<group>"; };
+		E8B5FDB178DA118BA766982955206D30 /* AWSFMDatabase+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSFMDatabase+Private.h"; path = "AWSCore/FMDB/AWSFMDatabase+Private.h"; sourceTree = "<group>"; };
+		E8D2519C6A2A39EC2767637F8B899FDB /* AWSCognitoAuthUICKeyChainStore.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoAuthUICKeyChainStore.m; path = AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.m; sourceTree = "<group>"; };
+		E946D357D1B824535DF21C71A74F7306 /* AWSEXTRuntimeExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSEXTRuntimeExtensions.m; path = AWSCore/Mantle/extobjc/AWSEXTRuntimeExtensions.m; sourceTree = "<group>"; };
+		EA5ACF18886A4FF581354E7504E25CCD /* AWSSignInButtonView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInButtonView.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInButtonView.h; sourceTree = "<group>"; };
+		EAB2EC18E32F6E2FCA424AE80D8412DB /* AWSCognitoIdentityASF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityASF.h; path = AWSCognitoIdentityProviderASF/Internal/AWSCognitoIdentityASF.h; sourceTree = "<group>"; };
+		EB037FE1BB0944A9A0396B42155C798B /* AWSUIConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSUIConfiguration.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSUIConfiguration.h; sourceTree = "<group>"; };
+		EB3B13702A64602EEE8777F3A9C91B70 /* AWSValidation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSValidation.m; path = AWSCore/Serialization/AWSValidation.m; sourceTree = "<group>"; };
+		ED595581B874044815E93AAC0D4FB3A4 /* AWSIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSIdentityProvider.h; path = AWSCore/Authentication/AWSIdentityProvider.h; sourceTree = "<group>"; };
+		EE13CC64B7D51AA8D246157E67E7DDB0 /* AWSMobileClientExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClientExtensions.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift; sourceTree = "<group>"; };
 		EE377F76EBC89AD773429D3EBE8EF8D5 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.modulemap"; sourceTree = "<group>"; };
 		EE49F6473631850D3EC76C328D5772CB /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		EFD2AEC8F92F60614948319DA39DDA2C /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-dummy.m"; sourceTree = "<group>"; };
-		EFFCCAE331008549C9E453221F29B95B /* AWSAuthCore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSAuthCore.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSAuthCore.h; sourceTree = "<group>"; };
+		EFEA0F24602DFAEAAC189215C3C59E39 /* AWSCategory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCategory.h; path = AWSCore/Utility/AWSCategory.h; sourceTree = "<group>"; };
 		F046E64EB8EA7F1638E89AFEA89BD856 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-acknowledgements.plist"; sourceTree = "<group>"; };
-		F0572A28051693DA8F8FEFDD2D1AB217 /* AWSModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSModel.h; path = AWSCore/Utility/AWSModel.h; sourceTree = "<group>"; };
-		F0E0AE0D981A07A94FB82B3749ED4294 /* aws_tommath_class.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath_class.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath_class.h; sourceTree = "<group>"; };
+		F14752C7AAF0C272D64F8DB9DB35D1FB /* CwlPreconditionTesting-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CwlPreconditionTesting-dummy.m"; sourceTree = "<group>"; };
 		F15EBDBF674EB1666EE4635030DAB0DE /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.debug.xcconfig"; sourceTree = "<group>"; };
+		F170E6A7DDECEFE5838C092C79B21FDA /* AWSMTLReflection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLReflection.m; path = AWSCore/Mantle/AWSMTLReflection.m; sourceTree = "<group>"; };
 		F1B77771753AD2D834119C6AF9F65C72 /* Pods-Amplify-AWSPluginsCore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore.debug.xcconfig"; sourceTree = "<group>"; };
-		F3C8CC46B2D8F801024481E5D2D742FA /* AWSTMCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMCache.m; path = AWSCore/TMCache/AWSTMCache.m; sourceTree = "<group>"; };
-		F48C0396440C39938B23C0BD6D7F0102 /* FABAttributes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FABAttributes.h; path = AWSCore/Fabric/FABAttributes.h; sourceTree = "<group>"; };
-		F6B703033BBE0A61D18CA101C30E1AC6 /* AWSFMDatabaseQueue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabaseQueue.m; path = AWSCore/FMDB/AWSFMDatabaseQueue.m; sourceTree = "<group>"; };
-		F6F2FC19E23CBF1C81BE3432A3164D83 /* AWSDDAssertMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDAssertMacros.h; path = AWSCore/Logging/AWSDDAssertMacros.h; sourceTree = "<group>"; };
-		F7340A8BA0E851BE7376BBE09CF7FC33 /* AWSCore-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCore-prefix.pch"; sourceTree = "<group>"; };
-		F8C0DA431C7BEEB8C8DBDC93FC331138 /* AWSSTSResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSResources.m; path = AWSCore/STS/AWSSTSResources.m; sourceTree = "<group>"; };
-		F8C53AA0E9793A1A70374EAB2FD6FB99 /* AWSFMResultSet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMResultSet.h; path = AWSCore/FMDB/AWSFMResultSet.h; sourceTree = "<group>"; };
+		F271D7B7BA1C38C1E117F07AA0BB9E42 /* AWSCognitoAuth.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoAuth.m; path = AWSCognitoAuth/AWSCognitoAuth.m; sourceTree = "<group>"; };
+		F2F95957A8A28F91A1A0FE2164F2234D /* AWSSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSerialization.h; path = AWSCore/Serialization/AWSSerialization.h; sourceTree = "<group>"; };
+		F3CB9777F44C0BDB4C2F7226731D7A17 /* AWSFMDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabase.h; path = AWSCore/FMDB/AWSFMDatabase.h; sourceTree = "<group>"; };
+		F427531291DB1D1C9D8F6A709F1BBD2A /* NSValueTransformer+AWSMTLInversionAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+AWSMTLInversionAdditions.h"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLInversionAdditions.h"; sourceTree = "<group>"; };
+		F512671A8CA89ACEF7575B062F6AD0DC /* AWSDDASLLogCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDASLLogCapture.h; path = AWSCore/Logging/AWSDDASLLogCapture.h; sourceTree = "<group>"; };
+		F5D4071126A64D42B2F302F608505CE9 /* AWSUserPoolCustomAuthHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSUserPoolCustomAuthHandler.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSUserPoolCustomAuthHandler.swift; sourceTree = "<group>"; };
+		F5DABEBB1A7AE30FC002FA9F7D7C32BC /* _AWSMobileClient.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = _AWSMobileClient.m; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.m; sourceTree = "<group>"; };
+		F739532763F64777B91327F4DD6E9AB0 /* AWSMTLValueTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLValueTransformer.m; path = AWSCore/Mantle/AWSMTLValueTransformer.m; sourceTree = "<group>"; };
+		F752DCF3576E6E8F2191593BA7C6F05A /* AWSSignInProviderApplicationIntercept.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInProviderApplicationIntercept.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInProviderApplicationIntercept.h; sourceTree = "<group>"; };
+		F7BD476B02A70C2CA36E64D4DDF32DAD /* AWSURLRequestRetryHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLRequestRetryHandler.h; path = AWSCore/Serialization/AWSURLRequestRetryHandler.h; sourceTree = "<group>"; };
+		F7D6FB7A816C9E5F5B9FD5344DFA7EA6 /* CwlCatchException-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "CwlCatchException-Info.plist"; sourceTree = "<group>"; };
+		F917BC5B219C19085ED19ED90CB19D15 /* CwlCatchException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchException.swift; path = Sources/CwlCatchException/CwlCatchException.swift; sourceTree = "<group>"; };
+		F95F5D2719024ECC7BF03F6832F6944E /* AWSFMDatabaseAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabaseAdditions.m; path = AWSCore/FMDB/AWSFMDatabaseAdditions.m; sourceTree = "<group>"; };
 		F9918FB3EA173FD1AC5374D0FE2A4C3D /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.debug.xcconfig"; sourceTree = "<group>"; };
 		F9B0E837F8889C0E70E3B3CAD7D9D949 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-frameworks.sh"; sourceTree = "<group>"; };
-		FA186FC8E0A7DA8AD1832D28E0F1230D /* Fabric+FABKits.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Fabric+FABKits.h"; path = "AWSCore/Fabric/Fabric+FABKits.h"; sourceTree = "<group>"; };
-		FA45D1A07F3B26B40BCAE39A6FC72003 /* AWSCognitoIdentityProviderModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderModel.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderModel.h; sourceTree = "<group>"; };
-		FABED7D2E0EDD2DB1CD3929AC70D4B1D /* AWSValidation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSValidation.m; path = AWSCore/Serialization/AWSValidation.m; sourceTree = "<group>"; };
-		FB3FB11FF4A8D28C1128AB30C30C71AA /* AWSMTLReflection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLReflection.m; path = AWSCore/Mantle/AWSMTLReflection.m; sourceTree = "<group>"; };
-		FD4A5C49B68FFDF313E84752A7A8C833 /* AWSMobileClientUserDetails.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClientUserDetails.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSMobileClientUserDetails.swift; sourceTree = "<group>"; };
-		FD8ABFA6F971C7126B39B12AED1B60B8 /* AWSJKBigDecimal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSJKBigDecimal.m; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigDecimal.m; sourceTree = "<group>"; };
+		F9E0D46A0F53CEF014CB608689479F5A /* AWSMTLModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLModel.h; path = AWSCore/Mantle/AWSMTLModel.h; sourceTree = "<group>"; };
+		FABA1EBEF087305EAED9649E53354E5E /* AWSCognitoIdentityProviderResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderResources.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderResources.h; sourceTree = "<group>"; };
+		FB67317B1299EE3D2F425CDDD6AFEEC0 /* AWSMobileClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClient.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift; sourceTree = "<group>"; };
+		FC3DCF579216C793C1D5986A399A2417 /* AWSCognitoIdentityProviderASF-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCognitoIdentityProviderASF-dummy.m"; sourceTree = "<group>"; };
+		FF9CFC24BCA0B14493B8518376969BEC /* AWSDDFileLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDFileLogger.m; path = AWSCore/Logging/AWSDDFileLogger.m; sourceTree = "<group>"; };
+		FFCB4AAE367BAD78D9C6A46083E63014 /* CwlCatchException-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CwlCatchException-dummy.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		175C02B4F1917AEEB418FFCDEAA7B8B4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A6598CE3C61D646FEB39A1CC9AC3BA6F /* CoreGraphics.framework in Frameworks */,
+				DEFC6955484751C28D36B1126354830B /* Foundation.framework in Frameworks */,
+				14BB10E6F64439F078229540A0807EE6 /* Security.framework in Frameworks */,
+				339FA6343AC88EB9B429322BAF8FF915 /* SystemConfiguration.framework in Frameworks */,
+				BEEC4A944FADA30EC4B4A113212AEEE5 /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1D313376400F2FB9C2178108EA0876A3 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1186,23 +1210,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3AF0D71CA3A170A18E1B86A0A0097D05 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				569E588EB848786109C851253D8FD05F /* CoreGraphics.framework in Frameworks */,
-				171EDC862D3E1A2CB45F12DE4BEBE706 /* Foundation.framework in Frameworks */,
-				C2CD857BBF59B9B268148536E01E9EB9 /* Security.framework in Frameworks */,
-				A694F17C4E57537B8C1F4BC122E5F725 /* SystemConfiguration.framework in Frameworks */,
-				EC025F0FE35A6932FAE9C9A66EFFBF91 /* UIKit.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		4A76839E88FACA782C1C6CF90585C55D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				D76CECDB2FAB94F3D8DD51B54EA7F510 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8DD65B45F2688280FD422D5D7364A10A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				46818E554C7902ABE93D24966BB50EE3 /* AWSAuthCore.framework in Frameworks */,
+				AD223728D8DFA18B28E0340459453763 /* AWSCognitoIdentityProvider.framework in Frameworks */,
+				5D97CDAB82AF5231ACF2D62F75FB4F55 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1222,13 +1244,12 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B5FE19A4A95D978D3136CDAF82CF6758 /* Frameworks */ = {
+		B4F36F9296FED9381CF05EB20D880D6B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0500B5952A472F8A25D1B1FC9347F745 /* AWSAuthCore.framework in Frameworks */,
-				938E74E70E290A74DF2953430022C5F1 /* AWSCognitoIdentityProvider.framework in Frameworks */,
-				CBDA1AF9C1C14DFCC8FB3F54C2602EFA /* Foundation.framework in Frameworks */,
+				960B8E71E94DFFC52104B7D2A005F701 /* AWSCore.framework in Frameworks */,
+				F57674F250149BF452F8E2CD1CFACB13 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1253,15 +1274,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				0B2EFA3514269B1827188E84004105AD /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		E41DD745B4E9C6C0B6145D504D2FF82E /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				9AEAF6CAD298F286AE1BC32B731A99FF /* AWSCore.framework in Frameworks */,
-				BF35E2B9FF252642569E97E514E203E4 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1305,18 +1317,189 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		07383DE5DAF37BA9BF3F74FF075830A0 /* Support Files */ = {
+		02D3095C4836936A4D26CFDAAA5A29E8 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				4DDAA621C1CDBD9DFFD60CDC770E0102 /* AWSCognitoIdentityProvider.modulemap */,
-				0669AB8647FCA850A2FAD6F35CAB9B21 /* AWSCognitoIdentityProvider.xcconfig */,
-				448B7D6B55A4A3F3BCE22250E82D5EB5 /* AWSCognitoIdentityProvider-dummy.m */,
-				524A30EDB9EFE391117EA5798D76BCCE /* AWSCognitoIdentityProvider-Info.plist */,
-				390C1C9CA7BE32F1E916129268C583BB /* AWSCognitoIdentityProvider-prefix.pch */,
-				998EE64602226D70380E0CEB420DE53C /* AWSCognitoIdentityProvider-umbrella.h */,
+				1811ACAB11403C7A7936597C357FA33F /* AWSAuthCore */,
+				2C6A834CCAE8EB26259C71E30848F767 /* AWSCognitoIdentityProvider */,
+				F54394C431F5EB529A6160FB3E437E7F /* AWSCognitoIdentityProviderASF */,
+				06C6A85FC6C767AFBB8E17BA37379CD0 /* AWSCore */,
+				BA904E8F7807E5CC859BDDBE0BAA43C5 /* AWSMobileClient */,
+				1E39A2F1394B55C0C838F5202B7F2C7C /* CwlCatchException */,
+				412F96643FE3AE1A69F36120130ADBF5 /* CwlPreconditionTesting */,
+				E9B1820AFEA9222E5AE6AF00D1419B29 /* SwiftFormat */,
+				7F1BD4DAED83CA45AC39DEDEB8F26247 /* SwiftLint */,
 			);
-			name = "Support Files";
-			path = "../Target Support Files/AWSCognitoIdentityProvider";
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		06C6A85FC6C767AFBB8E17BA37379CD0 /* AWSCore */ = {
+			isa = PBXGroup;
+			children = (
+				B6F8E974D59BB2C71C3998C162816143 /* AWSBolts.h */,
+				D87BBA54881BE0850CBFFDC4D8114FCA /* AWSBolts.m */,
+				E1EC8C3E16C71BF25AA7F00CDEF6C1DE /* AWSCancellationToken.h */,
+				6B78D374D0A051D9C447BCFAE475F4E2 /* AWSCancellationToken.m */,
+				9109D53E30C8C4C64FBC39ECF60C179E /* AWSCancellationTokenRegistration.h */,
+				281AC237A5385219FDCE6717E9C69709 /* AWSCancellationTokenRegistration.m */,
+				12D212D94038E4481D8C3C8043590F7C /* AWSCancellationTokenSource.h */,
+				D29FE4BBF56788C9AC325256DFB9A156 /* AWSCancellationTokenSource.m */,
+				EFEA0F24602DFAEAAC189215C3C59E39 /* AWSCategory.h */,
+				E128D8EF93BA4D893F0117811A205D83 /* AWSCategory.m */,
+				3A3C4EF0A54DFF8F64748AB9A6E364E0 /* AWSClientContext.h */,
+				11981CE8441163483F737D85DE32B1CE /* AWSClientContext.m */,
+				9348F3E0355579436D403C96DB0D7EF4 /* AWSCocoaLumberjack.h */,
+				66B10363FF226628014BC9AA0109E500 /* AWSCognitoIdentity.h */,
+				8712DFDF41458E13CDE557E792397356 /* AWSCognitoIdentity+Fabric.h */,
+				9CACA599E066FECF7765E60FB671E1A8 /* AWSCognitoIdentity+Fabric.m */,
+				4E57BA4A95EE17DEB99ECB5EBFC44EA9 /* AWSCognitoIdentityModel.h */,
+				91C2094C059BAFFFFBC229AC5C0F9CEF /* AWSCognitoIdentityModel.m */,
+				B2DB7B9AA67A4C2901A501179E35FDC8 /* AWSCognitoIdentityResources.h */,
+				185F0DC6368FA1D4547527B451DB8EB9 /* AWSCognitoIdentityResources.m */,
+				7771C2DFE4AD99CD3A269C7ADB017DAA /* AWSCognitoIdentityService.h */,
+				DCE1BA35810587B99C58F0FED53ABAC3 /* AWSCognitoIdentityService.m */,
+				99B54D708FFA50347BEFA9AD8730A8AA /* AWSCore.h */,
+				13A6AC4F2598B540AB29DEA12B8DA004 /* AWSCredentialsProvider.h */,
+				9CC392531C7DC92AB41B16939E55FBAC /* AWSCredentialsProvider.m */,
+				3F3CA727772902D38F633984F132084D /* AWSDDAbstractDatabaseLogger.h */,
+				13A70D9A2492A9A41C2BC8FDDE0C6707 /* AWSDDAbstractDatabaseLogger.m */,
+				F512671A8CA89ACEF7575B062F6AD0DC /* AWSDDASLLogCapture.h */,
+				C212D282C3A3524B1011E30E0E313E1C /* AWSDDASLLogCapture.m */,
+				5410D8EAB2C72480C6D03EAC64799186 /* AWSDDASLLogger.h */,
+				92A43858635F9C27ED94A05763E2521E /* AWSDDASLLogger.m */,
+				72AF9BE763154EB3F8872F62553004E1 /* AWSDDAssertMacros.h */,
+				390C1B329BDBA41B75D7590CFC85F033 /* AWSDDContextFilterLogFormatter.h */,
+				1E93344537320B3C5EB8604688C8560C /* AWSDDContextFilterLogFormatter.m */,
+				A30C60B5CD0C127A0F791708CFE9B42D /* AWSDDDispatchQueueLogFormatter.h */,
+				98015366A1F6CDB77D29D5B2458E7056 /* AWSDDDispatchQueueLogFormatter.m */,
+				98FCA979D8A8822E734476B6E58B8ED4 /* AWSDDFileLogger.h */,
+				FF9CFC24BCA0B14493B8518376969BEC /* AWSDDFileLogger.m */,
+				BB55B2CB2AA26552F0C51813928696F6 /* AWSDDLegacyMacros.h */,
+				6A425EA2780C3972162FA364B8134591 /* AWSDDLog.h */,
+				1853077C437335F8E40E76858B148CE5 /* AWSDDLog.m */,
+				3FB6BA58A3DC5A5334029E7C6BBF6990 /* AWSDDLog+LOGV.h */,
+				076B6FA2F32A84341788F1C2E42A79CA /* AWSDDLogMacros.h */,
+				3965E8754824714C58065089218E87C4 /* AWSDDMultiFormatter.h */,
+				86BE6A81DB57EC1FEA08B44FDD69B10E /* AWSDDMultiFormatter.m */,
+				745068DD32DDB8617322A32B3A678DDD /* AWSDDOSLogger.h */,
+				0831B18334CCA361EBE774FCE1C79065 /* AWSDDOSLogger.m */,
+				0E02F91D7B07EC8FC39A4CAF40D39746 /* AWSDDTTYLogger.h */,
+				AF9B52768BC4CE65526EAB63E2E75880 /* AWSDDTTYLogger.m */,
+				7281DA57E485275E8A49803FCDED939E /* AWSExecutor.h */,
+				D3E5DF2CC49F1C2A673519ADB5D725BE /* AWSExecutor.m */,
+				16A649B28EBAF292512D8F10FD00EEC0 /* AWSEXTKeyPathCoding.h */,
+				D30FB1471BD4A7F0CE23217C25A286D6 /* AWSEXTRuntimeExtensions.h */,
+				E946D357D1B824535DF21C71A74F7306 /* AWSEXTRuntimeExtensions.m */,
+				94327DFA9363831CE32D78455D699B69 /* AWSEXTScope.h */,
+				7AB1A2F26FDFD8E1CCDB36F0FFD0FDA0 /* AWSEXTScope.m */,
+				F3CB9777F44C0BDB4C2F7226731D7A17 /* AWSFMDatabase.h */,
+				9D814B6AF5A67FF1828ECF314845D1BD /* AWSFMDatabase.m */,
+				E8B5FDB178DA118BA766982955206D30 /* AWSFMDatabase+Private.h */,
+				810E6C0AEAF81CEF142AD224BC9FA4D7 /* AWSFMDatabaseAdditions.h */,
+				F95F5D2719024ECC7BF03F6832F6944E /* AWSFMDatabaseAdditions.m */,
+				CD9504574C2BEA74886D0BA7A7E51BE6 /* AWSFMDatabasePool.h */,
+				4D18BB847E2E5CA341022508986C0EA8 /* AWSFMDatabasePool.m */,
+				41F1BA5E8793C8CC6222D85413CE4C4A /* AWSFMDatabaseQueue.h */,
+				81685F61C04386054C6EB486CE045EB4 /* AWSFMDatabaseQueue.m */,
+				07ECE90907BE180F6A539BF08715EDE3 /* AWSFMDB.h */,
+				38C24E5DB4B1C541A80CDFF1952C4545 /* AWSFMDB+AWSHelpers.h */,
+				A52145D6322955C0D6C6F09871F24741 /* AWSFMDB+AWSHelpers.m */,
+				7A8546CE0DBDFE5D38B2046606E4B7CE /* AWSFMResultSet.h */,
+				9176A30EF537A984349EF0941C29042B /* AWSFMResultSet.m */,
+				1CB773EA726322B9A2CD42FF90D4DD17 /* AWSGeneric.h */,
+				59A459A5BE87F0DADD67EBB169FFF49A /* AWSGZIP.h */,
+				C0DB0C0B9E1C812A42914C8AA7BF1A8D /* AWSGZIP.m */,
+				ED595581B874044815E93AAC0D4FB3A4 /* AWSIdentityProvider.h */,
+				0A1CD521E28948276DB6DF5C1CEBC2C1 /* AWSIdentityProvider.m */,
+				A160B41090A56C0EFD3C4DF8921A1539 /* AWSInfo.h */,
+				2C5FAED483BFCC2F6ED318BFC0A89612 /* AWSInfo.m */,
+				0D58BF63FD36A36860F5EB44E38DD099 /* AWSKSReachability.h */,
+				9FF7C8B2AC413711B14A91BC15CD8431 /* AWSKSReachability.m */,
+				BFCEEE328F910F62BBDE90665F16FD72 /* AWSLogging.h */,
+				722FB0BF2F494C956CD49C0C75A2FDC0 /* AWSLogging.m */,
+				B11D75C0DCD9FF11DB626B078823A733 /* AWSMantle.h */,
+				7B69116025E7AE4E03FD9CB6AE7D4A79 /* AWSmetamacros.h */,
+				9FCBEE62A3337BC2F65D83AF4E6B900F /* AWSModel.h */,
+				115578294D5785F67A4164B425F3D299 /* AWSModel.m */,
+				3D02469A819F1238BA748181F1265632 /* AWSMTLJSONAdapter.h */,
+				12B99B810FB2E25531E1E4F2CAF6AABD /* AWSMTLJSONAdapter.m */,
+				BD6402601C3C46495B29A0B51C537439 /* AWSMTLManagedObjectAdapter.h */,
+				0E3D65FEA8DF69AB59F24058F42DCED6 /* AWSMTLManagedObjectAdapter.m */,
+				F9E0D46A0F53CEF014CB608689479F5A /* AWSMTLModel.h */,
+				18F8E4C791238DE2BC89F84EF383A00D /* AWSMTLModel.m */,
+				679BE254CFCDEE26015A8539E066D54F /* AWSMTLModel+NSCoding.h */,
+				BC067900E6CC27C9DAEE297A89AD2D0F /* AWSMTLModel+NSCoding.m */,
+				1A60E93D25B2C3C212B4679F93F75755 /* AWSMTLReflection.h */,
+				F170E6A7DDECEFE5838C092C79B21FDA /* AWSMTLReflection.m */,
+				D7E963C4F0D7D073D7546DDC482E53FD /* AWSMTLValueTransformer.h */,
+				F739532763F64777B91327F4DD6E9AB0 /* AWSMTLValueTransformer.m */,
+				1E2AEE92884E8A3660E2A5C368A9D134 /* AWSNetworking.h */,
+				46873E29496F81BE8EB8FC668D31C366 /* AWSNetworking.m */,
+				285440696A5920B5E6B03DE8351989B8 /* AWSNetworkingHelpers.h */,
+				42BB3C6979837861377DA5A89549AE64 /* AWSNetworkingHelpers.m */,
+				F2F95957A8A28F91A1A0FE2164F2234D /* AWSSerialization.h */,
+				B8785DC9A87864D9C1FDCB43C2469B74 /* AWSSerialization.m */,
+				CF52B59CF212AEF5EF49ED0B7A9E02C1 /* AWSService.h */,
+				65A25F6FD0D61706F9535950AFC406E4 /* AWSService.m */,
+				D0E94613A5F8B0E8267BE68F25F2F8CD /* AWSServiceEnum.h */,
+				6C401F43F3647CFB1A04369928781E0E /* AWSSignature.h */,
+				3B109D739CFC883289A6548766B8B7DD /* AWSSignature.m */,
+				37E8F49480EF8060BB37B26F5BC5DF99 /* AWSSTS.h */,
+				70B3F537BC06A2190DBA5545CA3BC9D1 /* AWSSTSModel.h */,
+				0C7EFC1FA0A94BB3040D38C1BBFCF76E /* AWSSTSModel.m */,
+				8A6AB7B64F3EA49D82336E6F2342E8F4 /* AWSSTSResources.h */,
+				0A3B34FAA9B84A5377B2D5C709DA6B92 /* AWSSTSResources.m */,
+				009CACF5738D03F5B64F3EF3C99FB61E /* AWSSTSService.h */,
+				BC78A1BE3112CD63FB79FC0D632C08AD /* AWSSTSService.m */,
+				26844A716609D618B953ADCC3477A9C2 /* AWSSynchronizedMutableDictionary.h */,
+				11EDEFEDFA365D9648D81979FF0CF2BA /* AWSSynchronizedMutableDictionary.m */,
+				6D2101718310C6801E3A00062C07C39C /* AWSTask.h */,
+				B22773A61D27574942BD3C76F4C90814 /* AWSTask.m */,
+				30642F131CF85895AB20D4764112A7B1 /* AWSTaskCompletionSource.h */,
+				25B48B5E2F240D5C178AEC37739F47BD /* AWSTaskCompletionSource.m */,
+				DE52C631AAD1F37EC85940B309484450 /* AWSTMCache.h */,
+				AE43657F8C0C1405A6F48A02C31C2CF5 /* AWSTMCache.m */,
+				B105C48272F594AC5233F7320470A5B7 /* AWSTMCacheBackgroundTaskManager.h */,
+				DAA8BB0506C2E9D42D5AED09D74156A6 /* AWSTMDiskCache.h */,
+				C163507295304A519E85051ED74A6209 /* AWSTMDiskCache.m */,
+				94701E2D8BEB1ECDDF758D0719854FAF /* AWSTMMemoryCache.h */,
+				60F4BE632949FAE284F63F70D7952C60 /* AWSTMMemoryCache.m */,
+				73D6A1A96394F99C88C2D192F6EE2472 /* AWSUICKeyChainStore.h */,
+				12DBB62EC989FA364779063935663723 /* AWSUICKeyChainStore.m */,
+				F7BD476B02A70C2CA36E64D4DDF32DAD /* AWSURLRequestRetryHandler.h */,
+				2EDE3BF19468DE4E9605AD1B08021DF4 /* AWSURLRequestRetryHandler.m */,
+				168E7EDD61CE770FCEEFF271776BDD39 /* AWSURLRequestSerialization.h */,
+				79F8F7318B8DE19209DA9DDF5193FC01 /* AWSURLRequestSerialization.m */,
+				CB5F5DD200C1796E0CD90E3B92A8DB28 /* AWSURLResponseSerialization.h */,
+				8A0ADFA07325170FDC5BB0CE2DB1EBA9 /* AWSURLResponseSerialization.m */,
+				C0B03B2C8F2862CAF77DEFE91DF50641 /* AWSURLSessionManager.h */,
+				9C738EC7E8D4A0BF95B09336DEDB98B1 /* AWSURLSessionManager.m */,
+				AD1FFEF90711E0EC311224E066703638 /* AWSValidation.h */,
+				EB3B13702A64602EEE8777F3A9C91B70 /* AWSValidation.m */,
+				49C1DACDE13725ACAFADE7825739F218 /* AWSXMLDictionary.h */,
+				0ADFD7E42BE139F259349496AA57A0A2 /* AWSXMLDictionary.m */,
+				CAB31BB0CB1979BC02AE603D4C767273 /* AWSXMLWriter.h */,
+				40D3E2ACC250193E898393BB5E5B0FAD /* AWSXMLWriter.m */,
+				5AF033D372099B17E4AD1ECEF2388C74 /* FABAttributes.h */,
+				920863BE9A25A6D24A89E4889EE0A014 /* FABKitProtocol.h */,
+				8CEEBBC83FB1A93562327EAFF615AA6B /* Fabric.h */,
+				ACCDDF8A621C80784B35192C5C55D9ED /* Fabric+FABKits.h */,
+				0A075F8FA03A8A6E504C77FC33DE7E6D /* NSArray+AWSMTLManipulationAdditions.h */,
+				2C69D27D99AAF70EBC5392FB14C7B7DA /* NSArray+AWSMTLManipulationAdditions.m */,
+				9F110F53CAAF1AB03CE1CA851F85859F /* NSDictionary+AWSMTLManipulationAdditions.h */,
+				52E8B5E00968480B2775F83181520231 /* NSDictionary+AWSMTLManipulationAdditions.m */,
+				8CAB3BD92207D2E252347FD79A669516 /* NSError+AWSMTLModelException.h */,
+				C9022B2A001A348E8DEDD1296B5E0716 /* NSError+AWSMTLModelException.m */,
+				0CF40D7AF9CA3F2F9A410759AE391171 /* NSObject+AWSMTLComparisonAdditions.h */,
+				B0F9182481E43628F757BAFB64AD0B54 /* NSObject+AWSMTLComparisonAdditions.m */,
+				F427531291DB1D1C9D8F6A709F1BBD2A /* NSValueTransformer+AWSMTLInversionAdditions.h */,
+				3802AAD88A0ED5ABF4155747E2EC95BC /* NSValueTransformer+AWSMTLInversionAdditions.m */,
+				13A27886A2A2BD9BDC18D4AA06E0BE8D /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */,
+				3D98814487113FC0451682BF2CA928D0 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */,
+				F1190B5C3CF3ED79D80F706422B61756 /* Support Files */,
+			);
+			name = AWSCore;
+			path = AWSCore;
 			sourceTree = "<group>";
 		};
 		07B15F0B0839BB873BF49FF0A5A12925 /* Pods-Amplify-AWSPluginsCore */ = {
@@ -1350,34 +1533,6 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		0C01863993CFD116B9A13B6119B5FCCE /* AWSMobileClient */ = {
-			isa = PBXGroup;
-			children = (
-				8319645FEC9FDF368C1C182C318B5C74 /* _AWSMobileClient.h */,
-				24D7C4A40FE6A6E8B9A1408D69A1312E /* _AWSMobileClient.m */,
-				188F37DEE01522564894F2F82EDD1EF6 /* AWSCognitoAuth.h */,
-				330803FE2581778D386F729BF4845395 /* AWSCognitoAuth.m */,
-				37306661AA76074040E8089831654A0E /* AWSCognitoAuth+Extensions.h */,
-				C21BE7FA37988912443776169E6B9145 /* AWSCognitoAuth+Extensions.m */,
-				167AA0AB77323674B63505B4C320DE54 /* AWSCognitoAuth_Internal.h */,
-				B225D9D4836594D19B6CBD2FF5D85D31 /* AWSCognitoAuthUICKeyChainStore.h */,
-				689C85B7A1BA6D62F0D490ABAD8A14D0 /* AWSCognitoAuthUICKeyChainStore.m */,
-				953E533AB3626686BC0DCFEE4DCDBCC9 /* AWSCognitoCredentialsProvider+Extension.h */,
-				559ED735E06A51AB1E085F76D239ECE2 /* AWSMobileClient.h */,
-				A1DAC56F84465C1D97C25BC1495B7607 /* AWSMobileClient.swift */,
-				53FDA22EA479098F4BD726442ADB34A1 /* AWSMobileClientExtensions.swift */,
-				FD4A5C49B68FFDF313E84752A7A8C833 /* AWSMobileClientUserDetails.swift */,
-				5BAA1591C171FABA209F8DD8CBDD9474 /* AWSMobileOptions.swift */,
-				82AB238158A3FCE734364EDE3C8F998A /* AWSMobileResults.swift */,
-				5ACEAA077B4DC5FF33706180C515F269 /* AWSUserPoolOperationsHandler.swift */,
-				2E0FC39EDE37B13F74EFD7D11094F05E /* DeviceOperations.swift */,
-				E0D51F01A2CCD2C6FB8821C4F7CC4507 /* JSONHelper.swift */,
-				43D7B8FB612DA2F2C9F569715A620052 /* Support Files */,
-			);
-			name = AWSMobileClient;
-			path = AWSMobileClient;
-			sourceTree = "<group>";
-		};
 		0C28D1231E7C310AEDF274A34182D73C /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -1408,13 +1563,33 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		0E8F360B060C0A9E3F56F1FAB7AA1BF0 /* SwiftLint */ = {
+		0D8EAE8D0C82066F079BBE49527FC539 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				6D440D10B46044960E8AAA84703C32A9 /* Support Files */,
+				3CE55D53ECA949420B445EF748A6B476 /* SwiftLint.xcconfig */,
 			);
-			name = SwiftLint;
-			path = SwiftLint;
+			name = "Support Files";
+			path = "../Target Support Files/SwiftLint";
+			sourceTree = "<group>";
+		};
+		1811ACAB11403C7A7936597C357FA33F /* AWSAuthCore */ = {
+			isa = PBXGroup;
+			children = (
+				A46B3233721574887E89B7E89E73CB49 /* AWSAuthCore.h */,
+				00ED9F12F787409584FD64E63CB00BFA /* AWSAuthUIHelper.h */,
+				3D7AD3753C2B976519ABD2B870B1AAF5 /* AWSAuthUIHelper.m */,
+				C5C34C491A183A09D49EF0138F8202FE /* AWSIdentityManager.h */,
+				3844849C30D28B47FF9C3DD61529455D /* AWSIdentityManager.m */,
+				EA5ACF18886A4FF581354E7504E25CCD /* AWSSignInButtonView.h */,
+				04F94581174EDFD77DD77D64E573D786 /* AWSSignInManager.h */,
+				13F6EC075EF080997FC5EAA557A51049 /* AWSSignInManager.m */,
+				316D632308F1EFBC2C0DF047773030DF /* AWSSignInProvider.h */,
+				F752DCF3576E6E8F2191593BA7C6F05A /* AWSSignInProviderApplicationIntercept.h */,
+				EB037FE1BB0944A9A0396B42155C798B /* AWSUIConfiguration.h */,
+				F7A91B718564D779417F4BAA7812A5AE /* Support Files */,
+			);
+			name = AWSAuthCore;
+			path = AWSAuthCore;
 			sourceTree = "<group>";
 		};
 		1AEAD31DC1C1DD9F4F43BEB61EDEB4C2 /* Pods-AmplifyTestApp */ = {
@@ -1434,66 +1609,106 @@
 			path = "Target Support Files/Pods-AmplifyTestApp";
 			sourceTree = "<group>";
 		};
-		2334C47B6A97E21EFDFD7A9402C7924C /* AWSCognitoIdentityProviderASF */ = {
+		1E39A2F1394B55C0C838F5202B7F2C7C /* CwlCatchException */ = {
 			isa = PBXGroup;
 			children = (
-				DA1C66EA6864356E4922848C7144C4DF /* AWSCognitoIdentityASF.h */,
-				4D79EA8A0193479BD7F7E122F9C1E9C0 /* AWSCognitoIdentityProviderASF.h */,
-				C2DAAF70CB9E19EA4D2313D99B529CBA /* AWSCognitoIdentityProviderASF.m */,
-				5C395BB53DD73A3BE6BD107FEC782DDA /* Frameworks */,
-				273911AB31522B431E175C47CE699113 /* Support Files */,
-			);
-			name = AWSCognitoIdentityProviderASF;
-			path = AWSCognitoIdentityProviderASF;
-			sourceTree = "<group>";
-		};
-		26376F84F1E769DC402866B8D062C8BB /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				188D37813096871738338C0AE719885C /* SwiftFormat.xcconfig */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/SwiftFormat";
-			sourceTree = "<group>";
-		};
-		273911AB31522B431E175C47CE699113 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				682069AC7E59C138843C82C76D694A59 /* AWSCognitoIdentityProviderASF.modulemap */,
-				A0E6E441D5D233E13E9794788839B361 /* AWSCognitoIdentityProviderASF.xcconfig */,
-				DDEFE9EFCE6276D0B23D56F4DCED501B /* AWSCognitoIdentityProviderASF-dummy.m */,
-				233BEDEACBE0EC3689AAAAC21BF3F84B /* AWSCognitoIdentityProviderASF-Info.plist */,
-				5458CB47C2EF22CEE66D77C5DEB15466 /* AWSCognitoIdentityProviderASF-prefix.pch */,
-				0310E0B59C9259ADAB4636C5A7010C7E /* AWSCognitoIdentityProviderASF-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/AWSCognitoIdentityProviderASF";
-			sourceTree = "<group>";
-		};
-		33DF86C82A080770571EEC803C524951 /* CwlCatchException */ = {
-			isa = PBXGroup;
-			children = (
-				AA7CA64F79A273DFB20A0536914C253F /* CwlCatchException.h */,
-				2DF90D7DF6E0AB0C6DAD5ACD71EE5837 /* CwlCatchException.m */,
-				4AEDCAB69641F21BD95E3D9568D7CBF2 /* CwlCatchException.swift */,
-				D7F68E9F92F613AA95240172646B49C6 /* Support Files */,
+				E727F698E5184B8A8F0AEF9CAF632FA8 /* CwlCatchException.h */,
+				673FC21F904E05922260C6F6C1055044 /* CwlCatchException.m */,
+				F917BC5B219C19085ED19ED90CB19D15 /* CwlCatchException.swift */,
+				8D46555916756E76EC60CB6B102FADD4 /* Support Files */,
 			);
 			name = CwlCatchException;
 			path = CwlCatchException;
 			sourceTree = "<group>";
 		};
-		43D7B8FB612DA2F2C9F569715A620052 /* Support Files */ = {
+		2798668B9A1CF9575742CF07A8B1C114 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				A729E887BEFAE11B8E6585C54E3C94B5 /* AWSMobileClient.modulemap */,
-				498D20AA560AEC314E9573CE635D2DE5 /* AWSMobileClient.xcconfig */,
-				71D1F9D0DBC89FD691F685E6A5AA15AE /* AWSMobileClient-dummy.m */,
-				D97F2B1789651B25F7979DA0F52D0067 /* AWSMobileClient-Info.plist */,
-				1A4792CC29627D2983F897C3A17E2818 /* AWSMobileClient-prefix.pch */,
-				5BF16544386127F9C6E26486D1BBA0C5 /* AWSMobileClient-umbrella.h */,
+				9FEEDF39BB2522F1F1564847E3D9021A /* AWSMobileClient.modulemap */,
+				C6FB30955DA68107EDEF56A9A1344D17 /* AWSMobileClient.xcconfig */,
+				A7521733F008AF096D52D74AF5F36981 /* AWSMobileClient-dummy.m */,
+				BB402C47244C897CE7236FE13AD98752 /* AWSMobileClient-Info.plist */,
+				BE4816820DBD8AD200627DBCE6504789 /* AWSMobileClient-prefix.pch */,
+				B3AE5FD3791D0D949459393DD40CD3DF /* AWSMobileClient-umbrella.h */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/AWSMobileClient";
+			sourceTree = "<group>";
+		};
+		2C6A834CCAE8EB26259C71E30848F767 /* AWSCognitoIdentityProvider */ = {
+			isa = PBXGroup;
+			children = (
+				2791EB61C4AFF9075545494144A5BD95 /* aws_tommath.h */,
+				388680EB7CAF4AB53E3DD89E2CC90F2E /* aws_tommath_class.h */,
+				9DD919F5D40936CBB175BC18C0CC012A /* aws_tommath_superclass.h */,
+				DADB698FF6F0FE317C721CB8277E3306 /* AWSCognitoIdentityProvider.h */,
+				1B0AAF84EC698F11CC63045004A9ED58 /* AWSCognitoIdentityProviderHKDF.h */,
+				A1D9BE851096D333C6BCF3DCC3CB8685 /* AWSCognitoIdentityProviderHKDF.m */,
+				64477AF05BB569C283F8CA75DC186B39 /* AWSCognitoIdentityProviderModel.h */,
+				557CB74CF255046C393A564440AE135F /* AWSCognitoIdentityProviderModel.m */,
+				FABA1EBEF087305EAED9649E53354E5E /* AWSCognitoIdentityProviderResources.h */,
+				DA93AD0D291E93447CCCCCEFD85708BB /* AWSCognitoIdentityProviderResources.m */,
+				58C89AD838EDC38CC8C7DBB462B82E56 /* AWSCognitoIdentityProviderService.h */,
+				27556645674390E079A50FAE1D38FFF1 /* AWSCognitoIdentityProviderService.m */,
+				2B531E9546AD9DB8A58EDF26D38A9FE1 /* AWSCognitoIdentityProviderSrpHelper.h */,
+				C751FB32301C38302A2EC137BA70D3EC /* AWSCognitoIdentityProviderSrpHelper.m */,
+				506993FFD5E43321C8EE111378E6B6C5 /* AWSCognitoIdentityUser.h */,
+				ACA1E3EBBEA1F5D3160841769800B0DC /* AWSCognitoIdentityUser.m */,
+				E7EC8830B686D3AA9F8A5EC5559D133E /* AWSCognitoIdentityUser_Internal.h */,
+				7B5D74163C65BA45F129C2F75A244A26 /* AWSCognitoIdentityUserPool.h */,
+				A1163FE82E3D89D2C4D5F59685F700D0 /* AWSCognitoIdentityUserPool.m */,
+				B9A3E48A5EBDD64DAE2ECD9EE0D19659 /* AWSCognitoIdentityUserPool_Internal.h */,
+				5CDCA759E2B524AD0D5B0529F695A28C /* AWSJKBigDecimal.h */,
+				85B16C1BEED6DAD6A2AB160002933CDA /* AWSJKBigDecimal.m */,
+				CEAA8CF19472EC4ACF9D738F775FC832 /* AWSJKBigInteger.h */,
+				856B9460EE390E948E972BC937AD38F4 /* AWSJKBigInteger.m */,
+				906357A4C1AA3FE5689B0E940D3D91F2 /* NSData+AWSCognitoIdentityProvider.h */,
+				9F45A88D28CED0D57D7F1D7138D0CDFF /* NSData+AWSCognitoIdentityProvider.m */,
+				0F18885B0C226C01535E4BC473565790 /* tommath.c */,
+				42851DE6B2F6C93AEDE5F7352627E5B4 /* Support Files */,
+			);
+			name = AWSCognitoIdentityProvider;
+			path = AWSCognitoIdentityProvider;
+			sourceTree = "<group>";
+		};
+		412F96643FE3AE1A69F36120130ADBF5 /* CwlPreconditionTesting */ = {
+			isa = PBXGroup;
+			children = (
+				38B52AFD8824D96B30C353421A67E04F /* CwlBadInstructionException.swift */,
+				983EDE1A47AA1B93CFCC5C3B7E1E5678 /* CwlCatchBadInstruction.swift */,
+				76183A993DAA4D030DEB79B1EE231C3C /* CwlDarwinDefinitions.swift */,
+				98EBAF29DC4D794957822E239F9C944B /* CwlMachBadInstructionHandler.h */,
+				63558BCBF0A625B52BCB547CD0DFB1BA /* CwlMachBadInstructionHandler.m */,
+				12163530DDDEF249BE3C311D0ED23327 /* CwlPreconditionTesting.h */,
+				8A5462580CC9DC68AF7075ACA8844031 /* mach_excServer.c */,
+				4BD2BB7E9FDBD0CD5EBDDACD4E5589AF /* mach_excServer.h */,
+				4EBF2523AEF0E390C69D94209C884745 /* Support Files */,
+			);
+			name = CwlPreconditionTesting;
+			path = CwlPreconditionTesting;
+			sourceTree = "<group>";
+		};
+		42851DE6B2F6C93AEDE5F7352627E5B4 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				7257E001ABB1CC1EF9EE34046FC8BCD2 /* AWSCognitoIdentityProvider.modulemap */,
+				5EDFE115C3392FB9863659189DFA9FD0 /* AWSCognitoIdentityProvider.xcconfig */,
+				A077A3D16945E07EBB64DF9B37B77A62 /* AWSCognitoIdentityProvider-dummy.m */,
+				CA847668DCC864011A6F5E61B5B8F788 /* AWSCognitoIdentityProvider-Info.plist */,
+				CA7B6E7179083414E201D1859C9528EB /* AWSCognitoIdentityProvider-prefix.pch */,
+				82AE0D4FE2C5DA296BA6072367A2F9F6 /* AWSCognitoIdentityProvider-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/AWSCognitoIdentityProvider";
+			sourceTree = "<group>";
+		};
+		4389FF4A5297B305E2B3B22BF5E9A6A3 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				A4F18ECC77B90BCC7C16CD58FFCA677C /* SwiftFormat.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/SwiftFormat";
 			sourceTree = "<group>";
 		};
 		4E14FB6CA44176BC9D0444841C733692 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests */ = {
@@ -1513,21 +1728,18 @@
 			path = "Target Support Files/Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests";
 			sourceTree = "<group>";
 		};
-		5C395BB53DD73A3BE6BD107FEC782DDA /* Frameworks */ = {
+		4EBF2523AEF0E390C69D94209C884745 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				1DD1F0DAB474DC311D2AD49F5739648D /* libAWSCognitoIdentityProviderASFBinary.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		6D440D10B46044960E8AAA84703C32A9 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				301896368726EDD96867206BBDD39070 /* SwiftLint.xcconfig */,
+				CD4393963F8EEB81AD47AEF6938B3646 /* CwlPreconditionTesting.modulemap */,
+				0E4D66772DCE19A7404EF983F3D98759 /* CwlPreconditionTesting.xcconfig */,
+				F14752C7AAF0C272D64F8DB9DB35D1FB /* CwlPreconditionTesting-dummy.m */,
+				7AA514D521D364F474E1B819D72E6CA6 /* CwlPreconditionTesting-Info.plist */,
+				70BCFF3866799D2A76B86625EB6F94A7 /* CwlPreconditionTesting-prefix.pch */,
+				D7E8BDCF5CB5DF64785E0DE7EDD5371A /* CwlPreconditionTesting-umbrella.h */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/SwiftLint";
+			path = "../Target Support Files/CwlPreconditionTesting";
 			sourceTree = "<group>";
 		};
 		7849ED9E3F18FE1FE213C9FB97D7F75F /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests */ = {
@@ -1547,185 +1759,13 @@
 			path = "Target Support Files/Pods-Amplify-AmplifyTestConfigs-AmplifyTests";
 			sourceTree = "<group>";
 		};
-		7C0126F6ADB988A10AFD41C66A817FC4 /* AWSCore */ = {
+		7F1BD4DAED83CA45AC39DEDEB8F26247 /* SwiftLint */ = {
 			isa = PBXGroup;
 			children = (
-				C53B9703FFDCF5CAC036A262B1D4F62C /* AWSBolts.h */,
-				954C6F2887E29DB41520A7D369558C27 /* AWSBolts.m */,
-				84274CDFE4A91976E91F70B196DB5FE3 /* AWSCancellationToken.h */,
-				E7B6AAB2A324861F81A30FFE86E53DF5 /* AWSCancellationToken.m */,
-				BF574DD5F235DC4861034E0CA2A88D7F /* AWSCancellationTokenRegistration.h */,
-				CB96EAB0130FC52A057E49780D95D87B /* AWSCancellationTokenRegistration.m */,
-				C8A48FB23DA4C723054237DD88FF8627 /* AWSCancellationTokenSource.h */,
-				7615572287FFAD3ADADE3696B49FBEA0 /* AWSCancellationTokenSource.m */,
-				72A71B300822301B02175A776829FDD5 /* AWSCategory.h */,
-				B0C4B1EB0A6EE847AB190230311FEDD2 /* AWSCategory.m */,
-				6075D205854C3273C42D6872BB69588E /* AWSClientContext.h */,
-				B6678B3BFB137395C6BFB6442F592DAF /* AWSClientContext.m */,
-				C60A8B140370A37C7542F37266CDA34A /* AWSCocoaLumberjack.h */,
-				B39F1BB26E3CFBE20F7F3FE417B47FD8 /* AWSCognitoIdentity.h */,
-				023B6B51414D71AD0293B95B3B78DBB1 /* AWSCognitoIdentity+Fabric.h */,
-				65BB125D267BA4B1D4FA8A28C9727E9F /* AWSCognitoIdentity+Fabric.m */,
-				9DE0E318F8B727F880BE50269334A1FB /* AWSCognitoIdentityModel.h */,
-				535C83A91CC020AFB7530E10C8EEF27F /* AWSCognitoIdentityModel.m */,
-				7EF841B46EC42CD1F560B98CD32D7CEE /* AWSCognitoIdentityResources.h */,
-				AEF6FE2870E54B10EF30BE095D07ADE5 /* AWSCognitoIdentityResources.m */,
-				4AD77E92817948CBE257C0921A8168E1 /* AWSCognitoIdentityService.h */,
-				526789E47E87CD57DC238155C82E851D /* AWSCognitoIdentityService.m */,
-				1385AC19B182894FE81125DDCE8C5F06 /* AWSCore.h */,
-				7B77ED9825E341DEF2A12FAE12D669D2 /* AWSCredentialsProvider.h */,
-				BEBAB3C7809690613DC9CAFA944D8EDA /* AWSCredentialsProvider.m */,
-				ED153D8760D84C9A9D3C2419AFEA1E27 /* AWSDDAbstractDatabaseLogger.h */,
-				470DACED7FA482EE4F2D2F781A78EB9B /* AWSDDAbstractDatabaseLogger.m */,
-				18239979C2E3508F26FBE3C76EBAB6F9 /* AWSDDASLLogCapture.h */,
-				B17B2529C82595074FBB5299CA4C33F4 /* AWSDDASLLogCapture.m */,
-				3020E70B872491E1D6E28FD21ECC2157 /* AWSDDASLLogger.h */,
-				4BCA6DA44439111C917017DE70D65CAB /* AWSDDASLLogger.m */,
-				F6F2FC19E23CBF1C81BE3432A3164D83 /* AWSDDAssertMacros.h */,
-				42D1C9714D461A6FEBFA26A038D4F780 /* AWSDDContextFilterLogFormatter.h */,
-				03CADE1D8C5CA75A636F2DE98BF8FC26 /* AWSDDContextFilterLogFormatter.m */,
-				BCE30B479D2F9EEE3D3AC4ECDC256CD2 /* AWSDDDispatchQueueLogFormatter.h */,
-				272846E6C6A1F75201AEF412E1F113E6 /* AWSDDDispatchQueueLogFormatter.m */,
-				EDAF6B48646B5CF2EC92CB5195E0F966 /* AWSDDFileLogger.h */,
-				8F101994E77186A9F9F09402BFC3E1CB /* AWSDDFileLogger.m */,
-				597F1FBC284F71F3B4FA26BA2D7073CF /* AWSDDLegacyMacros.h */,
-				EDE386C04D660CD52D88BD3C45334C9D /* AWSDDLog.h */,
-				00A9F9D487F770ACF4AE33F74AB275D3 /* AWSDDLog.m */,
-				2133A4C34B9432D76D7E52785CF5DFA3 /* AWSDDLog+LOGV.h */,
-				550678CEB07A27206F9F706AC35ECB8E /* AWSDDLogMacros.h */,
-				22630171D3A1BBBCC8F31BCF32D10570 /* AWSDDMultiFormatter.h */,
-				4536DFB3A87AAD633645038FAD6A82FC /* AWSDDMultiFormatter.m */,
-				67CD77FFD4E62B560C010929AFDF8FC8 /* AWSDDOSLogger.h */,
-				AFB26DF1FE16A5A49EE8FE0638EDE5C8 /* AWSDDOSLogger.m */,
-				E93B01FE03FA51348290E064579C896C /* AWSDDTTYLogger.h */,
-				C542DA5A0D1AC50D6BBE628AD7322953 /* AWSDDTTYLogger.m */,
-				027E6E6E1397ECEC532588E2FEA6CF38 /* AWSExecutor.h */,
-				35EBDFBE4DD338E13AE38E0D38C691A3 /* AWSExecutor.m */,
-				A8408C93D1D7483BF3AF2267895FB47A /* AWSEXTKeyPathCoding.h */,
-				05C3FADC70C4131D4CE2CA995C9B4732 /* AWSEXTRuntimeExtensions.h */,
-				3A611C30E177DDD6F14CECE647238E0F /* AWSEXTRuntimeExtensions.m */,
-				9869A18656334720E2709AB030CED186 /* AWSEXTScope.h */,
-				1210644233B0F05F9A3BF152ADCAF1AF /* AWSEXTScope.m */,
-				C5492BB52A5B3D8B009B9878B5E25987 /* AWSFMDatabase.h */,
-				52E2C3D83CDE56B97DAB55CAA571A422 /* AWSFMDatabase.m */,
-				9ECDF6559A006DFA06D0518D79726410 /* AWSFMDatabase+Private.h */,
-				4A2E468F0E0CED3E36EB9CB4C868FEB9 /* AWSFMDatabaseAdditions.h */,
-				5C87FDEBC481B70900979EF90CF27CFF /* AWSFMDatabaseAdditions.m */,
-				191511A3810F3B192E24B321C4589C46 /* AWSFMDatabasePool.h */,
-				264C21DDA41C552389D593887842E2E5 /* AWSFMDatabasePool.m */,
-				6AD3460A804CAD6E3F709F0BBC359B7F /* AWSFMDatabaseQueue.h */,
-				F6B703033BBE0A61D18CA101C30E1AC6 /* AWSFMDatabaseQueue.m */,
-				B7B517F0B29949FB45D5A65D1D283A0A /* AWSFMDB.h */,
-				95EE31B5AE458FE53DD0805178E1CD88 /* AWSFMDB+AWSHelpers.h */,
-				643A75097C14026359E5647074040E50 /* AWSFMDB+AWSHelpers.m */,
-				F8C53AA0E9793A1A70374EAB2FD6FB99 /* AWSFMResultSet.h */,
-				CD01F6BEAD7597F2BE12DF5DEAD8EFCE /* AWSFMResultSet.m */,
-				619965D8A2E8B9EBD1D1D6AD46124CF8 /* AWSGeneric.h */,
-				0576434B9FA7F8432DB8317EFE254CE6 /* AWSGZIP.h */,
-				9E0D15EADD3AADC19B695054A1D13C64 /* AWSGZIP.m */,
-				2A4364EE7C5AC1D626C2EC5F6473A9A7 /* AWSIdentityProvider.h */,
-				6964272CECA346AC5ED20E7B33457069 /* AWSIdentityProvider.m */,
-				480BAF4B1C5C9B17EC75A49C9A44BE85 /* AWSInfo.h */,
-				E167A6671830F3708A2B1FB69032281F /* AWSInfo.m */,
-				27FD7CAF337CC5B059781204CD63D3F8 /* AWSKSReachability.h */,
-				CD9D5488378B8834D5DAE698D0FBE073 /* AWSKSReachability.m */,
-				285C6FD84C4982A2B5F25DABB08C7897 /* AWSLogging.h */,
-				35E60246C30F13E28F5682FD4ADA6C01 /* AWSLogging.m */,
-				799B96796EC00C7068F5E7BBAB3EC905 /* AWSMantle.h */,
-				9E81A98248D90B4D4CBA3247B45A6DAC /* AWSmetamacros.h */,
-				F0572A28051693DA8F8FEFDD2D1AB217 /* AWSModel.h */,
-				6FA8ED3AD37F037DC824A5F6E91A7405 /* AWSModel.m */,
-				97E93588591EFDC4639A147B175BCCDD /* AWSMTLJSONAdapter.h */,
-				2B50B70E9AB640910D0909A9A6D00D10 /* AWSMTLJSONAdapter.m */,
-				18A3E400D3F817D016218A417D6F7D3D /* AWSMTLManagedObjectAdapter.h */,
-				17BE1A5690F7F5D226BB85EE0C715F82 /* AWSMTLManagedObjectAdapter.m */,
-				AB361E23A65D4E6BD16AF9720259A168 /* AWSMTLModel.h */,
-				A6E435979BE405717E44EA6820003765 /* AWSMTLModel.m */,
-				1F400E46236066397175BEF33AB11D46 /* AWSMTLModel+NSCoding.h */,
-				5350CDE7B953DE51333978AFC91C00FD /* AWSMTLModel+NSCoding.m */,
-				6AAB32D7539E8EDCE5671C5EF2B2C202 /* AWSMTLReflection.h */,
-				FB3FB11FF4A8D28C1128AB30C30C71AA /* AWSMTLReflection.m */,
-				7B83B37411DCD7F7FA695BF3ADFB3477 /* AWSMTLValueTransformer.h */,
-				A7744B1868C57C4A60A47A7ED5DD0800 /* AWSMTLValueTransformer.m */,
-				18D74676CDF8DA9E34ACD1D1FB077F8D /* AWSNetworking.h */,
-				A4CEFBF2F47127AB8796BFEB091E3927 /* AWSNetworking.m */,
-				C1B8B4FEACAF1420B0B96475BE90AD87 /* AWSSerialization.h */,
-				E4CC35AA518D998C368B3FE4C929B95A /* AWSSerialization.m */,
-				760FEF898396FB1D507B4561369EC431 /* AWSService.h */,
-				5EAB57F27B14013C8DD9ACC0853D0832 /* AWSService.m */,
-				887EDB2AF4A6615AB0046559981DDC4A /* AWSServiceEnum.h */,
-				3D320BB78515CC43BFB72D75526267FD /* AWSSignature.h */,
-				2A78B2CC4203D1B81AC6F03B00947583 /* AWSSignature.m */,
-				989EDB692EAD309BA42690776AF9415E /* AWSSTS.h */,
-				58CAF26D90978B1CEF93B2CE577F090E /* AWSSTSModel.h */,
-				58C2F31559199BF7D5D53164AA6F019A /* AWSSTSModel.m */,
-				6E21FE623B6D96ED3B851CE8586FD882 /* AWSSTSResources.h */,
-				F8C0DA431C7BEEB8C8DBDC93FC331138 /* AWSSTSResources.m */,
-				302410B8A963352D5D9582F1052A757E /* AWSSTSService.h */,
-				D4E14945D602237E27049F763EA18FBE /* AWSSTSService.m */,
-				776091FCE4C283ABB38949973F5703CD /* AWSSynchronizedMutableDictionary.h */,
-				B2C7AF41AC3469F6AA08497AB92DED4F /* AWSSynchronizedMutableDictionary.m */,
-				166566D85854749EA3E2EA5703125695 /* AWSTask.h */,
-				DC69A6FCA7057AAD299BDF046A8E8253 /* AWSTask.m */,
-				19893BD9311EEA1ED479F6A2BC5C66A1 /* AWSTaskCompletionSource.h */,
-				B662F5F03B62A30404A4A72883EF2BBD /* AWSTaskCompletionSource.m */,
-				165FBC6E04E5ACC477E3062D62C32B2E /* AWSTMCache.h */,
-				F3C8CC46B2D8F801024481E5D2D742FA /* AWSTMCache.m */,
-				B61A4055F0155D4A7FAEE9EA54CB4A60 /* AWSTMCacheBackgroundTaskManager.h */,
-				6D0D8DBA1E4C65DC5ABCA805122C1EAB /* AWSTMDiskCache.h */,
-				6ADEE001834A1EB63E83AD9FF5E2E657 /* AWSTMDiskCache.m */,
-				29C1909F8CEAA8A3BD1A7E3D3B2094E9 /* AWSTMMemoryCache.h */,
-				E98868DF74CFC121476E71CAF5D5B917 /* AWSTMMemoryCache.m */,
-				1857920E16FDBE7B45549583A1E0F961 /* AWSUICKeyChainStore.h */,
-				7D5E9435E602D6E154E08200A3D0499A /* AWSUICKeyChainStore.m */,
-				8F02B57322A914C3ABD0AEC8402B3EE6 /* AWSURLRequestRetryHandler.h */,
-				46E25C0067451C42478D6F8D0E2D0BB4 /* AWSURLRequestRetryHandler.m */,
-				B65C31B8D395F09A9D5F06EC043B14E2 /* AWSURLRequestSerialization.h */,
-				12F91AD721DA3E5AEAEDF9C4C2D5F9B6 /* AWSURLRequestSerialization.m */,
-				4309152BC40096DDD5A7CD143D059A18 /* AWSURLResponseSerialization.h */,
-				2331E13421EDE769751BEB53A865341B /* AWSURLResponseSerialization.m */,
-				5658CFB1EE58DB90BACB45071B93D3FA /* AWSURLSessionManager.h */,
-				29D585CE1EF74476EE6E9FC8653F1186 /* AWSURLSessionManager.m */,
-				BAACC47EBE7463E76E1A7A527FEFD7E2 /* AWSValidation.h */,
-				FABED7D2E0EDD2DB1CD3929AC70D4B1D /* AWSValidation.m */,
-				7B3F626DDF47B7A62A8143255FA2E51A /* AWSXMLDictionary.h */,
-				1493B5FD643C880E892290EEFF76F37A /* AWSXMLDictionary.m */,
-				AE67B5FC8A1D844635C8C85C6836466D /* AWSXMLWriter.h */,
-				ED507E39D0E6A513CFA5C09ADDBBE7F7 /* AWSXMLWriter.m */,
-				F48C0396440C39938B23C0BD6D7F0102 /* FABAttributes.h */,
-				7D63B32CF1F9ED5B8E6C8305468A8484 /* FABKitProtocol.h */,
-				1E45C810F244B77A58178FD3D2B7BB80 /* Fabric.h */,
-				FA186FC8E0A7DA8AD1832D28E0F1230D /* Fabric+FABKits.h */,
-				50D64E42E6221E8FF4AB21C399E7EFA7 /* NSArray+AWSMTLManipulationAdditions.h */,
-				AF646CD18863080860DF747A69722D6B /* NSArray+AWSMTLManipulationAdditions.m */,
-				AB74DE22440765B4DB2FA75152FCDB4E /* NSDictionary+AWSMTLManipulationAdditions.h */,
-				61A099F78198AE7CBE498B4173A29059 /* NSDictionary+AWSMTLManipulationAdditions.m */,
-				51D2C28D5E7E89A421341AEDF1725E85 /* NSError+AWSMTLModelException.h */,
-				A95E336C4D29585F2AD392A2F8D10FFC /* NSError+AWSMTLModelException.m */,
-				AB024C083DC49727FA7E4F405892ED3A /* NSObject+AWSMTLComparisonAdditions.h */,
-				1DA59FBF1D71A43520DFAEECD69EC2AB /* NSObject+AWSMTLComparisonAdditions.m */,
-				372F6716342DA6EE1616FE8E41DCF50F /* NSValueTransformer+AWSMTLInversionAdditions.h */,
-				CE0CC5FA3F31C10F3B50A8AE74853213 /* NSValueTransformer+AWSMTLInversionAdditions.m */,
-				C668F5F5F1FCA13477AEA34A9A87FB75 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */,
-				DCEB76D109419AFAE5EF55575C9F69EE /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */,
-				7E3BC47557E3EB88AD2B183D5B7F48DB /* Support Files */,
+				0D8EAE8D0C82066F079BBE49527FC539 /* Support Files */,
 			);
-			name = AWSCore;
-			path = AWSCore;
-			sourceTree = "<group>";
-		};
-		7E3BC47557E3EB88AD2B183D5B7F48DB /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				CFB22AC768E6929AE82F7D73FDC64B65 /* AWSCore.modulemap */,
-				82ED6B642009AEBCB14888FADDD771DF /* AWSCore.xcconfig */,
-				5B135F6001AFFAF6D2C0B9753AFD9497 /* AWSCore-dummy.m */,
-				A4D68A02BDE42E83CFD7E214A90E94F9 /* AWSCore-Info.plist */,
-				F7340A8BA0E851BE7376BBE09CF7FC33 /* AWSCore-prefix.pch */,
-				2A961C296142A0DF7ECC521DE76D4B01 /* AWSCore-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/AWSCore";
+			name = SwiftLint;
+			path = SwiftLint;
 			sourceTree = "<group>";
 		};
 		8B4308E9F48A6891A7915CA1BC478FDA /* Products */ = {
@@ -1750,43 +1790,32 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		8BE597BEABABB4C4704E2BD566B68DEA /* Support Files */ = {
+		8D46555916756E76EC60CB6B102FADD4 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				46AAC543E8596322357324D02944C052 /* CwlPreconditionTesting.modulemap */,
-				DF631E62A7EE783A0B2B9A5796CDE669 /* CwlPreconditionTesting.xcconfig */,
-				0276AA0305ACFA3EEB7AC9822B834C03 /* CwlPreconditionTesting-dummy.m */,
-				7F749536B6554065641E229399AE2E2D /* CwlPreconditionTesting-Info.plist */,
-				6FEDCA780BD39F32B34903769AA07865 /* CwlPreconditionTesting-prefix.pch */,
-				02E17769E68C64E4ED79B645F74F2E65 /* CwlPreconditionTesting-umbrella.h */,
+				3A9A9123BBE11A58771EB87A087316B6 /* CwlCatchException.modulemap */,
+				5292499829C37C41F261711AC72F7168 /* CwlCatchException.xcconfig */,
+				FFCB4AAE367BAD78D9C6A46083E63014 /* CwlCatchException-dummy.m */,
+				F7D6FB7A816C9E5F5B9FD5344DFA7EA6 /* CwlCatchException-Info.plist */,
+				2F6A9E75313D30A2B28F68110FF230A2 /* CwlCatchException-prefix.pch */,
+				66D34A65BD719CA839A366AED5ACE1F2 /* CwlCatchException-umbrella.h */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/CwlPreconditionTesting";
+			path = "../Target Support Files/CwlCatchException";
 			sourceTree = "<group>";
 		};
-		97CFB123591220C380D91B6FA119A676 /* Pods */ = {
+		8F42B06208C9BBA4BF078658353A8926 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				C4515E1DDD18B575BA1E543EE83B4094 /* AWSAuthCore */,
-				D4EB36AF39EB03C34A343C6E6FEF4ACC /* AWSCognitoIdentityProvider */,
-				2334C47B6A97E21EFDFD7A9402C7924C /* AWSCognitoIdentityProviderASF */,
-				7C0126F6ADB988A10AFD41C66A817FC4 /* AWSCore */,
-				0C01863993CFD116B9A13B6119B5FCCE /* AWSMobileClient */,
-				33DF86C82A080770571EEC803C524951 /* CwlCatchException */,
-				B89253046D0ED92224042223101A25EF /* CwlPreconditionTesting */,
-				B38F74044F9A8643E99DB826DDB060DA /* SwiftFormat */,
-				0E8F360B060C0A9E3F56F1FAB7AA1BF0 /* SwiftLint */,
+				4E04EDF5782C184E748B3557700E2640 /* AWSCognitoIdentityProviderASF.modulemap */,
+				1EEAEFF4390C69F3ED0B2E72D09E4966 /* AWSCognitoIdentityProviderASF.xcconfig */,
+				FC3DCF579216C793C1D5986A399A2417 /* AWSCognitoIdentityProviderASF-dummy.m */,
+				DD0529F2FD94E94EE9F9F9EA3B418E22 /* AWSCognitoIdentityProviderASF-Info.plist */,
+				795169AE5537F5799BCDE954951A68F6 /* AWSCognitoIdentityProviderASF-prefix.pch */,
+				9DAF63CB3927C45D2346F11705E3AFA7 /* AWSCognitoIdentityProviderASF-umbrella.h */,
 			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		B38F74044F9A8643E99DB826DDB060DA /* SwiftFormat */ = {
-			isa = PBXGroup;
-			children = (
-				26376F84F1E769DC402866B8D062C8BB /* Support Files */,
-			);
-			name = SwiftFormat;
-			path = SwiftFormat;
+			name = "Support Files";
+			path = "../Target Support Files/AWSCognitoIdentityProviderASF";
 			sourceTree = "<group>";
 		};
 		B4EABFCFD498135F4126D3A716F7B109 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon */ = {
@@ -1805,39 +1834,34 @@
 			path = "Target Support Files/Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon";
 			sourceTree = "<group>";
 		};
-		B89253046D0ED92224042223101A25EF /* CwlPreconditionTesting */ = {
+		BA904E8F7807E5CC859BDDBE0BAA43C5 /* AWSMobileClient */ = {
 			isa = PBXGroup;
 			children = (
-				3B74700571E45B4B8084C2CF6DC7122A /* CwlBadInstructionException.swift */,
-				7829B6EBCFB30A013745B15EA9035B94 /* CwlCatchBadInstruction.swift */,
-				847C7997045CF6766083BAB662053174 /* CwlDarwinDefinitions.swift */,
-				16D16C7F3CC2A777770BD46E5A36DAB9 /* CwlMachBadInstructionHandler.h */,
-				8D7C69697E9FEB677A5FD0883D9E63DE /* CwlMachBadInstructionHandler.m */,
-				C57087617E12CE6B735EB2F37693BF70 /* CwlPreconditionTesting.h */,
-				CE892E9AE80BCC61D0650AB6C6E4906B /* mach_excServer.c */,
-				849F64B469D3BB22311DDDB52E8CDF2D /* mach_excServer.h */,
-				8BE597BEABABB4C4704E2BD566B68DEA /* Support Files */,
+				0CACEC397330066C8C398ECECCE8BD5F /* _AWSMobileClient.h */,
+				F5DABEBB1A7AE30FC002FA9F7D7C32BC /* _AWSMobileClient.m */,
+				04498D780108D3EBDF53FD76FB42D380 /* AWSCognitoAuth.h */,
+				F271D7B7BA1C38C1E117F07AA0BB9E42 /* AWSCognitoAuth.m */,
+				DBF4A88D5942D7C441128C119BAF0999 /* AWSCognitoAuth+Extensions.h */,
+				AFE6CA3E54E94B93879D0415A2FA535C /* AWSCognitoAuth+Extensions.m */,
+				57E610DB1C9834B93B86B32AE203D34B /* AWSCognitoAuth_Internal.h */,
+				1B7083ED686E473C67DDF5D1E86E724C /* AWSCognitoAuthUICKeyChainStore.h */,
+				E8D2519C6A2A39EC2767637F8B899FDB /* AWSCognitoAuthUICKeyChainStore.m */,
+				B785B0927F487DA24F8777BAA7C3FD3E /* AWSCognitoCredentialsProvider+Extension.h */,
+				4D3E0FBF0A1B96D9B0A1670BC8C4117E /* AWSCognitoIdentityUserPool+Extension.h */,
+				CA9BF82B9D49B3E34E31C82200838ACE /* AWSMobileClient.h */,
+				FB67317B1299EE3D2F425CDDD6AFEEC0 /* AWSMobileClient.swift */,
+				EE13CC64B7D51AA8D246157E67E7DDB0 /* AWSMobileClientExtensions.swift */,
+				B1E046FABC7AEB1DDEAF83E80E8A23E5 /* AWSMobileClientUserDetails.swift */,
+				05F0A6A210EDEAFCB636DEF2E8E2C143 /* AWSMobileOptions.swift */,
+				2F8E1C643E55898382E15AC05AA7365E /* AWSMobileResults.swift */,
+				F5D4071126A64D42B2F302F608505CE9 /* AWSUserPoolCustomAuthHandler.swift */,
+				B5FA5040145A5FC42FC743FA56514940 /* AWSUserPoolOperationsHandler.swift */,
+				1B1415B741EF9175334EEB8D7110C62F /* DeviceOperations.swift */,
+				9ADAC8F37FB83D9A1FAE60863BAE22A2 /* JSONHelper.swift */,
+				2798668B9A1CF9575742CF07A8B1C114 /* Support Files */,
 			);
-			name = CwlPreconditionTesting;
-			path = CwlPreconditionTesting;
-			sourceTree = "<group>";
-		};
-		C4515E1DDD18B575BA1E543EE83B4094 /* AWSAuthCore */ = {
-			isa = PBXGroup;
-			children = (
-				EFFCCAE331008549C9E453221F29B95B /* AWSAuthCore.h */,
-				A91CA38278370894947C0EE0FBEC9746 /* AWSIdentityManager.h */,
-				D445676006ADD383CA026790E342881A /* AWSIdentityManager.m */,
-				B8E90544C20A9FE810B7903869974FD1 /* AWSSignInButtonView.h */,
-				94AD95A8DB82AF9AD0B9B7C124E6109E /* AWSSignInManager.h */,
-				4ED297B820F96D037627E4109EDBEF25 /* AWSSignInManager.m */,
-				E27B6AFE92FC2D4B1D7D6617EFEDACE0 /* AWSSignInProvider.h */,
-				44B546B0A6D74703ADCFBD38A0D6EABE /* AWSSignInProviderApplicationIntercept.h */,
-				CA682CBF0E44BDD635C0FBB679D6C5EC /* AWSUIConfiguration.h */,
-				ED8F4C63F55079C1BB85DD33E19014B0 /* Support Files */,
-			);
-			name = AWSAuthCore;
-			path = AWSAuthCore;
+			name = AWSMobileClient;
+			path = AWSMobileClient;
 			sourceTree = "<group>";
 		};
 		CF1408CF629C7361332E53B88F7BD30C = {
@@ -1845,46 +1869,18 @@
 			children = (
 				9D940727FF8FB9C785EB98E56350EF41 /* Podfile */,
 				0CEE57DA1055C19A1014C9B885209183 /* Frameworks */,
-				97CFB123591220C380D91B6FA119A676 /* Pods */,
+				02D3095C4836936A4D26CFDAAA5A29E8 /* Pods */,
 				8B4308E9F48A6891A7915CA1BC478FDA /* Products */,
 				09AD8BEF7343A541603839F476C7F70E /* Targets Support Files */,
 			);
 			sourceTree = "<group>";
 		};
-		D4EB36AF39EB03C34A343C6E6FEF4ACC /* AWSCognitoIdentityProvider */ = {
+		D3577260291B47D9CE68407C73B49CA1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				EAE123BA511E10D801798B996DBA65A2 /* aws_tommath.h */,
-				F0E0AE0D981A07A94FB82B3749ED4294 /* aws_tommath_class.h */,
-				0C05D3E8BB489B73FDF8C5A2F0993DC1 /* aws_tommath_superclass.h */,
-				09CF2AF892B02F271301BDC969A95E14 /* AWSCognitoIdentityProvider.h */,
-				2671FF7E927AEACE1D57CD183C23B33A /* AWSCognitoIdentityProviderHKDF.h */,
-				4E7C334C7718E548C12E9BD587E2E334 /* AWSCognitoIdentityProviderHKDF.m */,
-				FA45D1A07F3B26B40BCAE39A6FC72003 /* AWSCognitoIdentityProviderModel.h */,
-				8E1EE4E86046CCC1C42AD5EFC671D6A3 /* AWSCognitoIdentityProviderModel.m */,
-				77BAFF4FE895704E891DA828C3F2CA60 /* AWSCognitoIdentityProviderResources.h */,
-				EA658D78FC406AFA945D31B0D046AB03 /* AWSCognitoIdentityProviderResources.m */,
-				E88BE96FAF2EA8862751E14F4E1E1260 /* AWSCognitoIdentityProviderService.h */,
-				9EB91CF25CF930E29224C18C6BCC4E20 /* AWSCognitoIdentityProviderService.m */,
-				4847747404AB74113FFD8EC4DA63AA4E /* AWSCognitoIdentityProviderSrpHelper.h */,
-				2116F89D162EED1D1AF6937894DFAADE /* AWSCognitoIdentityProviderSrpHelper.m */,
-				2B2CEB7C609DE754234286DB0B2099D2 /* AWSCognitoIdentityUser.h */,
-				9D48C5F3D2DEEE640B846066CB4126EA /* AWSCognitoIdentityUser.m */,
-				5471E69EB7F11DB1920AFA5EFA4CFF00 /* AWSCognitoIdentityUser_Internal.h */,
-				66EE313AB25CB9F796B40540A13890D7 /* AWSCognitoIdentityUserPool.h */,
-				754CA60E9D4F3F509CD3D0CD69803593 /* AWSCognitoIdentityUserPool.m */,
-				E0C152ACE24CF32262809F5D86181BBF /* AWSCognitoIdentityUserPool_Internal.h */,
-				BFDD9C67B3B6CB96B20718D49380ECE9 /* AWSJKBigDecimal.h */,
-				FD8ABFA6F971C7126B39B12AED1B60B8 /* AWSJKBigDecimal.m */,
-				CEBD24D90E4FFBE94B3CE017E20BBC63 /* AWSJKBigInteger.h */,
-				986C98B931A676FC118C9E1BBD676265 /* AWSJKBigInteger.m */,
-				79D06071864E7D2C2A583BA20A80FE96 /* NSData+AWSCognitoIdentityProvider.h */,
-				B7614A9E198573F33364E08A44D191A2 /* NSData+AWSCognitoIdentityProvider.m */,
-				6D6EE3BB562D22B7BDBB0E108ACA5649 /* tommath.c */,
-				07383DE5DAF37BA9BF3F74FF075830A0 /* Support Files */,
+				5085A6145D46202038A579642BB3B761 /* libAWSCognitoIdentityProviderASFBinary.a */,
 			);
-			name = AWSCognitoIdentityProvider;
-			path = AWSCognitoIdentityProvider;
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		D5CE6FD3F74C74F66A240B353AF7E722 /* iOS */ = {
@@ -1897,20 +1893,6 @@
 				EE49F6473631850D3EC76C328D5772CB /* UIKit.framework */,
 			);
 			name = iOS;
-			sourceTree = "<group>";
-		};
-		D7F68E9F92F613AA95240172646B49C6 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				736ED39179608901F09197369E221D00 /* CwlCatchException.modulemap */,
-				68745D588A16410345510D25D11B08F5 /* CwlCatchException.xcconfig */,
-				CF91665F677AFEFDDEBA8528174E0846 /* CwlCatchException-dummy.m */,
-				0C261BF596A4C5600D2FC1674D411BD9 /* CwlCatchException-Info.plist */,
-				7F5E975E46445A4810198027571DB7D7 /* CwlCatchException-prefix.pch */,
-				22BE5BDD8BEA74A45AE7BA7B7E27C2CA /* CwlCatchException-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/CwlCatchException";
 			sourceTree = "<group>";
 		};
 		DA4CFB6078BFB0EAF8D8703EAF07CDAF /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon */ = {
@@ -1929,18 +1911,27 @@
 			path = "Target Support Files/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon";
 			sourceTree = "<group>";
 		};
-		ED8F4C63F55079C1BB85DD33E19014B0 /* Support Files */ = {
+		E9B1820AFEA9222E5AE6AF00D1419B29 /* SwiftFormat */ = {
 			isa = PBXGroup;
 			children = (
-				7715655789C4DEFA42CCEDADF986EB1A /* AWSAuthCore.modulemap */,
-				B73BB8777F0FF75A2C999665718D660C /* AWSAuthCore.xcconfig */,
-				9E630833E85807E70FC177062E5C07B8 /* AWSAuthCore-dummy.m */,
-				B20B01BB89E1F1933267835A149A1CE2 /* AWSAuthCore-Info.plist */,
-				05C0F4E4C138B9133220D879EB6297D0 /* AWSAuthCore-prefix.pch */,
-				79641B7E0DED5BBD74610BDBF3C5B665 /* AWSAuthCore-umbrella.h */,
+				4389FF4A5297B305E2B3B22BF5E9A6A3 /* Support Files */,
+			);
+			name = SwiftFormat;
+			path = SwiftFormat;
+			sourceTree = "<group>";
+		};
+		F1190B5C3CF3ED79D80F706422B61756 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				66931E8F9AFA69143E52E4F621951059 /* AWSCore.modulemap */,
+				80C849937AD2C88BA17636FFE3EEE60C /* AWSCore.xcconfig */,
+				51F546FB05338188F9D16DCA20239565 /* AWSCore-dummy.m */,
+				0D9574530C129769D1D1F03203C85D7C /* AWSCore-Info.plist */,
+				6BCC572FE610F38AA38FE89EDDD3EDEE /* AWSCore-prefix.pch */,
+				017996FA9F98A7E1AC8B1FB672D4E557 /* AWSCore-umbrella.h */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/AWSAuthCore";
+			path = "../Target Support Files/AWSCore";
 			sourceTree = "<group>";
 		};
 		F317EA87105ABDAE64570CCCC20B5912 /* Pods-Amplify */ = {
@@ -1959,24 +1950,36 @@
 			path = "Target Support Files/Pods-Amplify";
 			sourceTree = "<group>";
 		};
+		F54394C431F5EB529A6160FB3E437E7F /* AWSCognitoIdentityProviderASF */ = {
+			isa = PBXGroup;
+			children = (
+				EAB2EC18E32F6E2FCA424AE80D8412DB /* AWSCognitoIdentityASF.h */,
+				CDA38353C499EAFBF0C7F4C481DB06D1 /* AWSCognitoIdentityProviderASF.h */,
+				4108872B2D9F35982F849D20935EFE58 /* AWSCognitoIdentityProviderASF.m */,
+				D3577260291B47D9CE68407C73B49CA1 /* Frameworks */,
+				8F42B06208C9BBA4BF078658353A8926 /* Support Files */,
+			);
+			name = AWSCognitoIdentityProviderASF;
+			path = AWSCognitoIdentityProviderASF;
+			sourceTree = "<group>";
+		};
+		F7A91B718564D779417F4BAA7812A5AE /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				ACCDCDE3D9BB24C9A28284F325A016D5 /* AWSAuthCore.modulemap */,
+				25DFBB76C1BF492E05A46B34178281AD /* AWSAuthCore.xcconfig */,
+				0AEEFB1F4D4875A426FBE8C5C6D76AB1 /* AWSAuthCore-dummy.m */,
+				DAD1437F5D9BFFE96ADE2AC63A18703F /* AWSAuthCore-Info.plist */,
+				96A2D651BCE8019612EBFDAB5CBD48F2 /* AWSAuthCore-prefix.pch */,
+				B4E599012C75D7A133B5D77EB7591134 /* AWSAuthCore-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/AWSAuthCore";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		02DABDD7BECC44BA301980A0F5164771 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				369BCA5193B509F7ED9C4510C0B854C4 /* _AWSMobileClient.h in Headers */,
-				7AAEE9E9F355EFB9B22A47AC3E2D8BA1 /* AWSCognitoAuth+Extensions.h in Headers */,
-				C146BB6121D1E7BB4B9C7DA7770086E6 /* AWSCognitoAuth.h in Headers */,
-				30426E1360A92453C47781E08C3C6719 /* AWSCognitoAuth_Internal.h in Headers */,
-				0E8089A141DC626BC0673739E4005994 /* AWSCognitoAuthUICKeyChainStore.h in Headers */,
-				004DE85F3AE8FFE0816925652FFFBB75 /* AWSCognitoCredentialsProvider+Extension.h in Headers */,
-				5440C426F9AD47F83C786597EED5074B /* AWSMobileClient-umbrella.h in Headers */,
-				FD85A372868510FDFD6534963B952E71 /* AWSMobileClient.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		06D071C6CA89BE8B451CCD4A37481DD7 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -1996,12 +1999,142 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4FA2461680E769976C4D06608A2A9004 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3CA6B00BEC52629874A59C4425B040FF /* _AWSMobileClient.h in Headers */,
+				5D1E1ED20C02309D4897C489A4FF1385 /* AWSCognitoAuth+Extensions.h in Headers */,
+				4DF330318C6863C9A9457AB6A0D931AC /* AWSCognitoAuth.h in Headers */,
+				080A963CA88B480650FFE9DA4C1FB652 /* AWSCognitoAuth_Internal.h in Headers */,
+				FF5A3D0068C906E484D9FB5CC613556E /* AWSCognitoAuthUICKeyChainStore.h in Headers */,
+				06286FFF5F9A837D882033756A51BA6F /* AWSCognitoCredentialsProvider+Extension.h in Headers */,
+				4B0A6C1C5E40CA5991F72FE870380789 /* AWSCognitoIdentityUserPool+Extension.h in Headers */,
+				51250616CA565F13AACEBE3D53B538A9 /* AWSMobileClient-umbrella.h in Headers */,
+				2D0A57953832EF83AD2FA1511820B602 /* AWSMobileClient.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		530F033EBEA7F08AD9A8EC993F9E578A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CAC63FC5740B67E322F64FA92C51BE29 /* AWSBolts.h in Headers */,
+				AF8EBCA0F90060448E15E47025733327 /* AWSCancellationToken.h in Headers */,
+				FDCCAC00A99C74E2BE6C3FD070D45C3D /* AWSCancellationTokenRegistration.h in Headers */,
+				58F04275CDDD17740755E139361A104A /* AWSCancellationTokenSource.h in Headers */,
+				ED85DB4CE570B57E433BCFB56BBCBF04 /* AWSCategory.h in Headers */,
+				D448DBF68ABFA8F084BE3AAE05171D4C /* AWSClientContext.h in Headers */,
+				B12C8A1CC225C17AFCA43D4BAF707E7B /* AWSCocoaLumberjack.h in Headers */,
+				E2121B84A87B54637022A745BA905991 /* AWSCognitoIdentity+Fabric.h in Headers */,
+				BA498D6F2E108FF6A250EF156FB199CA /* AWSCognitoIdentity.h in Headers */,
+				221795EAC91598916CB8F66DAEEB2AE1 /* AWSCognitoIdentityModel.h in Headers */,
+				33AB80FF79E9E8922EB6414ECA6D13F4 /* AWSCognitoIdentityResources.h in Headers */,
+				9E6E606BC775C9D70B5F73B75F6466D7 /* AWSCognitoIdentityService.h in Headers */,
+				94E032B726F3F3D2425C5803AA3905E5 /* AWSCore-umbrella.h in Headers */,
+				11D1DF9ADBCB93C6643F9C14E8E5ABF6 /* AWSCore.h in Headers */,
+				ABC164C2B5402553E19E1CE32AE65E14 /* AWSCredentialsProvider.h in Headers */,
+				7E72445D57E2B1377BB8C31D0D45F583 /* AWSDDAbstractDatabaseLogger.h in Headers */,
+				014D5B8A4928C9A387534875206E8AFE /* AWSDDASLLogCapture.h in Headers */,
+				5FE479276304FDA83745E989DA2F79DF /* AWSDDASLLogger.h in Headers */,
+				FC0DF3B29BF928EB487F36248496068F /* AWSDDAssertMacros.h in Headers */,
+				3D20174EDA7E54ACF0B3FA03BC9BAF4F /* AWSDDContextFilterLogFormatter.h in Headers */,
+				C2A8E95E1378D95C29118217596E5EEA /* AWSDDDispatchQueueLogFormatter.h in Headers */,
+				AE2C16CE9FB6CCEC0BAE444DEBD69234 /* AWSDDFileLogger.h in Headers */,
+				FDBB04B8FC16CF6EAD1AAC14B5E7B978 /* AWSDDLegacyMacros.h in Headers */,
+				565F48D47A3D4B7210AD3710A6D5DC31 /* AWSDDLog+LOGV.h in Headers */,
+				1B3F193F03EA731E027EB54639B9AFAE /* AWSDDLog.h in Headers */,
+				1B4699D8D8A9FA361461FA0918FB1BBD /* AWSDDLogMacros.h in Headers */,
+				DABA700D6E837C34EA646731E2426132 /* AWSDDMultiFormatter.h in Headers */,
+				1CEC54C8680C61BAE07A09608EE075A1 /* AWSDDOSLogger.h in Headers */,
+				189C52695A137B58704DF3C5BD57BCA7 /* AWSDDTTYLogger.h in Headers */,
+				F0C669060B8BFEF00131CC06B6995586 /* AWSExecutor.h in Headers */,
+				BDAFBC302AFBD0169D63A493EF24F019 /* AWSEXTKeyPathCoding.h in Headers */,
+				13603B0B004ADA8FA4C6A29F8C255F00 /* AWSEXTRuntimeExtensions.h in Headers */,
+				45036FC7C954DBE6E733CB429174B2EA /* AWSEXTScope.h in Headers */,
+				D4F6F977E4D77F9982B1AF5B6ABBDC46 /* AWSFMDatabase+Private.h in Headers */,
+				121B62241BE1752EA25A5BA6E017616A /* AWSFMDatabase.h in Headers */,
+				AFD9EAAB3DD21504017BEA68684667AD /* AWSFMDatabaseAdditions.h in Headers */,
+				92944936808E537A51D7FB76879573B0 /* AWSFMDatabasePool.h in Headers */,
+				7AD034A4C74DD3FAC09164FF4462B682 /* AWSFMDatabaseQueue.h in Headers */,
+				4CAC8656530CBAB205D1B329885B2420 /* AWSFMDB+AWSHelpers.h in Headers */,
+				327212D4B1210D85CEBFEE82E654D5A8 /* AWSFMDB.h in Headers */,
+				867F53F6C252DB86B6980B38127D670A /* AWSFMResultSet.h in Headers */,
+				4D6195524E59D17144D2463C2245ACAC /* AWSGeneric.h in Headers */,
+				585B8C3A6DD4AF9F63247DAEE3950B55 /* AWSGZIP.h in Headers */,
+				0D975819F09C9DCD588638EC7D2C3C91 /* AWSIdentityProvider.h in Headers */,
+				D3C7CEE1ABDD4DB9F318808066874630 /* AWSInfo.h in Headers */,
+				3B0F330CAAE0F4DF8D362E5C00EF3715 /* AWSKSReachability.h in Headers */,
+				DBF5AAEC5F1978380EC14D82EDF31054 /* AWSLogging.h in Headers */,
+				5881547D10D0115CB765498C4DD879C5 /* AWSMantle.h in Headers */,
+				295FA629B96FCE0C14815243AF6F4DA6 /* AWSmetamacros.h in Headers */,
+				2A45D2B2E9015B55E07DD13D43E1A197 /* AWSModel.h in Headers */,
+				617A71B50115147C51AD0C6D00BFCCCF /* AWSMTLJSONAdapter.h in Headers */,
+				4EA7E8C75835B7707BCC449C87AE56B8 /* AWSMTLManagedObjectAdapter.h in Headers */,
+				466CB5C4FE8DD7AA3EE53FE3D1E728E1 /* AWSMTLModel+NSCoding.h in Headers */,
+				6D4394F1745698365A9C40BB0A7A7AD2 /* AWSMTLModel.h in Headers */,
+				C3525FB9301A85B4E55C6F01D3BBDD5A /* AWSMTLReflection.h in Headers */,
+				D50A080B30C8131DB858F71727E0B271 /* AWSMTLValueTransformer.h in Headers */,
+				A9E6B3F4412CAA30168D675A302122E9 /* AWSNetworking.h in Headers */,
+				264783C2F064A47445C5894BC568C1EB /* AWSNetworkingHelpers.h in Headers */,
+				B5AFCE15B9D849BD84A6D6E46C144F16 /* AWSSerialization.h in Headers */,
+				FCB0E2F79322AAE4808375602EE9E27C /* AWSService.h in Headers */,
+				CA8CAC4B7D5CEA18AEC162BE523E3368 /* AWSServiceEnum.h in Headers */,
+				016F99722715BF88A9636B87434EA4F8 /* AWSSignature.h in Headers */,
+				865DC647D80B2C560666A8BC90753092 /* AWSSTS.h in Headers */,
+				45AFA12190BAF394C1B57536268CBD8D /* AWSSTSModel.h in Headers */,
+				B67CE9FC51F77CC591562D2BF2CA3EA2 /* AWSSTSResources.h in Headers */,
+				07C22CB8F0D5D1D155E99E7FAA03E922 /* AWSSTSService.h in Headers */,
+				34D02615F8968D64CC0F5B2F1CFB6CFD /* AWSSynchronizedMutableDictionary.h in Headers */,
+				4FF58842A18EEBA4291A5A9BC8DBA9D3 /* AWSTask.h in Headers */,
+				1A39D1693474EB62977EF09A9433600E /* AWSTaskCompletionSource.h in Headers */,
+				96D859318FE7B536D841C4B7ED8915B9 /* AWSTMCache.h in Headers */,
+				82B604223403F2D8913736CDBCBD3421 /* AWSTMCacheBackgroundTaskManager.h in Headers */,
+				85DF3750F9FDC7219E7E1BF6F9194D4D /* AWSTMDiskCache.h in Headers */,
+				41427B4C2C98D529E00FDDEEEAB32D0D /* AWSTMMemoryCache.h in Headers */,
+				3C295496C91AFABA2DA6D3202C7C482B /* AWSUICKeyChainStore.h in Headers */,
+				600A24E9D61C48AE2664008652AF340C /* AWSURLRequestRetryHandler.h in Headers */,
+				623B9A6697A87E1F42B847CA8F2FE28B /* AWSURLRequestSerialization.h in Headers */,
+				EBDCAD5D12AE793D0A153530B8461492 /* AWSURLResponseSerialization.h in Headers */,
+				657547730A8E5358B795A62B0A80137A /* AWSURLSessionManager.h in Headers */,
+				4851DF7728E1A4D83BEBD0259F55894A /* AWSValidation.h in Headers */,
+				786A00B206FE67A484E80BB4F52C65D5 /* AWSXMLDictionary.h in Headers */,
+				53BB8CAB8C037542DF1E4D61B141C140 /* AWSXMLWriter.h in Headers */,
+				4169B42294AE9AB96766A16B1293ED08 /* FABAttributes.h in Headers */,
+				E67AC75CF625D30A349F06B872AD7DC7 /* FABKitProtocol.h in Headers */,
+				090E87DED2A7E745AB4B80D9D40A3B0F /* Fabric+FABKits.h in Headers */,
+				292DFC7361D422AB72038DBEA947ECEC /* Fabric.h in Headers */,
+				5C6F85ECFE37588A579291C57BA28E44 /* NSArray+AWSMTLManipulationAdditions.h in Headers */,
+				D995F1889A0498202C5B04A04ED81688 /* NSDictionary+AWSMTLManipulationAdditions.h in Headers */,
+				99D77CDBCF4C3CF91116F5E54921F181 /* NSError+AWSMTLModelException.h in Headers */,
+				A26278DDB3EBC5C5A65C4C86382B0AF8 /* NSObject+AWSMTLComparisonAdditions.h in Headers */,
+				BE8ABD8C2F11BF351AEC13B6FFFDF99A /* NSValueTransformer+AWSMTLInversionAdditions.h in Headers */,
+				2A7389B92220C12253767AA85D2B23AB /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		680B59EF0E01AB847F251599663C284D /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				DA8E7AD70C4E70661341B17628B98B9D /* CwlCatchException-umbrella.h in Headers */,
 				A81152A334E18EC67B13C8DE062572C9 /* CwlCatchException.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6BD79647A2EFFA3594FCBF8FBCDEC380 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				55B7F2064D84D89F672A51C07FAF3F25 /* AWSAuthCore-umbrella.h in Headers */,
+				7BA450B429AD6BFB0CD6903F48A3A73A /* AWSAuthCore.h in Headers */,
+				416B3D71CD66C2F82429B252EDC0C4A7 /* AWSAuthUIHelper.h in Headers */,
+				248507F49B3F12E442FE6AC425DD398B /* AWSIdentityManager.h in Headers */,
+				6E4FD2AB420D24BA1FE7D53D4CABEAC8 /* AWSSignInButtonView.h in Headers */,
+				9F178FED04D876360188F685980EC42B /* AWSSignInManager.h in Headers */,
+				4724A9B83CF9F3763A6C9B7AB185F780 /* AWSSignInProvider.h in Headers */,
+				CEAD5A825A2B2228733F1F745D85024D /* AWSSignInProviderApplicationIntercept.h in Headers */,
+				9343EE314C0B2A5126CC43BA07AC6001 /* AWSUIConfiguration.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2036,118 +2169,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				3C5CF7D00A143641F05F9B6BC1C1FEB1 /* Pods-Amplify-AWSPluginsCore-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8E14DE40B992C12B3B7B4B5CE570901B /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BC816D50344B3DD5EBBEB5357A59C346 /* AWSBolts.h in Headers */,
-				3D99527A2F315AB5E526327D7CE1FA8C /* AWSCancellationToken.h in Headers */,
-				3AA24C39040281FDD5BA57C431899954 /* AWSCancellationTokenRegistration.h in Headers */,
-				A835CA432F8492BBFBBDDBA98F66D1BE /* AWSCancellationTokenSource.h in Headers */,
-				7A055B5CFE741CF5E8D86258EA7B1332 /* AWSCategory.h in Headers */,
-				E929D0F5359AE8857624AA8CDEACD8AB /* AWSClientContext.h in Headers */,
-				E561099206E38F18CF7EBEB5B1B78E80 /* AWSCocoaLumberjack.h in Headers */,
-				164E856DD6E9D75266BD63DBE756E8D5 /* AWSCognitoIdentity+Fabric.h in Headers */,
-				51A2C93AC4E003767439629FCDB9CD03 /* AWSCognitoIdentity.h in Headers */,
-				236F8B8D6AC456B756907BB2304A845C /* AWSCognitoIdentityModel.h in Headers */,
-				A5C6D3348F0648627589AF623D7EFDC5 /* AWSCognitoIdentityResources.h in Headers */,
-				E2E307C6CB768DB60D6FE577A8492AEF /* AWSCognitoIdentityService.h in Headers */,
-				EE8E9629C3ACB289EDC89260B539BD41 /* AWSCore-umbrella.h in Headers */,
-				B249CEEC9F02F95B0382FFF224AC495C /* AWSCore.h in Headers */,
-				DDA5DD81D769898BD292F0B182859EFE /* AWSCredentialsProvider.h in Headers */,
-				71320470245F75D31B044D2124F50B4D /* AWSDDAbstractDatabaseLogger.h in Headers */,
-				E55CFDBB36EBDE881066C3DBF58B8DAC /* AWSDDASLLogCapture.h in Headers */,
-				BEB73441F0DAC067FDACBDFA540901CD /* AWSDDASLLogger.h in Headers */,
-				067065D83D1701E8457EFF708593E7CF /* AWSDDAssertMacros.h in Headers */,
-				B2055B59F47FA0688CF56E1959CF9703 /* AWSDDContextFilterLogFormatter.h in Headers */,
-				283D6D2E0D6D3C28C6111AE57D50F9DC /* AWSDDDispatchQueueLogFormatter.h in Headers */,
-				2AAB30EBA4663ED5F7D8753356C26F2E /* AWSDDFileLogger.h in Headers */,
-				9B33FC6B8FDB513847D980A15669BB87 /* AWSDDLegacyMacros.h in Headers */,
-				A6A9848E773D9E5E0AB1550639A9D748 /* AWSDDLog+LOGV.h in Headers */,
-				A2FF0AACA73E0D90A8E4E4B4E92F64E0 /* AWSDDLog.h in Headers */,
-				20B984C335C8FC46AB2E1F2EE8804028 /* AWSDDLogMacros.h in Headers */,
-				54D748980BE1085042B7CA495973F34E /* AWSDDMultiFormatter.h in Headers */,
-				C4D4135EC7E448AF8291FD16971D51BF /* AWSDDOSLogger.h in Headers */,
-				1FEDF05177016B30BEE6388DE35BCDE8 /* AWSDDTTYLogger.h in Headers */,
-				7A56A77E670018AD7C96B575EDD2F2D8 /* AWSExecutor.h in Headers */,
-				2663B6509C0E948A2AB8F026F958C991 /* AWSEXTKeyPathCoding.h in Headers */,
-				3800CA780F69128004ED8D8477F8387A /* AWSEXTRuntimeExtensions.h in Headers */,
-				56A4293D4326B2AD8C75AE6363CAFE6A /* AWSEXTScope.h in Headers */,
-				95C3EDA1C39362E679186B1905041F62 /* AWSFMDatabase+Private.h in Headers */,
-				5357D2210C2C37C547AAFB35C2685C7B /* AWSFMDatabase.h in Headers */,
-				F1958DDD97662963D1D386A7274A4C3B /* AWSFMDatabaseAdditions.h in Headers */,
-				D73D19AACFA1A61E7C5B338298ABFA74 /* AWSFMDatabasePool.h in Headers */,
-				CBFC476A9C141CA0FA835A672F10BD62 /* AWSFMDatabaseQueue.h in Headers */,
-				994AD321CFD65367815ACF04BAB369AA /* AWSFMDB+AWSHelpers.h in Headers */,
-				C493C5E2602242F0F5DDECCFCF9D1AFA /* AWSFMDB.h in Headers */,
-				C04F7B51A7AD38D0055EA82A0176EED1 /* AWSFMResultSet.h in Headers */,
-				1DF599F2B8BF8C21CC90E0EBC96FEA09 /* AWSGeneric.h in Headers */,
-				4A8E2E181E0171FDE012F1B5765BD726 /* AWSGZIP.h in Headers */,
-				0F5FE030071823DFE9F130C40B19BEC0 /* AWSIdentityProvider.h in Headers */,
-				B4103ECBACFEA13A55407D22F3E56A33 /* AWSInfo.h in Headers */,
-				219CB19925CD761730E5AFC746D07A33 /* AWSKSReachability.h in Headers */,
-				62BFE5376C245EAA54F1F93E7B335459 /* AWSLogging.h in Headers */,
-				A4C8EAA5B9CFA9409292F5A4632B5383 /* AWSMantle.h in Headers */,
-				84C888AA44AC965AA122EFDC5E9DFA33 /* AWSmetamacros.h in Headers */,
-				D68A1087FDAFC7AFDA9E7EDEEAC760BC /* AWSModel.h in Headers */,
-				09D0000737838FD4D8234BBE7B52BCE7 /* AWSMTLJSONAdapter.h in Headers */,
-				C671EBBDB2A304FE606E2A7689AC44B4 /* AWSMTLManagedObjectAdapter.h in Headers */,
-				0CE4D459B21390FBAA64FDB4213E6FAB /* AWSMTLModel+NSCoding.h in Headers */,
-				8768FC3B9795070C95E616AD2F604712 /* AWSMTLModel.h in Headers */,
-				4454CCAB09AB97EC1F396D37DFF469ED /* AWSMTLReflection.h in Headers */,
-				FEBE606A0C5598ACFD3AB28694B62852 /* AWSMTLValueTransformer.h in Headers */,
-				177AF0BB8CCB1E9F6E3B59C63653D6BF /* AWSNetworking.h in Headers */,
-				1E650874FB9DB87F5841D5B9A2F316C9 /* AWSSerialization.h in Headers */,
-				01A5950E9EFD7E3A5B723870607D30BA /* AWSService.h in Headers */,
-				1826140B28141D15526A6496F027EEA2 /* AWSServiceEnum.h in Headers */,
-				45A7F1B5826DB4453A9221390FDB4283 /* AWSSignature.h in Headers */,
-				07B59E01154974D12F41F89734C12541 /* AWSSTS.h in Headers */,
-				9F8E4A338D88949F73048DC5C6BCA831 /* AWSSTSModel.h in Headers */,
-				4E12FAB55DF8FEBBECCDAAD2EEF41A6D /* AWSSTSResources.h in Headers */,
-				1B792DF647AA6A2BE2F0DCF2706ED403 /* AWSSTSService.h in Headers */,
-				D749F6C4A5B21788FB368EFFA00196F1 /* AWSSynchronizedMutableDictionary.h in Headers */,
-				EF48789F2529FBABFC8032DD7CD2C023 /* AWSTask.h in Headers */,
-				4A1EC2418BCB3DAF31BCF0D2E53972B7 /* AWSTaskCompletionSource.h in Headers */,
-				F06C38ADE5EBE33DB5A49FB236597552 /* AWSTMCache.h in Headers */,
-				F7ECDD7582930DBC43027FF5FBF8E44F /* AWSTMCacheBackgroundTaskManager.h in Headers */,
-				EF34D0B237DCB7D3209E3489B5568CE9 /* AWSTMDiskCache.h in Headers */,
-				369225211AFC463F2090CEE05DC5A97E /* AWSTMMemoryCache.h in Headers */,
-				499E5B186AB37B5EAE9524B3F6A1543C /* AWSUICKeyChainStore.h in Headers */,
-				B4E9077F189C342F80BADA5A2CE1A110 /* AWSURLRequestRetryHandler.h in Headers */,
-				AF0DFE57311A572448946175FA8ABAA2 /* AWSURLRequestSerialization.h in Headers */,
-				A77676E23AADF400ACFEFDC714FE69B4 /* AWSURLResponseSerialization.h in Headers */,
-				9F031D2C1D45AF3F7F9F802CD43F4CB4 /* AWSURLSessionManager.h in Headers */,
-				A713621EF397D381EE3C41219649F48D /* AWSValidation.h in Headers */,
-				0D9F55C573A165D3B7437DEE8F91BFFD /* AWSXMLDictionary.h in Headers */,
-				4BDF2CD9D7938D71F3DEDE57E5A4DA20 /* AWSXMLWriter.h in Headers */,
-				9CE73F8C8F261B13AF986C3A19ADD23C /* FABAttributes.h in Headers */,
-				248189324987696703F2538E3505E96E /* FABKitProtocol.h in Headers */,
-				8125C10721A3639BD9ACF9335897111A /* Fabric+FABKits.h in Headers */,
-				4894E3D5FE3088AB3E36EF52ACE38761 /* Fabric.h in Headers */,
-				AC78540F570C892CFB0617CC99A6D87A /* NSArray+AWSMTLManipulationAdditions.h in Headers */,
-				76C2EE375F6E45975723188B609D8CFC /* NSDictionary+AWSMTLManipulationAdditions.h in Headers */,
-				55F93CF763DD2623520A0B800B7B58D2 /* NSError+AWSMTLModelException.h in Headers */,
-				500E1A7931E8A0AE6D2700B384B00653 /* NSObject+AWSMTLComparisonAdditions.h in Headers */,
-				970F0A8B1FBD05F16DAC6BE24F2E2AA9 /* NSValueTransformer+AWSMTLInversionAdditions.h in Headers */,
-				19CE9907C75259C041A78F894689E189 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		A5443B3B896F59B89BCDF35C19A1D5E3 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0F8A8555DB78C4DCE2A50E397F9B292F /* AWSAuthCore-umbrella.h in Headers */,
-				64FB0F82B4B57ACAB52BC6917BBA1972 /* AWSAuthCore.h in Headers */,
-				C64E8C289FE51FD28664A25A6AF7B95C /* AWSIdentityManager.h in Headers */,
-				6B1C83D7CC83EE2DAA018496423257C2 /* AWSSignInButtonView.h in Headers */,
-				F3F88A9F3028498A198989B1AACCC93A /* AWSSignInManager.h in Headers */,
-				B05C34E599B60EE6147198C28771EA0E /* AWSSignInProvider.h in Headers */,
-				82BFAD55E61B70C232D78AED3AA10431 /* AWSSignInProviderApplicationIntercept.h in Headers */,
-				47330E097ADC7F4D604B2D1E95959D17 /* AWSUIConfiguration.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2331,18 +2352,18 @@
 		};
 		6428ED7DAC8003D918A4F549769F079D /* AWSMobileClient */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = B7A25F64167EDC70379CA76465F9D769 /* Build configuration list for PBXNativeTarget "AWSMobileClient" */;
+			buildConfigurationList = 6C1B0082F55622F61D55E4DF5F89B58D /* Build configuration list for PBXNativeTarget "AWSMobileClient" */;
 			buildPhases = (
-				02DABDD7BECC44BA301980A0F5164771 /* Headers */,
-				04D60D20D876B1C6DC3D9353987C2CA9 /* Sources */,
-				B5FE19A4A95D978D3136CDAF82CF6758 /* Frameworks */,
-				C610607DB61FB7D57E5FB787894CEE3A /* Resources */,
+				4FA2461680E769976C4D06608A2A9004 /* Headers */,
+				49C4F997373C728DF83F55FD7FCCB1A8 /* Sources */,
+				8DD65B45F2688280FD422D5D7364A10A /* Frameworks */,
+				B219A243F752A8EC273DCB0D9186D7C0 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				4FD3FB7BC4D49D78D78F4CD847DA0ACB /* PBXTargetDependency */,
-				B7BBCF7EA09C9EA97960EE8C7CD8A034 /* PBXTargetDependency */,
+				06729402D244E9B3898403BE3BECA781 /* PBXTargetDependency */,
+				3956B7AEEEE178E01F0DEA935F7D7E02 /* PBXTargetDependency */,
 			);
 			name = AWSMobileClient;
 			productName = AWSMobileClient;
@@ -2351,17 +2372,17 @@
 		};
 		8042F2B0721B13AEDEB81F058C2B2125 /* AWSAuthCore */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CAC51FDC5DF9384861199B5F7A442D45 /* Build configuration list for PBXNativeTarget "AWSAuthCore" */;
+			buildConfigurationList = 95205485CA4D05E429CC813BF3F3185A /* Build configuration list for PBXNativeTarget "AWSAuthCore" */;
 			buildPhases = (
-				A5443B3B896F59B89BCDF35C19A1D5E3 /* Headers */,
-				0DA9DD391759190DFF2CAC0303C6E7AD /* Sources */,
-				E41DD745B4E9C6C0B6145D504D2FF82E /* Frameworks */,
-				7DCAD016931269B379CD59AA00103216 /* Resources */,
+				6BD79647A2EFFA3594FCBF8FBCDEC380 /* Headers */,
+				A6EAB7CECD211FA17C7E486BC9FCD47F /* Sources */,
+				B4F36F9296FED9381CF05EB20D880D6B /* Frameworks */,
+				2827631FC40A3F6C617D9E65A33BE298 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				6231A799AB105D1BD9F00B45E71B4FE3 /* PBXTargetDependency */,
+				69FCA5BFE1F9B83AA980D65FFA2CCBAA /* PBXTargetDependency */,
 			);
 			name = AWSAuthCore;
 			productName = AWSAuthCore;
@@ -2395,12 +2416,12 @@
 		};
 		9B172FACE90046AA5E100E650B6109DD /* AWSCore */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 80646B31F3D7EC6D5FF70E8A7F2E189A /* Build configuration list for PBXNativeTarget "AWSCore" */;
+			buildConfigurationList = 3C091373BF430C54D1D7ECA69D4440CF /* Build configuration list for PBXNativeTarget "AWSCore" */;
 			buildPhases = (
-				8E14DE40B992C12B3B7B4B5CE570901B /* Headers */,
-				0F8DA3147A82B9A4F6B52D212D3CB985 /* Sources */,
-				3AF0D71CA3A170A18E1B86A0A0097D05 /* Frameworks */,
-				69DD9CD935A6DEC5C35DE88D20FF51C3 /* Resources */,
+				530F033EBEA7F08AD9A8EC993F9E578A /* Headers */,
+				36F88A8DCF026E62CF1E5B8738AC579C /* Sources */,
+				175C02B4F1917AEEB418FFCDEAA7B8B4 /* Frameworks */,
+				887D04FB0859D20C38B7417F6B854761 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -2564,7 +2585,6 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
-				Base,
 			);
 			mainGroup = CF1408CF629C7361332E53B88F7BD30C;
 			productRefGroup = 8B4308E9F48A6891A7915CA1BC478FDA /* Products */;
@@ -2607,6 +2627,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		2827631FC40A3F6C617D9E65A33BE298 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4B124986EE1B96094B062771EA3D80AE /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2621,21 +2648,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		69DD9CD935A6DEC5C35DE88D20FF51C3 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		7DCAD016931269B379CD59AA00103216 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		85B6296E174618E1DE5D8860A3A1D180 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		887D04FB0859D20C38B7417F6B854761 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2650,6 +2670,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		A861415C9DA3F221326319F5A5C78DA4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B219A243F752A8EC273DCB0D9186D7C0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2677,13 +2704,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C610607DB61FB7D57E5FB787894CEE3A /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		C6382061AB56189BEDD1298D41A69B8F /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2701,110 +2721,81 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		04D60D20D876B1C6DC3D9353987C2CA9 /* Sources */ = {
+		36F88A8DCF026E62CF1E5B8738AC579C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				383EC2E1434114137D1F92B759289079 /* _AWSMobileClient.m in Sources */,
-				2B798A8D55F738CB910A57B79A33156D /* AWSCognitoAuth+Extensions.m in Sources */,
-				21603C2FBCE8E5F81B367775FEC1CC3B /* AWSCognitoAuth.m in Sources */,
-				FB1F231D217D2914C4C03FE5B66F6301 /* AWSCognitoAuthUICKeyChainStore.m in Sources */,
-				3BCC2938CD89D34C6D4CBF06C215B8A5 /* AWSMobileClient-dummy.m in Sources */,
-				508AEBB842172D9A8A8E6F868E533147 /* AWSMobileClient.swift in Sources */,
-				EA97672CE9D5E84D129FBFA113A74D18 /* AWSMobileClientExtensions.swift in Sources */,
-				2777406E199904C8BA33A1B3D608EE75 /* AWSMobileClientUserDetails.swift in Sources */,
-				253D4842116A87463AE2FE2E6F22C11E /* AWSMobileOptions.swift in Sources */,
-				2A306E0FAEC68DCFD212A47F58E4C992 /* AWSMobileResults.swift in Sources */,
-				94DF5723F5F4F98EED3FAF91CA73F685 /* AWSUserPoolOperationsHandler.swift in Sources */,
-				CE5D986CDF7DBEF4F11DCC9EA3B5B929 /* DeviceOperations.swift in Sources */,
-				0987A78DE6F0F75CAFBE9B683D640A02 /* JSONHelper.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		0DA9DD391759190DFF2CAC0303C6E7AD /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				C20E9D9EF169BFD9A31A364683D3ECAF /* AWSAuthCore-dummy.m in Sources */,
-				C74236311AEE52428383FCD4820606C4 /* AWSIdentityManager.m in Sources */,
-				45C54CF80A7289E3B8EAC70A5C8CDBAE /* AWSSignInManager.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		0F8DA3147A82B9A4F6B52D212D3CB985 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				1A02B3201A7036F4A28FD76E097B654B /* AWSBolts.m in Sources */,
-				2A87B8AEB95293084FE0C7EBC1232791 /* AWSCancellationToken.m in Sources */,
-				CF78E377AE49A86D20A00D51793979C9 /* AWSCancellationTokenRegistration.m in Sources */,
-				9C29016A79E85593D4903D4AC0EE9795 /* AWSCancellationTokenSource.m in Sources */,
-				02AB04EAA02008DCACB322A63238278A /* AWSCategory.m in Sources */,
-				9A4979568AB7A750A8303BDD21E1F230 /* AWSClientContext.m in Sources */,
-				0E8BDDEF31A17BB3E2D73F7A6812E1C1 /* AWSCognitoIdentity+Fabric.m in Sources */,
-				2C2E4BD9840B2B646A8FF31C7B5D221B /* AWSCognitoIdentityModel.m in Sources */,
-				D1BEC8D155F8C308122CDE89D5E8BD64 /* AWSCognitoIdentityResources.m in Sources */,
-				DABD5E5E42113F1287706F95ED57787F /* AWSCognitoIdentityService.m in Sources */,
-				F5BCDBEEE390E1ED42E433E015CF3265 /* AWSCore-dummy.m in Sources */,
-				812E6FE7C800C026A4C38E2C51290A85 /* AWSCredentialsProvider.m in Sources */,
-				8F6A4531EC93144BE668A81137B2DF44 /* AWSDDAbstractDatabaseLogger.m in Sources */,
-				9F35EB8A76445B4265DBD4D0C1D81CDC /* AWSDDASLLogCapture.m in Sources */,
-				896DAD7E4351CB1280A69219F2F87A66 /* AWSDDASLLogger.m in Sources */,
-				59ED9B8BC229B43BC758FE771D7ACAFD /* AWSDDContextFilterLogFormatter.m in Sources */,
-				40BE279FC7854E78878AF51B3C577357 /* AWSDDDispatchQueueLogFormatter.m in Sources */,
-				5387F4AAAA5B69E24747A06DD2DEC19A /* AWSDDFileLogger.m in Sources */,
-				2918ACDE197F4019785CDAAD6EE91694 /* AWSDDLog.m in Sources */,
-				F234C9C6995F787397767C99BAE466FE /* AWSDDMultiFormatter.m in Sources */,
-				06FCF9F78279F32E1AD8A412C1C22847 /* AWSDDOSLogger.m in Sources */,
-				9BF996D39A3A712D2A41F03F493B708D /* AWSDDTTYLogger.m in Sources */,
-				B6BBFC993B975EE185C9ADD4C5D2420B /* AWSExecutor.m in Sources */,
-				78BEB096DCE534C58CDB8F3F30E7DCEC /* AWSEXTRuntimeExtensions.m in Sources */,
-				37220D2A3B31AF9959B09420F265BD8B /* AWSEXTScope.m in Sources */,
-				30069C4206C76CA80F829F9E30AD8846 /* AWSFMDatabase.m in Sources */,
-				7B05CC1AF6780F68F1FF089B48652318 /* AWSFMDatabaseAdditions.m in Sources */,
-				C4EAE6EC8670168F0EF052C269AA4E71 /* AWSFMDatabasePool.m in Sources */,
-				6D47C12FB2A3F1A9975FD8A4F26DF5EE /* AWSFMDatabaseQueue.m in Sources */,
-				E590C90C490A4CB76A59FC13589FB166 /* AWSFMDB+AWSHelpers.m in Sources */,
-				2D43D835AE1B1C72D2F8663693B99E55 /* AWSFMResultSet.m in Sources */,
-				EBA1D2EEAF45E71A8E2079605D3746E2 /* AWSGZIP.m in Sources */,
-				FCAB654F98D73A6F5EFE4EA356EF600D /* AWSIdentityProvider.m in Sources */,
-				E5F9A1CF6A4BE96B761B733635FFA377 /* AWSInfo.m in Sources */,
-				55D2EA9F7607F558A25F4E1AB80F23E8 /* AWSKSReachability.m in Sources */,
-				6EC58DAF1B0A34FD2313DA6C441B0D8A /* AWSLogging.m in Sources */,
-				A2C6D38BF055B80D1E379AC093FC07E6 /* AWSModel.m in Sources */,
-				2D60A8250C636D5DA78E1A8214DE3E00 /* AWSMTLJSONAdapter.m in Sources */,
-				B924412F3326FD285D0DF5145D1AFF3E /* AWSMTLManagedObjectAdapter.m in Sources */,
-				56DF8DBA0E60DE0E0B74FA839E59480B /* AWSMTLModel+NSCoding.m in Sources */,
-				8C779BB6EEC04BE3152B057CD6695282 /* AWSMTLModel.m in Sources */,
-				82B1792780A182252D1634A1684CB898 /* AWSMTLReflection.m in Sources */,
-				0FDB6FCA2363C99C65277783725A2856 /* AWSMTLValueTransformer.m in Sources */,
-				1228FA123FF29FBB8C673ABB8693B9B5 /* AWSNetworking.m in Sources */,
-				6748B3A09288B9405215998F2284851F /* AWSSerialization.m in Sources */,
-				9BB751C6E1D43B8323EFC34DCB0A39EB /* AWSService.m in Sources */,
-				1CFD278435B7BB1D3F2F37EEB5B75E23 /* AWSSignature.m in Sources */,
-				531404E8A2ABACA0EFACCD951A7222EE /* AWSSTSModel.m in Sources */,
-				73A9A7C30E71B2ADA50DDC2A8132C4DC /* AWSSTSResources.m in Sources */,
-				8005CFE2A71D0D93FB37D9D0D0FEC5D1 /* AWSSTSService.m in Sources */,
-				737BF3747D1EA411B13BAFDBD564288C /* AWSSynchronizedMutableDictionary.m in Sources */,
-				AB958B4B2C4703DFEB18B8142B688E64 /* AWSTask.m in Sources */,
-				AE1D3AE6FC610797CA01072C4C81D9BD /* AWSTaskCompletionSource.m in Sources */,
-				B0F30D051C98A799C09BA355E5A4D7DF /* AWSTMCache.m in Sources */,
-				204CE0D1375D7D27DB6707826EE0BB17 /* AWSTMDiskCache.m in Sources */,
-				2D1078002F1C28A0C300A25FE1D56F6A /* AWSTMMemoryCache.m in Sources */,
-				86EB3D9547E5B06DE5C12D144139C578 /* AWSUICKeyChainStore.m in Sources */,
-				2EA2267D6B555455AD9F617935CD1F16 /* AWSURLRequestRetryHandler.m in Sources */,
-				5948FB5077F766182F92BD1A5A9D7D79 /* AWSURLRequestSerialization.m in Sources */,
-				1D9A5130624A73FF361E1E21F4FD6EFC /* AWSURLResponseSerialization.m in Sources */,
-				3CD5E4A964E12AA39B1C5BF153CD3E27 /* AWSURLSessionManager.m in Sources */,
-				ACAA7A9F47BA86060AD4D4F320D3FBA1 /* AWSValidation.m in Sources */,
-				FC1BFF263F28DF45B48C6088192D5479 /* AWSXMLDictionary.m in Sources */,
-				D7DB71375E75568144A6F44787C896AE /* AWSXMLWriter.m in Sources */,
-				D57941F71569BF2BD17F084BA72A870B /* NSArray+AWSMTLManipulationAdditions.m in Sources */,
-				6C1438AA5192213903C163AAA8810952 /* NSDictionary+AWSMTLManipulationAdditions.m in Sources */,
-				E65A2AD89A723E22FF8244A0CC487318 /* NSError+AWSMTLModelException.m in Sources */,
-				165E2ECAD0CBD103023BCA5CC87D3EE3 /* NSObject+AWSMTLComparisonAdditions.m in Sources */,
-				46A2EC60005AE658F6582003385B0AEE /* NSValueTransformer+AWSMTLInversionAdditions.m in Sources */,
-				BAFF65E2953B8E9393F1294F1D380458 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m in Sources */,
+				CBFDA937C68D277582439A7F827791FA /* AWSBolts.m in Sources */,
+				00245045D5E45577751253E413EB5A41 /* AWSCancellationToken.m in Sources */,
+				15558E6E6B5B340AE9A56594910085DC /* AWSCancellationTokenRegistration.m in Sources */,
+				96D71A9A27A288204F9C2C6FB0938075 /* AWSCancellationTokenSource.m in Sources */,
+				452B95EB46C02DE66D5E2F415EAD1F85 /* AWSCategory.m in Sources */,
+				1B607F8C305C2DDE2170D517993A0542 /* AWSClientContext.m in Sources */,
+				A26C2FD9F3C6A6D8C8859C915163A0B6 /* AWSCognitoIdentity+Fabric.m in Sources */,
+				2814D4D361A4E86079D72A04F0AB30D5 /* AWSCognitoIdentityModel.m in Sources */,
+				3A211A601A173429FC164E21BFBD925C /* AWSCognitoIdentityResources.m in Sources */,
+				AC0913A1E4C9CDEC5699AD154BA254A1 /* AWSCognitoIdentityService.m in Sources */,
+				C35B120FF2B1D18672753CF6EC0985DD /* AWSCore-dummy.m in Sources */,
+				FCF5EF0D7D0E39CEF61A1F8E7029923A /* AWSCredentialsProvider.m in Sources */,
+				D9A075C15C47BC77535148A5A2D2C468 /* AWSDDAbstractDatabaseLogger.m in Sources */,
+				3EE59D51700D3E008C115C34DDC73403 /* AWSDDASLLogCapture.m in Sources */,
+				A3E2BFD1F35BCE94C2023D88AA5BC579 /* AWSDDASLLogger.m in Sources */,
+				36793D105BE701C00338BDF313AB6C46 /* AWSDDContextFilterLogFormatter.m in Sources */,
+				11E98BE334C469A1C9694F6891B2119D /* AWSDDDispatchQueueLogFormatter.m in Sources */,
+				2757F826A5D3164D7FF294C3C0D2DA44 /* AWSDDFileLogger.m in Sources */,
+				1060FCAC1ACCA3BA3F7B2B266177E21D /* AWSDDLog.m in Sources */,
+				37E3C990B6B94ED3A68546B534D113F7 /* AWSDDMultiFormatter.m in Sources */,
+				06920E9A30F8C694426F31326AEC669F /* AWSDDOSLogger.m in Sources */,
+				C6E6CC33D0DC9F7F706B5BEECD5C5A75 /* AWSDDTTYLogger.m in Sources */,
+				39678AF6674F85C354F294BE9F490B2F /* AWSExecutor.m in Sources */,
+				E93E93B977E8B8E4C067729097481601 /* AWSEXTRuntimeExtensions.m in Sources */,
+				440B8ECC492853A954F9EF74E134A1A9 /* AWSEXTScope.m in Sources */,
+				781205D14C8BB2089F3A5EACB8D848CC /* AWSFMDatabase.m in Sources */,
+				E14859804FDF14B09F1DDF7C2E3404E4 /* AWSFMDatabaseAdditions.m in Sources */,
+				3037B29B6276CF8FE3546D3E977DD84A /* AWSFMDatabasePool.m in Sources */,
+				5E0032B52DC5BB5FB3CA69F45D484781 /* AWSFMDatabaseQueue.m in Sources */,
+				788692E6436FAA77FB4106A8A43A6D43 /* AWSFMDB+AWSHelpers.m in Sources */,
+				A325BDDE98FB22C8DCB42AFCA0A0A1A1 /* AWSFMResultSet.m in Sources */,
+				8C4F65C6BCEB1D62FD195E15403F01F9 /* AWSGZIP.m in Sources */,
+				FA57383E56731300CB3E661B5BEF21DE /* AWSIdentityProvider.m in Sources */,
+				8DE2768806CC526886BF6D06E8E83C1D /* AWSInfo.m in Sources */,
+				61B1A698911FFEDAC3E17424104462CF /* AWSKSReachability.m in Sources */,
+				98E684975408A0A06FE6BCE1431F686A /* AWSLogging.m in Sources */,
+				46239FCB5AA1A9C393996E3975E4AB72 /* AWSModel.m in Sources */,
+				EC8750873DB5F6265E48BA9315A7B2F5 /* AWSMTLJSONAdapter.m in Sources */,
+				7FAAD3074FCCD0FB5F7DC085A79F1352 /* AWSMTLManagedObjectAdapter.m in Sources */,
+				FF2758D837FB5A2D465659698E8D095F /* AWSMTLModel+NSCoding.m in Sources */,
+				BE6A0ECFE8619D15EF84F45C240644F5 /* AWSMTLModel.m in Sources */,
+				E1702B4EF8EC1AB6F934AC3BC6600A6F /* AWSMTLReflection.m in Sources */,
+				34D0E0F7CFB4DFE1D93A31A57C6D97AD /* AWSMTLValueTransformer.m in Sources */,
+				F091C99F7BB142D1DB6152C7E144B9D2 /* AWSNetworking.m in Sources */,
+				FF35610D44E99E6782EF579730D183DF /* AWSNetworkingHelpers.m in Sources */,
+				9330A6BAFFA518B4BECBFAD3412BF162 /* AWSSerialization.m in Sources */,
+				8B56F42D143D78C6F5BD42A941106BA9 /* AWSService.m in Sources */,
+				9C348F0554641CE5E4D400226C483C84 /* AWSSignature.m in Sources */,
+				5EB28630A9CC30863DE4382D0A18BB38 /* AWSSTSModel.m in Sources */,
+				20DE217DA9E41A2BFD1E4A71C564929B /* AWSSTSResources.m in Sources */,
+				FA1F41CB174865C3ABAA696511940338 /* AWSSTSService.m in Sources */,
+				95465C26DCAF34829BEDF0B2873E5D22 /* AWSSynchronizedMutableDictionary.m in Sources */,
+				C682CF45DC1BE3A1391C38D98B23178D /* AWSTask.m in Sources */,
+				CA226D1FC3EC02847A70C9DC565362CC /* AWSTaskCompletionSource.m in Sources */,
+				62D392DC89FC9697970873E8455C503E /* AWSTMCache.m in Sources */,
+				7823E936D9B566B90F997812337AFF6D /* AWSTMDiskCache.m in Sources */,
+				C7BB5752DCF16A55A09916C85EB64EA1 /* AWSTMMemoryCache.m in Sources */,
+				F5EFC3BA946FAB0C653C0EFB9187348D /* AWSUICKeyChainStore.m in Sources */,
+				CD9C8503D19F1E4D26A2D1705B7C922C /* AWSURLRequestRetryHandler.m in Sources */,
+				BAC85A39D3808CE79873936E4231A6DA /* AWSURLRequestSerialization.m in Sources */,
+				DBCA55BB7256CF0FCC1535AB9B0D3550 /* AWSURLResponseSerialization.m in Sources */,
+				C3E5346133EC63B83B5B163399B39A1B /* AWSURLSessionManager.m in Sources */,
+				FCCD667C2ECB8F6AB815CFBE869B7BAE /* AWSValidation.m in Sources */,
+				2D7804C365C5B74B4CFCE9DCDB990FDA /* AWSXMLDictionary.m in Sources */,
+				3979D282ECA583525A2099DDA11E1EBD /* AWSXMLWriter.m in Sources */,
+				4E7A6FAE1EDFAEECBB22F317BB0A5619 /* NSArray+AWSMTLManipulationAdditions.m in Sources */,
+				3140BF9E55F36B4CE5E2FAC0317FBE58 /* NSDictionary+AWSMTLManipulationAdditions.m in Sources */,
+				7C54E87DA0FEDA01C2E6466361F2E915 /* NSError+AWSMTLModelException.m in Sources */,
+				36F73E51FDF6AD36471B99E64C4A7730 /* NSObject+AWSMTLComparisonAdditions.m in Sources */,
+				EBB5629A5A587AB94332D976DE76116B /* NSValueTransformer+AWSMTLInversionAdditions.m in Sources */,
+				858196891699CB779D9415EE462CD40B /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2813,6 +2804,27 @@
 			buildActionMask = 2147483647;
 			files = (
 				7E563800D6BC72004F79096CF284A320 /* Pods-Amplify-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		49C4F997373C728DF83F55FD7FCCB1A8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6A6F7F27DCCF6D5F73EA43FCCA1DAB92 /* _AWSMobileClient.m in Sources */,
+				0DC60DC3F6A7EDA73648721C422359A7 /* AWSCognitoAuth+Extensions.m in Sources */,
+				6026B603F1245AD52915F34CA6A83CC5 /* AWSCognitoAuth.m in Sources */,
+				5296910C64F9CFF68149C484D4FCB927 /* AWSCognitoAuthUICKeyChainStore.m in Sources */,
+				37899F8A7B0ED0B72C99334BAA54CEAB /* AWSMobileClient-dummy.m in Sources */,
+				FEBDB02A795559B8678FF609BD63DC5D /* AWSMobileClient.swift in Sources */,
+				9C756224993E158189C803D1CF6DB659 /* AWSMobileClientExtensions.swift in Sources */,
+				67D8229426E3B531C446102C3F290D63 /* AWSMobileClientUserDetails.swift in Sources */,
+				BE7ADABCCDB533FDC0433D0D631EF85E /* AWSMobileOptions.swift in Sources */,
+				CD670349157D1CC299C595DBC118D553 /* AWSMobileResults.swift in Sources */,
+				D0008DB1D694408559F50AD06E9DCF00 /* AWSUserPoolCustomAuthHandler.swift in Sources */,
+				CCF3D812222A96CB42B542F4D68A6B3F /* AWSUserPoolOperationsHandler.swift in Sources */,
+				35A9EDB5F19A0AA37CFAC061744C58A4 /* DeviceOperations.swift in Sources */,
+				97C52BFCC42E09EEE37E0F079375C892 /* JSONHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2864,6 +2876,17 @@
 				7A91CEDA043B8B5257FD9D1EAA5614A7 /* AWSJKBigInteger.m in Sources */,
 				13E1E9094F5329494002200340B1AF65 /* NSData+AWSCognitoIdentityProvider.m in Sources */,
 				2145910BF9E8293B01895487859507A7 /* tommath.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A6EAB7CECD211FA17C7E486BC9FCD47F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				39182F41F7B148E56863FD6A48300A15 /* AWSAuthCore-dummy.m in Sources */,
+				C61912BA5E6897BB6DF7A83C5114AC61 /* AWSAuthUIHelper.m in Sources */,
+				1C458B6D3529A73474CA7ED48C718CEA /* AWSIdentityManager.m in Sources */,
+				3A7F8C983F3205D2586B913580D7818D /* AWSSignInManager.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2938,6 +2961,12 @@
 			target = 52B60EC2A583F24ACBB69C113F5488B9 /* SwiftLint */;
 			targetProxy = D39665078EF67EB882056A22CF65FE80 /* PBXContainerItemProxy */;
 		};
+		06729402D244E9B3898403BE3BECA781 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AWSAuthCore;
+			target = 8042F2B0721B13AEDEB81F058C2B2125 /* AWSAuthCore */;
+			targetProxy = ABF241B4BEC3E8ADB5E0B8D8BB34B97C /* PBXContainerItemProxy */;
+		};
 		0677872B62BA77DECE8C9125D7C238B1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = SwiftLint;
@@ -3010,6 +3039,12 @@
 			target = 1CD0618C486973D5588EF20D2E8C0AEA /* SwiftFormat */;
 			targetProxy = B74E5D04FC60F052519803DF490FA801 /* PBXContainerItemProxy */;
 		};
+		3956B7AEEEE178E01F0DEA935F7D7E02 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AWSCognitoIdentityProvider;
+			target = 29212B2F049288E035AB98405A23E41E /* AWSCognitoIdentityProvider */;
+			targetProxy = 808E02155DEA9FFFA7AB26A41DE112FA /* PBXContainerItemProxy */;
+		};
 		3D8B7F3F5BB71669A7C025928D1072D2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = AWSAuthCore;
@@ -3040,12 +3075,6 @@
 			target = E4D853F6FBAB5A9BDBE843E4EFB22EB7 /* CwlPreconditionTesting */;
 			targetProxy = 3C8F087850A785C814157E25220E9FC6 /* PBXContainerItemProxy */;
 		};
-		4FD3FB7BC4D49D78D78F4CD847DA0ACB /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = AWSAuthCore;
-			target = 8042F2B0721B13AEDEB81F058C2B2125 /* AWSAuthCore */;
-			targetProxy = 380E6810679FD8527F8690183215C99C /* PBXContainerItemProxy */;
-		};
 		555C6CEB7B08255F87C3FC5B93473E46 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = SwiftFormat;
@@ -3070,12 +3099,6 @@
 			target = 308B5C440C446909122081D367A27A8F /* CwlCatchException */;
 			targetProxy = 79033E4F4F1C0C3F143CAB7370425C6D /* PBXContainerItemProxy */;
 		};
-		6231A799AB105D1BD9F00B45E71B4FE3 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = AWSCore;
-			target = 9B172FACE90046AA5E100E650B6109DD /* AWSCore */;
-			targetProxy = 30894E0F73D05EABEF118596786A61A7 /* PBXContainerItemProxy */;
-		};
 		6389EF5757EF403EFC931CAA5E0D5B1F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = CwlPreconditionTesting;
@@ -3099,6 +3122,12 @@
 			name = AWSCore;
 			target = 9B172FACE90046AA5E100E650B6109DD /* AWSCore */;
 			targetProxy = 0BF9E0DE7F9BD115106C7D14B4FBBF44 /* PBXContainerItemProxy */;
+		};
+		69FCA5BFE1F9B83AA980D65FFA2CCBAA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AWSCore;
+			target = 9B172FACE90046AA5E100E650B6109DD /* AWSCore */;
+			targetProxy = 198F4C9BE19725A59DDC93CD8A13CAE0 /* PBXContainerItemProxy */;
 		};
 		6AD6EA8AFC5C5AC5372551F0D44FED3F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3207,12 +3236,6 @@
 			name = AWSCognitoIdentityProviderASF;
 			target = BBF90BA4F6EC5653945C7B0FFD9128D2 /* AWSCognitoIdentityProviderASF */;
 			targetProxy = C11EDAD6A1504B19CF07D09E6310F723 /* PBXContainerItemProxy */;
-		};
-		B7BBCF7EA09C9EA97960EE8C7CD8A034 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = AWSCognitoIdentityProvider;
-			target = 29212B2F049288E035AB98405A23E41E /* AWSCognitoIdentityProvider */;
-			targetProxy = BE94540EF0C0E21FBAB6B1151DB42390 /* PBXContainerItemProxy */;
 		};
 		BA1256D3979F86507DF549BB8DA24477 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3457,6 +3480,41 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
+		};
+		0AB23DA2C855470186D5B8116100B50B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 80C849937AD2C88BA17636FFE3EEE60C /* AWSCore.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/AWSCore/AWSCore-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/AWSCore/AWSCore-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/AWSCore/AWSCore.modulemap";
+				PRODUCT_MODULE_NAME = AWSCore;
+				PRODUCT_NAME = AWSCore;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
 		};
 		1470B3EEE121006994B619BF5AE2E7ED /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -3750,9 +3808,9 @@
 			};
 			name = Release;
 		};
-		3ABB506121EA2BF592E6A7F6852B2CCD /* Release */ = {
+		40FB7DF87715899C41DE4BFC0E32DCA3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 82ED6B642009AEBCB14888FADDD771DF /* AWSCore.xcconfig */;
+			baseConfigurationReference = C6FB30955DA68107EDEF56A9A1344D17 /* AWSMobileClient.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3763,28 +3821,27 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/AWSCore/AWSCore-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/AWSCore/AWSCore-Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/AWSMobileClient/AWSMobileClient-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MODULEMAP_FILE = "Target Support Files/AWSCore/AWSCore.modulemap";
-				PRODUCT_MODULE_NAME = AWSCore;
-				PRODUCT_NAME = AWSCore;
+				MODULEMAP_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient.modulemap";
+				PRODUCT_MODULE_NAME = AWSMobileClient;
+				PRODUCT_NAME = AWSMobileClient;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Release;
+			name = Debug;
 		};
 		48F6A6E15897D3D8C499170A423CFE8F /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -3865,7 +3922,7 @@
 		};
 		61D16562C88F67A248B236668FAC8E96 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 188D37813096871738338C0AE719885C /* SwiftFormat.xcconfig */;
+			baseConfigurationReference = A4F18ECC77B90BCC7C16CD58FFCA677C /* SwiftFormat.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -3918,9 +3975,44 @@
 			};
 			name = Debug;
 		};
+		64A9859A733876E4E55A5B60695C5E4B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 25DFBB76C1BF492E05A46B34178281AD /* AWSAuthCore.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/AWSAuthCore/AWSAuthCore-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/AWSAuthCore/AWSAuthCore-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/AWSAuthCore/AWSAuthCore.modulemap";
+				PRODUCT_MODULE_NAME = AWSAuthCore;
+				PRODUCT_NAME = AWSAuthCore;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		84D7C4574E8F0F3095623F0E06F5B402 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 301896368726EDD96867206BBDD39070 /* SwiftLint.xcconfig */;
+			baseConfigurationReference = 3CE55D53ECA949420B445EF748A6B476 /* SwiftLint.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -3937,7 +4029,7 @@
 		};
 		928A9CF8F7DC9E60D390F3E0FCC0717D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 68745D588A16410345510D25D11B08F5 /* CwlCatchException.xcconfig */;
+			baseConfigurationReference = 5292499829C37C41F261711AC72F7168 /* CwlCatchException.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3960,6 +4052,78 @@
 				MODULEMAP_FILE = "Target Support Files/CwlCatchException/CwlCatchException.modulemap";
 				PRODUCT_MODULE_NAME = CwlCatchException;
 				PRODUCT_NAME = CwlCatchException;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		9582552BB2F8FFE35DD0951280A2C193 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C6FB30955DA68107EDEF56A9A1344D17 /* AWSMobileClient.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/AWSMobileClient/AWSMobileClient-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient.modulemap";
+				PRODUCT_MODULE_NAME = AWSMobileClient;
+				PRODUCT_NAME = AWSMobileClient;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		97FC9D3288E512074D4653E6D51CCA73 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 80C849937AD2C88BA17636FFE3EEE60C /* AWSCore.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/AWSCore/AWSCore-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/AWSCore/AWSCore-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/AWSCore/AWSCore.modulemap";
+				PRODUCT_MODULE_NAME = AWSCore;
+				PRODUCT_NAME = AWSCore;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
@@ -4010,9 +4174,44 @@
 			};
 			name = Release;
 		};
-		9F2D973A9F79FA887D4C5AA6A472FF3A /* Release */ = {
+		A4A57FD36DD30772507B9A3AD28CB752 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B73BB8777F0FF75A2C999665718D660C /* AWSAuthCore.xcconfig */;
+			baseConfigurationReference = 0E4D66772DCE19A7404EF983F3D98759 /* CwlPreconditionTesting.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/CwlPreconditionTesting/CwlPreconditionTesting-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/CwlPreconditionTesting/CwlPreconditionTesting-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/CwlPreconditionTesting/CwlPreconditionTesting.modulemap";
+				PRODUCT_MODULE_NAME = CwlPreconditionTesting;
+				PRODUCT_NAME = CwlPreconditionTesting;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		A54E9CD02041BDE6A02174EE5A58EA97 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 25DFBB76C1BF492E05A46B34178281AD /* AWSAuthCore.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4046,79 +4245,9 @@
 			};
 			name = Release;
 		};
-		A0B6672C38880C777872B62CA33E9BC6 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 82ED6B642009AEBCB14888FADDD771DF /* AWSCore.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/AWSCore/AWSCore-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/AWSCore/AWSCore-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/AWSCore/AWSCore.modulemap";
-				PRODUCT_MODULE_NAME = AWSCore;
-				PRODUCT_NAME = AWSCore;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		A4A57FD36DD30772507B9A3AD28CB752 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = DF631E62A7EE783A0B2B9A5796CDE669 /* CwlPreconditionTesting.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/CwlPreconditionTesting/CwlPreconditionTesting-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/CwlPreconditionTesting/CwlPreconditionTesting-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/CwlPreconditionTesting/CwlPreconditionTesting.modulemap";
-				PRODUCT_MODULE_NAME = CwlPreconditionTesting;
-				PRODUCT_NAME = CwlPreconditionTesting;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		A82ABF3A5034931D5FB9563326AFB8E3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0669AB8647FCA850A2FAD6F35CAB9B21 /* AWSCognitoIdentityProvider.xcconfig */;
+			baseConfigurationReference = 5EDFE115C3392FB9863659189DFA9FD0 /* AWSCognitoIdentityProvider.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4153,7 +4282,7 @@
 		};
 		A8A39F86ED80874B567AC60703BA6FA1 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 188D37813096871738338C0AE719885C /* SwiftFormat.xcconfig */;
+			baseConfigurationReference = A4F18ECC77B90BCC7C16CD58FFCA677C /* SwiftFormat.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -4169,7 +4298,7 @@
 		};
 		AA5A2AABF10AA289D052CC2477A1DDF5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0669AB8647FCA850A2FAD6F35CAB9B21 /* AWSCognitoIdentityProvider.xcconfig */;
+			baseConfigurationReference = 5EDFE115C3392FB9863659189DFA9FD0 /* AWSCognitoIdentityProvider.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4205,7 +4334,7 @@
 		};
 		AB8EA580E69DD4917550E086C71FFCBA /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A0E6E441D5D233E13E9794788839B361 /* AWSCognitoIdentityProviderASF.xcconfig */;
+			baseConfigurationReference = 1EEAEFF4390C69F3ED0B2E72D09E4966 /* AWSCognitoIdentityProviderASF.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4239,115 +4368,9 @@
 			};
 			name = Release;
 		};
-		ACCDEF4EA3CB6A4AAFDB92543A36446D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 498D20AA560AEC314E9573CE635D2DE5 /* AWSMobileClient.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/AWSMobileClient/AWSMobileClient-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient.modulemap";
-				PRODUCT_MODULE_NAME = AWSMobileClient;
-				PRODUCT_NAME = AWSMobileClient;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		B00E79F7A6EAB86AE6C5AD0B2FDD323A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B73BB8777F0FF75A2C999665718D660C /* AWSAuthCore.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/AWSAuthCore/AWSAuthCore-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/AWSAuthCore/AWSAuthCore-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/AWSAuthCore/AWSAuthCore.modulemap";
-				PRODUCT_MODULE_NAME = AWSAuthCore;
-				PRODUCT_NAME = AWSAuthCore;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		BE4E7E2A89502B88620F2CEABA0A2D85 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 498D20AA560AEC314E9573CE635D2DE5 /* AWSMobileClient.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/AWSMobileClient/AWSMobileClient-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient.modulemap";
-				PRODUCT_MODULE_NAME = AWSMobileClient;
-				PRODUCT_NAME = AWSMobileClient;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 		BF762AF3FA0BD3A6F21E92E355CE0648 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A0E6E441D5D233E13E9794788839B361 /* AWSCognitoIdentityProviderASF.xcconfig */;
+			baseConfigurationReference = 1EEAEFF4390C69F3ED0B2E72D09E4966 /* AWSCognitoIdentityProviderASF.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4459,7 +4482,7 @@
 		};
 		D2F61928062703C27432E49CB425D03D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DF631E62A7EE783A0B2B9A5796CDE669 /* CwlPreconditionTesting.xcconfig */;
+			baseConfigurationReference = 0E4D66772DCE19A7404EF983F3D98759 /* CwlPreconditionTesting.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4559,7 +4582,7 @@
 		};
 		DEED47E09AF743F48544C1C4FEADEF47 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 301896368726EDD96867206BBDD39070 /* SwiftLint.xcconfig */;
+			baseConfigurationReference = 3CE55D53ECA949420B445EF748A6B476 /* SwiftLint.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -4575,7 +4598,7 @@
 		};
 		DFA2EA1406BE3C6CCAD3F47AFCEA53A2 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 68745D588A16410345510D25D11B08F5 /* CwlCatchException.xcconfig */;
+			baseConfigurationReference = 5292499829C37C41F261711AC72F7168 /* CwlCatchException.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4667,6 +4690,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		3C091373BF430C54D1D7ECA69D4440CF /* Build configuration list for PBXNativeTarget "AWSCore" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0AB23DA2C855470186D5B8116100B50B /* Debug */,
+				97FC9D3288E512074D4653E6D51CCA73 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		456F8DC3F809F76B7C5835C133255E67 /* Build configuration list for PBXNativeTarget "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -4694,20 +4726,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		6C1B0082F55622F61D55E4DF5F89B58D /* Build configuration list for PBXNativeTarget "AWSMobileClient" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				40FB7DF87715899C41DE4BFC0E32DCA3 /* Debug */,
+				9582552BB2F8FFE35DD0951280A2C193 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		7C3B83A384027AAE79E0A6C8D268CC69 /* Build configuration list for PBXNativeTarget "Pods-AmplifyTestApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				018A6D71EC5BCAC6F0A37D87974E596D /* Debug */,
 				9DEEE6868679007B228157ABEE9989F3 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		80646B31F3D7EC6D5FF70E8A7F2E189A /* Build configuration list for PBXNativeTarget "AWSCore" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				A0B6672C38880C777872B62CA33E9BC6 /* Debug */,
-				3ABB506121EA2BF592E6A7F6852B2CCD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -4739,6 +4771,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		95205485CA4D05E429CC813BF3F3185A /* Build configuration list for PBXNativeTarget "AWSAuthCore" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				64A9859A733876E4E55A5B60695C5E4B /* Debug */,
+				A54E9CD02041BDE6A02174EE5A58EA97 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		AD49CB60EED70438B01ECB5C32F3780C /* Build configuration list for PBXNativeTarget "Pods-Amplify" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -4762,24 +4803,6 @@
 			buildConfigurations = (
 				BF762AF3FA0BD3A6F21E92E355CE0648 /* Debug */,
 				AB8EA580E69DD4917550E086C71FFCBA /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		B7A25F64167EDC70379CA76465F9D769 /* Build configuration list for PBXNativeTarget "AWSMobileClient" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				ACCDEF4EA3CB6A4AAFDB92543A36446D /* Debug */,
-				BE4E7E2A89502B88620F2CEABA0A2D85 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		CAC51FDC5DF9384861199B5F7A442D45 /* Build configuration list for PBXNativeTarget "AWSAuthCore" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				B00E79F7A6EAB86AE6C5AD0B2FDD323A /* Debug */,
-				9F2D973A9F79FA887D4C5AA6A472FF3A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
This pr is a continuation of the royjit@'s work here:
https://github.com/aws-amplify/amplify-ios/pull/166

* Created (mostly copy and pasted) ServiceConfiguration -> AmplifyAWSServiceConfiguration
* Updated (mostly copy and pasted) Predictions category to use this new class (which should be used when using aws-sdk-ios)
* Updated Amplify API to leverage AmplifyAWSServiceConfiguration
* URLRequestContants.swift -> URLRequestConstants
 * removed placeholder useragent
* Update for Analytics to use AmplifyAWSServiceConfiguration
* Update for Storage to use AmplifyAWSServiceConfiguration


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
