### PR TITLE
Add Rest API with UserPool Integration tests

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		210922522359634C00CEC295 /* AnalyticsPropertyValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2109224B2359634C00CEC295 /* AnalyticsPropertyValue.swift */; };
 		210922572359693900CEC295 /* BasicAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210922562359693800CEC295 /* BasicAnalyticsEvent.swift */; };
 		2109225A23596BCD00CEC295 /* AnalyticsCategoryClientBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2109225923596BCD00CEC295 /* AnalyticsCategoryClientBehavior.swift */; };
+		210A8C2623F4999E003F4D91 /* AWSMobileClientError+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210A8C2523F4999E003F4D91 /* AWSMobileClientError+Extension.swift */; };
 		210DBC122332B3C0009B9E51 /* StorageDownloadFileOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210DBC112332B3C0009B9E51 /* StorageDownloadFileOperation.swift */; };
 		210DBC142332B3C6009B9E51 /* StorageGetURLOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210DBC132332B3C6009B9E51 /* StorageGetURLOperation.swift */; };
 		210DBC162332B3CB009B9E51 /* StorageDownloadDataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210DBC152332B3CB009B9E51 /* StorageDownloadDataOperation.swift */; };
@@ -525,6 +526,7 @@
 		2109224B2359634C00CEC295 /* AnalyticsPropertyValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsPropertyValue.swift; sourceTree = "<group>"; };
 		210922562359693800CEC295 /* BasicAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicAnalyticsEvent.swift; sourceTree = "<group>"; };
 		2109225923596BCD00CEC295 /* AnalyticsCategoryClientBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsCategoryClientBehavior.swift; sourceTree = "<group>"; };
+		210A8C2523F4999E003F4D91 /* AWSMobileClientError+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSMobileClientError+Extension.swift"; sourceTree = "<group>"; };
 		210DBC112332B3C0009B9E51 /* StorageDownloadFileOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageDownloadFileOperation.swift; sourceTree = "<group>"; };
 		210DBC132332B3C6009B9E51 /* StorageGetURLOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageGetURLOperation.swift; sourceTree = "<group>"; };
 		210DBC152332B3CB009B9E51 /* StorageDownloadDataOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageDownloadDataOperation.swift; sourceTree = "<group>"; };
@@ -1960,6 +1962,7 @@
 				21420A81237222A700FA140C /* AWSAuthServiceBehavior.swift */,
 				21420A8C237222A900FA140C /* AWSMobileClientAdapter.swift */,
 				21420A8E237222A900FA140C /* AWSMobileClientBehavior.swift */,
+				210A8C2523F4999E003F4D91 /* AWSMobileClientError+Extension.swift */,
 				21420A7A237222A700FA140C /* Configuration */,
 				21420A83237222A800FA140C /* Provider */,
 			);
@@ -3433,6 +3436,7 @@
 				2129BE4423948951006363A1 /* MutationSyncMetadata.swift in Sources */,
 				2129BE1E2394806B006363A1 /* QueryPredicate+GraphQL.swift in Sources */,
 				21420A8F237222A900FA140C /* AWSIAMConfiguration.swift in Sources */,
+				210A8C2623F4999E003F4D91 /* AWSMobileClientError+Extension.swift in Sources */,
 				2129BE1723948065006363A1 /* GraphQLRequest+Model.swift in Sources */,
 				219A888523EB897700BBC5F2 /* GraphQLRequest+AnyModelWithSync.swift in Sources */,
 				219A88F123F3379900BBC5F2 /* GraphQLDocumentInput.swift in Sources */,

--- a/Amplify/Categories/Storage/Error/AuthError.swift
+++ b/Amplify/Categories/Storage/Error/AuthError.swift
@@ -9,6 +9,8 @@ import Foundation
 
 public enum AuthError {
     case identity(ErrorName, ErrorDescription, RecoverySuggestion, Error? = nil)
+    case notAuthenticated(ErrorDescription, RecoverySuggestion, Error? = nil)
+    case notAuthorized(ErrorDescription, RecoverySuggestion, Error? = nil)
     case unknown(ErrorDescription, Error? = nil)
 }
 
