### PR TITLE
Restart remote sync engine on errors emitted from API subscription

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
@@ -17,6 +17,7 @@ enum RemoteSyncEngineEvent {
     case subscriptionsActivated
     case mutationQueueStarted
     case syncStarted
+    case syncStopped
     case mutationEvent(MutationEvent)
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -15,13 +15,15 @@ import Combine
 final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPublisher {
 
     private let asyncEvents: IncomingAsyncSubscriptionEventPublisher
-    private let mapper: IncomingAsyncSubscriptionEventToAnyModelMapper
-
-    var publisher: AnyPublisher<MutationSync<AnyModel>, DataStoreError> {
-        mapper.publisher
+    private var mapper: IncomingAsyncSubscriptionEventToAnyModelMapper?
+    private let subscriptionEventSubject: PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>
+    private var mapperSink: AnyCancellable?
+    var publisher: AnyPublisher<IncomingSubscriptionEventPublisherEvent, DataStoreError> {
+        return subscriptionEventSubject.eraseToAnyPublisher()
     }
 
     init(modelType: Model.Type, api: APICategoryGraphQLBehavior) {
+        self.subscriptionEventSubject = PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>()
         self.asyncEvents = IncomingAsyncSubscriptionEventPublisher(modelType: modelType,
                                                                    api: api)
 
@@ -29,8 +31,25 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
         self.mapper = mapper
 
         asyncEvents.subscribe(subscriber: mapper)
+        self.mapperSink = mapper.publisher.sink(receiveCompletion: onReceiveCompletion(receiveCompletion:),
+                                                receiveValue: onReceive(receiveValue:))
     }
 
+    private func onReceiveCompletion(receiveCompletion: Subscribers.Completion<DataStoreError>) {
+        subscriptionEventSubject.send(completion: receiveCompletion)
+    }
+
+    private func onReceive(receiveValue: MutationSync<AnyModel>) {
+        subscriptionEventSubject.send(.mutationEvent(receiveValue))
+    }
+
+    func kill() {
+        mapperSink?.cancel()
+        mapperSink = nil
+
+        asyncEvents.kill()
+        mapper = nil
+    }
 }
 
 @available(iOS 13.0, *)
@@ -46,7 +65,7 @@ extension AWSIncomingSubscriptionEventPublisher: Resettable {
 
         group.enter()
         DispatchQueue.global().async {
-            self.mapper.reset { group.leave() }
+            self.mapper?.reset { group.leave() }
         }
 
         group.wait()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -94,6 +94,10 @@ final class IncomingAsyncSubscriptionEventPublisher {
         incomingSubscriptionEvents.subscribe(subscriber)
     }
 
+    func kill() {
+        reset(onComplete: {})
+    }
+
     func reset(onComplete: () -> Void) {
         onCreateOperation?.cancel()
         onCreateOperation = nil

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
@@ -9,7 +9,12 @@ import Amplify
 import AWSPluginsCore
 import Combine
 
+enum IncomingSubscriptionEventPublisherEvent {
+    case mutationEvent(MutationSync<AnyModel>)
+}
+
 @available(iOS 13.0, *)
 protocol IncomingSubscriptionEventPublisher {
-    var publisher: AnyPublisher<MutationSync<AnyModel>, DataStoreError> { get }
+    var publisher: AnyPublisher<IncomingSubscriptionEventPublisherEvent, DataStoreError> { get }
+    func kill()
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
@@ -20,6 +20,7 @@ protocol ModelReconciliationQueue {
     func start()
     func pause()
     func cancel()
+    func kill()
     func enqueue(_ remoteModel: MutationSync<AnyModel>)
     var publisher: AnyPublisher<ModelReconciliationQueueEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
@@ -34,11 +34,13 @@ class LocalSubscriptionTests: XCTestCase {
             let awsMutationEventPublisher = AWSMutationEventPublisher(eventSource: mutationDatabaseAdapter)
 
             let syncEngine = RemoteSyncEngine(storageAdapter: storageAdapter,
-                                             outgoingMutationQueue: outgoingMutationQueue,
-                                             mutationEventIngester: mutationDatabaseAdapter,
-                                             mutationEventPublisher: awsMutationEventPublisher,
-                                             initialSyncOrchestratorFactory: NoOpInitialSyncOrchestrator.factory,
-                                             reconciliationQueueFactory: MockAWSIncomingEventReconciliationQueue.factory)
+                                              outgoingMutationQueue: outgoingMutationQueue,
+                                              mutationEventIngester: mutationDatabaseAdapter,
+                                              mutationEventPublisher: awsMutationEventPublisher,
+                                              initialSyncOrchestratorFactory: NoOpInitialSyncOrchestrator.factory,
+                                              reconciliationQueueFactory: MockAWSIncomingEventReconciliationQueue.factory,
+                                              networkReachabilityPublisher: nil,
+                                              requestRetryablePolicy: MockRequestRetryablePolicy())
 
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
                                           syncEngine: syncEngine)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -42,7 +42,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                                                     lastChangedAt: Date().unixSeconds,
                                                     version: 1)
             let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
-            subscriptionEventsSubject.send(mutationSync)
+            subscriptionEventsSubject.send(.mutationEvent(mutationSync))
         }
 
         wait(for: [eventsNotSaved], timeout: 5.0)
@@ -84,7 +84,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                                                     lastChangedAt: Date().unixSeconds,
                                                     version: 1)
             let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
-            subscriptionEventsSubject.send(mutationSync)
+            subscriptionEventsSubject.send(.mutationEvent(mutationSync))
         }
 
         queue.start()
@@ -150,7 +150,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                                                     lastChangedAt: Date().unixSeconds,
                                                     version: 1)
             let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
