### PR TITLE
WIP: Plumb through dataStorePublisher from AWSDataStorePlugin to ReconcileAndLocalSaveOperation to allow callbacks to toplevel subscribe calls

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -39,3 +39,10 @@ public protocol DataStoreSubscribeBehavior {
     @available(iOS 13.0, *)
     func publisher<M: Model>(for modelType: M.Type) -> AnyPublisher<MutationEvent, DataStoreError>
 }
+
+public protocol DataStorePublisherBehavior {
+    /// Protocol for sending a mutation event to subscription based mutation events
+    /// - Parameter input: a mutation event that will be sent to all subscribers
+    @available(iOS 13.0, *)
+    func send(input: MutationEvent)
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -76,7 +76,11 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
             return
         }
 
-        storageEngine = try StorageEngine(isSyncEnabled: isSyncEnabled)
+        storageEngine = try StorageEngine(isSyncEnabled: isSyncEnabled, dataStorePublisher: resolveDataStorePublisher())
+    }
+
+    private func resolveDataStorePublisher() -> DataStorePublisherBehavior? {
+        return dataStorePublisher as? DataStorePublisherBehavior
     }
 
     public func reset(onComplete: @escaping (() -> Void)) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStorePublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStorePublisher.swift
@@ -10,7 +10,7 @@ import Combine
 
 // TODO: Should this be a multicast publisher?
 @available(iOS 13.0, *)
-struct DataStorePublisher: DataStoreSubscribeBehavior {
+struct DataStorePublisher: DataStoreSubscribeBehavior, DataStorePublisherBehavior {
 
     private let subject = PassthroughSubject<MutationEvent, DataStoreError>()
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -17,12 +17,14 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
 
     init(modelTypes: [Model.Type],
          api: APICategoryGraphQLBehavior,
-         storageAdapter: StorageEngineAdapter) {
+         storageAdapter: StorageEngineAdapter,
+         dataStorePublisher: DataStorePublisherBehavior) {
         for modelType in modelTypes {
             let modelName = modelType.modelName
             let queue = AWSModelReconciliationQueue(modelType: modelType,
                                                     storageAdapter: storageAdapter,
-                                                    api: api)
+                                                    api: api,
+                                                    dataStorePublisher: dataStorePublisher)
             guard reconciliationQueues[modelName] == nil else {
                 Amplify.DataStore.log
                     .warn("Duplicate model name found: \(modelName), not subscribing")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -54,16 +54,23 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
 
     private let modelName: String
 
+    ///  todo fill this in
+    ///
+    private let dataStorePublisher: DataStorePublisherBehavior
+
     private var incomingEventsSink: AnyCancellable?
 
     init(modelType: Model.Type,
          storageAdapter: StorageEngineAdapter?,
          api: APICategoryGraphQLBehavior,
+         dataStorePublisher: DataStorePublisherBehavior,
          incomingSubscriptionEvents: IncomingSubscriptionEventPublisher? = nil) {
 
         self.modelName = modelType.modelName
 
         self.storageAdapter = storageAdapter
+
+        self.dataStorePublisher = dataStorePublisher
 
         self.reconcileAndSaveQueue = OperationQueue()
         reconcileAndSaveQueue.name = "com.amazonaws.DataStore.\(modelType).reconcile"
@@ -114,7 +121,8 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
 
     func enqueue(_ remoteModel: MutationSync<AnyModel>) {
         let reconcileOp = ReconcileAndLocalSaveOperation(remoteModel: remoteModel,
-                                                         storageAdapter: storageAdapter)
+                                                         storageAdapter: storageAdapter,
+                                                         dataStorePublisher: dataStorePublisher)
         reconcileAndSaveQueue.addOperation(reconcileOp)
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -30,15 +30,18 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
                                           target: DispatchQueue.global())
 
     private weak var storageAdapter: StorageEngineAdapter?
+    private let dataStorePublisher: DataStorePublisherBehavior
     private let stateMachine: StateMachine<State, Action>
     private let remoteModel: RemoteModel
     private var stateMachineSink: AnyCancellable?
 
     init(remoteModel: RemoteModel,
          storageAdapter: StorageEngineAdapter?,
+         dataStorePublisher: DataStorePublisherBehavior,
          stateMachine: StateMachine<State, Action>? = nil) {
         self.remoteModel = remoteModel
         self.storageAdapter = storageAdapter
+        self.dataStorePublisher = dataStorePublisher
         self.stateMachine = stateMachine ?? StateMachine(initialState: .waiting,
                                                          resolver: Resolver.resolve(currentState:action:))
         super.init()
@@ -290,7 +293,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
                                  data: mutationEvent)
         Amplify.Hub.dispatch(to: .dataStore, payload: payload)
 
-        // TODO: Add publisher
+        dataStorePublisher.send(input: mutationEvent)
         // publisher?.send(input: mutationEvent)
 
         stateMachine.notify(action: .notified)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
@@ -66,12 +66,13 @@ extension APICategoryDependencyTests {
         let connection = try Connection(.inMemory)
         storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
         try storageAdapter.setUp(models: StorageEngine.systemModels)
-
-        let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter)
-        let storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          syncEngine: syncEngine)
-
         let dataStorePublisher = DataStorePublisher()
+        let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
+                                              dataStorePublisher: dataStorePublisher)
+        let storageEngine = StorageEngine(storageAdapter: storageAdapter,
+                                          syncEngine: syncEngine,
+                                          dataStorePublisher: dataStorePublisher)
+
         let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
                                                          storageEngine: storageEngine,
                                                          dataStorePublisher: dataStorePublisher)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
@@ -32,15 +32,18 @@ class LocalSubscriptionTests: XCTestCase {
             let outgoingMutationQueue = NoOpMutationQueue()
             let mutationDatabaseAdapter = try AWSMutationDatabaseAdapter(storageAdapter: storageAdapter)
             let awsMutationEventPublisher = AWSMutationEventPublisher(eventSource: mutationDatabaseAdapter)
+            let dataStorePublisher = DataStorePublisher() //as! DataStorePublisherBehavior
 
             let syncEngine = RemoteSyncEngine(storageAdapter: storageAdapter,
                                              outgoingMutationQueue: outgoingMutationQueue,
                                              mutationEventIngester: mutationDatabaseAdapter,
                                              mutationEventPublisher: awsMutationEventPublisher,
+                                             dataStorePublisher: dataStorePublisher,
                                              initialSyncOrchestratorFactory: NoOpInitialSyncOrchestrator.factory)
 
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          syncEngine: syncEngine)
+                                          syncEngine: syncEngine,
+                                          dataStorePublisher: dataStorePublisher)
         } catch {
             XCTFail(String(describing: error))
             return

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
@@ -32,15 +32,18 @@ class AWSMutationEventIngesterTests: XCTestCase {
 
         let apiPlugin = MockAPICategoryPlugin()
 
+        let dataStorePublisher = DataStorePublisher()
         do {
             let connection = try Connection(.inMemory)
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
             try storageAdapter.setUp(models: StorageEngine.systemModels)
 
-            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter)
+            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
+                                                  dataStorePublisher: dataStorePublisher)
 
             let storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                              syncEngine: syncEngine)