@@ -17,6 +19,10 @@ extension AuthError: AmplifyError {
         switch self {
         case .identity(let errorName, let errorDescription, _, _):
             return "Could not get IdentityId due to [\(errorName)] with message: \(errorDescription)"
+        case .notAuthenticated(let errorDescription, _, _):
+            return "The user is not authenticated: \(errorDescription)"
+        case .notAuthorized(let errorDescription, _, _):
+            return "The user is not authorized: \(errorDescription)"
         case .unknown(let errorDescription, _):
             return "Unexpected error occurred with message: \(errorDescription)"
         }
@@ -26,6 +32,10 @@ extension AuthError: AmplifyError {
         switch self {
         case .identity(_, _, let recoverySuggestion, _):
             return recoverySuggestion
+        case .notAuthenticated(_, let recoverySuggestion, _):
+            return recoverySuggestion
+        case .notAuthorized(_, let recoverySuggestion, _):
+            return recoverySuggestion
         case .unknown:
             return AmplifyErrorMessages.shouldNotHappenReportBugToAWS()
         }
@@ -34,6 +44,8 @@ extension AuthError: AmplifyError {
     public var underlyingError: Error? {
         switch self {
         case .identity(_, _, _, let underlyingError),
+             .notAuthenticated(_, _, let underlyingError),
+             .notAuthorized(_, _, let underlyingError),
              .unknown(_, let underlyingError):
             return underlyingError
         }

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		13066F229854831AA628ECEC /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithUserPoolIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DD6386039136045F18D44AC /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithUserPoolIntegrationTests.framework */; };
 		2129BE3E239486D2006363A1 /* AnyModel+JSONInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2129BE3D239486D2006363A1 /* AnyModel+JSONInit.swift */; };
 		21409C4F2384BA7E000A53C9 /* APIOperationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21409C4E2384BA7E000A53C9 /* APIOperationResponse.swift */; };
 		21409C5E2384DE2C000A53C9 /* AWSAPIPlugin+GraphQLModelBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21409C5D2384DE2C000A53C9 /* AWSAPIPlugin+GraphQLModelBehavior.swift */; };
@@ -28,6 +29,12 @@
 		217856A423810B9400A30D19 /* AWSAPICategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B478F5FB2374DBF400C4F92B /* AWSAPICategoryPlugin.framework */; };
 		217856B72381F19400A30D19 /* AWSAPICategoryPluginEndpointType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217856B62381F19300A30D19 /* AWSAPICategoryPluginEndpointType.swift */; };
 		217856C22383339D00A30D19 /* GraphQLModelBasedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217856C12383339D00A30D19 /* GraphQLModelBasedTests.swift */; };
+		219A888F23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219A888E23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.swift */; };
+		219A889123ECF8A500BBC5F2 /* AWSAPICategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B478F5FB2374DBF400C4F92B /* AWSAPICategoryPlugin.framework */; };
+		219A88A223EE034F00BBC5F2 /* RESTWithUserPoolIntegrationTests-amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 219A889F23EE01A700BBC5F2 /* RESTWithUserPoolIntegrationTests-amplifyconfiguration.json */; };
+		219A88A323EE034F00BBC5F2 /* RESTWithUserPoolIntegrationTests-awsconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 219A889E23EE01A600BBC5F2 /* RESTWithUserPoolIntegrationTests-awsconfiguration.json */; };
+		219A88A523EE054000BBC5F2 /* RESTWithUserPoolIntegrationTests-credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = 219A88A423EE054000BBC5F2 /* RESTWithUserPoolIntegrationTests-credentials.json */; };
+		219A88A723EE05C200BBC5F2 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 219A88A623EE05C200BBC5F2 /* README.md */; };
 		21A3EFC623A946590095D8E6 /* GraphQLWithUserPoolIntegrationTests-credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = 21A3EFC523A946580095D8E6 /* GraphQLWithUserPoolIntegrationTests-credentials.json */; };
 		21D7A0DF237B54D90057D00D /* AWSGraphQLOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A08D237B54D90057D00D /* AWSGraphQLOperation.swift */; };
 		21D7A0E0237B54D90057D00D /* AWSGraphQLSubscriptionOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A08E237B54D90057D00D /* AWSGraphQLSubscriptionOperation.swift */; };
@@ -231,6 +238,27 @@
 			remoteGlobalIDString = B478F6BB2374E0B500C4F92B;
 			remoteInfo = HostApp;
 		};
+		219A889223ECF8A500BBC5F2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B478F5F22374DBF400C4F92B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B478F5FA2374DBF400C4F92B;
+			remoteInfo = AWSAPICategoryPlugin;
+		};
+		219A889723ECF8AD00BBC5F2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B478F5F22374DBF400C4F92B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B478F6BB2374E0B500C4F92B;
+			remoteInfo = HostApp;
+		};
+		219A889923ECF91500BBC5F2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B478F5F22374DBF400C4F92B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 21409C6623850A9E000A53C9;
+			remoteInfo = AWSAPICategoryPluginTestCommon;
+		};
 		B478F64F2374DCE700C4F92B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B478F5F22374DBF400C4F92B /* Project object */;