-            subscriptionEventsSubject.send(mutationSync)
+            subscriptionEventsSubject.send(.mutationEvent(mutationSync))
         }
 
         queue.start()
@@ -195,7 +195,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                                                     lastChangedAt: Date().unixSeconds,
                                                     version: 1)
             let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
-            subscriptionEventsSubject.send(mutationSync)
+            subscriptionEventsSubject.send(.mutationEvent(mutationSync))
         }
 
         queue.start()
@@ -228,7 +228,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                                                 lastChangedAt: Date().unixSeconds,
                                                 version: 1)
         let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
-        subscriptionEventsSubject.send(mutationSync)
+        subscriptionEventsSubject.send(.mutationEvent(mutationSync))
 
         wait(for: [event1ShouldNotBeProcessed, event2ShouldNotBeProcessed, event3ShouldBeProcessed], timeout: 1.0)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/ReconciliationQueueTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/ReconciliationQueueTestBase.swift
@@ -18,7 +18,7 @@ class ReconciliationQueueTestBase: XCTestCase {
     var apiPlugin: MockAPICategoryPlugin!
     var storageAdapter: MockSQLiteStorageEngineAdapter!
     var subscriptionEventsPublisher: MockIncomingSubscriptionEventPublisher!
-    var subscriptionEventsSubject: PassthroughSubject<MutationSync<AnyModel>, DataStoreError>!
+    var subscriptionEventsSubject: PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>!
 
     override func setUp() {
         ModelRegistry.register(modelType: MockSynced.self)
@@ -33,9 +33,11 @@ class ReconciliationQueueTestBase: XCTestCase {
 }
 
 struct MockIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPublisher {
-    let subject = PassthroughSubject<MutationSync<AnyModel>, DataStoreError>()
+    let subject = PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>()
 
-    var publisher: AnyPublisher<MutationSync<AnyModel>, DataStoreError> {
+    var publisher: AnyPublisher<IncomingSubscriptionEventPublisherEvent, DataStoreError> {
         subject.eraseToAnyPublisher()
+    }
+    func kill() {
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -7,7 +7,7 @@
 
 import SQLite
 import XCTest
-
+import Combine
 @testable import Amplify
 @testable import AmplifyTestCommon
 @testable import AWSDataStoreCategoryPlugin
@@ -24,6 +24,7 @@ class SyncEngineTestBase: XCTestCase {
     /// Used for DB manipulation to mock starting data for tests
     var storageAdapter: SQLiteStorageEngineAdapter!
 
+    var reachabilityPublisher: PassthroughSubject<ReachabilityUpdate, Never>?
     // MARK: - Setup
 
     override func setUp() {
@@ -41,6 +42,7 @@ class SyncEngineTestBase: XCTestCase {
         ])
 
         amplifyConfig = AmplifyConfiguration(api: apiConfig, dataStore: dataStoreConfig)
+        reachabilityPublisher = PassthroughSubject<ReachabilityUpdate, Never>()
 
         apiPlugin = MockAPICategoryPlugin()
         tryOrFail {
@@ -73,7 +75,9 @@ class SyncEngineTestBase: XCTestCase {
                                           mutationEventIngester: mutationDatabaseAdapter,
                                           mutationEventPublisher: awsMutationEventPublisher,
                                           initialSyncOrchestratorFactory: initialSyncOrchestratorFactory,
-                                          reconciliationQueueFactory: AWSIncomingEventReconciliationQueue.factory)
+                                          reconciliationQueueFactory: AWSIncomingEventReconciliationQueue.factory,
+                                          networkReachabilityPublisher: reachabilityPublisher?.eraseToAnyPublisher(),
+                                          requestRetryablePolicy: MockRequestRetryablePolicy())
 
         let storageEngine = StorageEngine(storageAdapter: storageAdapter,
                                           syncEngine: syncEngine)

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -59,7 +59,7 @@
 		6B91DEBF238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */; };
 		6BC4FDA823A899180027D20C /* RequestRetryablePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC4FDA723A899180027D20C /* RequestRetryablePolicyTests.swift */; };
 		6BC4FDAA23A899680027D20C /* MockRequestRetryablePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */; };
-		6BDC224023E21A4E007C8410 /* RemoteEngineSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC223F23E21A4E007C8410 /* RemoteEngineSyncTests.swift */; };
+		6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */; };
 		6BDC224223E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */; };
 		9BDB42C47E6D7F9A113AE558 /* Pods_HostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C6448DF009E54C11ACE4515 /* Pods_HostApp.framework */; };
 		B9E010E4239167E000DCE8C8 /* TestModelRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E010E3239167E000DCE8C8 /* TestModelRegistration.swift */; };