+                                              syncEngine: syncEngine,
+                                              dataStorePublisher: dataStorePublisher)
 
             let publisher = DataStorePublisher()
             let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
@@ -39,10 +39,12 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
             let connection = try Connection(.inMemory)
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
             try storageAdapter.setUp(models: StorageEngine.systemModels)
-
-            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter)
+            let dataStorePublisher = DataStorePublisher()
+            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
+                                                  dataStorePublisher: dataStorePublisher)
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          syncEngine: syncEngine)
+                                          syncEngine: syncEngine,
+                                          dataStorePublisher: dataStorePublisher)
         } catch {
             XCTFail(String(describing: error))
             return

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -25,10 +25,11 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
         storageAdapter.responders[.saveUntypedModel] = SaveUntypedModelResponder { _, _ in
             eventsNotSaved.fulfill()
         }
-
+        let dataStorePublisher = DataStorePublisher()
         let queue = AWSModelReconciliationQueue(modelType: MockSynced.self,
                                                 storageAdapter: storageAdapter,
                                                 api: apiPlugin,
+                                                dataStorePublisher: dataStorePublisher,
                                                 incomingSubscriptionEvents: subscriptionEventsPublisher)
 
         // We know this won't be nil, but we need to keep a reference to the queue in memory for the duration of the
@@ -71,10 +72,11 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
             completion(.success(model))
         }
-
+        let dataStorePublisher = DataStorePublisher()
         let queue = AWSModelReconciliationQueue(modelType: MockSynced.self,
                                                 storageAdapter: storageAdapter,
                                                 api: apiPlugin,
+                                                dataStorePublisher: dataStorePublisher,
                                                 incomingSubscriptionEvents: subscriptionEventsPublisher)
 
         for iteration in 1 ... 3 {
@@ -139,9 +141,11 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                 completion(.success(model))
         }
 