@@ -282,6 +310,13 @@
 		217856A323810B9400A30D19 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		217856B62381F19300A30D19 /* AWSAPICategoryPluginEndpointType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAPICategoryPluginEndpointType.swift; sourceTree = "<group>"; };
 		217856C12383339D00A30D19 /* GraphQLModelBasedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLModelBasedTests.swift; sourceTree = "<group>"; };
+		219A888C23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RESTWithUserPoolIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		219A888E23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTWithUserPoolIntegrationTests.swift; sourceTree = "<group>"; };
+		219A889023ECF8A500BBC5F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		219A889E23EE01A600BBC5F2 /* RESTWithUserPoolIntegrationTests-awsconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "RESTWithUserPoolIntegrationTests-awsconfiguration.json"; sourceTree = "<group>"; };
+		219A889F23EE01A700BBC5F2 /* RESTWithUserPoolIntegrationTests-amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "RESTWithUserPoolIntegrationTests-amplifyconfiguration.json"; sourceTree = "<group>"; };
+		219A88A423EE054000BBC5F2 /* RESTWithUserPoolIntegrationTests-credentials.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "RESTWithUserPoolIntegrationTests-credentials.json"; sourceTree = "<group>"; };
+		219A88A623EE05C200BBC5F2 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		21A3EFC523A946580095D8E6 /* GraphQLWithUserPoolIntegrationTests-credentials.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GraphQLWithUserPoolIntegrationTests-credentials.json"; sourceTree = "<group>"; };
 		21D7A08D237B54D90057D00D /* AWSGraphQLOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSGraphQLOperation.swift; sourceTree = "<group>"; };
 		21D7A08E237B54D90057D00D /* AWSGraphQLSubscriptionOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSGraphQLSubscriptionOperation.swift; sourceTree = "<group>"; };
@@ -365,6 +400,7 @@
 		4AD63A179BA4F1B0F5A8239C /* Pods-HostApp-GraphQLWithIAMIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-GraphQLWithIAMIntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-HostApp-GraphQLWithIAMIntegrationTests/Pods-HostApp-GraphQLWithIAMIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		4B77D41B0A0DF50AD28492CC /* Pods-HostApp-AWSAPICategoryPluginTestCommon.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAPICategoryPluginTestCommon.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAPICategoryPluginTestCommon/Pods-HostApp-AWSAPICategoryPluginTestCommon.release.xcconfig"; sourceTree = "<group>"; };
 		4C9D31E2654F5401D8DFA1EC /* Pods-AWSAPICategoryHostAppWithIAM.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAPICategoryHostAppWithIAM.debug.xcconfig"; path = "Target Support Files/Pods-AWSAPICategoryHostAppWithIAM/Pods-AWSAPICategoryHostAppWithIAM.debug.xcconfig"; sourceTree = "<group>"; };
+		53890B4754019D7240753060 /* Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		590266D0504CD8553B44EAE8 /* Pods-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.release.xcconfig"; path = "Target Support Files/Pods-AWSAPICategoryPlugin-AWSAPICategoryPluginTests/Pods-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.release.xcconfig"; sourceTree = "<group>"; };
 		60CE874DF1685CDF2AF2A276 /* Pods-HostApp-AWSAPICategoryPluginIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAPICategoryPluginIntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAPICategoryPluginIntegrationTests/Pods-HostApp-AWSAPICategoryPluginIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		63092F520F1DF39786D6A000 /* Pods-HostApp-AWSAPICategoryPluginFunctionalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAPICategoryPluginFunctionalTests.debug.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAPICategoryPluginFunctionalTests/Pods-HostApp-AWSAPICategoryPluginFunctionalTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -376,12 +412,14 @@
 		6B33896D23AABEEE00561E5B /* MockReachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockReachability.swift; sourceTree = "<group>"; };
 		6B33896F23AABF1800561E5B /* NetworkReachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachability.swift; sourceTree = "<group>"; };
 		6B33897123AAD94800561E5B /* AWSAPIPlugin+Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSAPIPlugin+Reachability.swift"; sourceTree = "<group>"; };
+		6DD6386039136045F18D44AC /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithUserPoolIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithUserPoolIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74EDB7008F5342ED4B38C9CA /* Pods_HostApp_AWSAPICategoryPluginIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSAPICategoryPluginIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		77792DD821FC754D857FC63C /* Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithIAMIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithIAMIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithIAMIntegrationTests/Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithIAMIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		7866FCFB5807C2D20219CEBE /* Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithIAMIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithIAMIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithIAMIntegrationTests/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithIAMIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		7A255F655FE0AE43E68F2972 /* Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests/Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7CAC5A88BE3D8AAD8B926A28 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_AWSAPICategoryPluginFunctionalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSAPICategoryPluginTestCommon_AWSAPICategoryPluginFunctionalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		881AB4B98B48235DEC7754C2 /* Pods_AWSAPICategoryPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSAPICategoryPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		89457627057299D7047B9C40 /* Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		8F6C44235DD3AB8DB1C1F976 /* Pods-AWSAPICategoryPlugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAPICategoryPlugin.release.xcconfig"; path = "Target Support Files/Pods-AWSAPICategoryPlugin/Pods-AWSAPICategoryPlugin.release.xcconfig"; sourceTree = "<group>"; };
 		90C677B6FAC9BCDE6385E3C4 /* Pods-HostApp-AWSAPICategoryPluginGraphQLAPIKeyIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAPICategoryPluginGraphQLAPIKeyIntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAPICategoryPluginGraphQLAPIKeyIntegrationTests/Pods-HostApp-AWSAPICategoryPluginGraphQLAPIKeyIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		930DD773E0FB4047393CA2AD /* Pods_HostApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -489,6 +527,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		219A888923ECF8A400BBC5F2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				219A889123ECF8A500BBC5F2 /* AWSAPICategoryPlugin.framework in Frameworks */,