@@ -218,7 +218,7 @@
 		6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcileAndLocalSaveOperationTests.swift; sourceTree = "<group>"; };
 		6BC4FDA723A899180027D20C /* RequestRetryablePolicyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestRetryablePolicyTests.swift; sourceTree = "<group>"; };
 		6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRequestRetryablePolicy.swift; sourceTree = "<group>"; };
-		6BDC223F23E21A4E007C8410 /* RemoteEngineSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteEngineSyncTests.swift; sourceTree = "<group>"; };
+		6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSyncEngineTests.swift; sourceTree = "<group>"; };
 		6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSInitialSyncOrchestrator.swift; sourceTree = "<group>"; };
 		6CF3060AE9E227813325029F /* Pods_AWSDataStoreCategoryPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSDataStoreCategoryPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		715777CA4DC182BC96B88C19 /* Pods_HostApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -603,7 +603,7 @@
 				2149E5F1238869CF00873955 /* APICategoryDependencyTests.swift */,
 				FA0427CF2396CDD800D25AB0 /* DataStoreHubTests.swift */,
 				2149E5F3238869CF00873955 /* LocalSubscriptionTests.swift */,
-				6BDC223F23E21A4E007C8410 /* RemoteEngineSyncTests.swift */,
+				6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */,
 				6BC4FDA723A899180027D20C /* RequestRetryablePolicyTests.swift */,
 				FAE01F9923997BD900B468DA /* InitialSync */,
 				FAE01F9823997B7600B468DA /* MutationQueue */,
@@ -1260,7 +1260,7 @@
 				6B64027923E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift in Sources */,
 				FA0427D02396CDD800D25AB0 /* DataStoreHubTests.swift in Sources */,
 				FA3B3F09238F39DE002EFDB3 /* AWSMutationEventIngesterTests.swift in Sources */,
-				6BDC224023E21A4E007C8410 /* RemoteEngineSyncTests.swift in Sources */,
+				6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */,
 				FA4B8E962391C609009FC10F /* XCTest+AmplifyExtensions.swift in Sources */,
 				FAE4146C239AA40600CE94C2 /* MockSQLiteStorageEngineAdapter.swift in Sources */,
 				FA8D932F239EA5C4001ED336 /* NoOpInitialSyncOrchestrator.swift in Sources */,


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