+        let dataStorePublisher = DataStorePublisher()
         let queue = AWSModelReconciliationQueue(modelType: MockSynced.self,
                                                 storageAdapter: storageAdapter,
                                                 api: apiPlugin,
+                                                dataStorePublisher: dataStorePublisher,
                                                 incomingSubscriptionEvents: subscriptionEventsPublisher)
         for iteration in 1 ... 3 {
             let model = try MockSynced(id: "id-\(iteration)").eraseToAnyModel()
@@ -184,9 +188,11 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                 completion(.success(model))
         }
 
+        let dataStorePublisher = DataStorePublisher()
         let queue = AWSModelReconciliationQueue(modelType: MockSynced.self,
                                                 storageAdapter: storageAdapter,
                                                 api: apiPlugin,
+                                                dataStorePublisher: dataStorePublisher,
                                                 incomingSubscriptionEvents: subscriptionEventsPublisher)
         for iteration in 1 ... 2 {
             let model = try MockSynced(id: "id-\(iteration)").eraseToAnyModel()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -18,6 +18,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
     var anyPostMetadata: MutationSyncMetadata!
     var anyPostMutationSync: MutationSync<AnyModel>!
     var anyPostDeletedMutationSync: MutationSync<AnyModel>!
+    var dataStorePublisher: DataStorePublisherBehavior!
 
     var operation: ReconcileAndLocalSaveOperation!
     var stateMachine: MockStateMachine<ReconcileAndLocalSaveOperation.State, ReconcileAndLocalSaveOperation.Action>!
@@ -49,9 +50,10 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         storageAdapter.returnOnSave(dataStoreResult: .none)
         stateMachine = MockStateMachine(initialState: .waiting,
                                         resolver: ReconcileAndLocalSaveOperation.Resolver.resolve(currentState:action:))
-
+        dataStorePublisher = DataStorePublisher() as? DataStorePublisherBehavior
         operation = ReconcileAndLocalSaveOperation(remoteModel: anyPostMutationSync,
                                                    storageAdapter: storageAdapter,
+                                                   dataStorePublisher: dataStorePublisher,
                                                    stateMachine: stateMachine)
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
@@ -32,10 +32,13 @@ class BaseDataStoreTests: XCTestCase {
             connection = try Connection(.inMemory)
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
             try storageAdapter.setUp(models: StorageEngine.systemModels)
+            let dataStorePublisher = DataStorePublisher()
 
-            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter)
+            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
+                                                  dataStorePublisher: dataStorePublisher)
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          syncEngine: syncEngine)
+                                          syncEngine: syncEngine,
+                                          dataStorePublisher: dataStorePublisher)
         } catch {
             XCTFail(String(describing: error))
             return

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -67,15 +67,17 @@ class SyncEngineTestBase: XCTestCase {
     ) throws {
         let mutationDatabaseAdapter = try AWSMutationDatabaseAdapter(storageAdapter: storageAdapter)
         let awsMutationEventPublisher = AWSMutationEventPublisher(eventSource: mutationDatabaseAdapter)
-
+        let dataStorePublisher = DataStorePublisher()
         let syncEngine = RemoteSyncEngine(storageAdapter: storageAdapter,
                                           outgoingMutationQueue: mutationQueue,
                                           mutationEventIngester: mutationDatabaseAdapter,
                                           mutationEventPublisher: awsMutationEventPublisher,
+                                          dataStorePublisher: dataStorePublisher,
                                           initialSyncOrchestratorFactory: initialSyncOrchestratorFactory)
 
         let storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          syncEngine: syncEngine)
+                                          syncEngine: syncEngine,
+                                          dataStorePublisher: dataStorePublisher)
 
         let publisher = DataStorePublisher()
         let dataStorePlugin = AWSDataStorePlugin(modelRegistration: modelRegistration,


### PR DESCRIPTION
Wanted to push this out early to get feedback on how we plumb through the DataStorePublisher.  

Two things to pay attention to:
1.  It didn't seem to make sense to attach it to the StorageEngineAdapter, so keeping the DataStorePublisherBehavior as a separate entity seemed appropriate
2.  I felt that it would be good to separate out a DataStoreSubscribeBehavior which is different than DataStorePublisherBehavior (despite them currently living in the same class), to be specific about which class is expecting a publisher vs subscriber.

Reason for making this change was in attempts to get callbacks working for:
```
        noteSubscription = Amplify.DataStore.publisher(for: Note.self)
            .sink(receiveCompletion: {completion in
                if case .failure(let err) =  completion { 
                    print("issue with subscription: \(err)")
                }
            }, receiveValue: { value in
                print("Subscription got this value: \(value)")
        })
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