+				13066F229854831AA628ECEC /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithUserPoolIntegrationTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B478F5F82374DBF400C4F92B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -533,6 +580,7 @@
 				A5B78DFE063D156DDD5BC634 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_GraphQLWithIAMIntegrationTests.framework */,
 				B1AB915DA3F982E560CD6E47 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_GraphQLWithUserPoolIntegrationTests.framework */,
 				2D57635393A9898E665C00A1 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithIAMIntegrationTests.framework */,
+				6DD6386039136045F18D44AC /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithUserPoolIntegrationTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -612,6 +660,7 @@
 			isa = PBXGroup;
 			children = (
 				217856812380C90600A30D19 /* RESTWithIAMIntegrationTests */,
+				219A888D23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests */,
 			);
 			path = REST;
 			sourceTree = "<group>";
@@ -662,6 +711,19 @@
 				21598CE723A0036600529F29 /* README.md */,
 			);
 			path = GraphQLWithUserPoolIntegrationTests;
+			sourceTree = "<group>";
+		};
+		219A888D23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests */ = {
+			isa = PBXGroup;
+			children = (
+				219A889023ECF8A500BBC5F2 /* Info.plist */,
+				219A88A623EE05C200BBC5F2 /* README.md */,
+				219A889F23EE01A700BBC5F2 /* RESTWithUserPoolIntegrationTests-amplifyconfiguration.json */,
+				219A889E23EE01A600BBC5F2 /* RESTWithUserPoolIntegrationTests-awsconfiguration.json */,
+				219A88A423EE054000BBC5F2 /* RESTWithUserPoolIntegrationTests-credentials.json */,
+				219A888E23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.swift */,
+			);
+			path = RESTWithUserPoolIntegrationTests;
 			sourceTree = "<group>";
 		};
 		21D7A08B237B54D90057D00D /* AWSAPICategoryPlugin */ = {
@@ -916,6 +978,7 @@
 				217856802380C90600A30D19 /* RESTWithIAMIntegrationTests.xctest */,
 				2178569F23810B9400A30D19 /* GraphQLWithUserPoolIntegrationTests.xctest */,
 				21409C6723850A9E000A53C9 /* AWSAPICategoryPluginTestCommon.framework */,
+				219A888C23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1089,6 +1152,8 @@
 				226F79D02FF47C0A8AE75467 /* Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests.release.xcconfig */,
 				3296753A87B70EB2A31690FF /* Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithIAMIntegrationTests.debug.xcconfig */,
 				7866FCFB5807C2D20219CEBE /* Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithIAMIntegrationTests.release.xcconfig */,
+				89457627057299D7047B9C40 /* Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests.debug.xcconfig */,
+				53890B4754019D7240753060 /* Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -1237,6 +1302,30 @@
 			productReference = 2178569F23810B9400A30D19 /* GraphQLWithUserPoolIntegrationTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		219A888B23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 219A889623ECF8A500BBC5F2 /* Build configuration list for PBXNativeTarget "RESTWithUserPoolIntegrationTests" */;
+			buildPhases = (
+				6BE74C5110F87DCF4A249DA5 /* [CP] Check Pods Manifest.lock */,
+				219A888823ECF8A400BBC5F2 /* Sources */,
+				219A889C23ECF99400BBC5F2 /* SwiftFormat */,
+				219A889D23ECF9B200BBC5F2 /* SwiftLint */,
+				219A888923ECF8A400BBC5F2 /* Frameworks */,
+				219A888A23ECF8A400BBC5F2 /* Resources */,
+				BCA8E4CCFF8385874F3DEDB6 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				219A889A23ECF91500BBC5F2 /* PBXTargetDependency */,
+				219A889323ECF8A500BBC5F2 /* PBXTargetDependency */,
+				219A889823ECF8AD00BBC5F2 /* PBXTargetDependency */,
+			);
+			name = RESTWithUserPoolIntegrationTests;
+			productName = RESTWithUserPoolIntegrationTests;
+			productReference = 219A888C23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		B478F5FA2374DBF400C4F92B /* AWSAPICategoryPlugin */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B478F6032374DBF400C4F92B /* Build configuration list for PBXNativeTarget "AWSAPICategoryPlugin" */;
@@ -1305,7 +1394,7 @@
 		B478F5F22374DBF400C4F92B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1120;
+				LastSwiftUpdateCheck = 1130;
 				LastUpgradeCheck = 1110;
 				ORGANIZATIONNAME = "Amazon Web Services";
 				TargetAttributes = {
@@ -1327,6 +1416,10 @@
 					};
 					2178569E23810B9400A30D19 = {
 						CreatedOnToolsVersion = 11.2.1;
+						TestTargetID = B478F6BB2374E0B500C4F92B;
+					};
+					219A888B23ECF8A400BBC5F2 = {
+						CreatedOnToolsVersion = 11.3.1;
 						TestTargetID = B478F6BB2374E0B500C4F92B;
 					};
 					B478F5FA2374DBF400C4F92B = {
@@ -1360,6 +1453,7 @@
 				2178565F2380C60400A30D19 /* GraphQLWithIAMIntegrationTests */,
 				2178569E23810B9400A30D19 /* GraphQLWithUserPoolIntegrationTests */,
 				2178567F2380C90600A30D19 /* RESTWithIAMIntegrationTests */,
+				219A888B23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests */,
 				B478F6BB2374E0B500C4F92B /* HostApp */,
 			);
 		};
