### PR TITLE
Add mutation events to publisher() interfaces in sync engine components to bubble up status and mutation events

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -28,8 +28,8 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
     @available(iOS 13.0, *)
     var cancellable: AnyCancellable? {
         get {
-            if let iCancellable = iCancellable {
-                return (iCancellable as! AnyCancellable) //swiftlint:disable:this force_cast
+            if let iCancellable = iCancellable as? AnyCancellable {
+                return iCancellable
             }
             return nil
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -23,18 +23,17 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
     /// The local storage provider. Resolved during configuration phase
     var storageEngine: StorageEngineBehavior!
 
-    var iCancellable: Any?
-
+    var iStorageEngineSink: Any?
     @available(iOS 13.0, *)
-    var cancellable: AnyCancellable? {
+    var storageEngineSink: AnyCancellable? {
         get {
-            if let iCancellable = iCancellable as? AnyCancellable {
-                return iCancellable
+            if let iStorageEngineSink = iStorageEngineSink as? AnyCancellable {
+                return iStorageEngineSink
             }
             return nil
         }
         set {
-            iCancellable = newValue
+            iStorageEngineSink = newValue
         }
     }
 
@@ -94,27 +93,39 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
 
         storageEngine = try StorageEngine(isSyncEnabled: isSyncEnabled)
         if #available(iOS 13.0, *) {
-            cancellable = storageEngine.publisher.sink(receiveCompletion: { completion in
-                guard let dataStorePublisher = self.dataStorePublisher as? DataStorePublisher else {
-                    self.log.error("Data store publisher not initalized")
-                    return
-                }
-                switch completion {
-                case .failure(let dataStoreError):
-                    dataStorePublisher.send(dataStoreError: dataStoreError)
-                case .finished:
-                    dataStorePublisher.sendFinished()
-                }
+            setupStorageSink()
+        }
+    }
 
-            }, receiveValue: { event in
-                guard let dataStorePublisher = self.dataStorePublisher as? DataStorePublisher else {
-                    self.log.error("Data store publisher not initalized")
-                    return
-                }
-                if case .mutationEvent(let mutationEvent) = event {
-                    dataStorePublisher.send(input: mutationEvent)
-                }
-            })
+    @available(iOS 13.0, *)
+    private func setupStorageSink() {
+        storageEngineSink = storageEngine.publisher.sink(receiveCompletion: onReceiveCompletion(completed:),
+                                                         receiveValue: onRecieveValue(receiveValue:))
+    }
+
+    @available(iOS 13.0, *)
+    private func onReceiveCompletion(completed: Subscribers.Completion<DataStoreError>) {
+        guard let dataStorePublisher = self.dataStorePublisher as? DataStorePublisher else {
+            log.error("Data store publisher not initalized")
+            return
+        }
+        switch completed {
+        case .failure(let dataStoreError):
+            dataStorePublisher.send(dataStoreError: dataStoreError)
+        case .finished:
+            dataStorePublisher.sendFinished()
+        }
+    }
+
+    @available(iOS 13.0, *)
+    private func onRecieveValue(receiveValue: StorageEngineEvent) {
+        guard let dataStorePublisher = self.dataStorePublisher as? DataStorePublisher else {
+            log.error("Data store publisher not initalized")
+            return
+        }
+
+        if case .mutationEvent(let mutationEvent) = receiveValue {
+            dataStorePublisher.send(input: mutationEvent)
         }
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -24,8 +24,8 @@ final class StorageEngine: StorageEngineBehavior {
     @available(iOS 13.0, *)
     var cancellable: AnyCancellable? {
         get {
-            if let iCancellable = iCancellable {
-                return (iCancellable as! AnyCancellable) //swiftlint:disable:this force_cast
+            if let iCancellable = iCancellable as? AnyCancellable {
+                return iCancellable
             }
             return nil
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineBehavior.swift
@@ -7,8 +7,17 @@
 
 import Amplify
 import Foundation
+import Combine
+
+enum StorageEngineEvent {
+    case started
+    case mutationEvent(MutationEvent)
+}
 
 protocol StorageEngineBehavior: class, ModelStorageBehavior {
+
+    @available(iOS 13.0, *)
+    var publisher: AnyPublisher<StorageEngineEvent, DataStoreError> { get }
 
     /// Tells the StorageEngine to begin syncing, if sync is enabled
     func startSync()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStorePublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStorePublisher.swift
@@ -23,4 +23,12 @@ struct DataStorePublisher: DataStoreSubscribeBehavior {
     func send(input: MutationEvent) {
         subject.send(input)
     }
+
+    func send(dataStoreError: DataStoreError) {
+        subject.send(completion: .failure(dataStoreError))
+    }
+
+    func sendFinished() {
+        subject.send(completion: .finished)
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -166,11 +166,10 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
                 self.remoteSyncTopicPublisher.send(completion: .failure(error))
             }
             if case .finished = completionMode {
-                self.log.error("reconciliationQueue was finished.  This is unexpected")
-                let unexpectedFinish = DataStoreError.unknown("ReconcilationQueue finished unexpectedly",
-                                                              "Restart the sync queue",
-                                                              nil)
-                self.remoteSyncTopicPublisher.send(completion: .failure(unexpectedFinish))
+                let unexpectedFinishError = DataStoreError.unknown("ReconcilationQueue sent .finished message",
+                                                                   AmplifyErrorMessages.shouldNotHappenReportBugToAWS(),
+                                                                   nil)
+                self.remoteSyncTopicPublisher.send(completion: .failure(unexpectedFinishError))
             }
         }, receiveValue: { event in
             switch event {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -11,6 +11,7 @@ import Foundation
 
 @available(iOS 13.0, *)
 class RemoteSyncEngine: RemoteSyncEngineBehavior {
+
     private weak var storageAdapter: StorageEngineAdapter?
 
     // Assigned at `start`
@@ -24,37 +25,56 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     private let mutationEventPublisher: MutationEventPublisher
     private let outgoingMutationQueue: OutgoingMutationQueueBehavior
 
+    private var reconciliationQueueCancellable: AnyCancellable?
+
+    private let remoteSyncTopicPublisher: PassthroughSubject<RemoteSyncEngineEvent, DataStoreError>
+    var publisher: AnyPublisher<RemoteSyncEngineEvent, DataStoreError> {
+        return remoteSyncTopicPublisher.eraseToAnyPublisher()
+    }
+
     /// Synchronizes startup operations
     let syncQueue: OperationQueue
 
     // Assigned at `setUpCloudSubscriptions`
     var reconciliationQueue: IncomingEventReconciliationQueue?
+    var reconciliationQueueFactory: IncomingEventReconciliationQueueFactory
 
     /// Initializes the CloudSyncEngine with the specified storageAdapter as the provider for persistence of
     /// MutationEvents, sync metadata, and conflict resolution metadata. Immediately initializes the incoming mutation
     /// queue so it can begin accepting incoming mutations from DataStore.
-    convenience init(storageAdapter: StorageEngineAdapter) throws {
+    convenience init(storageAdapter: StorageEngineAdapter,
+                     outgoingMutationQueue: OutgoingMutationQueueBehavior? = nil,
+                     initialSyncOrchestratorFactory: InitialSyncOrchestratorFactory? = nil,
+                     reconciliationQueueFactory: IncomingEventReconciliationQueueFactory? = nil) throws {
         let mutationDatabaseAdapter = try AWSMutationDatabaseAdapter(storageAdapter: storageAdapter)
         let awsMutationEventPublisher = AWSMutationEventPublisher(eventSource: mutationDatabaseAdapter)
-        let outgoingMutationQueue = OutgoingMutationQueue()
-        let initialSyncOrchestratorFactory = AWSInitialSyncOrchestrator.init(api:reconciliationQueue:storageAdapter:)
+        let outgoingMutationQueue = outgoingMutationQueue ?? OutgoingMutationQueue()
+        let reconciliationQueueFactory = reconciliationQueueFactory ??
+            AWSIncomingEventReconciliationQueue.init(modelTypes:api:storageAdapter:)
+        let initialSyncOrchestratorFactory = initialSyncOrchestratorFactory ??
+            AWSInitialSyncOrchestrator.init(api:reconciliationQueue:storageAdapter:)
+
         self.init(storageAdapter: storageAdapter,
                   outgoingMutationQueue: outgoingMutationQueue,
                   mutationEventIngester: mutationDatabaseAdapter,
                   mutationEventPublisher: awsMutationEventPublisher,
-                  initialSyncOrchestratorFactory: initialSyncOrchestratorFactory)
+                  initialSyncOrchestratorFactory: initialSyncOrchestratorFactory,
+                  reconciliationQueueFactory: reconciliationQueueFactory)
     }
 
     init(storageAdapter: StorageEngineAdapter,
          outgoingMutationQueue: OutgoingMutationQueueBehavior,
          mutationEventIngester: MutationEventIngester,
          mutationEventPublisher: MutationEventPublisher,
-         initialSyncOrchestratorFactory: @escaping InitialSyncOrchestratorFactory) {
+         initialSyncOrchestratorFactory: @escaping InitialSyncOrchestratorFactory,
+         reconciliationQueueFactory: @escaping IncomingEventReconciliationQueueFactory) {
         self.storageAdapter = storageAdapter
         self.mutationEventIngester = mutationEventIngester
         self.mutationEventPublisher = mutationEventPublisher
         self.outgoingMutationQueue = outgoingMutationQueue
         self.initialSyncOrchestratorFactory = initialSyncOrchestratorFactory
+        self.reconciliationQueueFactory = reconciliationQueueFactory
+        self.remoteSyncTopicPublisher = PassthroughSubject<RemoteSyncEngineEvent, DataStoreError>()
 
         self.syncQueue = OperationQueue()
         syncQueue.name = "com.amazonaws.Amplify.\(AWSDataStorePlugin.self).CloudSyncEngine"
@@ -66,10 +86,11 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         self.api = api
 
         guard let storageAdapter = storageAdapter else {
-            // TODO: Error handling
             log.error(error: DataStoreError.nilStorageAdapter())
+            remoteSyncTopicPublisher.send(completion: .failure(DataStoreError.nilStorageAdapter()))
             return
         }
+        remoteSyncTopicPublisher.send(.storageAdapterAvailable)
 
         let pauseSubscriptionsOp = CancelAwareBlockOperation {
             self.pauseSubscriptions()
@@ -103,6 +124,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         let updateStateOp = CancelAwareBlockOperation {
             Amplify.Hub.dispatch(to: .dataStore,
                                  payload: HubPayload(eventName: HubPayload.EventName.DataStore.syncStarted))
+            self.remoteSyncTopicPublisher.send(.syncStarted)
         }
         updateStateOp.addDependency(startMutationQueueOp)
 
@@ -131,15 +153,36 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     private func pauseMutations() {
         log.debug(#function)
         outgoingMutationQueue.pauseSyncingToCloud()
+        remoteSyncTopicPublisher.send(.mutationsPaused)
     }
 
     private func setUpCloudSubscriptions(api: APICategoryGraphQLBehavior,
                                          storageAdapter: StorageEngineAdapter) {
         log.debug(#function)
         let syncableModelTypes = ModelRegistry.models.filter { $0.schema.isSyncable }
-        reconciliationQueue = AWSIncomingEventReconciliationQueue(modelTypes: syncableModelTypes,
-                                                                  api: api,
-                                                                  storageAdapter: storageAdapter)
+        reconciliationQueue = reconciliationQueueFactory(syncableModelTypes, api, storageAdapter)
+        reconciliationQueueCancellable = reconciliationQueue?.publisher.sink(receiveCompletion: { completionMode in
+            if case .failure(let error) = completionMode {
+                self.remoteSyncTopicPublisher.send(completion: .failure(error))
+            }
+            if case .finished = completionMode {
+                self.log.error("reconciliationQueue was finished.  This is unexpected")
+                let unexpectedFinish = DataStoreError.unknown("ReconcilationQueue finished unexpectedly",
+                                                              "Restart the sync queue",
+                                                              nil)
+                self.remoteSyncTopicPublisher.send(completion: .failure(unexpectedFinish))
+            }
+        }, receiveValue: { event in
+            switch event {
+            case .started:
+                self.remoteSyncTopicPublisher.send(.subscriptionsActivated)
+            case .paused:
+                self.remoteSyncTopicPublisher.send(.subscriptionsPaused)
+            case .mutationEvent(let mutationEvent):
+                self.remoteSyncTopicPublisher.send(.mutationEvent(mutationEvent))
+            }
+        })
+        remoteSyncTopicPublisher.send(.subscriptionsInitialized)
     }
 
     private func performInitialQueries() {
@@ -155,20 +198,20 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
 
         initialSyncOrchestrator.sync { result in
             if case .failure(let dataStoreError) = result {
-                // TODO: Error handling
                 self.log.error(dataStoreError.errorDescription)
                 self.log.error(dataStoreError.recoverySuggestion)
                 if let underlyingError = dataStoreError.underlyingError {
                     self.log.error("\(underlyingError)")
                 }
+                self.remoteSyncTopicPublisher.send(completion: .failure(dataStoreError))
             } else {
                 self.log.info("Successfully finished sync")
+                self.remoteSyncTopicPublisher.send(.performedInitialSync)
             }
             semaphore.signal()
         }
 
         semaphore.wait()
-
         self.initialSyncOrchestrator = nil
     }
 
@@ -181,6 +224,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
                                     mutationEventPublisher: MutationEventPublisher) {
         log.debug(#function)
         outgoingMutationQueue.startSyncingToCloud(api: api, mutationEventPublisher: mutationEventPublisher)
+        remoteSyncTopicPublisher.send(.mutationQueueStarted)
     }
 
     func reset(onComplete: () -> Void) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
@@ -8,6 +8,18 @@
 import Amplify
 import Combine
 
+enum RemoteSyncEngineEvent {
+    case storageAdapterAvailable
+    case subscriptionsPaused
+    case mutationsPaused
+    case subscriptionsInitialized
+    case performedInitialSync
+    case subscriptionsActivated
+    case mutationQueueStarted
+    case syncStarted
+    case mutationEvent(MutationEvent)
+}
+
 /// Behavior to sync mutation events to the remote API, and to subscribe to mutations from the remote API
 protocol RemoteSyncEngineBehavior: class {
 
@@ -28,4 +40,6 @@ protocol RemoteSyncEngineBehavior: class {
     @available(iOS 13.0, *)
     func submit(_ mutationEvent: MutationEvent) -> Future<MutationEvent, DataStoreError>
 
+    @available(iOS 13.0, *)
+    var publisher: AnyPublisher<RemoteSyncEngineEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -10,14 +10,32 @@ import AWSPluginsCore
 import Combine
 import Foundation
 
+//Used for testing:
+@available(iOS 13.0, *)
+typealias IncomingEventReconciliationQueueFactory =
+    ([Model.Type], APICategoryGraphQLBehavior, StorageEngineAdapter) -> IncomingEventReconciliationQueue
+
 @available(iOS 13.0, *)
 final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue {
+
+    static let factory: IncomingEventReconciliationQueueFactory = { modelTypes, api, storageAdapter in
+        AWSIncomingEventReconciliationQueue(modelTypes: modelTypes, api: api, storageAdapter: storageAdapter)
+    }
+
+    private let reconciliationQueueTopic: PassthroughSubject<IncomingEventReconciliationQueueEvent, DataStoreError>
+    private var reconciliationQueueTopicCancellable = [String: AnyCancellable]()
+    var publisher: AnyPublisher<IncomingEventReconciliationQueueEvent, DataStoreError> {
+        return reconciliationQueueTopic.eraseToAnyPublisher()
+    }
 
     private var reconciliationQueues = [String: ModelReconciliationQueue]()
 
     init(modelTypes: [Model.Type],
          api: APICategoryGraphQLBehavior,
          storageAdapter: StorageEngineAdapter) {
+
+        self.reconciliationQueueTopic = PassthroughSubject<IncomingEventReconciliationQueueEvent, DataStoreError>()
+
         for modelType in modelTypes {
             let modelName = modelType.modelName
             let queue = AWSModelReconciliationQueue(modelType: modelType,
@@ -29,15 +47,31 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
                 continue
             }
             reconciliationQueues[modelName] = queue
+
+            let cancellable = queue.publisher.sink(receiveCompletion: { completed in
+                switch completed {
+                case .failure(let error):
+                    self.reconciliationQueueTopic.send(completion: .failure(error))
+                case .finished:
+                    self.reconciliationQueueTopic.send(completion: .finished)
+                }
+            }, receiveValue: { mutationEvent in
+                if case .mutationEvent(let event) = mutationEvent {
+                    self.reconciliationQueueTopic.send(.mutationEvent(event))
+                }
+            })
+            reconciliationQueueTopicCancellable[modelName] = cancellable
         }
     }
 
     func start() {
         reconciliationQueues.values.forEach { $0.start() }
+        reconciliationQueueTopic.send(.started)
     }
 
     func pause() {
         reconciliationQueues.values.forEach { $0.pause() }
+        reconciliationQueueTopic.send(.paused)
     }
 
     func offer(_ remoteModel: MutationSync<AnyModel>) {
@@ -48,7 +82,6 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
 
         queue.enqueue(remoteModel)
     }
-
 }
 
 @available(iOS 13.0, *)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
@@ -7,6 +7,13 @@
 
 import Amplify
 import AWSPluginsCore
+import Combine
+
+enum IncomingEventReconciliationQueueEvent {
+    case started
+    case paused
+    case mutationEvent(MutationEvent)
+}
 
 /// A queue that reconciles all incoming events for a model: responses from locally-sourced mutations, and subscription
 /// events for create, update, and delete events initiated by remote systems. In addition to pausing and resuming
@@ -17,4 +24,5 @@ protocol IncomingEventReconciliationQueue: class {
     func start()
     func pause()
     func offer(_ remoteModel: MutationSync<AnyModel>)
+    var publisher: AnyPublisher<IncomingEventReconciliationQueueEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -37,7 +37,6 @@ import Foundation
 ///   event.
 @available(iOS 13.0, *)
 final class AWSModelReconciliationQueue: ModelReconciliationQueue {
-
     /// Exposes a publisher for incoming subscription events
     private let incomingSubscriptionEvents: IncomingSubscriptionEventPublisher
 
@@ -56,6 +55,12 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
 
     private var incomingEventsSink: AnyCancellable?
 
+    private let modelReconciliationQueueSubject: PassthroughSubject<ModelReconciliationQueueEvent, DataStoreError>
+    var publisher: AnyPublisher<ModelReconciliationQueueEvent, DataStoreError> {
+        return modelReconciliationQueueSubject.eraseToAnyPublisher()
+    }
+
+    private var cancellableSubscription: AnyCancellable?
     init(modelType: Model.Type,
          storageAdapter: StorageEngineAdapter?,
          api: APICategoryGraphQLBehavior,
@@ -64,6 +69,8 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
         self.modelName = modelType.modelName
 
         self.storageAdapter = storageAdapter
+
+        self.modelReconciliationQueueSubject = PassthroughSubject<ModelReconciliationQueueEvent, DataStoreError>()
 
         self.reconcileAndSaveQueue = OperationQueue()
         reconcileAndSaveQueue.name = "com.amazonaws.DataStore.\(modelType).reconcile"
@@ -90,17 +97,18 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
                         self?.enqueue(remoteModel)
                     })
             })
-
     }
 
     /// (Re)starts the incoming subscription event queue.
     func start() {
         incomingSubscriptionEventQueue.isSuspended = false
+        modelReconciliationQueueSubject.send(.started)
     }
 
     /// Pauses only the incoming subscription event queue. Events submitted via `enqueue` will still be processed
     func pause() {
         incomingSubscriptionEventQueue.isSuspended = true
+        modelReconciliationQueueSubject.send(.paused)
     }
 
     /// Cancels all outstanding operations on both the incoming subscription event queue and the reconcile queue, and
@@ -115,6 +123,11 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
     func enqueue(_ remoteModel: MutationSync<AnyModel>) {
         let reconcileOp = ReconcileAndLocalSaveOperation(remoteModel: remoteModel,
                                                          storageAdapter: storageAdapter)
+        cancellableSubscription = reconcileOp.publisher.sink(receiveCompletion: { error in
+            self.modelReconciliationQueueSubject.send(completion: error)
+        }, receiveValue: { mutationEvent in
+            self.modelReconciliationQueueSubject.send(.mutationEvent(mutationEvent))
+        })
         reconcileAndSaveQueue.addOperation(reconcileOp)
     }
 
@@ -122,11 +135,12 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
         switch completion {
         case .finished:
             log.info("receivedCompletion: finished")
+            modelReconciliationQueueSubject.send(completion: .finished)
         case .failure(let dataStoreError):
             log.error("receiveCompletion: error: \(dataStoreError)")
+            modelReconciliationQueueSubject.send(completion: .failure(dataStoreError))
         }
     }
-
 }
 
 @available(iOS 13.0, *)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
@@ -7,6 +7,13 @@
 
 import Amplify
 import AWSPluginsCore
+import Combine
+
+enum ModelReconciliationQueueEvent {
+    case started
+    case paused
+    case mutationEvent(MutationEvent)
+}
 
 @available(iOS 13.0, *)
 protocol ModelReconciliationQueue {
@@ -14,5 +21,5 @@ protocol ModelReconciliationQueue {
     func pause()
     func cancel()
     func enqueue(_ remoteModel: MutationSync<AnyModel>)
-
+    var publisher: AnyPublisher<ModelReconciliationQueueEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -14,7 +14,6 @@ import AWSPluginsCore
 /// a later version than the stored model), then write the new data to the store.
 @available(iOS 13.0, *)
 class ReconcileAndLocalSaveOperation: AsynchronousOperation {
-
     /// Disambiguation for the version of the model incoming from the remote API
     typealias RemoteModel = MutationSync<AnyModel>
 
@@ -34,6 +33,11 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
     private let remoteModel: RemoteModel
     private var stateMachineSink: AnyCancellable?
 
+    public var publisher: AnyPublisher<MutationEvent, DataStoreError> {
+        return mutationEventPublisher.eraseToAnyPublisher()
+    }
+    private let mutationEventPublisher: PassthroughSubject<MutationEvent, DataStoreError>
+
     init(remoteModel: RemoteModel,
          storageAdapter: StorageEngineAdapter?,
          stateMachine: StateMachine<State, Action>? = nil) {
@@ -41,6 +45,8 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
         self.storageAdapter = storageAdapter
         self.stateMachine = stateMachine ?? StateMachine(initialState: .waiting,
                                                          resolver: Resolver.resolve(currentState:action:))
+        self.mutationEventPublisher = PassthroughSubject<MutationEvent, DataStoreError>()
+
         super.init()
 
         self.stateMachineSink = self.stateMachine
@@ -290,8 +296,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
                                  data: mutationEvent)
         Amplify.Hub.dispatch(to: .dataStore, payload: payload)
 
-        // TODO: Add publisher
-        // publisher?.send(input: mutationEvent)
+        mutationEventPublisher.send(mutationEvent)
 
         stateMachine.notify(action: .notified)
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -33,10 +33,10 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
     private let remoteModel: RemoteModel
     private var stateMachineSink: AnyCancellable?
 
+    private let mutationEventPublisher: PassthroughSubject<MutationEvent, DataStoreError>
     public var publisher: AnyPublisher<MutationEvent, DataStoreError> {
         return mutationEventPublisher.eraseToAnyPublisher()
     }
-    private let mutationEventPublisher: PassthroughSubject<MutationEvent, DataStoreError>
 
     init(remoteModel: RemoteModel,
          storageAdapter: StorageEngineAdapter?,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
@@ -37,7 +37,8 @@ class LocalSubscriptionTests: XCTestCase {
                                              outgoingMutationQueue: outgoingMutationQueue,
                                              mutationEventIngester: mutationDatabaseAdapter,
                                              mutationEventPublisher: awsMutationEventPublisher,
-                                             initialSyncOrchestratorFactory: NoOpInitialSyncOrchestrator.factory)
+                                             initialSyncOrchestratorFactory: NoOpInitialSyncOrchestrator.factory,
+                                             reconciliationQueueFactory: MockAWSIncomingEventReconciliationQueue.factory)
 
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
                                           syncEngine: syncEngine)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteEngineSyncTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteEngineSyncTests.swift
@@ -1,0 +1,189 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import SQLite
+
+import Combine
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+class RemoteEngineSyncTests: XCTestCase {
+    var apiPlugin: MockAPICategoryPlugin!
+
+    var amplifyConfig: AmplifyConfiguration!
+    var storageAdapter: StorageEngineAdapter!
+    var remoteSyncEngine: RemoteSyncEngine!
+    let defaultAsyncWaitTimeout = 2.0
+
+    override func setUp() {
+        super.setUp()
+        MockAWSInitialSyncOrchestrator.reset()
+        storageAdapter = MockSQLiteStorageEngineAdapter()
+        let mockOutgoingMutationQueue = MockOutgoingMutationQueue()
+        do {
+            remoteSyncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
+                                                    outgoingMutationQueue: mockOutgoingMutationQueue,
+                                                    initialSyncOrchestratorFactory: MockAWSInitialSyncOrchestrator.factory,
+                                                    reconciliationQueueFactory: MockAWSIncomingEventReconciliationQueue.factory)
+        } catch {
+            XCTFail("Failed to setup")
+            return
+        }
+    }
+
+    func testErrorOnNilStorageAdapter() throws {
+        let failureOnStorageAdapter = expectation(description: "Expect receiveCompletion on storageAdapterFailure")
+
+        storageAdapter = nil
+        let cancellable = remoteSyncEngine
+            .publisher
+            .sink(receiveCompletion: { _ in
+                failureOnStorageAdapter.fulfill()
+        }, receiveValue: { _ in
+            XCTFail("We should not expect the sync engine not to continue")
+        })
+
+        remoteSyncEngine.start()
+
+        wait(for: [failureOnStorageAdapter], timeout: defaultAsyncWaitTimeout)
+    }
+
+    func testFailureOnInitialSync() throws {
+        let storageAdapterAvailable = expectation(description: "storageAdapterAvailable")
+        let mutationsPaused = expectation(description: "mutationsPaused")
+        let subscriptionsInitialized = expectation(description: "subscriptionsInitialized")
+        let failureOnInitialSync = expectation(description: "failureOnInitialSync")
+
+        let cancellable = remoteSyncEngine
+            .publisher
+            .sink(receiveCompletion: { _ in
+                failureOnInitialSync.fulfill()
+            }, receiveValue: { event in
+                switch event {
+                case .storageAdapterAvailable:
+                    storageAdapterAvailable.fulfill()
+                case .subscriptionsPaused:
+                    XCTFail("subscriptions have not been created, so they are not paused")
+                case .mutationsPaused:
+                    mutationsPaused.fulfill()
+                case .subscriptionsInitialized:
+                    subscriptionsInitialized.fulfill()
+                case .performedInitialSync:
+                    XCTFail("performedInitialQueries should not be successful")
+                default:
+                    XCTFail("Unexpected case gets hit")
+                }
+            })
+        MockAWSInitialSyncOrchestrator.setResponseOnSync(result:
+            .failure(DataStoreError.internalOperation("forceError", "none", nil)))
+
+        remoteSyncEngine.start()
+
+        wait(for: [storageAdapterAvailable,
+                   mutationsPaused, subscriptionsInitialized,
+                   failureOnInitialSync], timeout: defaultAsyncWaitTimeout)
+    }
+
+    func testRemoteSyncEngineHappyPath() throws {
+        let storageAdapterAvailable = expectation(description: "storageAdapterAvailable")
+        let mutationsPaused = expectation(description: "mutationsPaused")
+        let subscriptionsInitialized = expectation(description: "subscriptionsInitialized")
+        let performedInitialSync = expectation(description: "performedInitialSync")
+        let subscriptionActivation = expectation(description: "failureOnSubscriptionActivation")
+        let mutationQueueStarted = expectation(description: "mutationQueueStarted")
+        let syncStarted = expectation(description: "sync started")
+
+        let cancellable = remoteSyncEngine
+            .publisher
+            .sink(receiveCompletion: { _ in
+                XCTFail("Completion should never happen")
+            }, receiveValue: { event in
+                switch event {
+                case .storageAdapterAvailable:
+                    storageAdapterAvailable.fulfill()
+                case .subscriptionsPaused:
+                    XCTFail("subscriptions have not been created, so they are not paused")
+                case .mutationsPaused:
+                    mutationsPaused.fulfill()
+                case .subscriptionsInitialized:
+                    subscriptionsInitialized.fulfill()
+                case .performedInitialSync:
+                    performedInitialSync.fulfill()
+                case .subscriptionsActivated:
+                    subscriptionActivation.fulfill()
+                case .mutationQueueStarted:
+                    mutationQueueStarted.fulfill()
+                case .syncStarted:
+                    syncStarted.fulfill()
+                default:
+                    XCTFail("unexpected call")
+                }
+            })
+
+        remoteSyncEngine.start()
+
+        wait(for: [storageAdapterAvailable,
+                   mutationsPaused,
+                   subscriptionsInitialized,
+                   performedInitialSync,
+                   subscriptionActivation,
+                   mutationQueueStarted,
+                   syncStarted], timeout: defaultAsyncWaitTimeout)
+    }
+
+    func testFailsAfterSyncStarted() throws {
+        let storageAdapterAvailable = expectation(description: "storageAdapterAvailable")
+        let mutationsPaused = expectation(description: "mutationsPaused")
+        let subscriptionsInitialized = expectation(description: "subscriptionsInitialized")
+        let performedInitialSync = expectation(description: "performedInitialSync")
+        let subscriptionActivation = expectation(description: "failureOnSubscriptionActivation")
+        let mutationQueueStarted = expectation(description: "mutationQueueStarted")
+        let syncStarted = expectation(description: "sync started")
+        let failureOnEventReconciliationQueue = expectation(description: "reconciliationQueue failed")
+
+        let cancellable = remoteSyncEngine
+            .publisher
+            .sink(receiveCompletion: { _ in
+                failureOnEventReconciliationQueue.fulfill()
+            }, receiveValue: { event in
+                switch event {
+                case .storageAdapterAvailable:
+                    storageAdapterAvailable.fulfill()
+                case .subscriptionsPaused:
+                    XCTFail("subscriptions have not been created, so they are not paused")
+                case .mutationsPaused:
+                    mutationsPaused.fulfill()
+                case .subscriptionsInitialized:
+                    subscriptionsInitialized.fulfill()
+                case .performedInitialSync:
+                    performedInitialSync.fulfill()
+                case .subscriptionsActivated:
+                    subscriptionActivation.fulfill()
+                case .mutationQueueStarted:
+                    mutationQueueStarted.fulfill()
+                case .syncStarted:
+                    syncStarted.fulfill()
+                    MockAWSIncomingEventReconciliationQueue.mockSendCompletion(completion: .failure(DataStoreError.unknown("", "", nil)))
+                default:
+                    XCTFail("unexpected call")
+                }
+            })
+
+        remoteSyncEngine.start()
+
+        wait(for: [storageAdapterAvailable,
+                   mutationsPaused,
+                   subscriptionsInitialized,
+                   performedInitialSync,
+                   subscriptionActivation,
+                   mutationQueueStarted,
+                   syncStarted,
+                   failureOnEventReconciliationQueue], timeout: defaultAsyncWaitTimeout)
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteEngineSyncTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteEngineSyncTests.swift
@@ -41,7 +41,7 @@ class RemoteEngineSyncTests: XCTestCase {
         let failureOnStorageAdapter = expectation(description: "Expect receiveCompletion on storageAdapterFailure")
 
         storageAdapter = nil
-        let cancellable = remoteSyncEngine
+        let remoteSyncEngineSink = remoteSyncEngine
             .publisher
             .sink(receiveCompletion: { _ in
                 failureOnStorageAdapter.fulfill()
@@ -60,7 +60,7 @@ class RemoteEngineSyncTests: XCTestCase {
         let subscriptionsInitialized = expectation(description: "subscriptionsInitialized")
         let failureOnInitialSync = expectation(description: "failureOnInitialSync")
 
-        let cancellable = remoteSyncEngine
+        let remoteSyncEngineSink = remoteSyncEngine
             .publisher
             .sink(receiveCompletion: { _ in
                 failureOnInitialSync.fulfill()
@@ -99,7 +99,7 @@ class RemoteEngineSyncTests: XCTestCase {
         let mutationQueueStarted = expectation(description: "mutationQueueStarted")
         let syncStarted = expectation(description: "sync started")
 
-        let cancellable = remoteSyncEngine
+        let remoteSyncEngineSink = remoteSyncEngine
             .publisher
             .sink(receiveCompletion: { _ in
                 XCTFail("Completion should never happen")
@@ -147,7 +147,7 @@ class RemoteEngineSyncTests: XCTestCase {
         let syncStarted = expectation(description: "sync started")
         let failureOnEventReconciliationQueue = expectation(description: "reconciliationQueue failed")
 
-        let cancellable = remoteSyncEngine
+        let remoteSyncEngineSink = remoteSyncEngine
             .publisher
             .sink(receiveCompletion: { _ in
                 failureOnEventReconciliationQueue.fulfill()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -7,6 +7,7 @@
 
 import XCTest
 import AWSPluginsCore
+import Combine
 
 @testable import Amplify
 @testable import AWSDataStoreCategoryPlugin
@@ -153,6 +154,14 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
 }
 
 class MockStorageEngineBehavior: StorageEngineBehavior {
+    func setupPublisher() {
+
+    }
+
+    var publisher: AnyPublisher<StorageEngineEvent, DataStoreError> {
+        return PassthroughSubject<StorageEngineEvent, DataStoreError>().eraseToAnyPublisher()
+    }
+
 
     func startSync() {
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSInitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSInitialSyncOrchestrator.swift
@@ -1,0 +1,44 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AWSPluginsCore
+import Combine
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+class MockAWSInitialSyncOrchestrator: InitialSyncOrchestrator {
+    static let factory: InitialSyncOrchestratorFactory = { api, reconciliationQueue, storageAdapter in
+        MockAWSInitialSyncOrchestrator(api: api, reconciliationQueue: reconciliationQueue, storageAdapter: storageAdapter)
+    }
+
+    typealias SyncOperationResult = Result<Void, DataStoreError>
+    typealias SyncOperationResultHandler = (SyncOperationResult) -> Void
+
+    private static var instance: MockAWSInitialSyncOrchestrator?
+    private static var mockedResponse: SyncOperationResult?
+
+    init(api: APICategoryGraphQLBehavior?,
+         reconciliationQueue: IncomingEventReconciliationQueue?,
+         storageAdapter: StorageEngineAdapter?) {
+    }
+
+    static func reset() {
+        mockedResponse = nil
+    }
+
+    static func setResponseOnSync(result: SyncOperationResult) {
+        mockedResponse = result
+    }
+
+    func sync(completion: @escaping SyncOperationResultHandler) {
+        let response = MockAWSInitialSyncOrchestrator.mockedResponse ?? .successfulVoid
+        completion(response)
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockOutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockOutgoingMutationQueue.swift
@@ -1,0 +1,24 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import AWSPluginsCore
+import Combine
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+class MockOutgoingMutationQueue: OutgoingMutationQueueBehavior {
+    func pauseSyncingToCloud() {
+        //no-op
+    }
+
+    func startSyncingToCloud(api: APICategoryGraphQLBehavior, mutationEventPublisher: MutationEventPublisher) {
+        //no-op
+    }
+
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
@@ -7,10 +7,12 @@
 
 import Amplify
 import AWSPluginsCore
+import Combine
 @testable import AmplifyTestCommon
 @testable import AWSDataStoreCategoryPlugin
 
 final class MockReconciliationQueue: MessageReporter, IncomingEventReconciliationQueue {
+
     func start() {
         notify()
     }
@@ -23,4 +25,7 @@ final class MockReconciliationQueue: MessageReporter, IncomingEventReconciliatio
         notify("offer(_:) remoteModel: \(remoteModel)")
     }
 
+    var publisher: AnyPublisher<IncomingEventReconciliationQueueEvent, DataStoreError> {
+        return PassthroughSubject<IncomingEventReconciliationQueueEvent, DataStoreError>().eraseToAnyPublisher()
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -72,7 +72,8 @@ class SyncEngineTestBase: XCTestCase {
                                           outgoingMutationQueue: mutationQueue,
                                           mutationEventIngester: mutationDatabaseAdapter,
                                           mutationEventPublisher: awsMutationEventPublisher,
-                                          initialSyncOrchestratorFactory: initialSyncOrchestratorFactory)
+                                          initialSyncOrchestratorFactory: initialSyncOrchestratorFactory,
+                                          reconciliationQueueFactory: AWSIncomingEventReconciliationQueue.factory)
 
         let storageEngine = StorageEngine(storageAdapter: storageAdapter,
                                           syncEngine: syncEngine)

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -54,9 +54,13 @@
 		6B4693E923A5645F006BE2C5 /* MutationRetryNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4693E823A5645F006BE2C5 /* MutationRetryNotifier.swift */; };
 		6B4E3DF42397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E3DF32397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift */; };
 		6B4E3DF62397327E00AD962B /* MockStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E3DF52397327E00AD962B /* MockStateMachine.swift */; };
+		6B64027923E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B64027823E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift */; };
+		6B64027B23E38B9900001FD7 /* MockOutgoingMutationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */; };
 		6B91DEBF238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */; };
 		6BC4FDA823A899180027D20C /* RequestRetryablePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC4FDA723A899180027D20C /* RequestRetryablePolicyTests.swift */; };
 		6BC4FDAA23A899680027D20C /* MockRequestRetryablePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */; };
+		6BDC224023E21A4E007C8410 /* RemoteEngineSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC223F23E21A4E007C8410 /* RemoteEngineSyncTests.swift */; };
+		6BDC224223E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */; };
 		9BDB42C47E6D7F9A113AE558 /* Pods_HostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C6448DF009E54C11ACE4515 /* Pods_HostApp.framework */; };
 		B9E010E4239167E000DCE8C8 /* TestModelRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E010E3239167E000DCE8C8 /* TestModelRegistration.swift */; };
 		B9FAA140238C600A009414B4 /* ListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FAA13F238C600A009414B4 /* ListTests.swift */; };
@@ -209,9 +213,13 @@
 		6B4693E823A5645F006BE2C5 /* MutationRetryNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationRetryNotifier.swift; sourceTree = "<group>"; };
 		6B4E3DF32397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingMutationQueueTestsWithMockStateMachine.swift; sourceTree = "<group>"; };
 		6B4E3DF52397327E00AD962B /* MockStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStateMachine.swift; sourceTree = "<group>"; };
+		6B64027823E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSIncomingEventReconciliationQueue.swift; sourceTree = "<group>"; };
+		6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOutgoingMutationQueue.swift; sourceTree = "<group>"; };
 		6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcileAndLocalSaveOperationTests.swift; sourceTree = "<group>"; };
 		6BC4FDA723A899180027D20C /* RequestRetryablePolicyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestRetryablePolicyTests.swift; sourceTree = "<group>"; };
 		6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRequestRetryablePolicy.swift; sourceTree = "<group>"; };
+		6BDC223F23E21A4E007C8410 /* RemoteEngineSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteEngineSyncTests.swift; sourceTree = "<group>"; };
+		6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSInitialSyncOrchestrator.swift; sourceTree = "<group>"; };
 		6CF3060AE9E227813325029F /* Pods_AWSDataStoreCategoryPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSDataStoreCategoryPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		715777CA4DC182BC96B88C19 /* Pods_HostApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74F804F52DF34831C8F60044 /* Pods-HostApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp.debug.xcconfig"; path = "Target Support Files/Pods-HostApp/Pods-HostApp.debug.xcconfig"; sourceTree = "<group>"; };
@@ -595,6 +603,7 @@
 				2149E5F1238869CF00873955 /* APICategoryDependencyTests.swift */,
 				FA0427CF2396CDD800D25AB0 /* DataStoreHubTests.swift */,
 				2149E5F3238869CF00873955 /* LocalSubscriptionTests.swift */,
+				6BDC223F23E21A4E007C8410 /* RemoteEngineSyncTests.swift */,
 				6BC4FDA723A899180027D20C /* RequestRetryablePolicyTests.swift */,
 				FAE01F9923997BD900B468DA /* InitialSync */,
 				FAE01F9823997B7600B468DA /* MutationQueue */,
@@ -716,12 +725,15 @@
 		FAF101A62398807100D5ECC9 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				B9E010E3239167E000DCE8C8 /* TestModelRegistration.swift */,
 				FAF5287A2399814F0053A717 /* MockReconciliationQueue.swift */,
 				6B4E3DF52397327E00AD962B /* MockStateMachine.swift */,
 				FA8D932E239EA5C4001ED336 /* NoOpInitialSyncOrchestrator.swift */,
 				FA23345B23955CEF009BEFE9 /* NoOpMutationQueue.swift */,
-				B9E010E3239167E000DCE8C8 /* TestModelRegistration.swift */,
 				6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */,
+				6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */,
+				6B64027823E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift */,
+				6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -1233,6 +1245,7 @@
 				6BC4FDAA23A899680027D20C /* MockRequestRetryablePolicy.swift in Sources */,
 				2149E5FD238869CF00873955 /* OutgoingMutationQueueTests.swift in Sources */,
 				6B91DEBF238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift in Sources */,
+				6BDC224223E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift in Sources */,
 				6B01B71D23A4615900AD0E97 /* SyncMutationToCloudOperationTests.swift in Sources */,
 				FA3841ED23889D8F0070AD5B /* StateMachineTests.swift in Sources */,
 				B9E010E4239167E000DCE8C8 /* TestModelRegistration.swift in Sources */,
@@ -1244,8 +1257,10 @@
 				FA0427CC2396C7E400D25AB0 /* InitialSyncOrchestratorTests.swift in Sources */,
 				FAE4146F239AA71300CE94C2 /* EquatableExtensions.swift in Sources */,
 				2149E5FF238869CF00873955 /* SQLStatementTests.swift in Sources */,
+				6B64027923E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift in Sources */,
 				FA0427D02396CDD800D25AB0 /* DataStoreHubTests.swift in Sources */,
 				FA3B3F09238F39DE002EFDB3 /* AWSMutationEventIngesterTests.swift in Sources */,
+				6BDC224023E21A4E007C8410 /* RemoteEngineSyncTests.swift in Sources */,
 				FA4B8E962391C609009FC10F /* XCTest+AmplifyExtensions.swift in Sources */,
 				FAE4146C239AA40600CE94C2 /* MockSQLiteStorageEngineAdapter.swift in Sources */,
 				FA8D932F239EA5C4001ED336 /* NoOpInitialSyncOrchestrator.swift in Sources */,
@@ -1266,6 +1281,7 @@
 				2149E5FE238869CF00873955 /* RemoteSyncAPIInvocationTests.swift in Sources */,
 				B9FAA142238C6082009414B4 /* BaseDataStoreTests.swift in Sources */,
 				FA4A955B239AD3F4008E876E /* Foundation+TestExtensions.swift in Sources */,
+				6B64027B23E38B9900001FD7 /* MockOutgoingMutationQueue.swift in Sources */,
 				2149E600238869CF00873955 /* SQLiteStorageEngineAdapterTests.swift in Sources */,
 				6B4E3DF62397327E00AD962B /* MockStateMachine.swift in Sources */,
 				FAF5287B2399814F0053A717 /* MockReconciliationQueue.swift in Sources */,

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - AWSAuthCore (2.12.2):
-    - AWSCore (= 2.12.2)
-  - AWSCognitoIdentityProvider (2.12.2):
+  - AWSAuthCore (2.12.6):
+    - AWSCore (= 2.12.6)
+  - AWSCognitoIdentityProvider (2.12.6):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.12.2)
+    - AWSCore (= 2.12.6)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.12.2)
-  - AWSMobileClient (2.12.2):
-    - AWSAuthCore (= 2.12.2)
-    - AWSCognitoIdentityProvider (= 2.12.2)
+  - AWSCore (2.12.6)
+  - AWSMobileClient (2.12.6):
+    - AWSAuthCore (= 2.12.6)
+    - AWSCognitoIdentityProvider (= 2.12.6)
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
@@ -16,7 +16,7 @@ PODS:
   - SwiftLint (0.37.0)
 
 DEPENDENCIES:
-  - AWSMobileClient (~> 2.12.2)
+  - AWSMobileClient (~> 2.12.6)
   - CwlCatchException (from `https://github.com/mattgallagher/CwlCatchException.git`, tag `1.2.0`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `1.2.0`)
   - SwiftFormat/CLI
@@ -49,16 +49,16 @@ CHECKOUT OPTIONS:
     :tag: 1.2.0
 
 SPEC CHECKSUMS:
-  AWSAuthCore: a67ecbfe4dfdb8470f85c31f9594476d5ed988a5
-  AWSCognitoIdentityProvider: 5ac7b7af7877e7a47585c08d6a0ef58bcd6314b6
+  AWSAuthCore: d981abe8fb987a1caa7ac6c76c428de12387dcf4
+  AWSCognitoIdentityProvider: 9502438e528185a2c61b97baf66e2fd2ac6833f3
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: bdc0933bcb1aca4a9af3352a9e6ec75b339faf71
-  AWSMobileClient: ed6cd3c6ecb935406bf392df81fc5b40f4660845
+  AWSCore: 48bb8d477d8137377e86b2ade9eb34a761f42df5
+  AWSMobileClient: d752ed540a75d45516c8d5b2054b3f3b6b9e7e65
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 5faa819600268dfaa5c19f1359730883db151678
   SwiftLint: c078a14d7d7ade75e5507795d185e3da41d844d2
 
-PODFILE CHECKSUM: 83398094b5ea63b7c181cccf545ad368c69588ec
+PODFILE CHECKSUM: 052b557087c76e48d6c09130d48e484e6b7ed701
 
 COCOAPODS: 1.8.4

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -1,14 +1,14 @@
 PODS:
-  - AWSAuthCore (2.12.2):
-    - AWSCore (= 2.12.2)
-  - AWSCognitoIdentityProvider (2.12.2):
+  - AWSAuthCore (2.12.6):
+    - AWSCore (= 2.12.6)
+  - AWSCognitoIdentityProvider (2.12.6):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.12.2)
+    - AWSCore (= 2.12.6)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.12.2)
-  - AWSMobileClient (2.12.2):
-    - AWSAuthCore (= 2.12.2)
-    - AWSCognitoIdentityProvider (= 2.12.2)
+  - AWSCore (2.12.6)
+  - AWSMobileClient (2.12.6):
+    - AWSAuthCore (= 2.12.6)
+    - AWSCognitoIdentityProvider (= 2.12.6)
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
@@ -16,7 +16,7 @@ PODS:
   - SwiftLint (0.37.0)
 
 DEPENDENCIES:
-  - AWSMobileClient (~> 2.12.2)
+  - AWSMobileClient (~> 2.12.6)
   - CwlCatchException (from `https://github.com/mattgallagher/CwlCatchException.git`, tag `1.2.0`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `1.2.0`)
   - SwiftFormat/CLI
@@ -49,16 +49,16 @@ CHECKOUT OPTIONS:
     :tag: 1.2.0
 
 SPEC CHECKSUMS:
-  AWSAuthCore: a67ecbfe4dfdb8470f85c31f9594476d5ed988a5
-  AWSCognitoIdentityProvider: 5ac7b7af7877e7a47585c08d6a0ef58bcd6314b6
+  AWSAuthCore: d981abe8fb987a1caa7ac6c76c428de12387dcf4
+  AWSCognitoIdentityProvider: 9502438e528185a2c61b97baf66e2fd2ac6833f3
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: bdc0933bcb1aca4a9af3352a9e6ec75b339faf71
-  AWSMobileClient: ed6cd3c6ecb935406bf392df81fc5b40f4660845
+  AWSCore: 48bb8d477d8137377e86b2ade9eb34a761f42df5
+  AWSMobileClient: d752ed540a75d45516c8d5b2054b3f3b6b9e7e65
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 5faa819600268dfaa5c19f1359730883db151678
   SwiftLint: c078a14d7d7ade75e5507795d185e3da41d844d2
 
-PODFILE CHECKSUM: 83398094b5ea63b7c181cccf545ad368c69588ec
+PODFILE CHECKSUM: 052b557087c76e48d6c09130d48e484e6b7ed701
 
 COCOAPODS: 1.8.4

--- a/Pods/Target Support Files/Pods-Amplify/Pods-Amplify-acknowledgements.markdown
+++ b/Pods/Target Support Files/Pods-Amplify/Pods-Amplify-acknowledgements.markdown
@@ -30,7 +30,7 @@ SOFTWARE.
 
 The MIT License (MIT)
 
-Copyright (c) 2020 Realm Inc.
+Copyright (c) 2015 Realm Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Pods/Target Support Files/Pods-Amplify/Pods-Amplify-acknowledgements.plist
+++ b/Pods/Target Support Files/Pods-Amplify/Pods-Amplify-acknowledgements.plist
@@ -47,7 +47,7 @@ SOFTWARE.
 			<key>FooterText</key>
 			<string>The MIT License (MIT)
 
-Copyright (c) 2020 Realm Inc.
+Copyright (c) 2015 Realm Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
* Compiled hello world app against this code to see mutation events being printed out w/:
```
        noteSubscription = Amplify.DataStore.publisher(for: Note.self)
            .sink(receiveCompletion: {completion in
                if case .failure(let err) =  completion { 
                    print("issue with subscription: \(err)")
                }
            }, receiveValue: { value in
                print("Subscription got this value: \(value)")
        })
```
* Ran unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