@@ -1401,6 +1495,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		219A888A23ECF8A400BBC5F2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				219A88A723EE05C200BBC5F2 /* README.md in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B478F5F92374DBF400C4F92B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1419,12 +1521,15 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				219A88A223EE034F00BBC5F2 /* RESTWithUserPoolIntegrationTests-amplifyconfiguration.json in Resources */,
+				219A88A323EE034F00BBC5F2 /* RESTWithUserPoolIntegrationTests-awsconfiguration.json in Resources */,
 				21598CE3239FF54E00529F29 /* RESTWithIAMIntegrationTests-amplifyconfiguration.json in Resources */,
 				B478F6E32374E0CF00C4F92B /* Main.storyboard in Resources */,
 				B478F6E12374E0CF00C4F92B /* Assets.xcassets in Resources */,
 				21598CF223A0164A00529F29 /* GraphQLWithUserPoolIntegrationTests-amplifyconfiguration.json in Resources */,
 				21F40A2B23A0423C0074678E /* GraphQLSyncBasedTests-amplifyconfiguration.json in Resources */,
 				21F40A2E23A0707E0074678E /* GraphQLModelBasedTests-amplifyconfiguration.json in Resources */,
+				219A88A523EE054000BBC5F2 /* RESTWithUserPoolIntegrationTests-credentials.json in Resources */,
 				21A3EFC623A946590095D8E6 /* GraphQLWithUserPoolIntegrationTests-credentials.json in Resources */,
 				21598CF323A0164A00529F29 /* GraphQLWithUserPoolIntegrationTests-awsconfiguration.json in Resources */,
 				B478F6E22374E0CF00C4F92B /* LaunchScreen.storyboard in Resources */,
@@ -1500,6 +1605,42 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		219A889C23ECF99400BBC5F2 /* SwiftFormat */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftFormat;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/SwiftFormat/CommandLineTool/swiftformat\" \"${SRCROOT}/$(PRODUCT_NAME)\"\n";
+		};
+		219A889D23ECF9B200BBC5F2 /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" --path \"${SRCROOT}/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests\" --config \"${SRCROOT}/../../.swiftlint.yml\"\n\n";
 		};
 		234EB4E426CA2A5E328F1760 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1598,6 +1739,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithIAMIntegrationTests/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithIAMIntegrationTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6BE74C5110F87DCF4A249DA5 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		744BE58EBECD1B4E20209489 /* [CP] Check Pods Manifest.lock */ = {
@@ -1749,6 +1912,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/SwiftFormat/CommandLineTool/swiftformat\" \"${SRCROOT}/$(PRODUCT_NAME)\"\n";
+		};
+		BCA8E4CCFF8385874F3DEDB6 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		F300E778EA070DB2E7D769A0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2012,6 +2192,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		219A888823ECF8A400BBC5F2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				219A888F23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B478F5F72374DBF400C4F92B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2199,6 +2387,21 @@
 			isa = PBXTargetDependency;
 			target = B478F6BB2374E0B500C4F92B /* HostApp */;
 			targetProxy = 217856AA23810B9F00A30D19 /* PBXContainerItemProxy */;
+		};
+		219A889323ECF8A500BBC5F2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B478F5FA2374DBF400C4F92B /* AWSAPICategoryPlugin */;
+			targetProxy = 219A889223ECF8A500BBC5F2 /* PBXContainerItemProxy */;
+		};
+		219A889823ECF8AD00BBC5F2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B478F6BB2374E0B500C4F92B /* HostApp */;
+			targetProxy = 219A889723ECF8AD00BBC5F2 /* PBXContainerItemProxy */;
+		};
+		219A889A23ECF91500BBC5F2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 21409C6623850A9E000A53C9 /* AWSAPICategoryPluginTestCommon */;
+			targetProxy = 219A889923ECF91500BBC5F2 /* PBXContainerItemProxy */;
 		};
 		B478F6502374DCE700C4F92B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2443,6 +2646,48 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.GraphQLWithUserPoolIntegrationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HostApp.app/HostApp";
+			};
+			name = Release;
+		};
+		219A889423ECF8A500BBC5F2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 89457627057299D7047B9C40 /* Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = W3DRXD72QU;
+				INFOPLIST_FILE = AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.RESTWithUserPoolIntegrationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HostApp.app/HostApp";
+			};
+			name = Debug;
+		};
+		219A889523ECF8A500BBC5F2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 53890B4754019D7240753060 /* Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithUserPoolIntegrationTests.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = W3DRXD72QU;
+				INFOPLIST_FILE = AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.RESTWithUserPoolIntegrationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2742,6 +2987,15 @@
 			buildConfigurations = (
 				217856A823810B9400A30D19 /* Debug */,
 				217856A923810B9400A30D19 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		219A889623ECF8A500BBC5F2 /* Build configuration list for PBXNativeTarget "RESTWithUserPoolIntegrationTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				219A889423ECF8A500BBC5F2 /* Debug */,
+				219A889523ECF8A500BBC5F2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/RESTWithUserPoolIntegrationTests.xcscheme
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/RESTWithUserPoolIntegrationTests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "219A888B23ECF8A400BBC5F2"
+               BuildableName = "RESTWithUserPoolIntegrationTests.xctest"
+               BlueprintName = "RESTWithUserPoolIntegrationTests"
+               ReferencedContainer = "container:APICategoryPlugin.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/IAMURLRequestInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/IAMURLRequestInterceptor.swift
@@ -33,8 +33,9 @@ struct IAMURLRequestInterceptor: URLRequestInterceptor {
                                 forHTTPHeaderField: URLRequestConstants.Header.xAmzDate)
         mutableRequest.setValue(URLRequestConstants.ContentType.applicationJson,
                                 forHTTPHeaderField: URLRequestConstants.Header.contentType)
-        let serviceConfiguration = AmplifyAWSServiceConfiguration(region: region,
-                                                                  credentialsProvider: iamCredentialsProvider.getCredentialsProvider())
+        let serviceConfiguration = AmplifyAWSServiceConfiguration(
+            region: region,
+            credentialsProvider: iamCredentialsProvider.getCredentialsProvider())
         mutableRequest.setValue(serviceConfiguration.userAgent,
                                 forHTTPHeaderField: URLRequestConstants.Header.userAgent)
 

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/UserPoolRequestInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/UserPoolRequestInterceptor.swift
@@ -34,7 +34,7 @@ struct UserPoolURLRequestInterceptor: URLRequestInterceptor {
         let tokenResult = userPoolTokenProvider.getToken()
         guard case let .success(token) = tokenResult else {
             if case let .failure(error) = tokenResult {
-                throw APIError.operationError("Got error trying to get token", "", error)
+                throw APIError.operationError("Failed to retrieve Cognito UserPool token.", "", error)
             }
 
             return mutableRequest as URLRequest

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLOperation.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLOperation.swift
@@ -89,6 +89,10 @@ final public class AWSGraphQLOperation<R: Decodable>: GraphQLOperation<R> {
         let finalRequest = endpointConfig.interceptors.reduce(urlRequest) { (request, interceptor) -> URLRequest in
             do {
                 return try interceptor.intercept(request)
+            } catch let error as APIError {
+                dispatch(event: .failed(error))
+                cancel()
+                return request
             } catch {
                 dispatch(event: .failed(APIError.operationError("Failed to intercept request fully..",
                                                                 "Something wrong with the interceptor",

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSRESTOperation.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSRESTOperation.swift
@@ -100,6 +100,10 @@ RESTOperation {
         let finalRequest = endpointConfig.interceptors.reduce(urlRequest) { (request, interceptor) -> URLRequest in
             do {
                 return try interceptor.intercept(request)
+            } catch let error as APIError {
+                dispatch(event: .failed(error))
+                cancel()
+                return request
             } catch {
                 dispatch(event: .failed(APIError.operationError("Failed to intercept request fully.",
                                                                 "Something wrong with the interceptor",
@@ -107,6 +111,11 @@ RESTOperation {
                 cancel()
                 return request
             }
+        }
+
+        if isCancelled {
+            finish()
+            return
         }
 
         // Begin network task

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/Info.plist
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/README.md
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/README.md
@@ -1,0 +1,94 @@
+## REST API with Cognito User Pool Integration Tests
+
+The following steps show how to set up an API endpoint with APIGateway and Lambda source. The auth configured will be Cognito User Pool. This set up is used to run the tests in `RESTWithUserPoolIntegrationTests.swift`.
+
+### Set-up
+
+1. Initialize an amplify project. `amplify init`
+
+2. Create an API Gateway which proxies requests to an AWS Lambda with no authorization needed. `amplify add api`. 
+
+```perl
+? Please select from one of the below mentioned services: `REST`
+? Provide a friendly name for your resource to be used as a label for this category in the project: `restAPI`
+? Provide a path (e.g., /items) `/items`
+? Choose a Lambda source `Create a new Lambda function`
+? Provide a friendly name for your resource to be used as a label for this category in the project: `restwithuserpoolinte22de6072`
+? Provide the AWS Lambda function name: `restwithuserpoolinte22de6072`
+? Choose the function template that you want to use: `Serverless express function (Integration with Amazon API Gateway)`
+? Do you want to access other resources created in this project from your Lambda function? `No`
+? Do you want to edit the local lambda function now? `No`
+Succesfully added the Lambda function locally
+? Restrict API access `No`
+? Do you want to add another path? `No`
+Successfully added resource apid7c040db locally
+```
+
+3. Create Cognito User Pool which accepts email as the username. Run `amplify add auth`
+```perl
+Using service: Cognito, provided by: awscloudformation
+ 
+ The current configured provider is Amazon Cognito. 
+ 
+ Do you want to use the default authentication and security configuration? Default configuration
+ Warning: you will not be able to edit these selections. 
+ How do you want users to be able to sign in? Email
+ Do you want to configure advanced settings? No, I am done.
+Successfully added resource restwithuserpoolintea05fdd00 locally
+```
+
+4. Provision the resources. Run `amplify push` to provision the API Gateway, Lambda, and the Cognito User Pool.
+
+5. Replace `RESTWithUserPoolIntegrationTests-amplifyconfiguration.json` and `RESTWithPoolIntegrationTests-awsconfiguration.json` with the generated `amplifyconfiguration.json` and `awsconfiguration.json` . 
+
+6. In `RESTWithUserPoolIntegrationTests-amplifyconfiguration.json`. update `authorizationType` to `AMAZON_COGNITO_USER_POOLS` like so
+```
+{
+    "UserAgent": "aws-amplify-cli/2.0",
+    "Version": "1.0",
+    "api": {
+        "plugins": {
+            "awsAPIPlugin": {
+                "apid7c040db": {
+                    "endpointType": "REST",
+                    "endpoint": "https://endpoint.execute-api.us-west-2.amazonaws.com/devo",
+                    "region": "us-west-2",
+                    "authorizationType": "AMAZON_COGNITO_USER_POOLS"
+                }
+            }
+        }
+    }
+}
+
+```
+
+7. Create a new user in the userpool. One method is to sign up the using `AWSMobileClient` and then open the User Pools console using `amplify console auth`. Select Users and groups, select the user, and click Confirm.
+
+8. Update `RESTWithUserPoolIntegrationTests-credentials.json` with a json object containing `user1` and `password` with the crendentials of the user that was created in the previous step 
+
+```json
+{
+    "user1": "<USER EMAIL>",
+    "password": "<PASSWORD>"
+}
+
+```
+
+9. Find your API name. Run `amplify console` to open the AWS Console. The latest deployment activty logs will indicate the API Gateway that is provisioned. There will be a Resource ID that looks like `<api name> (api)`. Navigate to API Gateway console, select your API. 
+
+10. Find your Cognito User Pool name by click on the Authentication tab in the AWS Console.
+
+10. Add Cognito User Pool as an authorization mechanism. Select Authorizers, click on "+ Create New Authorizer", 
+- type in a Name
+- select `Cognito` as the type
+- Select the Cognito UserPool
+- For Token Source, enter `Authorization`
+- Once completed, refresh the page.
+
+11. Enable requests to the API with the Cognito User Pool Authorizer as the authorization mechanism. 
+- Select Resources on the left, Under Resources, and each individual resource path, select `Any`. You will see a Test section, Method Request, Method Response, Integration Request, etc
+- Click on Method Request, under Settings, Authorization, click on edit. In the drop down, select the User Pool authorizer, then click on the check mark to save it.
+- Repeat this for each of the resource paths
+- Click on Actions, deploy API, and select the deployment stage, and click Deploy.
+
+12. Run the tests.

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/RESTWithUserPoolIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/RESTWithUserPoolIntegrationTests.swift
@@ -1,0 +1,117 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+import AWSAPICategoryPlugin
+import AWSMobileClient
+@testable import AmplifyTestCommon
+
+class RESTWithUserPoolIntegrationTests: XCTestCase {
+
+    static let amplifyConfiguration = "RESTWithUserPoolIntegrationTests-amplifyconfiguration"
+    static let awsconfiguration = "RESTWithUserPoolIntegrationTests-awsconfiguration"
+    static let credentials = "RESTWithUserPoolIntegrationTests-credentials"
+    static var user1: String!
+    static var password: String!
+
+    static override func setUp() {
+        do {
+
+            let credentials = try TestConfigHelper.retrieveCredentials(
+                forResource: RESTWithUserPoolIntegrationTests.credentials)
+
+            guard let user1 = credentials["user1"], let password = credentials["password"] else {
+                XCTFail("Missing credentials.json data")
+                return
+            }
+
+            RESTWithUserPoolIntegrationTests.user1 = user1
+            RESTWithUserPoolIntegrationTests.password = password
+
+            let awsConfiguration = try TestConfigHelper.retrieveAWSConfiguration(
+                forResource: RESTWithUserPoolIntegrationTests.awsconfiguration)
+            AWSInfo.configureDefaultAWSInfo(awsConfiguration)
+        } catch {
+            XCTFail("Error during setup: \(error)")
+        }
+    }
+
+    override func setUp() {
+        do {
+            AuthHelper.initializeMobileClient()
+
+            Amplify.reset()
+
+            try Amplify.add(plugin: AWSAPIPlugin())
+
+            let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(
+                forResource: RESTWithUserPoolIntegrationTests.amplifyConfiguration)
+            try Amplify.configure(amplifyConfig)
+        } catch {
+            XCTFail("Error during setup: \(error)")
+        }
+    }
+
+    override func tearDown() {
+        Amplify.reset()
+    }
+
+    func testGetAPISuccess() {
+        AuthHelper.signIn(username: RESTWithUserPoolIntegrationTests.user1,
+                          password: RESTWithUserPoolIntegrationTests.password)
+        let completeInvoked = expectation(description: "request completed")
+        let request = RESTRequest(path: "/items")
+        _ = Amplify.API.get(request: request) { event in
+            switch event {
+            case .completed(let data):
+                let result = String(decoding: data, as: UTF8.self)
+                print(result)
+                completeInvoked.fulfill()
+            case .failed(let error):
+                XCTFail("Unexpected .failed event: \(error)")
+            default:
+                XCTFail("Unexpected event: \(event)")
+            }
+        }
+
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+    }
+
+    func testGetAPIFailedWithNotAuthenticated() {
+        AuthHelper.signOut()
+        let failedInvoked = expectation(description: "request failed")
+        let request = RESTRequest(path: "/items")
+        _ = Amplify.API.get(request: request) { event in
+            switch event {
+            case .completed(let data):
+                XCTFail("Unexpected .complted event: \(data)")
+            case .failed(let error):
+                guard case let .operationError(_, _, underlyingError) = error else {
+                    XCTFail("Error should be operationError")
+                    return
+                }
+
+                guard let authError = underlyingError as? AuthError else {
+                    XCTFail("underlying error should be AuthError, but instead was \(underlyingError ?? "nil")")
+                    return
+                }
+
+                guard case .notAuthenticated = authError else {
+                    XCTFail("Error should be AuthError.notAuthenticated")
+                    return
+                }
+
+                failedInvoked.fulfill()
+            default:
+                XCTFail("Unexpected event: \(event)")
+            }
+        }
+
+        wait(for: [failedInvoked], timeout: TestCommonConstants.networkTimeout)
+    }
+}

--- a/AmplifyPlugins/API/Podfile
+++ b/AmplifyPlugins/API/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '11.0'
 use_frameworks!
 
-AWS_SDK_VERSION = "2.12.2"
+AWS_SDK_VERSION = "2.12.6"
 
 pod 'SwiftFormat/CLI'
 pod 'SwiftLint'
@@ -46,6 +46,10 @@ target "HostApp" do
     end
   
     target "RESTWithIAMIntegrationTests" do 
+      inherit! :complete
+    end
+
+    target "RESTWithUserPoolIntegrationTests" do 
       inherit! :complete
     end
   end

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSMobileClientError+Extension.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSMobileClientError+Extension.swift
@@ -1,0 +1,62 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import AWSMobileClient
+
+extension AWSMobileClientError {
+
+    /// Expose the underlying message, useful for populating Amplify errors in the default case when there isn't a
+    /// specific mapping from the enum case to an Amplify Error.
+    var message: String {
+        switch self {
+        case .aliasExists(let message),
+             .badRequest(let message),
+             .codeDeliveryFailure(let message),
+             .codeMismatch(let message),
+             .cognitoIdentityPoolNotConfigured(let message),
+             .deviceNotRemembered(let message),
+             .errorLoadingPage(let message),
+             .expiredCode(let message),
+             .expiredRefreshToken(let message),
+             .federationProviderExists(let message),
+             .groupExists(let message),
+             .guestAccessNotAllowed(let message),
+             .idTokenAndAcceessTokenNotIssued(let message),
+             .idTokenNotIssued(let message),
+             .identityIdUnavailable(let message),
+             .internalError(let message),
+             .invalidConfiguration(let message),
+             .invalidLambdaResponse(let message),
+             .invalidOAuthFlow(let message),
+             .invalidParameter(let message),
+             .invalidPassword(let message),
+             .invalidState(let message),
+             .invalidUserPoolConfiguration(let message),
+             .limitExceeded(let message),
+             .mfaMethodNotFound(let message),
+             .notAuthorized(let message),
+             .notSignedIn(let message),
+             .passwordResetRequired(let message),
+             .resourceNotFound(let message),
+             .scopeDoesNotExist(let message),
+             .securityFailed(let message),
+             .softwareTokenMFANotFound(let message),
+             .tooManyFailedAttempts(let message),
+             .tooManyRequests(let message),
+             .unableToSignIn(let message),
+             .unexpectedLambda(let message),
+             .unknown(let message),
+             .userCancelledSignIn(let message),
+             .userLambdaValidation(let message),
+             .userNotConfirmed(let message),
+             .userNotFound(let message),
+             .userPoolNotConfigured(let message),
+             .usernameExists(let message):
+            return message
+        }
+    }
+}


### PR DESCRIPTION
This adds integration tests around using APIGateway with Cognito User Pool token authentication. Updated some error handling logic to accurately bubble up the error for "User is not authenticated and tries to make a call against the API", so is reflected in the test.

Currently Amplify-CLI experience does not support creating REST API with cognito use pool authorizier, experience and feature request documented here: https://github.com/aws-amplify/amplify-cli/issues/3390

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
