### PR TITLE
Updating SDK versions to 2.12.7

### DIFF
--- a/AWSPluginsCore.podspec
+++ b/AWSPluginsCore.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   
   s.requires_arc = true
   
-  AWS_SDK_VERSION = "~> 2.12.6"
+  AWS_SDK_VERSION = "~> 2.12.7"
 
   s.source_files = 'AmplifyPlugins/Core/AWSPluginsCore/**/*.swift'
   s.dependency 'Amplify', '0.10.0'

--- a/AWSPredictionsPlugin.podspec
+++ b/AWSPredictionsPlugin.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     
     s.requires_arc = true
 
-    AWS_SDK_VERSION = '~> 2.12.6'
+    AWS_SDK_VERSION = '~> 2.12.7'
     AMPLIFY_VERSION = '0.10.0'
     
     s.source_files = 'AmplifyPlugins/Predictions/AWSPredictionsPlugin/**/*.swift'

--- a/AmplifyPlugins.podspec
+++ b/AmplifyPlugins.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   
   s.requires_arc = true 
 
-  AWS_SDK_VERSION = '~> 2.12.6'
+  AWS_SDK_VERSION = '~> 2.12.7'
   AMPLIFY_VERSION = '0.10.0'
   
   s.subspec 'AWSAPIPlugin' do |ss|

--- a/AmplifyPlugins/API/Podfile
+++ b/AmplifyPlugins/API/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '11.0'
 use_frameworks!
 
-AWS_SDK_VERSION = "2.12.6"
+AWS_SDK_VERSION = "2.12.7"
 
 pod 'SwiftFormat/CLI'
 pod 'SwiftLint'

--- a/AmplifyPlugins/Analytics/Podfile
+++ b/AmplifyPlugins/Analytics/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '12.0'
 use_frameworks!
 
-AWS_SDK_VERSION = "2.12.2"
+AWS_SDK_VERSION = "2.12.7"
 
 pod 'SwiftFormat/CLI'
 pod 'SwiftLint'

--- a/AmplifyPlugins/DataStore/Podfile
+++ b/AmplifyPlugins/DataStore/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '11.0'
 use_frameworks!
 
-AWS_SDK_VERSION = "2.12.2"
+AWS_SDK_VERSION = "2.12.7"
 
 pod 'SwiftFormat/CLI'
 pod 'SwiftLint'

--- a/AmplifyPlugins/Predictions/Podfile
+++ b/AmplifyPlugins/Predictions/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '13.0'
 use_frameworks!
 
-AWS_SDK_VERSION = "2.12.6"
+AWS_SDK_VERSION = "2.12.7"
 
 pod 'SwiftFormat/CLI'
 pod 'SwiftLint'

--- a/AmplifyPlugins/Storage/Podfile
+++ b/AmplifyPlugins/Storage/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '12.0'
 use_frameworks!
 
-AWS_SDK_VERSION = "2.12.5"
+AWS_SDK_VERSION = "2.12.7"
 
 pod 'SwiftFormat/CLI'
 pod 'SwiftLint'

--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 # Uncomment the next line to define a global platform for your project
 platform :ios, "11.0"
 
-AWS_SDK_VERSION = "2.12.6"
+AWS_SDK_VERSION = "2.12.7"
 
 target "Amplify" do
   # Comment the next line if you"re not using Swift and don"t want to use dynamic frameworks

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - AWSAuthCore (2.12.6):
-    - AWSCore (= 2.12.6)
-  - AWSCognitoIdentityProvider (2.12.6):
+  - AWSAuthCore (2.12.7):
+    - AWSCore (= 2.12.7)
+  - AWSCognitoIdentityProvider (2.12.7):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.12.6)
+    - AWSCore (= 2.12.7)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.12.6)
-  - AWSMobileClient (2.12.6):
-    - AWSAuthCore (= 2.12.6)
-    - AWSCognitoIdentityProvider (= 2.12.6)
+  - AWSCore (2.12.7)
+  - AWSMobileClient (2.12.7):
+    - AWSAuthCore (= 2.12.7)
+    - AWSCognitoIdentityProvider (= 2.12.7)
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
@@ -16,7 +16,7 @@ PODS:
   - SwiftLint (0.37.0)
 
 DEPENDENCIES:
-  - AWSMobileClient (~> 2.12.6)
+  - AWSMobileClient (~> 2.12.7)
   - CwlCatchException (from `https://github.com/mattgallagher/CwlCatchException.git`, tag `1.2.0`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `1.2.0`)
   - SwiftFormat/CLI
@@ -49,16 +49,16 @@ CHECKOUT OPTIONS:
     :tag: 1.2.0
 
 SPEC CHECKSUMS:
-  AWSAuthCore: d981abe8fb987a1caa7ac6c76c428de12387dcf4
-  AWSCognitoIdentityProvider: 9502438e528185a2c61b97baf66e2fd2ac6833f3
+  AWSAuthCore: 288cb737a35ff031fbf42edaa8d0062328791d4e
+  AWSCognitoIdentityProvider: 4998bdbfbafe5038dae0237a598580e102e7b6b5
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: 48bb8d477d8137377e86b2ade9eb34a761f42df5
-  AWSMobileClient: d752ed540a75d45516c8d5b2054b3f3b6b9e7e65
+  AWSCore: 2f0f88ae94a63a198274d683c7d0e18709d7090b
+  AWSMobileClient: bf1fb0868f9187141ca7b69220383c14878c0a29
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 5faa819600268dfaa5c19f1359730883db151678
   SwiftLint: c078a14d7d7ade75e5507795d185e3da41d844d2
 
-PODFILE CHECKSUM: 052b557087c76e48d6c09130d48e484e6b7ed701
+PODFILE CHECKSUM: bff62c5b364bf086285d90a29fcf58555eb06704
 
 COCOAPODS: 1.8.4

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -1,14 +1,14 @@
 PODS:
-  - AWSAuthCore (2.12.6):
-    - AWSCore (= 2.12.6)
-  - AWSCognitoIdentityProvider (2.12.6):
+  - AWSAuthCore (2.12.7):
+    - AWSCore (= 2.12.7)
+  - AWSCognitoIdentityProvider (2.12.7):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.12.6)
+    - AWSCore (= 2.12.7)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.12.6)
-  - AWSMobileClient (2.12.6):
-    - AWSAuthCore (= 2.12.6)
-    - AWSCognitoIdentityProvider (= 2.12.6)
+  - AWSCore (2.12.7)
+  - AWSMobileClient (2.12.7):
+    - AWSAuthCore (= 2.12.7)
+    - AWSCognitoIdentityProvider (= 2.12.7)
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
@@ -16,7 +16,7 @@ PODS:
   - SwiftLint (0.37.0)
 
 DEPENDENCIES:
-  - AWSMobileClient (~> 2.12.6)
+  - AWSMobileClient (~> 2.12.7)
   - CwlCatchException (from `https://github.com/mattgallagher/CwlCatchException.git`, tag `1.2.0`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `1.2.0`)
   - SwiftFormat/CLI
@@ -49,16 +49,16 @@ CHECKOUT OPTIONS:
     :tag: 1.2.0
 
 SPEC CHECKSUMS:
-  AWSAuthCore: d981abe8fb987a1caa7ac6c76c428de12387dcf4
-  AWSCognitoIdentityProvider: 9502438e528185a2c61b97baf66e2fd2ac6833f3
+  AWSAuthCore: 288cb737a35ff031fbf42edaa8d0062328791d4e
+  AWSCognitoIdentityProvider: 4998bdbfbafe5038dae0237a598580e102e7b6b5
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: 48bb8d477d8137377e86b2ade9eb34a761f42df5
-  AWSMobileClient: d752ed540a75d45516c8d5b2054b3f3b6b9e7e65
+  AWSCore: 2f0f88ae94a63a198274d683c7d0e18709d7090b
+  AWSMobileClient: bf1fb0868f9187141ca7b69220383c14878c0a29
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 5faa819600268dfaa5c19f1359730883db151678
   SwiftLint: c078a14d7d7ade75e5507795d185e3da41d844d2
 
-PODFILE CHECKSUM: 052b557087c76e48d6c09130d48e484e6b7ed701
+PODFILE CHECKSUM: bff62c5b364bf086285d90a29fcf58555eb06704
 
 COCOAPODS: 1.8.4

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -28,296 +28,297 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		00245045D5E45577751253E413EB5A41 /* AWSCancellationToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B78D374D0A051D9C447BCFAE475F4E2 /* AWSCancellationToken.m */; };
-		00F52188FE076B3977A110330D3A48C7 /* AWSCognitoIdentityProviderResources.h in Headers */ = {isa = PBXBuildFile; fileRef = FABA1EBEF087305EAED9649E53354E5E /* AWSCognitoIdentityProviderResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		014D5B8A4928C9A387534875206E8AFE /* AWSDDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = F512671A8CA89ACEF7575B062F6AD0DC /* AWSDDASLLogCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		016F99722715BF88A9636B87434EA4F8 /* AWSSignature.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C401F43F3647CFB1A04369928781E0E /* AWSSignature.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		06286FFF5F9A837D882033756A51BA6F /* AWSCognitoCredentialsProvider+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = B785B0927F487DA24F8777BAA7C3FD3E /* AWSCognitoCredentialsProvider+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		06920E9A30F8C694426F31326AEC669F /* AWSDDOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 0831B18334CCA361EBE774FCE1C79065 /* AWSDDOSLogger.m */; };
-		07C22CB8F0D5D1D155E99E7FAA03E922 /* AWSSTSService.h in Headers */ = {isa = PBXBuildFile; fileRef = 009CACF5738D03F5B64F3EF3C99FB61E /* AWSSTSService.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		07E00EE1AEB8DB9013DC357339E01573 /* AWSJKBigInteger.h in Headers */ = {isa = PBXBuildFile; fileRef = CEAA8CF19472EC4ACF9D738F775FC832 /* AWSJKBigInteger.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		080A963CA88B480650FFE9DA4C1FB652 /* AWSCognitoAuth_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 57E610DB1C9834B93B86B32AE203D34B /* AWSCognitoAuth_Internal.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		090E87DED2A7E745AB4B80D9D40A3B0F /* Fabric+FABKits.h in Headers */ = {isa = PBXBuildFile; fileRef = ACCDDF8A621C80784B35192C5C55D9ED /* Fabric+FABKits.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		00245045D5E45577751253E413EB5A41 /* AWSCancellationToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 1213A5418927CFBA7E61F3972A32D352 /* AWSCancellationToken.m */; };
+		00F52188FE076B3977A110330D3A48C7 /* AWSCognitoIdentityProviderResources.h in Headers */ = {isa = PBXBuildFile; fileRef = 943F781A6406C3C665785C8FC7D0B20C /* AWSCognitoIdentityProviderResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		014D5B8A4928C9A387534875206E8AFE /* AWSDDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = B12E7C422FC9A1B35382A270A70BBAC8 /* AWSDDASLLogCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		016F99722715BF88A9636B87434EA4F8 /* AWSSignature.h in Headers */ = {isa = PBXBuildFile; fileRef = 158BDE967B7C9FFF98317A8A1AF47B24 /* AWSSignature.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		06920E9A30F8C694426F31326AEC669F /* AWSDDOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 628F229771BD6D9333C17BA8DE3BBC71 /* AWSDDOSLogger.m */; };
+		07C22CB8F0D5D1D155E99E7FAA03E922 /* AWSSTSService.h in Headers */ = {isa = PBXBuildFile; fileRef = C113662AE6AF834F148159C71FB3E942 /* AWSSTSService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		07E00EE1AEB8DB9013DC357339E01573 /* AWSJKBigInteger.h in Headers */ = {isa = PBXBuildFile; fileRef = 94434239E6D897885741EAF1FDEE3EDC /* AWSJKBigInteger.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		090E87DED2A7E745AB4B80D9D40A3B0F /* Fabric+FABKits.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B9AA17ED6E6A642F5E8474D94DA778C /* Fabric+FABKits.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0B2EFA3514269B1827188E84004105AD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
 		0BE7171684CA5D10C9831EC4DFF28406 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		0D975819F09C9DCD588638EC7D2C3C91 /* AWSIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = ED595581B874044815E93AAC0D4FB3A4 /* AWSIdentityProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0DA5E07E1BA323EEA73D7E1675363EA2 /* AWSCognitoIdentityUserPool.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B5D74163C65BA45F129C2F75A244A26 /* AWSCognitoIdentityUserPool.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0DC60DC3F6A7EDA73648721C422359A7 /* AWSCognitoAuth+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = AFE6CA3E54E94B93879D0415A2FA535C /* AWSCognitoAuth+Extensions.m */; };
-		0F7ABBD637E331A9CA9F514904C5EF64 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983EDE1A47AA1B93CFCC5C3B7E1E5678 /* CwlCatchBadInstruction.swift */; };
-		1060FCAC1ACCA3BA3F7B2B266177E21D /* AWSDDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 1853077C437335F8E40E76858B148CE5 /* AWSDDLog.m */; };
-		11D1DF9ADBCB93C6643F9C14E8E5ABF6 /* AWSCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 99B54D708FFA50347BEFA9AD8730A8AA /* AWSCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		11E98BE334C469A1C9694F6891B2119D /* AWSDDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 98015366A1F6CDB77D29D5B2458E7056 /* AWSDDDispatchQueueLogFormatter.m */; };
-		121B62241BE1752EA25A5BA6E017616A /* AWSFMDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = F3CB9777F44C0BDB4C2F7226731D7A17 /* AWSFMDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		13603B0B004ADA8FA4C6A29F8C255F00 /* AWSEXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = D30FB1471BD4A7F0CE23217C25A286D6 /* AWSEXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		13E1E9094F5329494002200340B1AF65 /* NSData+AWSCognitoIdentityProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F45A88D28CED0D57D7F1D7138D0CDFF /* NSData+AWSCognitoIdentityProvider.m */; };
-		1443F4986172D7C166827E3E8CDAA21D /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76183A993DAA4D030DEB79B1EE231C3C /* CwlDarwinDefinitions.swift */; };
+		0D975819F09C9DCD588638EC7D2C3C91 /* AWSIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 422FA242D9F5ED9C37F90A6FD2FF2225 /* AWSIdentityProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0DA5E07E1BA323EEA73D7E1675363EA2 /* AWSCognitoIdentityUserPool.h in Headers */ = {isa = PBXBuildFile; fileRef = 84CC2DC999F384730595ACA3B9CB0A55 /* AWSCognitoIdentityUserPool.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F7ABBD637E331A9CA9F514904C5EF64 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E76DC27A81691F88AF5806683ADEF0 /* CwlCatchBadInstruction.swift */; };
+		1060FCAC1ACCA3BA3F7B2B266177E21D /* AWSDDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E25299C3E7143DC12BA797151D05C86 /* AWSDDLog.m */; };
+		11D1DF9ADBCB93C6643F9C14E8E5ABF6 /* AWSCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BF3F861431F5E73FB97B7D8762C387A /* AWSCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		11E98BE334C469A1C9694F6891B2119D /* AWSDDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A6D7B33D949723B982647BA1085C343 /* AWSDDDispatchQueueLogFormatter.m */; };
+		121B62241BE1752EA25A5BA6E017616A /* AWSFMDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 9319B5648119778AC2F13F3A9EEC73B2 /* AWSFMDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		13603B0B004ADA8FA4C6A29F8C255F00 /* AWSEXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = C80E1BAEA00F8C1A39BB5BFAFEB0F909 /* AWSEXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		13E1E9094F5329494002200340B1AF65 /* NSData+AWSCognitoIdentityProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A1AD2ECB0B52C7FE0EBCA97ABAE4F7F /* NSData+AWSCognitoIdentityProvider.m */; };
+		1443F4986172D7C166827E3E8CDAA21D /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F56C406427AA446ED6AC850F1D11F5C /* CwlDarwinDefinitions.swift */; };
 		14BB10E6F64439F078229540A0807EE6 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8DB7849FE18394F4C1421ABE0CEA2E /* Security.framework */; };
-		15558E6E6B5B340AE9A56594910085DC /* AWSCancellationTokenRegistration.m in Sources */ = {isa = PBXBuildFile; fileRef = 281AC237A5385219FDCE6717E9C69709 /* AWSCancellationTokenRegistration.m */; };
+		15558E6E6B5B340AE9A56594910085DC /* AWSCancellationTokenRegistration.m in Sources */ = {isa = PBXBuildFile; fileRef = B1F0999944AEC4156AD5258F82068B0A /* AWSCancellationTokenRegistration.m */; };
 		176EE1FC318E9CD5AA1E79B1A79070D7 /* CwlCatchException.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E95AAB996428D7874DB2E4B93260F35 /* CwlCatchException.framework */; };
-		189C52695A137B58704DF3C5BD57BCA7 /* AWSDDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E02F91D7B07EC8FC39A4CAF40D39746 /* AWSDDTTYLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1912D9BBE939D40B7F1D5D5006671F32 /* AWSCognitoIdentityProvider-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 82AE0D4FE2C5DA296BA6072367A2F9F6 /* AWSCognitoIdentityProvider-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1A39D1693474EB62977EF09A9433600E /* AWSTaskCompletionSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 30642F131CF85895AB20D4764112A7B1 /* AWSTaskCompletionSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1B3F193F03EA731E027EB54639B9AFAE /* AWSDDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A425EA2780C3972162FA364B8134591 /* AWSDDLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1B4699D8D8A9FA361461FA0918FB1BBD /* AWSDDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 076B6FA2F32A84341788F1C2E42A79CA /* AWSDDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1B607F8C305C2DDE2170D517993A0542 /* AWSClientContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 11981CE8441163483F737D85DE32B1CE /* AWSClientContext.m */; };
-		1BB794FB213EC4CA73B3C8BC4D05C3A5 /* CwlCatchException-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FFCB4AAE367BAD78D9C6A46083E63014 /* CwlCatchException-dummy.m */; };
-		1C3989F261B6DEB7427157E58FFAF18E /* AWSCognitoIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = DADB698FF6F0FE317C721CB8277E3306 /* AWSCognitoIdentityProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1C458B6D3529A73474CA7ED48C718CEA /* AWSIdentityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 3844849C30D28B47FF9C3DD61529455D /* AWSIdentityManager.m */; };
-		1CEC54C8680C61BAE07A09608EE075A1 /* AWSDDOSLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 745068DD32DDB8617322A32B3A678DDD /* AWSDDOSLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		189C52695A137B58704DF3C5BD57BCA7 /* AWSDDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C609A14E1972EE2654C9EA40769F3AE /* AWSDDTTYLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1912D9BBE939D40B7F1D5D5006671F32 /* AWSCognitoIdentityProvider-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2837F1492EC2CEC5B9DD4352EF5BDE5C /* AWSCognitoIdentityProvider-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1A39D1693474EB62977EF09A9433600E /* AWSTaskCompletionSource.h in Headers */ = {isa = PBXBuildFile; fileRef = AB46ADB2B0FACE56687DD120B4D5EDEF /* AWSTaskCompletionSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1B3F193F03EA731E027EB54639B9AFAE /* AWSDDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = FD90263907B9BD577E7F0850F86817D0 /* AWSDDLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1B4699D8D8A9FA361461FA0918FB1BBD /* AWSDDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 45976F280C6328A4C07F4BD4C4EC5932 /* AWSDDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1B607F8C305C2DDE2170D517993A0542 /* AWSClientContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 16C1587C7AC8C56C77374B292761DEB6 /* AWSClientContext.m */; };
+		1BB794FB213EC4CA73B3C8BC4D05C3A5 /* CwlCatchException-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BD20C472C43A246A6F2434B9E704BA3 /* CwlCatchException-dummy.m */; };
+		1C3989F261B6DEB7427157E58FFAF18E /* AWSCognitoIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E45CDF781E122D5B0032D5E10259043 /* AWSCognitoIdentityProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1C458B6D3529A73474CA7ED48C718CEA /* AWSIdentityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 47DF5785EA91BD8744624AB4E432880D /* AWSIdentityManager.m */; };
+		1CEC54C8680C61BAE07A09608EE075A1 /* AWSDDOSLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = AB967F9CFF776884A5B3215E374A1B1D /* AWSDDOSLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		20D58851C6F80D8EC03E236B6066D2E4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		20DE217DA9E41A2BFD1E4A71C564929B /* AWSSTSResources.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A3B34FAA9B84A5377B2D5C709DA6B92 /* AWSSTSResources.m */; };
-		20F5B6668A2D5C62774918E1554E7B1D /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B52AFD8824D96B30C353421A67E04F /* CwlBadInstructionException.swift */; };
-		2145910BF9E8293B01895487859507A7 /* tommath.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F18885B0C226C01535E4BC473565790 /* tommath.c */; };
-		221795EAC91598916CB8F66DAEEB2AE1 /* AWSCognitoIdentityModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E57BA4A95EE17DEB99ECB5EBFC44EA9 /* AWSCognitoIdentityModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		224E2C74968842E2CB20C0E708373B39 /* AWSCognitoIdentityProviderModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 557CB74CF255046C393A564440AE135F /* AWSCognitoIdentityProviderModel.m */; };
+		20DE217DA9E41A2BFD1E4A71C564929B /* AWSSTSResources.m in Sources */ = {isa = PBXBuildFile; fileRef = 70FB430AE49A1B952C747843DEDD64D0 /* AWSSTSResources.m */; };
+		20F5B6668A2D5C62774918E1554E7B1D /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA9718A32A9D07BB92F38401873C8E5 /* CwlBadInstructionException.swift */; };
+		2145910BF9E8293B01895487859507A7 /* tommath.c in Sources */ = {isa = PBXBuildFile; fileRef = 98B91CEED15E36B9E7F022C5FEFB9FE8 /* tommath.c */; };
+		221795EAC91598916CB8F66DAEEB2AE1 /* AWSCognitoIdentityModel.h in Headers */ = {isa = PBXBuildFile; fileRef = A8598EE9DFBE20826EC5C647B287555D /* AWSCognitoIdentityModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		224E2C74968842E2CB20C0E708373B39 /* AWSCognitoIdentityProviderModel.m in Sources */ = {isa = PBXBuildFile; fileRef = B912B8BDF2CFA91469BBC9485DA7EEC3 /* AWSCognitoIdentityProviderModel.m */; };
 		23B8ECAE96DAB3886CCE1CE90B8277F9 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 03D039338D77A6CA524CBC57DE6E2BCF /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-dummy.m */; };
-		248507F49B3F12E442FE6AC425DD398B /* AWSIdentityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = C5C34C491A183A09D49EF0138F8202FE /* AWSIdentityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		264783C2F064A47445C5894BC568C1EB /* AWSNetworkingHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 285440696A5920B5E6B03DE8351989B8 /* AWSNetworkingHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2757F826A5D3164D7FF294C3C0D2DA44 /* AWSDDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = FF9CFC24BCA0B14493B8518376969BEC /* AWSDDFileLogger.m */; };
-		2814D4D361A4E86079D72A04F0AB30D5 /* AWSCognitoIdentityModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 91C2094C059BAFFFFBC229AC5C0F9CEF /* AWSCognitoIdentityModel.m */; };
-		292DFC7361D422AB72038DBEA947ECEC /* Fabric.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CEEBBC83FB1A93562327EAFF615AA6B /* Fabric.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		295FA629B96FCE0C14815243AF6F4DA6 /* AWSmetamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B69116025E7AE4E03FD9CB6AE7D4A79 /* AWSmetamacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		29A30DF1ED433FF2CF086D2CD5FDE391 /* aws_tommath_superclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DD919F5D40936CBB175BC18C0CC012A /* aws_tommath_superclass.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		2A45D2B2E9015B55E07DD13D43E1A197 /* AWSModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FCBEE62A3337BC2F65D83AF4E6B900F /* AWSModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2A7389B92220C12253767AA85D2B23AB /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 13A27886A2A2BD9BDC18D4AA06E0BE8D /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		248507F49B3F12E442FE6AC425DD398B /* AWSIdentityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = BAD9B4CDCA171522E97D8BA20564EFB8 /* AWSIdentityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		264783C2F064A47445C5894BC568C1EB /* AWSNetworkingHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 6334474AFC15E10B8E910D351C5379B5 /* AWSNetworkingHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2757F826A5D3164D7FF294C3C0D2DA44 /* AWSDDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F9B0BE3560BA877F8EEDC69DDD37534 /* AWSDDFileLogger.m */; };
+		2814D4D361A4E86079D72A04F0AB30D5 /* AWSCognitoIdentityModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D51BF6733A6A0E115157B9762902702F /* AWSCognitoIdentityModel.m */; };
+		2861A1716ABD10B59138E0608BE1C775 /* AWSCognitoAuthUICKeyChainStore.h in Headers */ = {isa = PBXBuildFile; fileRef = CE10F2C9689101DC708A3559492AFAB3 /* AWSCognitoAuthUICKeyChainStore.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		2914C15AB2C025430066747BE42F6A39 /* AWSUserPoolOperationsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A374AD7C7E8F04E05236562AE54228F /* AWSUserPoolOperationsHandler.swift */; };
+		292DFC7361D422AB72038DBEA947ECEC /* Fabric.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D7A492EE74C55BEA2FD7E94061D172A /* Fabric.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		295FA629B96FCE0C14815243AF6F4DA6 /* AWSmetamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = C0F9349245E10F2DAF7ACDFFC42876BE /* AWSmetamacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		29A30DF1ED433FF2CF086D2CD5FDE391 /* aws_tommath_superclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 62CA243C98F405F83294789351907442 /* aws_tommath_superclass.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		29F001B4F1F5D8369E7793F2E2C7518E /* AWSCognitoAuth+Extensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 087170046A46680BA6789BBA5A452CED /* AWSCognitoAuth+Extensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A45D2B2E9015B55E07DD13D43E1A197 /* AWSModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 46855F19A1FA6C383444A696F925A3C2 /* AWSModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A7389B92220C12253767AA85D2B23AB /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FBA19C6EAB6B5D35D98981B307131F4 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2BCA4C45CE7BE68A677F5B3042BC4BD7 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 70EF68EF61C4587DEC5119A866265B57 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-dummy.m */; };
-		2C4C1A6C7BED9A111DA724CAB2AB778C /* AWSCognitoIdentityProviderASF-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DAF63CB3927C45D2346F11705E3AFA7 /* AWSCognitoIdentityProviderASF-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2D0A57953832EF83AD2FA1511820B602 /* AWSMobileClient.h in Headers */ = {isa = PBXBuildFile; fileRef = CA9BF82B9D49B3E34E31C82200838ACE /* AWSMobileClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2D7804C365C5B74B4CFCE9DCDB990FDA /* AWSXMLDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 0ADFD7E42BE139F259349496AA57A0A2 /* AWSXMLDictionary.m */; };
-		3037B29B6276CF8FE3546D3E977DD84A /* AWSFMDatabasePool.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D18BB847E2E5CA341022508986C0EA8 /* AWSFMDatabasePool.m */; };
-		3140BF9E55F36B4CE5E2FAC0317FBE58 /* NSDictionary+AWSMTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 52E8B5E00968480B2775F83181520231 /* NSDictionary+AWSMTLManipulationAdditions.m */; };
-		327212D4B1210D85CEBFEE82E654D5A8 /* AWSFMDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 07ECE90907BE180F6A539BF08715EDE3 /* AWSFMDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		33438D6A7B769D16F1D528B0ADC783C6 /* AWSCognitoIdentityASF.h in Headers */ = {isa = PBXBuildFile; fileRef = EAB2EC18E32F6E2FCA424AE80D8412DB /* AWSCognitoIdentityASF.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2C4C1A6C7BED9A111DA724CAB2AB778C /* AWSCognitoIdentityProviderASF-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BB9D98357DCFDB3958EE3BB3E35D948F /* AWSCognitoIdentityProviderASF-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D7804C365C5B74B4CFCE9DCDB990FDA /* AWSXMLDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 53E4CFA427DABB6BABEB4642C3CAB55E /* AWSXMLDictionary.m */; };
+		3037B29B6276CF8FE3546D3E977DD84A /* AWSFMDatabasePool.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BB005E4B39B32629A62D3E26272A2DE /* AWSFMDatabasePool.m */; };
+		3140BF9E55F36B4CE5E2FAC0317FBE58 /* NSDictionary+AWSMTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 377507ABBE77D13266D4692188AC4A90 /* NSDictionary+AWSMTLManipulationAdditions.m */; };
+		327212D4B1210D85CEBFEE82E654D5A8 /* AWSFMDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F73B91A2BBEF91A3BA691AF03391D24 /* AWSFMDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		33438D6A7B769D16F1D528B0ADC783C6 /* AWSCognitoIdentityASF.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D169BC3B420EB3E0536F23B34963823 /* AWSCognitoIdentityASF.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		339FA6343AC88EB9B429322BAF8FF915 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1073C3EE5CBDD8387A3FB523E790C5CA /* SystemConfiguration.framework */; };
-		33AB80FF79E9E8922EB6414ECA6D13F4 /* AWSCognitoIdentityResources.h in Headers */ = {isa = PBXBuildFile; fileRef = B2DB7B9AA67A4C2901A501179E35FDC8 /* AWSCognitoIdentityResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		34D02615F8968D64CC0F5B2F1CFB6CFD /* AWSSynchronizedMutableDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 26844A716609D618B953ADCC3477A9C2 /* AWSSynchronizedMutableDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		34D0E0F7CFB4DFE1D93A31A57C6D97AD /* AWSMTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = F739532763F64777B91327F4DD6E9AB0 /* AWSMTLValueTransformer.m */; };
-		35439200B23D406C07D5161DAEB9F046 /* AWSCognitoIdentityUser_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = E7EC8830B686D3AA9F8A5EC5559D133E /* AWSCognitoIdentityUser_Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		35A9EDB5F19A0AA37CFAC061744C58A4 /* DeviceOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B1415B741EF9175334EEB8D7110C62F /* DeviceOperations.swift */; };
-		36793D105BE701C00338BDF313AB6C46 /* AWSDDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E93344537320B3C5EB8604688C8560C /* AWSDDContextFilterLogFormatter.m */; };
-		36F73E51FDF6AD36471B99E64C4A7730 /* NSObject+AWSMTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B0F9182481E43628F757BAFB64AD0B54 /* NSObject+AWSMTLComparisonAdditions.m */; };
-		37899F8A7B0ED0B72C99334BAA54CEAB /* AWSMobileClient-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A7521733F008AF096D52D74AF5F36981 /* AWSMobileClient-dummy.m */; };
-		37CF2468721210240B585FC038355BAD /* AWSJKBigDecimal.m in Sources */ = {isa = PBXBuildFile; fileRef = 85B16C1BEED6DAD6A2AB160002933CDA /* AWSJKBigDecimal.m */; };
-		37E3C990B6B94ED3A68546B534D113F7 /* AWSDDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 86BE6A81DB57EC1FEA08B44FDD69B10E /* AWSDDMultiFormatter.m */; };
-		39182F41F7B148E56863FD6A48300A15 /* AWSAuthCore-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AEEFB1F4D4875A426FBE8C5C6D76AB1 /* AWSAuthCore-dummy.m */; };
-		39678AF6674F85C354F294BE9F490B2F /* AWSExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = D3E5DF2CC49F1C2A673519ADB5D725BE /* AWSExecutor.m */; };
-		3979D282ECA583525A2099DDA11E1EBD /* AWSXMLWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = 40D3E2ACC250193E898393BB5E5B0FAD /* AWSXMLWriter.m */; };
-		3A211A601A173429FC164E21BFBD925C /* AWSCognitoIdentityResources.m in Sources */ = {isa = PBXBuildFile; fileRef = 185F0DC6368FA1D4547527B451DB8EB9 /* AWSCognitoIdentityResources.m */; };
-		3A7F8C983F3205D2586B913580D7818D /* AWSSignInManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 13F6EC075EF080997FC5EAA557A51049 /* AWSSignInManager.m */; };
-		3B0F330CAAE0F4DF8D362E5C00EF3715 /* AWSKSReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D58BF63FD36A36860F5EB44E38DD099 /* AWSKSReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		33AB80FF79E9E8922EB6414ECA6D13F4 /* AWSCognitoIdentityResources.h in Headers */ = {isa = PBXBuildFile; fileRef = 64967ADE10969F821252AEE23895E34E /* AWSCognitoIdentityResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34D02615F8968D64CC0F5B2F1CFB6CFD /* AWSSynchronizedMutableDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = F7FC9BE173B3AAD3825EA854C06AB75E /* AWSSynchronizedMutableDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34D0E0F7CFB4DFE1D93A31A57C6D97AD /* AWSMTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 01406D2554960C95060691CFCAA31D92 /* AWSMTLValueTransformer.m */; };
+		35439200B23D406C07D5161DAEB9F046 /* AWSCognitoIdentityUser_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A4BE50365F0355639CFCCDE678470A0 /* AWSCognitoIdentityUser_Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		36793D105BE701C00338BDF313AB6C46 /* AWSDDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = BC18EC7B6416CEED09F73528AE71AA31 /* AWSDDContextFilterLogFormatter.m */; };
+		36F73E51FDF6AD36471B99E64C4A7730 /* NSObject+AWSMTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E9E777591741F7713A15CED1A8CC19D /* NSObject+AWSMTLComparisonAdditions.m */; };
+		37CF2468721210240B585FC038355BAD /* AWSJKBigDecimal.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C7C8994C24425413D1870B567869C47 /* AWSJKBigDecimal.m */; };
+		37E3C990B6B94ED3A68546B534D113F7 /* AWSDDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 410EA7B41FE060205FC4011920FA6597 /* AWSDDMultiFormatter.m */; };
+		39182F41F7B148E56863FD6A48300A15 /* AWSAuthCore-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A45E4C5772CFEFFC6E77C0624C651A0E /* AWSAuthCore-dummy.m */; };
+		39678AF6674F85C354F294BE9F490B2F /* AWSExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BF3152809C0C7F2A37F2AA076B8BD80 /* AWSExecutor.m */; };
+		3979D282ECA583525A2099DDA11E1EBD /* AWSXMLWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = B03BF899ECCAE4CE7E3DAD96B6066B3D /* AWSXMLWriter.m */; };
+		3A211A601A173429FC164E21BFBD925C /* AWSCognitoIdentityResources.m in Sources */ = {isa = PBXBuildFile; fileRef = 9949A94419F2281C1EF0E2EC108965FF /* AWSCognitoIdentityResources.m */; };
+		3A7F8C983F3205D2586B913580D7818D /* AWSSignInManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 465060C70F108952D6A6D0B6B0B85133 /* AWSSignInManager.m */; };
+		3B0F330CAAE0F4DF8D362E5C00EF3715 /* AWSKSReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 61FFB55F7016DCDE8C2FB463C98FADB8 /* AWSKSReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3B34E32ACD49583FA677CE0E51257228 /* JSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99BA5D0889BB958E0926C060B9649DAA /* JSONHelper.swift */; };
 		3B9FFB26452B15D69C725846E481624F /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8DB7849FE18394F4C1421ABE0CEA2E /* Security.framework */; };
-		3C295496C91AFABA2DA6D3202C7C482B /* AWSUICKeyChainStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 73D6A1A96394F99C88C2D192F6EE2472 /* AWSUICKeyChainStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3C295496C91AFABA2DA6D3202C7C482B /* AWSUICKeyChainStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 073E77A65347582ED7A81E3D956DD22E /* AWSUICKeyChainStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C5CF7D00A143641F05F9B6BC1C1FEB1 /* Pods-Amplify-AWSPluginsCore-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B350FFEF637C6AF934EE101CD54DCE5 /* Pods-Amplify-AWSPluginsCore-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3CA3FA796B4F76092847C7CE45C7B2B0 /* AWSCognitoIdentityProviderASF-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FC3DCF579216C793C1D5986A399A2417 /* AWSCognitoIdentityProviderASF-dummy.m */; };
-		3CA6B00BEC52629874A59C4425B040FF /* _AWSMobileClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 0CACEC397330066C8C398ECECCE8BD5F /* _AWSMobileClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3D20174EDA7E54ACF0B3FA03BC9BAF4F /* AWSDDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 390C1B329BDBA41B75D7590CFC85F033 /* AWSDDContextFilterLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3CA3FA796B4F76092847C7CE45C7B2B0 /* AWSCognitoIdentityProviderASF-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 661CA20D4112179C1D8140902C0FA46C /* AWSCognitoIdentityProviderASF-dummy.m */; };
+		3D20174EDA7E54ACF0B3FA03BC9BAF4F /* AWSDDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E77E16BC664FA930B5F100306836D97 /* AWSDDContextFilterLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3E7788CD8A9220F214923E66A480F5E7 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = EFD2AEC8F92F60614948319DA39DDA2C /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-dummy.m */; };
 		3EBD1DFC7072E4D27E1C6EE9BCF7A5EC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		3EE59D51700D3E008C115C34DDC73403 /* AWSDDASLLogCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = C212D282C3A3524B1011E30E0E313E1C /* AWSDDASLLogCapture.m */; };
-		41427B4C2C98D529E00FDDEEEAB32D0D /* AWSTMMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 94701E2D8BEB1ECDDF758D0719854FAF /* AWSTMMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4169B42294AE9AB96766A16B1293ED08 /* FABAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AF033D372099B17E4AD1ECEF2388C74 /* FABAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		416B3D71CD66C2F82429B252EDC0C4A7 /* AWSAuthUIHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 00ED9F12F787409584FD64E63CB00BFA /* AWSAuthUIHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		440B8ECC492853A954F9EF74E134A1A9 /* AWSEXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AB1A2F26FDFD8E1CCDB36F0FFD0FDA0 /* AWSEXTScope.m */; };
-		45036FC7C954DBE6E733CB429174B2EA /* AWSEXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 94327DFA9363831CE32D78455D699B69 /* AWSEXTScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		452B95EB46C02DE66D5E2F415EAD1F85 /* AWSCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = E128D8EF93BA4D893F0117811A205D83 /* AWSCategory.m */; };
-		45A742EBBE1D814917D2F4F44E48B9B7 /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = 8A5462580CC9DC68AF7075ACA8844031 /* mach_excServer.c */; };
-		45AFA12190BAF394C1B57536268CBD8D /* AWSSTSModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 70B3F537BC06A2190DBA5545CA3BC9D1 /* AWSSTSModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		46239FCB5AA1A9C393996E3975E4AB72 /* AWSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 115578294D5785F67A4164B425F3D299 /* AWSModel.m */; };
-		466CB5C4FE8DD7AA3EE53FE3D1E728E1 /* AWSMTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 679BE254CFCDEE26015A8539E066D54F /* AWSMTLModel+NSCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		46818E554C7902ABE93D24966BB50EE3 /* AWSAuthCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C49CC694143B932ACAEDAB2B998DE32A /* AWSAuthCore.framework */; };
-		4724A9B83CF9F3763A6C9B7AB185F780 /* AWSSignInProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 316D632308F1EFBC2C0DF047773030DF /* AWSSignInProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3EE59D51700D3E008C115C34DDC73403 /* AWSDDASLLogCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EDDFBA65505F58B53C44E3ADE1B7525 /* AWSDDASLLogCapture.m */; };
+		408E26270F1ADEBB526CEDF85AD131DC /* AWSMobileClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 1005679B00726AC1ED9911E5237C9C36 /* AWSMobileClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		41427B4C2C98D529E00FDDEEEAB32D0D /* AWSTMMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 4EB7448C2B60EDE6846DFA0806F4639D /* AWSTMMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4169B42294AE9AB96766A16B1293ED08 /* FABAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 77F4A236D1F851232D48EBDF90147885 /* FABAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		416B3D71CD66C2F82429B252EDC0C4A7 /* AWSAuthUIHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AEEB68BA19668B4D0FE9A705816EF70 /* AWSAuthUIHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		440B8ECC492853A954F9EF74E134A1A9 /* AWSEXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F06DA83B9E53426EF78C32536C25671 /* AWSEXTScope.m */; };
+		45036FC7C954DBE6E733CB429174B2EA /* AWSEXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 237C34B9822D7E7B6E0CEF798C76A4F9 /* AWSEXTScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		452B95EB46C02DE66D5E2F415EAD1F85 /* AWSCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = B113FF367E590A74DFC88C56C2CAF166 /* AWSCategory.m */; };
+		4589F69C4934F11F1A17ACA1B08BC0E0 /* AWSMobileClient-Mixed-Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 26124B8EBEDB7DD09D52BF33E2E59931 /* AWSMobileClient-Mixed-Swift.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		45A742EBBE1D814917D2F4F44E48B9B7 /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = 683B6C1E23EACE20AD23E1EE20C1F0E2 /* mach_excServer.c */; };
+		45AFA12190BAF394C1B57536268CBD8D /* AWSSTSModel.h in Headers */ = {isa = PBXBuildFile; fileRef = C2F60A5A19FDE9D43EC3A8800F3192D6 /* AWSSTSModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		46239FCB5AA1A9C393996E3975E4AB72 /* AWSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 9493D78EBBFA335F5E10EF8CF66548EF /* AWSModel.m */; };
+		466CB5C4FE8DD7AA3EE53FE3D1E728E1 /* AWSMTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BBE4054B04F674C1F60D31FA106362C /* AWSMTLModel+NSCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4724A9B83CF9F3763A6C9B7AB185F780 /* AWSSignInProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = F8841AFA6EEBA04ED1A278D30AB02563 /* AWSSignInProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4746D2E0317722A3DED3470DB2DBFCD7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		4851DF7728E1A4D83BEBD0259F55894A /* AWSValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = AD1FFEF90711E0EC311224E066703638 /* AWSValidation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		49BFAFCF8CD24786DBEE0DB525590378 /* AWSCognitoIdentityUserPool.m in Sources */ = {isa = PBXBuildFile; fileRef = A1163FE82E3D89D2C4D5F59685F700D0 /* AWSCognitoIdentityUserPool.m */; };
-		49FB3545535B5BA67CAC16F4ADEC0D39 /* CwlPreconditionTesting-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D7E8BDCF5CB5DF64785E0DE7EDD5371A /* CwlPreconditionTesting-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4B0A6C1C5E40CA5991F72FE870380789 /* AWSCognitoIdentityUserPool+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D3E0FBF0A1B96D9B0A1670BC8C4117E /* AWSCognitoIdentityUserPool+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4CAC8656530CBAB205D1B329885B2420 /* AWSFMDB+AWSHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 38C24E5DB4B1C541A80CDFF1952C4545 /* AWSFMDB+AWSHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4D6195524E59D17144D2463C2245ACAC /* AWSGeneric.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CB773EA726322B9A2CD42FF90D4DD17 /* AWSGeneric.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4851DF7728E1A4D83BEBD0259F55894A /* AWSValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = 91C2B142988FBE04C888E53876BA2642 /* AWSValidation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		49BFAFCF8CD24786DBEE0DB525590378 /* AWSCognitoIdentityUserPool.m in Sources */ = {isa = PBXBuildFile; fileRef = 6988CED39EF50031FDCFEF5E9848AFB6 /* AWSCognitoIdentityUserPool.m */; };
+		49FB3545535B5BA67CAC16F4ADEC0D39 /* CwlPreconditionTesting-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D0E83F4975799D8D677867E97B00A081 /* CwlPreconditionTesting-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CAC8656530CBAB205D1B329885B2420 /* AWSFMDB+AWSHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 68D965159C213A311C522050217704B2 /* AWSFMDB+AWSHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4D6195524E59D17144D2463C2245ACAC /* AWSGeneric.h in Headers */ = {isa = PBXBuildFile; fileRef = D7166CDD70AFA0C6433623748FD475E9 /* AWSGeneric.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4D68B5FF0FDD5D66EC75E01E4E55E881 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A7F5959C56A2F6E93DDA0D9EB3274DE /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-dummy.m */; };
-		4DF330318C6863C9A9457AB6A0D931AC /* AWSCognitoAuth.h in Headers */ = {isa = PBXBuildFile; fileRef = 04498D780108D3EBDF53FD76FB42D380 /* AWSCognitoAuth.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4E7A6FAE1EDFAEECBB22F317BB0A5619 /* NSArray+AWSMTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C69D27D99AAF70EBC5392FB14C7B7DA /* NSArray+AWSMTLManipulationAdditions.m */; };
-		4EA7E8C75835B7707BCC449C87AE56B8 /* AWSMTLManagedObjectAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = BD6402601C3C46495B29A0B51C537439 /* AWSMTLManagedObjectAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4F775EE0184C10B66E9DCFC15493E1A3 /* AWSCognitoIdentityProviderSrpHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = C751FB32301C38302A2EC137BA70D3EC /* AWSCognitoIdentityProviderSrpHelper.m */; };
-		4FDF5A63D4580132177948D42603FB35 /* AWSCognitoIdentityProviderResources.m in Sources */ = {isa = PBXBuildFile; fileRef = DA93AD0D291E93447CCCCCEFD85708BB /* AWSCognitoIdentityProviderResources.m */; };
-		4FF58842A18EEBA4291A5A9BC8DBA9D3 /* AWSTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D2101718310C6801E3A00062C07C39C /* AWSTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		50C0FACEDA7EAF330865E3ABCF646734 /* CwlPreconditionTesting-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F14752C7AAF0C272D64F8DB9DB35D1FB /* CwlPreconditionTesting-dummy.m */; };
-		51250616CA565F13AACEBE3D53B538A9 /* AWSMobileClient-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B3AE5FD3791D0D949459393DD40CD3DF /* AWSMobileClient-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E7A6FAE1EDFAEECBB22F317BB0A5619 /* NSArray+AWSMTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 02CBA27505E2262F5F64DAEDB8CE8E87 /* NSArray+AWSMTLManipulationAdditions.m */; };
+		4EA7E8C75835B7707BCC449C87AE56B8 /* AWSMTLManagedObjectAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 99BC7FA61E5480A10F9CC2701F43B9A3 /* AWSMTLManagedObjectAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4F775EE0184C10B66E9DCFC15493E1A3 /* AWSCognitoIdentityProviderSrpHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = CA2C71AB4AF430CD7C3F0BBFA980970B /* AWSCognitoIdentityProviderSrpHelper.m */; };
+		4FDF5A63D4580132177948D42603FB35 /* AWSCognitoIdentityProviderResources.m in Sources */ = {isa = PBXBuildFile; fileRef = 929336265CFD5286CD800DF27904879E /* AWSCognitoIdentityProviderResources.m */; };
+		4FF58842A18EEBA4291A5A9BC8DBA9D3 /* AWSTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A7150AD06A15FFA3B7777DE68DE4842 /* AWSTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		50C0FACEDA7EAF330865E3ABCF646734 /* CwlPreconditionTesting-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F291DBE453B14BE33FD687E62A995465 /* CwlPreconditionTesting-dummy.m */; };
 		51BB5558A79C35EFC02ED63C95726B97 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E7D5AC68E43CA3768505A58681304E1 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5296910C64F9CFF68149C484D4FCB927 /* AWSCognitoAuthUICKeyChainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = E8D2519C6A2A39EC2767637F8B899FDB /* AWSCognitoAuthUICKeyChainStore.m */; };
 		52CE898391D84D10885B9453ADF3335F /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47D46D2BEC1D90EDAE4F1B547348EEFB /* AWSCore.framework */; };
-		53BB8CAB8C037542DF1E4D61B141C140 /* AWSXMLWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = CAB31BB0CB1979BC02AE603D4C767273 /* AWSXMLWriter.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		551C054C3C2762ED76904044493A3649 /* AWSCognitoIdentityProviderService.m in Sources */ = {isa = PBXBuildFile; fileRef = 27556645674390E079A50FAE1D38FFF1 /* AWSCognitoIdentityProviderService.m */; };
-		55B7F2064D84D89F672A51C07FAF3F25 /* AWSAuthCore-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B4E599012C75D7A133B5D77EB7591134 /* AWSAuthCore-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		565F48D47A3D4B7210AD3710A6D5DC31 /* AWSDDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FB6BA58A3DC5A5334029E7C6BBF6990 /* AWSDDLog+LOGV.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		585B8C3A6DD4AF9F63247DAEE3950B55 /* AWSGZIP.h in Headers */ = {isa = PBXBuildFile; fileRef = 59A459A5BE87F0DADD67EBB169FFF49A /* AWSGZIP.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5881547D10D0115CB765498C4DD879C5 /* AWSMantle.h in Headers */ = {isa = PBXBuildFile; fileRef = B11D75C0DCD9FF11DB626B078823A733 /* AWSMantle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		58BD66C69F22A39246C34EF273B1F368 /* aws_tommath.h in Headers */ = {isa = PBXBuildFile; fileRef = 2791EB61C4AFF9075545494144A5BD95 /* aws_tommath.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		58F04275CDDD17740755E139361A104A /* AWSCancellationTokenSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 12D212D94038E4481D8C3C8043590F7C /* AWSCancellationTokenSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		53BB8CAB8C037542DF1E4D61B141C140 /* AWSXMLWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4EBC18983124FC057E4F6DF2898A82 /* AWSXMLWriter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		54D6C81AB4089CE00C5F58D243DCC8FA /* AWSCognitoAuth.h in Headers */ = {isa = PBXBuildFile; fileRef = E3532D3DEC3B3B7120EC060FE9C7499B /* AWSCognitoAuth.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		551C054C3C2762ED76904044493A3649 /* AWSCognitoIdentityProviderService.m in Sources */ = {isa = PBXBuildFile; fileRef = 9968838C214BDC48C6247783D9B28594 /* AWSCognitoIdentityProviderService.m */; };
+		55B7F2064D84D89F672A51C07FAF3F25 /* AWSAuthCore-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4857CE19C8C5F2FBCD5D178C8925E32F /* AWSAuthCore-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		565F48D47A3D4B7210AD3710A6D5DC31 /* AWSDDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AB1E6FA5B776255F1A3537BE9AA357E /* AWSDDLog+LOGV.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		585B8C3A6DD4AF9F63247DAEE3950B55 /* AWSGZIP.h in Headers */ = {isa = PBXBuildFile; fileRef = 97E3422FF53B92A9D5AFEA9D66AAA4F6 /* AWSGZIP.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5881547D10D0115CB765498C4DD879C5 /* AWSMantle.h in Headers */ = {isa = PBXBuildFile; fileRef = C77683D48729E6AB6FA9EB8451E29E32 /* AWSMantle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		589B4BDB54D0D172D532FC88D5D7C953 /* AWSAuthCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C49CC694143B932ACAEDAB2B998DE32A /* AWSAuthCore.framework */; };
+		58BD66C69F22A39246C34EF273B1F368 /* aws_tommath.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E167C8879A46B30A2FDB093B65ADCBE /* aws_tommath.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		58F04275CDDD17740755E139361A104A /* AWSCancellationTokenSource.h in Headers */ = {isa = PBXBuildFile; fileRef = EC6A357AB15EB63B0204FADCF79A97F8 /* AWSCancellationTokenSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		58F513DBEC30590405F5B3CDC4C472B2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
 		590D69E6710099A3290F2650B7FB5BB5 /* Pods-AmplifyTestApp-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D7E43FB42F81273FADA2B41F8A59397E /* Pods-AmplifyTestApp-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5997B9CD7C53755E5280D4C388059906 /* AWSJKBigDecimal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CDCA759E2B524AD0D5B0529F695A28C /* AWSJKBigDecimal.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		5A41DCFDD03C1FDF56839D98E31941EB /* AWSCognitoIdentityProviderSrpHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B531E9546AD9DB8A58EDF26D38A9FE1 /* AWSCognitoIdentityProviderSrpHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5C6F85ECFE37588A579291C57BA28E44 /* NSArray+AWSMTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A075F8FA03A8A6E504C77FC33DE7E6D /* NSArray+AWSMTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5D1E1ED20C02309D4897C489A4FF1385 /* AWSCognitoAuth+Extensions.h in Headers */ = {isa = PBXBuildFile; fileRef = DBF4A88D5942D7C441128C119BAF0999 /* AWSCognitoAuth+Extensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5D97CDAB82AF5231ACF2D62F75FB4F55 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		5E0032B52DC5BB5FB3CA69F45D484781 /* AWSFMDatabaseQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 81685F61C04386054C6EB486CE045EB4 /* AWSFMDatabaseQueue.m */; };
-		5EB28630A9CC30863DE4382D0A18BB38 /* AWSSTSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C7EFC1FA0A94BB3040D38C1BBFCF76E /* AWSSTSModel.m */; };
-		5FE479276304FDA83745E989DA2F79DF /* AWSDDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 5410D8EAB2C72480C6D03EAC64799186 /* AWSDDASLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		600A24E9D61C48AE2664008652AF340C /* AWSURLRequestRetryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = F7BD476B02A70C2CA36E64D4DDF32DAD /* AWSURLRequestRetryHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6026B603F1245AD52915F34CA6A83CC5 /* AWSCognitoAuth.m in Sources */ = {isa = PBXBuildFile; fileRef = F271D7B7BA1C38C1E117F07AA0BB9E42 /* AWSCognitoAuth.m */; };
-		617A71B50115147C51AD0C6D00BFCCCF /* AWSMTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D02469A819F1238BA748181F1265632 /* AWSMTLJSONAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		61B1A698911FFEDAC3E17424104462CF /* AWSKSReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FF7C8B2AC413711B14A91BC15CD8431 /* AWSKSReachability.m */; };
-		623B9A6697A87E1F42B847CA8F2FE28B /* AWSURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 168E7EDD61CE770FCEEFF271776BDD39 /* AWSURLRequestSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		62D392DC89FC9697970873E8455C503E /* AWSTMCache.m in Sources */ = {isa = PBXBuildFile; fileRef = AE43657F8C0C1405A6F48A02C31C2CF5 /* AWSTMCache.m */; };
-		657547730A8E5358B795A62B0A80137A /* AWSURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = C0B03B2C8F2862CAF77DEFE91DF50641 /* AWSURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		67D8229426E3B531C446102C3F290D63 /* AWSMobileClientUserDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E046FABC7AEB1DDEAF83E80E8A23E5 /* AWSMobileClientUserDetails.swift */; };
-		69426D3130E20C2B3A6679390F539131 /* AWSCognitoIdentityProvider-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A077A3D16945E07EBB64DF9B37B77A62 /* AWSCognitoIdentityProvider-dummy.m */; };
-		6A6F7F27DCCF6D5F73EA43FCCA1DAB92 /* _AWSMobileClient.m in Sources */ = {isa = PBXBuildFile; fileRef = F5DABEBB1A7AE30FC002FA9F7D7C32BC /* _AWSMobileClient.m */; };
+		5997B9CD7C53755E5280D4C388059906 /* AWSJKBigDecimal.h in Headers */ = {isa = PBXBuildFile; fileRef = 23B3726BA8188C858679F4A62BC5CBE9 /* AWSJKBigDecimal.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		5A41DCFDD03C1FDF56839D98E31941EB /* AWSCognitoIdentityProviderSrpHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A4B58BC9B812E6EFFD4E6FE0BA16141 /* AWSCognitoIdentityProviderSrpHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5B96288E92790AC284A258082D40A1C9 /* AWSMobileClientExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5C76E4BCB1631B533E28A1DA95403A /* AWSMobileClientExtensions.swift */; };
+		5C6F85ECFE37588A579291C57BA28E44 /* NSArray+AWSMTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5917F431683B8C300E8F61292DB9C977 /* NSArray+AWSMTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5E0032B52DC5BB5FB3CA69F45D484781 /* AWSFMDatabaseQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 351B029C4F1BEDEA7476F09758D57E5D /* AWSFMDatabaseQueue.m */; };
+		5E64CCB1D7FC10661B116F8ED8819648 /* AWSCognitoAuth_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 33E7E7A2DD1B06B19C2F0B2B692890C2 /* AWSCognitoAuth_Internal.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		5EB28630A9CC30863DE4382D0A18BB38 /* AWSSTSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = BC715587BE425079FAA4305951B22D71 /* AWSSTSModel.m */; };
+		5FE479276304FDA83745E989DA2F79DF /* AWSDDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = D283F1B77F53E197BA10ED0DAB9F2445 /* AWSDDASLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		600A24E9D61C48AE2664008652AF340C /* AWSURLRequestRetryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = E20654D1C7C32E38165102AE5ABFB0F0 /* AWSURLRequestRetryHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		601D294DEA3B5DA9613371722EAB154D /* DeviceOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25D5299C21355193D7C2A76F8CEEFDD /* DeviceOperations.swift */; };
+		617A71B50115147C51AD0C6D00BFCCCF /* AWSMTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = FC341DFA15E436E927491FB260311C9B /* AWSMTLJSONAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		61B1A698911FFEDAC3E17424104462CF /* AWSKSReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 438977A2FC2F79FA90059803F47E7388 /* AWSKSReachability.m */; };
+		623B9A6697A87E1F42B847CA8F2FE28B /* AWSURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = BECA5D4C0B1E2BE1E29EFA8A6FD6DF19 /* AWSURLRequestSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		62D392DC89FC9697970873E8455C503E /* AWSTMCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 16A162C41F0549F96E8E860FE210AFBF /* AWSTMCache.m */; };
+		657547730A8E5358B795A62B0A80137A /* AWSURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F5E803FC9650596AEA2F9A353BE31401 /* AWSURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66F79AA0A7BADE7040571FBA367C4239 /* AWSUserPoolCustomAuthHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B1E9500E2EA7365DD37F18E40DB00C5 /* AWSUserPoolCustomAuthHandler.swift */; };
+		69426D3130E20C2B3A6679390F539131 /* AWSCognitoIdentityProvider-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CF10481CDDC747914614A828F8E73CD /* AWSCognitoIdentityProvider-dummy.m */; };
 		6CC5A1D52EF2B655C4F784DDF05E6570 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		6D4394F1745698365A9C40BB0A7A7AD2 /* AWSMTLModel.h in Headers */ = {isa = PBXBuildFile; fileRef = F9E0D46A0F53CEF014CB608689479F5A /* AWSMTLModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6E4FD2AB420D24BA1FE7D53D4CABEAC8 /* AWSSignInButtonView.h in Headers */ = {isa = PBXBuildFile; fileRef = EA5ACF18886A4FF581354E7504E25CCD /* AWSSignInButtonView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6D4394F1745698365A9C40BB0A7A7AD2 /* AWSMTLModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B5A27D1F00D26D77D2F1FB2BED6F0A8 /* AWSMTLModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6E4FD2AB420D24BA1FE7D53D4CABEAC8 /* AWSSignInButtonView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E641F4FC82C85952BAF9B257C40A701 /* AWSSignInButtonView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6F173BDEC3D52002ECE0AFF78D666654 /* AWSMobileResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F05F078F444866691A7A4F880388E71 /* AWSMobileResults.swift */; };
 		719C0EFB3578E7E5303BDE1B25596ABD /* Pods-Amplify-AWSPluginsCore-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DEC3E3C3510C8A55F95F909E0207C7DD /* Pods-Amplify-AWSPluginsCore-dummy.m */; };
 		7220D03973258EA8DE357E18142CFBCE /* Pods-Amplify-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 64802F2E333FD29A93B939784FB965FE /* Pods-Amplify-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		781205D14C8BB2089F3A5EACB8D848CC /* AWSFMDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D814B6AF5A67FF1828ECF314845D1BD /* AWSFMDatabase.m */; };
-		7823E936D9B566B90F997812337AFF6D /* AWSTMDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = C163507295304A519E85051ED74A6209 /* AWSTMDiskCache.m */; };
-		786A00B206FE67A484E80BB4F52C65D5 /* AWSXMLDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 49C1DACDE13725ACAFADE7825739F218 /* AWSXMLDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		788692E6436FAA77FB4106A8A43A6D43 /* AWSFMDB+AWSHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = A52145D6322955C0D6C6F09871F24741 /* AWSFMDB+AWSHelpers.m */; };
-		7A91CEDA043B8B5257FD9D1EAA5614A7 /* AWSJKBigInteger.m in Sources */ = {isa = PBXBuildFile; fileRef = 856B9460EE390E948E972BC937AD38F4 /* AWSJKBigInteger.m */; };
-		7AD034A4C74DD3FAC09164FF4462B682 /* AWSFMDatabaseQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 41F1BA5E8793C8CC6222D85413CE4C4A /* AWSFMDatabaseQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7B81C22E00652B512C92118BE69467EE /* AWSCognitoIdentityProviderASF.h in Headers */ = {isa = PBXBuildFile; fileRef = CDA38353C499EAFBF0C7F4C481DB06D1 /* AWSCognitoIdentityProviderASF.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7BA450B429AD6BFB0CD6903F48A3A73A /* AWSAuthCore.h in Headers */ = {isa = PBXBuildFile; fileRef = A46B3233721574887E89B7E89E73CB49 /* AWSAuthCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7C54E87DA0FEDA01C2E6466361F2E915 /* NSError+AWSMTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = C9022B2A001A348E8DEDD1296B5E0716 /* NSError+AWSMTLModelException.m */; };
+		774615D361214800A581F3588FB96E5A /* AWSMobileClientUserDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2467B4C12BFB43EE82B2C9FCCA58B4E /* AWSMobileClientUserDetails.swift */; };
+		781205D14C8BB2089F3A5EACB8D848CC /* AWSFMDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 49DDC8B4B8A0008C33DC34FFEE3FC90F /* AWSFMDatabase.m */; };
+		7823E936D9B566B90F997812337AFF6D /* AWSTMDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = A34C3FFA168434E053A947A44448184E /* AWSTMDiskCache.m */; };
+		786A00B206FE67A484E80BB4F52C65D5 /* AWSXMLDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = B6277D3F2C6FEE504D3735AE99072576 /* AWSXMLDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		788692E6436FAA77FB4106A8A43A6D43 /* AWSFMDB+AWSHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = C5E6F0C0A4A580010558CD9BF7B954F5 /* AWSFMDB+AWSHelpers.m */; };
+		7A91CEDA043B8B5257FD9D1EAA5614A7 /* AWSJKBigInteger.m in Sources */ = {isa = PBXBuildFile; fileRef = 5310AD54B79AE33BED07FE6266C6C464 /* AWSJKBigInteger.m */; };
+		7AD034A4C74DD3FAC09164FF4462B682 /* AWSFMDatabaseQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 795B8F8866B38DB939E35FDBA96AF27E /* AWSFMDatabaseQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7B81C22E00652B512C92118BE69467EE /* AWSCognitoIdentityProviderASF.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B680E6B9305CB9D4018616634665303 /* AWSCognitoIdentityProviderASF.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BA450B429AD6BFB0CD6903F48A3A73A /* AWSAuthCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 42C4CB6E6E4C46091EEC21ACAA570A13 /* AWSAuthCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7C54E87DA0FEDA01C2E6466361F2E915 /* NSError+AWSMTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CEA978C394A670DE913406DF84C37B3 /* NSError+AWSMTLModelException.m */; };
 		7E563800D6BC72004F79096CF284A320 /* Pods-Amplify-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B8A667E74EC0A8A4EDFB8F2D2364FC92 /* Pods-Amplify-dummy.m */; };
-		7E72445D57E2B1377BB8C31D0D45F583 /* AWSDDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F3CA727772902D38F633984F132084D /* AWSDDAbstractDatabaseLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7FAAD3074FCCD0FB5F7DC085A79F1352 /* AWSMTLManagedObjectAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E3D65FEA8DF69AB59F24058F42DCED6 /* AWSMTLManagedObjectAdapter.m */; };
-		82B604223403F2D8913736CDBCBD3421 /* AWSTMCacheBackgroundTaskManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B105C48272F594AC5233F7320470A5B7 /* AWSTMCacheBackgroundTaskManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		84F1B973AFBCCC12088C40C41A9AAD0E /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 98EBAF29DC4D794957822E239F9C944B /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		858196891699CB779D9415EE462CD40B /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D98814487113FC0451682BF2CA928D0 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */; };
-		85DF3750F9FDC7219E7E1BF6F9194D4D /* AWSTMDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = DAA8BB0506C2E9D42D5AED09D74156A6 /* AWSTMDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		865DC647D80B2C560666A8BC90753092 /* AWSSTS.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E8F49480EF8060BB37B26F5BC5DF99 /* AWSSTS.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		867F53F6C252DB86B6980B38127D670A /* AWSFMResultSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A8546CE0DBDFE5D38B2046606E4B7CE /* AWSFMResultSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8B56F42D143D78C6F5BD42A941106BA9 /* AWSService.m in Sources */ = {isa = PBXBuildFile; fileRef = 65A25F6FD0D61706F9535950AFC406E4 /* AWSService.m */; };
-		8B674E154C488891F92084314F681415 /* AWSCognitoIdentityProviderService.h in Headers */ = {isa = PBXBuildFile; fileRef = 58C89AD838EDC38CC8C7DBB462B82E56 /* AWSCognitoIdentityProviderService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7E72445D57E2B1377BB8C31D0D45F583 /* AWSDDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = B8892F2ADBD009DECB8C1D0B654A930D /* AWSDDAbstractDatabaseLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7FAAD3074FCCD0FB5F7DC085A79F1352 /* AWSMTLManagedObjectAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 20C60E4B329922D1F91D8DC3DE396DA6 /* AWSMTLManagedObjectAdapter.m */; };
+		82B604223403F2D8913736CDBCBD3421 /* AWSTMCacheBackgroundTaskManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 80009A829D5F19DFB029CD1074D46FD4 /* AWSTMCacheBackgroundTaskManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		84F1B973AFBCCC12088C40C41A9AAD0E /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = CF059F400C23E801FC3E8CADBC196680 /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		858196891699CB779D9415EE462CD40B /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = BDDF6B882BD969BB837E4A5A683B83C7 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */; };
+		85DF3750F9FDC7219E7E1BF6F9194D4D /* AWSTMDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = B6D8BE1666950E8A45057CC6666024C2 /* AWSTMDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		865DC647D80B2C560666A8BC90753092 /* AWSSTS.h in Headers */ = {isa = PBXBuildFile; fileRef = BBFE758649A0AFC2A4DFF34C4B5AB080 /* AWSSTS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		867F53F6C252DB86B6980B38127D670A /* AWSFMResultSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D98BF8E4B6395E80EDB1448E308861F /* AWSFMResultSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		899F3EC9E3871788006C0546EBC03291 /* AWSMobileOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3514C8A4F0642770992CBA9207EA5342 /* AWSMobileOptions.swift */; };
+		8B56F42D143D78C6F5BD42A941106BA9 /* AWSService.m in Sources */ = {isa = PBXBuildFile; fileRef = 65A614203886ABADE199A0B800ECEE41 /* AWSService.m */; };
+		8B674E154C488891F92084314F681415 /* AWSCognitoIdentityProviderService.h in Headers */ = {isa = PBXBuildFile; fileRef = A6EA21687C72BE41C8EB5778B6F7D519 /* AWSCognitoIdentityProviderService.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8C3D6083788CFA96F014554916B47E96 /* Pods-AmplifyTestApp-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CC60529D233360B1F356DC750E15164 /* Pods-AmplifyTestApp-dummy.m */; };
-		8C4F65C6BCEB1D62FD195E15403F01F9 /* AWSGZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = C0DB0C0B9E1C812A42914C8AA7BF1A8D /* AWSGZIP.m */; };
-		8DE2768806CC526886BF6D06E8E83C1D /* AWSInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C5FAED483BFCC2F6ED318BFC0A89612 /* AWSInfo.m */; };
-		8E17B1081D3CEBCA661AF6EF03AA9B91 /* AWSCognitoIdentityProviderASF.m in Sources */ = {isa = PBXBuildFile; fileRef = 4108872B2D9F35982F849D20935EFE58 /* AWSCognitoIdentityProviderASF.m */; };
-		92944936808E537A51D7FB76879573B0 /* AWSFMDatabasePool.h in Headers */ = {isa = PBXBuildFile; fileRef = CD9504574C2BEA74886D0BA7A7E51BE6 /* AWSFMDatabasePool.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9330A6BAFFA518B4BECBFAD3412BF162 /* AWSSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = B8785DC9A87864D9C1FDCB43C2469B74 /* AWSSerialization.m */; };
-		9343EE314C0B2A5126CC43BA07AC6001 /* AWSUIConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = EB037FE1BB0944A9A0396B42155C798B /* AWSUIConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		94E032B726F3F3D2425C5803AA3905E5 /* AWSCore-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 017996FA9F98A7E1AC8B1FB672D4E557 /* AWSCore-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		95465C26DCAF34829BEDF0B2873E5D22 /* AWSSynchronizedMutableDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 11EDEFEDFA365D9648D81979FF0CF2BA /* AWSSynchronizedMutableDictionary.m */; };
+		8C4F65C6BCEB1D62FD195E15403F01F9 /* AWSGZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = 741F49C40E6FA66D5CD23136107A9A2C /* AWSGZIP.m */; };
+		8DE2768806CC526886BF6D06E8E83C1D /* AWSInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 4776EB5C7291FE4BC37305AA93543C01 /* AWSInfo.m */; };
+		8E17B1081D3CEBCA661AF6EF03AA9B91 /* AWSCognitoIdentityProviderASF.m in Sources */ = {isa = PBXBuildFile; fileRef = 881C4F7AD68CE9C1D2FF602B2C79FA9A /* AWSCognitoIdentityProviderASF.m */; };
+		8ED2F8EE57C9042901D80E722D41AC0D /* AWSCognitoIdentityUserPool+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 4840EABAFD9EACE0BD6B3FFF209208C0 /* AWSCognitoIdentityUserPool+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		900EB0A2321005B91FC71C7F8C7B92ED /* AWSCognitoIdentityProvider.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 897BE0E1152364146DF9E84966A20D23 /* AWSCognitoIdentityProvider.framework */; };
+		92944936808E537A51D7FB76879573B0 /* AWSFMDatabasePool.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FD575266288E008C6989EF6E2A2AC9C /* AWSFMDatabasePool.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9330A6BAFFA518B4BECBFAD3412BF162 /* AWSSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CAB5F26082AF7C2C342C8BF2B511189 /* AWSSerialization.m */; };
+		9343EE314C0B2A5126CC43BA07AC6001 /* AWSUIConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 7861A4ABA0A851F8F55F302EBCA9588A /* AWSUIConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		941E42D1D509D1F582000664CD91E228 /* _AWSMobileClient.m in Sources */ = {isa = PBXBuildFile; fileRef = D04928F7B7DF5814379C4B5B12F50A99 /* _AWSMobileClient.m */; };
+		94E032B726F3F3D2425C5803AA3905E5 /* AWSCore-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A6784ED93641EB4F41049EFBFAE024D1 /* AWSCore-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		95465C26DCAF34829BEDF0B2873E5D22 /* AWSSynchronizedMutableDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A549DBDF126AD830CF93ABF538B614D /* AWSSynchronizedMutableDictionary.m */; };
 		960B8E71E94DFFC52104B7D2A005F701 /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47D46D2BEC1D90EDAE4F1B547348EEFB /* AWSCore.framework */; };
-		96D71A9A27A288204F9C2C6FB0938075 /* AWSCancellationTokenSource.m in Sources */ = {isa = PBXBuildFile; fileRef = D29FE4BBF56788C9AC325256DFB9A156 /* AWSCancellationTokenSource.m */; };
-		96D859318FE7B536D841C4B7ED8915B9 /* AWSTMCache.h in Headers */ = {isa = PBXBuildFile; fileRef = DE52C631AAD1F37EC85940B309484450 /* AWSTMCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		97C52BFCC42E09EEE37E0F079375C892 /* JSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAC8F37FB83D9A1FAE60863BAE22A2 /* JSONHelper.swift */; };
-		98E684975408A0A06FE6BCE1431F686A /* AWSLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 722FB0BF2F494C956CD49C0C75A2FDC0 /* AWSLogging.m */; };
-		99D77CDBCF4C3CF91116F5E54921F181 /* NSError+AWSMTLModelException.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CAB3BD92207D2E252347FD79A669516 /* NSError+AWSMTLModelException.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9C348F0554641CE5E4D400226C483C84 /* AWSSignature.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B109D739CFC883289A6548766B8B7DD /* AWSSignature.m */; };
-		9C756224993E158189C803D1CF6DB659 /* AWSMobileClientExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE13CC64B7D51AA8D246157E67E7DDB0 /* AWSMobileClientExtensions.swift */; };
+		96D71A9A27A288204F9C2C6FB0938075 /* AWSCancellationTokenSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 76E072AC48744E37B1968B34E9FB8990 /* AWSCancellationTokenSource.m */; };
+		96D859318FE7B536D841C4B7ED8915B9 /* AWSTMCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 6460C32B00D43D9E0499355B51800A75 /* AWSTMCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		98E684975408A0A06FE6BCE1431F686A /* AWSLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 611E4441D39C5B5170F8B169E0740B35 /* AWSLogging.m */; };
+		99D77CDBCF4C3CF91116F5E54921F181 /* NSError+AWSMTLModelException.h in Headers */ = {isa = PBXBuildFile; fileRef = 440558432306D065896EAE19BE1FDCF2 /* NSError+AWSMTLModelException.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C348F0554641CE5E4D400226C483C84 /* AWSSignature.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C6E66CCCA2AE2C466B9B3E4E7E352DE /* AWSSignature.m */; };
 		9D914E2C5BB01F438CE2CEFAF3518D6F /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C6DDDDA1D966AED315AB70664004815 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9E6E606BC775C9D70B5F73B75F6466D7 /* AWSCognitoIdentityService.h in Headers */ = {isa = PBXBuildFile; fileRef = 7771C2DFE4AD99CD3A269C7ADB017DAA /* AWSCognitoIdentityService.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9F178FED04D876360188F685980EC42B /* AWSSignInManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F94581174EDFD77DD77D64E573D786 /* AWSSignInManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A1B8BC6F446260D9062F08EE602A11BB /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 63558BCBF0A625B52BCB547CD0DFB1BA /* CwlMachBadInstructionHandler.m */; };
-		A26278DDB3EBC5C5A65C4C86382B0AF8 /* NSObject+AWSMTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0CF40D7AF9CA3F2F9A410759AE391171 /* NSObject+AWSMTLComparisonAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A26C2FD9F3C6A6D8C8859C915163A0B6 /* AWSCognitoIdentity+Fabric.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CACA599E066FECF7765E60FB671E1A8 /* AWSCognitoIdentity+Fabric.m */; };
-		A325BDDE98FB22C8DCB42AFCA0A0A1A1 /* AWSFMResultSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 9176A30EF537A984349EF0941C29042B /* AWSFMResultSet.m */; };
-		A3E2BFD1F35BCE94C2023D88AA5BC579 /* AWSDDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 92A43858635F9C27ED94A05763E2521E /* AWSDDASLLogger.m */; };
+		9E6E606BC775C9D70B5F73B75F6466D7 /* AWSCognitoIdentityService.h in Headers */ = {isa = PBXBuildFile; fileRef = B1FE6F1140144DE02164800F5A36634D /* AWSCognitoIdentityService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F178FED04D876360188F685980EC42B /* AWSSignInManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 64F1263957BE1770DED0ABCC5F3872D8 /* AWSSignInManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A16C4E9390E6BB2980D939DC8E65B67C /* AWSCognitoAuthUICKeyChainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = BA53451B0AAF0009E78D037F9A02F878 /* AWSCognitoAuthUICKeyChainStore.m */; };
+		A1B8BC6F446260D9062F08EE602A11BB /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C441590C7A204DED15D0F8637E15D83 /* CwlMachBadInstructionHandler.m */; };
+		A26278DDB3EBC5C5A65C4C86382B0AF8 /* NSObject+AWSMTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B13015BDFD766A5AA586CA772B1E3EF /* NSObject+AWSMTLComparisonAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A26C2FD9F3C6A6D8C8859C915163A0B6 /* AWSCognitoIdentity+Fabric.m in Sources */ = {isa = PBXBuildFile; fileRef = C9C7A3FBCE1D43323505FAAA796042CB /* AWSCognitoIdentity+Fabric.m */; };
+		A325BDDE98FB22C8DCB42AFCA0A0A1A1 /* AWSFMResultSet.m in Sources */ = {isa = PBXBuildFile; fileRef = C2F7721C7D4AB4BD517C4A7A90EC2AF7 /* AWSFMResultSet.m */; };
+		A3E2BFD1F35BCE94C2023D88AA5BC579 /* AWSDDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B09EDE3A624F7ABBDC0599DB913A0F8 /* AWSDDASLLogger.m */; };
 		A6598CE3C61D646FEB39A1CC9AC3BA6F /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9000133D745E33FE1ED02390F5F7E717 /* CoreGraphics.framework */; };
-		A81152A334E18EC67B13C8DE062572C9 /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = E727F698E5184B8A8F0AEF9CAF632FA8 /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9E6B3F4412CAA30168D675A302122E9 /* AWSNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E2AEE92884E8A3660E2A5C368A9D134 /* AWSNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A81152A334E18EC67B13C8DE062572C9 /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C768E0E6854399915626CEF3A4AD186 /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A9E6B3F4412CAA30168D675A302122E9 /* AWSNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = A042B28A3C211CA9A4F74DAF7311F33D /* AWSNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA518F23ECB9642D933EEB2D112C00FB /* AWSCognitoIdentityProviderASF.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4144DE60EA249CC4A98549069F402FB /* AWSCognitoIdentityProviderASF.framework */; };
 		AA66B7FEEAF81CA08B1515A1BDFA8511 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		ABC164C2B5402553E19E1CE32AE65E14 /* AWSCredentialsProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 13A6AC4F2598B540AB29DEA12B8DA004 /* AWSCredentialsProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AC0913A1E4C9CDEC5699AD154BA254A1 /* AWSCognitoIdentityService.m in Sources */ = {isa = PBXBuildFile; fileRef = DCE1BA35810587B99C58F0FED53ABAC3 /* AWSCognitoIdentityService.m */; };
-		AD223728D8DFA18B28E0340459453763 /* AWSCognitoIdentityProvider.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 897BE0E1152364146DF9E84966A20D23 /* AWSCognitoIdentityProvider.framework */; };
-		AE2C16CE9FB6CCEC0BAE444DEBD69234 /* AWSDDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 98FCA979D8A8822E734476B6E58B8ED4 /* AWSDDFileLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AF66AF015E286081DB48279E84D00286 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 673FC21F904E05922260C6F6C1055044 /* CwlCatchException.m */; };
-		AF8EBCA0F90060448E15E47025733327 /* AWSCancellationToken.h in Headers */ = {isa = PBXBuildFile; fileRef = E1EC8C3E16C71BF25AA7F00CDEF6C1DE /* AWSCancellationToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AFD9EAAB3DD21504017BEA68684667AD /* AWSFMDatabaseAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 810E6C0AEAF81CEF142AD224BC9FA4D7 /* AWSFMDatabaseAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B12C8A1CC225C17AFCA43D4BAF707E7B /* AWSCocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = 9348F3E0355579436D403C96DB0D7EF4 /* AWSCocoaLumberjack.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ABC164C2B5402553E19E1CE32AE65E14 /* AWSCredentialsProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = D9223D3012D6A3F0E45D477716FC783A /* AWSCredentialsProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AC0913A1E4C9CDEC5699AD154BA254A1 /* AWSCognitoIdentityService.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF046703AE413CFEFDEA5EE438FF370 /* AWSCognitoIdentityService.m */; };
+		AE2C16CE9FB6CCEC0BAE444DEBD69234 /* AWSDDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 0816FEAC15987BEA5F0AAC291F36AF7F /* AWSDDFileLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AF66AF015E286081DB48279E84D00286 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 38643E84B084A0BEB5CED73C2759B5BF /* CwlCatchException.m */; };
+		AF8EBCA0F90060448E15E47025733327 /* AWSCancellationToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 41594B5134424E94E3C96777AA52D60A /* AWSCancellationToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AFD9EAAB3DD21504017BEA68684667AD /* AWSFMDatabaseAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 821D30FC1FA05A779392557905809822 /* AWSFMDatabaseAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B12C8A1CC225C17AFCA43D4BAF707E7B /* AWSCocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F5251F3952F1FA41D25883D9DB6C8C0 /* AWSCocoaLumberjack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B496D83E23179346F1978A44D72C8CA5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		B5AFCE15B9D849BD84A6D6E46C144F16 /* AWSSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = F2F95957A8A28F91A1A0FE2164F2234D /* AWSSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B5AFCE15B9D849BD84A6D6E46C144F16 /* AWSSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 2941F0841B1124B775BC2CCF8C3FB149 /* AWSSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5F01854ADFAC527435AAC6D505D9A46 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 11618E052B1995FC3B058B8E47104CFA /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-dummy.m */; };
-		B67CE9FC51F77CC591562D2BF2CA3EA2 /* AWSSTSResources.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6AB7B64F3EA49D82336E6F2342E8F4 /* AWSSTSResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B79F025D9EF7BB4E4860A39308B967B1 /* AWSCognitoIdentityUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 506993FFD5E43321C8EE111378E6B6C5 /* AWSCognitoIdentityUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BA498D6F2E108FF6A250EF156FB199CA /* AWSCognitoIdentity.h in Headers */ = {isa = PBXBuildFile; fileRef = 66B10363FF226628014BC9AA0109E500 /* AWSCognitoIdentity.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BAC85A39D3808CE79873936E4231A6DA /* AWSURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 79F8F7318B8DE19209DA9DDF5193FC01 /* AWSURLRequestSerialization.m */; };
-		BAF1E92557EF7F7F16BEBAB2E1A512A7 /* CwlPreconditionTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 12163530DDDEF249BE3C311D0ED23327 /* CwlPreconditionTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BDAFBC302AFBD0169D63A493EF24F019 /* AWSEXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 16A649B28EBAF292512D8F10FD00EEC0 /* AWSEXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		BE6A0ECFE8619D15EF84F45C240644F5 /* AWSMTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 18F8E4C791238DE2BC89F84EF383A00D /* AWSMTLModel.m */; };
-		BE7ADABCCDB533FDC0433D0D631EF85E /* AWSMobileOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F0A6A210EDEAFCB636DEF2E8E2C143 /* AWSMobileOptions.swift */; };
-		BE8ABD8C2F11BF351AEC13B6FFFDF99A /* NSValueTransformer+AWSMTLInversionAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F427531291DB1D1C9D8F6A709F1BBD2A /* NSValueTransformer+AWSMTLInversionAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B67CE9FC51F77CC591562D2BF2CA3EA2 /* AWSSTSResources.h in Headers */ = {isa = PBXBuildFile; fileRef = 0886BCD226D6B5190149C85BA3210FCB /* AWSSTSResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B79F025D9EF7BB4E4860A39308B967B1 /* AWSCognitoIdentityUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2836D98A865986A534EDB5C920AF2460 /* AWSCognitoIdentityUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BA498D6F2E108FF6A250EF156FB199CA /* AWSCognitoIdentity.h in Headers */ = {isa = PBXBuildFile; fileRef = E41A4F6C5931A151F14ADD44D2C53F73 /* AWSCognitoIdentity.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BAC85A39D3808CE79873936E4231A6DA /* AWSURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = E6FDC0CFF3356A4962E09D5E960ABB17 /* AWSURLRequestSerialization.m */; };
+		BAF1E92557EF7F7F16BEBAB2E1A512A7 /* CwlPreconditionTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 46FB3D57F1B7BFC2E0DECB2BD2A0E07B /* CwlPreconditionTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BDAFBC302AFBD0169D63A493EF24F019 /* AWSEXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 8DC83450666908D92C002EA49A394A08 /* AWSEXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BE6A0ECFE8619D15EF84F45C240644F5 /* AWSMTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = E93D888F2358613A1772D77597C493E9 /* AWSMTLModel.m */; };
+		BE8ABD8C2F11BF351AEC13B6FFFDF99A /* NSValueTransformer+AWSMTLInversionAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E8A8CA0DDD90CB39D32CE5FD24DC429 /* NSValueTransformer+AWSMTLInversionAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BEA4DBC17C6B9BCE2C41179ECC3DAA1D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
 		BEEC4A944FADA30EC4B4A113212AEEE5 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE49F6473631850D3EC76C328D5772CB /* UIKit.framework */; };
-		C2A8E95E1378D95C29118217596E5EEA /* AWSDDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = A30C60B5CD0C127A0F791708CFE9B42D /* AWSDDDispatchQueueLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C3525FB9301A85B4E55C6F01D3BBDD5A /* AWSMTLReflection.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A60E93D25B2C3C212B4679F93F75755 /* AWSMTLReflection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C35B120FF2B1D18672753CF6EC0985DD /* AWSCore-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 51F546FB05338188F9D16DCA20239565 /* AWSCore-dummy.m */; };
-		C3E5346133EC63B83B5B163399B39A1B /* AWSURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C738EC7E8D4A0BF95B09336DEDB98B1 /* AWSURLSessionManager.m */; };
-		C46FEE5166870EAC61B19C9EDB7AADC3 /* AWSCognitoIdentityProviderHKDF.m in Sources */ = {isa = PBXBuildFile; fileRef = A1D9BE851096D333C6BCF3DCC3CB8685 /* AWSCognitoIdentityProviderHKDF.m */; };
+		C2A8E95E1378D95C29118217596E5EEA /* AWSDDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = B6C416894DABEDED0EA160A85B935848 /* AWSDDDispatchQueueLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C3525FB9301A85B4E55C6F01D3BBDD5A /* AWSMTLReflection.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F48EA94451797FD4F975F332D56208F /* AWSMTLReflection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C35B120FF2B1D18672753CF6EC0985DD /* AWSCore-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D08680B5CB880D99A30DF2ABB5ABB192 /* AWSCore-dummy.m */; };
+		C3E5346133EC63B83B5B163399B39A1B /* AWSURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AEE0DFAEAE5810A498869F32312A98CC /* AWSURLSessionManager.m */; };
+		C46FEE5166870EAC61B19C9EDB7AADC3 /* AWSCognitoIdentityProviderHKDF.m in Sources */ = {isa = PBXBuildFile; fileRef = 493DA8219B45D565C4ECC2D16A23529F /* AWSCognitoIdentityProviderHKDF.m */; };
 		C4F5A55C56D472D4F7D140D0950B6E97 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 189C8021820D164FA9236F1D27850C3F /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C61912BA5E6897BB6DF7A83C5114AC61 /* AWSAuthUIHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D7AD3753C2B976519ABD2B870B1AAF5 /* AWSAuthUIHelper.m */; };
-		C682CF45DC1BE3A1391C38D98B23178D /* AWSTask.m in Sources */ = {isa = PBXBuildFile; fileRef = B22773A61D27574942BD3C76F4C90814 /* AWSTask.m */; };
-		C6E6CC33D0DC9F7F706B5BEECD5C5A75 /* AWSDDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = AF9B52768BC4CE65526EAB63E2E75880 /* AWSDDTTYLogger.m */; };
-		C7BB5752DCF16A55A09916C85EB64EA1 /* AWSTMMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 60F4BE632949FAE284F63F70D7952C60 /* AWSTMMemoryCache.m */; };
-		CA226D1FC3EC02847A70C9DC565362CC /* AWSTaskCompletionSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 25B48B5E2F240D5C178AEC37739F47BD /* AWSTaskCompletionSource.m */; };
-		CA46FB0B92B5831CD73B49D188549037 /* aws_tommath_class.h in Headers */ = {isa = PBXBuildFile; fileRef = 388680EB7CAF4AB53E3DD89E2CC90F2E /* aws_tommath_class.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		CA8CAC4B7D5CEA18AEC162BE523E3368 /* AWSServiceEnum.h in Headers */ = {isa = PBXBuildFile; fileRef = D0E94613A5F8B0E8267BE68F25F2F8CD /* AWSServiceEnum.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CAC63FC5740B67E322F64FA92C51BE29 /* AWSBolts.h in Headers */ = {isa = PBXBuildFile; fileRef = B6F8E974D59BB2C71C3998C162816143 /* AWSBolts.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CAD5041B5768C4F6E0EE0C3D3EA1C439 /* AWSCognitoIdentityProviderHKDF.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B0AAF84EC698F11CC63045004A9ED58 /* AWSCognitoIdentityProviderHKDF.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBFDA937C68D277582439A7F827791FA /* AWSBolts.m in Sources */ = {isa = PBXBuildFile; fileRef = D87BBA54881BE0850CBFFDC4D8114FCA /* AWSBolts.m */; };
+		C61912BA5E6897BB6DF7A83C5114AC61 /* AWSAuthUIHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 815CCB2AE451A2908705CF17B1B45765 /* AWSAuthUIHelper.m */; };
+		C682CF45DC1BE3A1391C38D98B23178D /* AWSTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 710605340E5A8DDE7D63BD3EBD553A7E /* AWSTask.m */; };
+		C6E6CC33D0DC9F7F706B5BEECD5C5A75 /* AWSDDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 1364C2E6FFB3D6CA23B8E4F7EA192804 /* AWSDDTTYLogger.m */; };
+		C7BB5752DCF16A55A09916C85EB64EA1 /* AWSTMMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 0907C13F03EF67C1D2365ACFD20D38D6 /* AWSTMMemoryCache.m */; };
+		CA226D1FC3EC02847A70C9DC565362CC /* AWSTaskCompletionSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 0581448F3A1EE16FE6877A21192B3174 /* AWSTaskCompletionSource.m */; };
+		CA46FB0B92B5831CD73B49D188549037 /* aws_tommath_class.h in Headers */ = {isa = PBXBuildFile; fileRef = D34262BF92ECE4D3009E5F09892D60F0 /* aws_tommath_class.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		CA8CAC4B7D5CEA18AEC162BE523E3368 /* AWSServiceEnum.h in Headers */ = {isa = PBXBuildFile; fileRef = 174B19F5C049FC2721C627519446CAC4 /* AWSServiceEnum.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CAC63FC5740B67E322F64FA92C51BE29 /* AWSBolts.h in Headers */ = {isa = PBXBuildFile; fileRef = 41F8F2B38046526CF3AC8DF1690BE9CF /* AWSBolts.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CAD5041B5768C4F6E0EE0C3D3EA1C439 /* AWSCognitoIdentityProviderHKDF.h in Headers */ = {isa = PBXBuildFile; fileRef = CAEB52D72F180BE2D87F708E35A82DA1 /* AWSCognitoIdentityProviderHKDF.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CBFDA937C68D277582439A7F827791FA /* AWSBolts.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E125CA7F667A530C30603C40C195AD9 /* AWSBolts.m */; };
 		CC3489D3AE121850205206C8DA3AC9BB /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 71803B908C82923324FBC55B50603420 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CCF3D812222A96CB42B542F4D68A6B3F /* AWSUserPoolOperationsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA5040145A5FC42FC743FA56514940 /* AWSUserPoolOperationsHandler.swift */; };
-		CD670349157D1CC299C595DBC118D553 /* AWSMobileResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8E1C643E55898382E15AC05AA7365E /* AWSMobileResults.swift */; };
-		CD9C8503D19F1E4D26A2D1705B7C922C /* AWSURLRequestRetryHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EDE3BF19468DE4E9605AD1B08021DF4 /* AWSURLRequestRetryHandler.m */; };
-		CEAD5A825A2B2228733F1F745D85024D /* AWSSignInProviderApplicationIntercept.h in Headers */ = {isa = PBXBuildFile; fileRef = F752DCF3576E6E8F2191593BA7C6F05A /* AWSSignInProviderApplicationIntercept.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D0008DB1D694408559F50AD06E9DCF00 /* AWSUserPoolCustomAuthHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D4071126A64D42B2F302F608505CE9 /* AWSUserPoolCustomAuthHandler.swift */; };
-		D3C7CEE1ABDD4DB9F318808066874630 /* AWSInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = A160B41090A56C0EFD3C4DF8921A1539 /* AWSInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D3F34BB211709B19D794F38CAE744DCF /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = F917BC5B219C19085ED19ED90CB19D15 /* CwlCatchException.swift */; };
-		D448DBF68ABFA8F084BE3AAE05171D4C /* AWSClientContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A3C4EF0A54DFF8F64748AB9A6E364E0 /* AWSClientContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D4F6F977E4D77F9982B1AF5B6ABBDC46 /* AWSFMDatabase+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E8B5FDB178DA118BA766982955206D30 /* AWSFMDatabase+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D50A080B30C8131DB858F71727E0B271 /* AWSMTLValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = D7E963C4F0D7D073D7546DDC482E53FD /* AWSMTLValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CD9C8503D19F1E4D26A2D1705B7C922C /* AWSURLRequestRetryHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 45C8E5D78BC076CF097C783401D30675 /* AWSURLRequestRetryHandler.m */; };
+		CE96BB65FD82A94CC9C9BBE2FEDC0872 /* AWSCognitoAuth+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D241CB74335071761B49679EA021634 /* AWSCognitoAuth+Extensions.m */; };
+		CEAD5A825A2B2228733F1F745D85024D /* AWSSignInProviderApplicationIntercept.h in Headers */ = {isa = PBXBuildFile; fileRef = DF3BBE962830C1EDC2E1806CFDFE0272 /* AWSSignInProviderApplicationIntercept.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D3C7CEE1ABDD4DB9F318808066874630 /* AWSInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = EF561B1B40611C880C1A51E5F00A234D /* AWSInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D3F34BB211709B19D794F38CAE744DCF /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E9CFEC86D03F8A1BE4DBB1CC4A7D751 /* CwlCatchException.swift */; };
+		D448DBF68ABFA8F084BE3AAE05171D4C /* AWSClientContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 547C3C8BF2543737907362529ADFF79F /* AWSClientContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D4F6F977E4D77F9982B1AF5B6ABBDC46 /* AWSFMDatabase+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = F2F0FD149643708FDA4C151010A65162 /* AWSFMDatabase+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D50A080B30C8131DB858F71727E0B271 /* AWSMTLValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B2E251F1BA7B31D4A6B515A842E4660 /* AWSMTLValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D543D7550F4B79012301D277113C1132 /* AWSMobileClient-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1251F545E945C3264EA3F89BA9BA3878 /* AWSMobileClient-dummy.m */; };
 		D5C3DC01A7E8D3CA0C9F9E2A09D56C86 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE49F6473631850D3EC76C328D5772CB /* UIKit.framework */; };
 		D6B6F05BD0397853158A47B854089582 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
 		D76CECDB2FAB94F3D8DD51B54EA7F510 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		D995F1889A0498202C5B04A04ED81688 /* NSDictionary+AWSMTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F110F53CAAF1AB03CE1CA851F85859F /* NSDictionary+AWSMTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D9A075C15C47BC77535148A5A2D2C468 /* AWSDDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 13A70D9A2492A9A41C2BC8FDDE0C6707 /* AWSDDAbstractDatabaseLogger.m */; };
-		DA8E7AD70C4E70661341B17628B98B9D /* CwlCatchException-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 66D34A65BD719CA839A366AED5ACE1F2 /* CwlCatchException-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DABA700D6E837C34EA646731E2426132 /* AWSDDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3965E8754824714C58065089218E87C4 /* AWSDDMultiFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DBCA55BB7256CF0FCC1535AB9B0D3550 /* AWSURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A0ADFA07325170FDC5BB0CE2DB1EBA9 /* AWSURLResponseSerialization.m */; };
-		DBF5AAEC5F1978380EC14D82EDF31054 /* AWSLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = BFCEEE328F910F62BBDE90665F16FD72 /* AWSLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D995F1889A0498202C5B04A04ED81688 /* NSDictionary+AWSMTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C0F2E4B66427F654937124F663CAE /* NSDictionary+AWSMTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9A075C15C47BC77535148A5A2D2C468 /* AWSDDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 2121A06D4729CB181DA9851CB038F767 /* AWSDDAbstractDatabaseLogger.m */; };
+		DA8E7AD70C4E70661341B17628B98B9D /* CwlCatchException-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = EA8CCC92D9F0AC3169E2EB6118110571 /* CwlCatchException-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DABA700D6E837C34EA646731E2426132 /* AWSDDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = E57C86135FE3E1EB1A2782F47F0B61E1 /* AWSDDMultiFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBCA55BB7256CF0FCC1535AB9B0D3550 /* AWSURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = B3CA7B68BCCBF9C94B7209BDD71BBDB3 /* AWSURLResponseSerialization.m */; };
+		DBF5AAEC5F1978380EC14D82EDF31054 /* AWSLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 0986180FBBE79C4B527D81D16F04FDBC /* AWSLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD391DA8A4F2D8D3EFA2387964725A24 /* AWSCognitoAuth.m in Sources */ = {isa = PBXBuildFile; fileRef = BEB8D765884E650AFA25EB7CB3820CAB /* AWSCognitoAuth.m */; };
 		DEFC6955484751C28D36B1126354830B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		E14859804FDF14B09F1DDF7C2E3404E4 /* AWSFMDatabaseAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = F95F5D2719024ECC7BF03F6832F6944E /* AWSFMDatabaseAdditions.m */; };
-		E1702B4EF8EC1AB6F934AC3BC6600A6F /* AWSMTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = F170E6A7DDECEFE5838C092C79B21FDA /* AWSMTLReflection.m */; };
-		E2121B84A87B54637022A745BA905991 /* AWSCognitoIdentity+Fabric.h in Headers */ = {isa = PBXBuildFile; fileRef = 8712DFDF41458E13CDE557E792397356 /* AWSCognitoIdentity+Fabric.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		E67AC75CF625D30A349F06B872AD7DC7 /* FABKitProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 920863BE9A25A6D24A89E4889EE0A014 /* FABKitProtocol.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E14859804FDF14B09F1DDF7C2E3404E4 /* AWSFMDatabaseAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C4303F39E4BFB31F28AB5CE5FEEC723 /* AWSFMDatabaseAdditions.m */; };
+		E1702B4EF8EC1AB6F934AC3BC6600A6F /* AWSMTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = BA0CC7A8195152F4DDF67D0A4D7C2283 /* AWSMTLReflection.m */; };
+		E2121B84A87B54637022A745BA905991 /* AWSCognitoIdentity+Fabric.h in Headers */ = {isa = PBXBuildFile; fileRef = 079B74F72A04181513C47299DF1DE291 /* AWSCognitoIdentity+Fabric.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E2C09DB09ACE2CA2677337DB8BD28CF9 /* AWSCognitoCredentialsProvider+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = F468789ADD71CDF2D656C188FC55C800 /* AWSCognitoCredentialsProvider+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E67AC75CF625D30A349F06B872AD7DC7 /* FABKitProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B34DD7531CB06921522A0A382644596 /* FABKitProtocol.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E70FC945E697C5DB7BEB83F5DDA67DA4 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 16B0120C1306E487433FCA2B1B0D2673 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E93E93B977E8B8E4C067729097481601 /* AWSEXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = E946D357D1B824535DF21C71A74F7306 /* AWSEXTRuntimeExtensions.m */; };
-		EBB5629A5A587AB94332D976DE76116B /* NSValueTransformer+AWSMTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3802AAD88A0ED5ABF4155747E2EC95BC /* NSValueTransformer+AWSMTLInversionAdditions.m */; };
-		EBDCAD5D12AE793D0A153530B8461492 /* AWSURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = CB5F5DD200C1796E0CD90E3B92A8DB28 /* AWSURLResponseSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E93E93B977E8B8E4C067729097481601 /* AWSEXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = DEE1DCA4A5FB0656C92086E64BA674E8 /* AWSEXTRuntimeExtensions.m */; };
+		EBB5629A5A587AB94332D976DE76116B /* NSValueTransformer+AWSMTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CA996DE4D8F1EF552C13984CECAD7D4B /* NSValueTransformer+AWSMTLInversionAdditions.m */; };
+		EBDCAD5D12AE793D0A153530B8461492 /* AWSURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 9EC8D9E31650B69ACA6F529EE143216D /* AWSURLResponseSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EC2BC6AB009C3407813297E7660041CD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		EC8750873DB5F6265E48BA9315A7B2F5 /* AWSMTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 12B99B810FB2E25531E1E4F2CAF6AABD /* AWSMTLJSONAdapter.m */; };
-		ED85DB4CE570B57E433BCFB56BBCBF04 /* AWSCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = EFEA0F24602DFAEAAC189215C3C59E39 /* AWSCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EE24CB2671D97C781BA65442CA43DB00 /* AWSCognitoIdentityUser.m in Sources */ = {isa = PBXBuildFile; fileRef = ACA1E3EBBEA1F5D3160841769800B0DC /* AWSCognitoIdentityUser.m */; };
-		F091C99F7BB142D1DB6152C7E144B9D2 /* AWSNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 46873E29496F81BE8EB8FC668D31C366 /* AWSNetworking.m */; };
-		F0C669060B8BFEF00131CC06B6995586 /* AWSExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = 7281DA57E485275E8A49803FCDED939E /* AWSExecutor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3909ADAF51026D1484701DFCB9F515D /* NSData+AWSCognitoIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 906357A4C1AA3FE5689B0E940D3D91F2 /* NSData+AWSCognitoIdentityProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EC8750873DB5F6265E48BA9315A7B2F5 /* AWSMTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A31E6C80451E19FB2CCD3F9E764BB37 /* AWSMTLJSONAdapter.m */; };
+		ED85DB4CE570B57E433BCFB56BBCBF04 /* AWSCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = 407114E9393182165733176F6B463C75 /* AWSCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EE24CB2671D97C781BA65442CA43DB00 /* AWSCognitoIdentityUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 538DAF67D15820217B1911184A939AE2 /* AWSCognitoIdentityUser.m */; };
+		F091C99F7BB142D1DB6152C7E144B9D2 /* AWSNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 953D7D189B0B0AA34FE2A00F7B1580B3 /* AWSNetworking.m */; };
+		F0C669060B8BFEF00131CC06B6995586 /* AWSExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = E8F6A95D7BE53B66C196833D9CA26FA9 /* AWSExecutor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F3909ADAF51026D1484701DFCB9F515D /* NSData+AWSCognitoIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D71720CED398A05A893DF8906571124 /* NSData+AWSCognitoIdentityProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F57674F250149BF452F8E2CD1CFACB13 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		F5EFC3BA946FAB0C653C0EFB9187348D /* AWSUICKeyChainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 12DBB62EC989FA364779063935663723 /* AWSUICKeyChainStore.m */; };
-		F785DACA06792679253D0114D2B1B1C1 /* AWSCognitoIdentityProviderModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 64477AF05BB569C283F8CA75DC186B39 /* AWSCognitoIdentityProviderModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F96D20AF94D29F7EF73DD8CD5F3197E0 /* AWSCognitoIdentityUserPool_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B9A3E48A5EBDD64DAE2ECD9EE0D19659 /* AWSCognitoIdentityUserPool_Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FA1F41CB174865C3ABAA696511940338 /* AWSSTSService.m in Sources */ = {isa = PBXBuildFile; fileRef = BC78A1BE3112CD63FB79FC0D632C08AD /* AWSSTSService.m */; };
-		FA57383E56731300CB3E661B5BEF21DE /* AWSIdentityProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A1CD521E28948276DB6DF5C1CEBC2C1 /* AWSIdentityProvider.m */; };
-		FB8B41B95B8FCACA60CD482A37357212 /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BD2BB7E9FDBD0CD5EBDDACD4E5589AF /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FC0DF3B29BF928EB487F36248496068F /* AWSDDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 72AF9BE763154EB3F8872F62553004E1 /* AWSDDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FCB0E2F79322AAE4808375602EE9E27C /* AWSService.h in Headers */ = {isa = PBXBuildFile; fileRef = CF52B59CF212AEF5EF49ED0B7A9E02C1 /* AWSService.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FCCD667C2ECB8F6AB815CFBE869B7BAE /* AWSValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = EB3B13702A64602EEE8777F3A9C91B70 /* AWSValidation.m */; };
-		FCF5EF0D7D0E39CEF61A1F8E7029923A /* AWSCredentialsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CC392531C7DC92AB41B16939E55FBAC /* AWSCredentialsProvider.m */; };
-		FDBB04B8FC16CF6EAD1AAC14B5E7B978 /* AWSDDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = BB55B2CB2AA26552F0C51813928696F6 /* AWSDDLegacyMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FDCCAC00A99C74E2BE6C3FD070D45C3D /* AWSCancellationTokenRegistration.h in Headers */ = {isa = PBXBuildFile; fileRef = 9109D53E30C8C4C64FBC39ECF60C179E /* AWSCancellationTokenRegistration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FEBDB02A795559B8678FF609BD63DC5D /* AWSMobileClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB67317B1299EE3D2F425CDDD6AFEEC0 /* AWSMobileClient.swift */; };
-		FF2758D837FB5A2D465659698E8D095F /* AWSMTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = BC067900E6CC27C9DAEE297A89AD2D0F /* AWSMTLModel+NSCoding.m */; };
-		FF35610D44E99E6782EF579730D183DF /* AWSNetworkingHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 42BB3C6979837861377DA5A89549AE64 /* AWSNetworkingHelpers.m */; };
-		FF5A3D0068C906E484D9FB5CC613556E /* AWSCognitoAuthUICKeyChainStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B7083ED686E473C67DDF5D1E86E724C /* AWSCognitoAuthUICKeyChainStore.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		F5EFC3BA946FAB0C653C0EFB9187348D /* AWSUICKeyChainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D722FE0E92693EA328A01D0C30DE69C /* AWSUICKeyChainStore.m */; };
+		F785DACA06792679253D0114D2B1B1C1 /* AWSCognitoIdentityProviderModel.h in Headers */ = {isa = PBXBuildFile; fileRef = F315E4DD3CDFF2005E5797FC3DA761A8 /* AWSCognitoIdentityProviderModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F96D20AF94D29F7EF73DD8CD5F3197E0 /* AWSCognitoIdentityUserPool_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = A5C4755E18CF7D73FD5757B42817C8A7 /* AWSCognitoIdentityUserPool_Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FA1F41CB174865C3ABAA696511940338 /* AWSSTSService.m in Sources */ = {isa = PBXBuildFile; fileRef = C44C1B8D58F0B38ADB731A5082B0CAB0 /* AWSSTSService.m */; };
+		FA57383E56731300CB3E661B5BEF21DE /* AWSIdentityProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 0738F3F1322771D982BAB3661AE24214 /* AWSIdentityProvider.m */; };
+		FB10B80CC418942706405C6FDA423234 /* AWSMobileClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703E3BD1050E13C9D54DD0E20BE74878 /* AWSMobileClient.swift */; };
+		FB8B41B95B8FCACA60CD482A37357212 /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = B4E133BDBC60371D1C4C31859E4C8C7A /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FC0DF3B29BF928EB487F36248496068F /* AWSDDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = EDE35F033F8789A514C6E98B2E720923 /* AWSDDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FC33B5AE93CAD05125F41344A7DC295C /* _AWSMobileClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 41AAC3F5C52861B3D940EF01D950DDD5 /* _AWSMobileClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FCB0E2F79322AAE4808375602EE9E27C /* AWSService.h in Headers */ = {isa = PBXBuildFile; fileRef = CBC63B38BFED9913CCC459F4312FC6EB /* AWSService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FCCD667C2ECB8F6AB815CFBE869B7BAE /* AWSValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DFE245507CD57FBD4B44DEC84BBF871 /* AWSValidation.m */; };
+		FCF5EF0D7D0E39CEF61A1F8E7029923A /* AWSCredentialsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = EFAE02E7CEADBC4AB4A4F59052C630F4 /* AWSCredentialsProvider.m */; };
+		FD3A3329F3101AF1F8969EA38080957E /* AWSMobileClient-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = ABC5884D8B8D580C98E6127C4041BEB3 /* AWSMobileClient-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FDBB04B8FC16CF6EAD1AAC14B5E7B978 /* AWSDDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F2C9BD8FD6A62BE547C156A2CB4555A /* AWSDDLegacyMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FDCCAC00A99C74E2BE6C3FD070D45C3D /* AWSCancellationTokenRegistration.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C51B363039417DEAD5F8456DEE3B877 /* AWSCancellationTokenRegistration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF2758D837FB5A2D465659698E8D095F /* AWSMTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D7ED8661EF857706C34D2758977F62B /* AWSMTLModel+NSCoding.m */; };
+		FF35610D44E99E6782EF579730D183DF /* AWSNetworkingHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = D2069E3BA0CE303E2ACED88BB858900C /* AWSNetworkingHelpers.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -489,6 +490,13 @@
 			remoteGlobalIDString = E4D853F6FBAB5A9BDBE843E4EFB22EB7;
 			remoteInfo = CwlPreconditionTesting;
 		};
+		5E6F9F34B5C8CFC5E5A1534148440CAD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8042F2B0721B13AEDEB81F058C2B2125;
+			remoteInfo = AWSAuthCore;
+		};
 		64D33CCA8C986FD4F0DE98C883594278 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
@@ -545,13 +553,6 @@
 			remoteGlobalIDString = 308B5C440C446909122081D367A27A8F;
 			remoteInfo = CwlCatchException;
 		};
-		808E02155DEA9FFFA7AB26A41DE112FA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 29212B2F049288E035AB98405A23E41E;
-			remoteInfo = AWSCognitoIdentityProvider;
-		};
 		823ACA39C425FB28F6D8371F2DAAC525 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
@@ -579,6 +580,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = BBF90BA4F6EC5653945C7B0FFD9128D2;
 			remoteInfo = AWSCognitoIdentityProviderASF;
+		};
+		93D132FE40403BE2D60EC7A29146AB21 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 29212B2F049288E035AB98405A23E41E;
+			remoteInfo = AWSCognitoIdentityProvider;
 		};
 		95AF594731E7B749152FEA1779660277 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -621,13 +629,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 29212B2F049288E035AB98405A23E41E;
 			remoteInfo = AWSCognitoIdentityProvider;
-		};
-		ABF241B4BEC3E8ADB5E0B8D8BB34B97C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8042F2B0721B13AEDEB81F058C2B2125;
-			remoteInfo = AWSAuthCore;
 		};
 		ACA985698F78CE51CD54B4CC2C26CF5A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -807,378 +808,379 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		009CACF5738D03F5B64F3EF3C99FB61E /* AWSSTSService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSService.h; path = AWSCore/STS/AWSSTSService.h; sourceTree = "<group>"; };
-		00ED9F12F787409584FD64E63CB00BFA /* AWSAuthUIHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSAuthUIHelper.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.h; sourceTree = "<group>"; };
-		017996FA9F98A7E1AC8B1FB672D4E557 /* AWSCore-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCore-umbrella.h"; sourceTree = "<group>"; };
+		01406D2554960C95060691CFCAA31D92 /* AWSMTLValueTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLValueTransformer.m; path = AWSCore/Mantle/AWSMTLValueTransformer.m; sourceTree = "<group>"; };
 		01CEDC80C5B028F2AE09C4BECC2F076B /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsCoreTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsCoreTests.framework; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		02CBA27505E2262F5F64DAEDB8CE8E87 /* NSArray+AWSMTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+AWSMTLManipulationAdditions.m"; path = "AWSCore/Mantle/NSArray+AWSMTLManipulationAdditions.m"; sourceTree = "<group>"; };
 		03D039338D77A6CA524CBC57DE6E2BCF /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-dummy.m"; sourceTree = "<group>"; };
-		04498D780108D3EBDF53FD76FB42D380 /* AWSCognitoAuth.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuth.h; path = AWSCognitoAuth/AWSCognitoAuth.h; sourceTree = "<group>"; };
-		04F94581174EDFD77DD77D64E573D786 /* AWSSignInManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInManager.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInManager.h; sourceTree = "<group>"; };
 		055A209829E9548F5285CA89F94E6CC2 /* Pods-Amplify-AWSPluginsCore.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AWSPluginsCore.modulemap"; sourceTree = "<group>"; };
-		05F0A6A210EDEAFCB636DEF2E8E2C143 /* AWSMobileOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileOptions.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileOptions.swift; sourceTree = "<group>"; };
-		076B6FA2F32A84341788F1C2E42A79CA /* AWSDDLogMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLogMacros.h; path = AWSCore/Logging/AWSDDLogMacros.h; sourceTree = "<group>"; };
-		07ECE90907BE180F6A539BF08715EDE3 /* AWSFMDB.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDB.h; path = AWSCore/FMDB/AWSFMDB.h; sourceTree = "<group>"; };
-		0831B18334CCA361EBE774FCE1C79065 /* AWSDDOSLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDOSLogger.m; path = AWSCore/Logging/AWSDDOSLogger.m; sourceTree = "<group>"; };
-		0A075F8FA03A8A6E504C77FC33DE7E6D /* NSArray+AWSMTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+AWSMTLManipulationAdditions.h"; path = "AWSCore/Mantle/NSArray+AWSMTLManipulationAdditions.h"; sourceTree = "<group>"; };
-		0A1CD521E28948276DB6DF5C1CEBC2C1 /* AWSIdentityProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSIdentityProvider.m; path = AWSCore/Authentication/AWSIdentityProvider.m; sourceTree = "<group>"; };
-		0A3B34FAA9B84A5377B2D5C709DA6B92 /* AWSSTSResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSResources.m; path = AWSCore/STS/AWSSTSResources.m; sourceTree = "<group>"; };
-		0ADFD7E42BE139F259349496AA57A0A2 /* AWSXMLDictionary.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSXMLDictionary.m; path = AWSCore/XMLDictionary/AWSXMLDictionary.m; sourceTree = "<group>"; };
-		0AEEFB1F4D4875A426FBE8C5C6D76AB1 /* AWSAuthCore-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSAuthCore-dummy.m"; sourceTree = "<group>"; };
+		0581448F3A1EE16FE6877A21192B3174 /* AWSTaskCompletionSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTaskCompletionSource.m; path = AWSCore/Bolts/AWSTaskCompletionSource.m; sourceTree = "<group>"; };
+		064ADE545B584F856974A8D04E6DDED1 /* SwiftLint.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLint.xcconfig; sourceTree = "<group>"; };
+		0738F3F1322771D982BAB3661AE24214 /* AWSIdentityProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSIdentityProvider.m; path = AWSCore/Authentication/AWSIdentityProvider.m; sourceTree = "<group>"; };
+		073E77A65347582ED7A81E3D956DD22E /* AWSUICKeyChainStore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSUICKeyChainStore.h; path = AWSCore/UICKeyChainStore/AWSUICKeyChainStore.h; sourceTree = "<group>"; };
+		079B74F72A04181513C47299DF1DE291 /* AWSCognitoIdentity+Fabric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoIdentity+Fabric.h"; path = "AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.h"; sourceTree = "<group>"; };
+		0816FEAC15987BEA5F0AAC291F36AF7F /* AWSDDFileLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDFileLogger.h; path = AWSCore/Logging/AWSDDFileLogger.h; sourceTree = "<group>"; };
+		087170046A46680BA6789BBA5A452CED /* AWSCognitoAuth+Extensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoAuth+Extensions.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h"; sourceTree = "<group>"; };
+		0886BCD226D6B5190149C85BA3210FCB /* AWSSTSResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSResources.h; path = AWSCore/STS/AWSSTSResources.h; sourceTree = "<group>"; };
+		0907C13F03EF67C1D2365ACFD20D38D6 /* AWSTMMemoryCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMMemoryCache.m; path = AWSCore/TMCache/AWSTMMemoryCache.m; sourceTree = "<group>"; };
+		0986180FBBE79C4B527D81D16F04FDBC /* AWSLogging.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSLogging.h; path = AWSCore/Utility/AWSLogging.h; sourceTree = "<group>"; };
+		0A31E6C80451E19FB2CCD3F9E764BB37 /* AWSMTLJSONAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLJSONAdapter.m; path = AWSCore/Mantle/AWSMTLJSONAdapter.m; sourceTree = "<group>"; };
+		0B1E9500E2EA7365DD37F18E40DB00C5 /* AWSUserPoolCustomAuthHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSUserPoolCustomAuthHandler.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSUserPoolCustomAuthHandler.swift; sourceTree = "<group>"; };
 		0B350FFEF637C6AF934EE101CD54DCE5 /* Pods-Amplify-AWSPluginsCore-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AWSPluginsCore-umbrella.h"; sourceTree = "<group>"; };
 		0B8DB7849FE18394F4C1421ABE0CEA2E /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
-		0C7EFC1FA0A94BB3040D38C1BBFCF76E /* AWSSTSModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSModel.m; path = AWSCore/STS/AWSSTSModel.m; sourceTree = "<group>"; };
-		0CACEC397330066C8C398ECECCE8BD5F /* _AWSMobileClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = _AWSMobileClient.h; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.h; sourceTree = "<group>"; };
-		0CF40D7AF9CA3F2F9A410759AE391171 /* NSObject+AWSMTLComparisonAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+AWSMTLComparisonAdditions.h"; path = "AWSCore/Mantle/NSObject+AWSMTLComparisonAdditions.h"; sourceTree = "<group>"; };
-		0D58BF63FD36A36860F5EB44E38DD099 /* AWSKSReachability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSKSReachability.h; path = AWSCore/KSReachability/AWSKSReachability.h; sourceTree = "<group>"; };
-		0D9574530C129769D1D1F03203C85D7C /* AWSCore-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCore-Info.plist"; sourceTree = "<group>"; };
-		0E02F91D7B07EC8FC39A4CAF40D39746 /* AWSDDTTYLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDTTYLogger.h; path = AWSCore/Logging/AWSDDTTYLogger.h; sourceTree = "<group>"; };
-		0E3D65FEA8DF69AB59F24058F42DCED6 /* AWSMTLManagedObjectAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLManagedObjectAdapter.m; path = AWSCore/Mantle/AWSMTLManagedObjectAdapter.m; sourceTree = "<group>"; };
-		0E4D66772DCE19A7404EF983F3D98759 /* CwlPreconditionTesting.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CwlPreconditionTesting.xcconfig; sourceTree = "<group>"; };
-		0F18885B0C226C01535E4BC473565790 /* tommath.c */ = {isa = PBXFileReference; includeInIndex = 1; name = tommath.c; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/tommath.c; sourceTree = "<group>"; };
+		0BB005E4B39B32629A62D3E26272A2DE /* AWSFMDatabasePool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabasePool.m; path = AWSCore/FMDB/AWSFMDatabasePool.m; sourceTree = "<group>"; };
+		0BF3152809C0C7F2A37F2AA076B8BD80 /* AWSExecutor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSExecutor.m; path = AWSCore/Bolts/AWSExecutor.m; sourceTree = "<group>"; };
+		0D98BF8E4B6395E80EDB1448E308861F /* AWSFMResultSet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMResultSet.h; path = AWSCore/FMDB/AWSFMResultSet.h; sourceTree = "<group>"; };
+		0DFE245507CD57FBD4B44DEC84BBF871 /* AWSValidation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSValidation.m; path = AWSCore/Serialization/AWSValidation.m; sourceTree = "<group>"; };
+		0E641F4FC82C85952BAF9B257C40A701 /* AWSSignInButtonView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInButtonView.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInButtonView.h; sourceTree = "<group>"; };
+		0E9E777591741F7713A15CED1A8CC19D /* NSObject+AWSMTLComparisonAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+AWSMTLComparisonAdditions.m"; path = "AWSCore/Mantle/NSObject+AWSMTLComparisonAdditions.m"; sourceTree = "<group>"; };
 		0F1DEDC150BBA9D337427317717EC680 /* Pods_AmplifyTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_AmplifyTestApp.framework; path = "Pods-AmplifyTestApp.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1005679B00726AC1ED9911E5237C9C36 /* AWSMobileClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMobileClient.h; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.h; sourceTree = "<group>"; };
 		1073C3EE5CBDD8387A3FB523E790C5CA /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
-		115578294D5785F67A4164B425F3D299 /* AWSModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSModel.m; path = AWSCore/Utility/AWSModel.m; sourceTree = "<group>"; };
+		1133E0EC9A119ECACA5D55C5DC030291 /* AWSMobileClient.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSMobileClient.modulemap; sourceTree = "<group>"; };
 		11618E052B1995FC3B058B8E47104CFA /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-dummy.m"; sourceTree = "<group>"; };
-		11981CE8441163483F737D85DE32B1CE /* AWSClientContext.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSClientContext.m; path = AWSCore/Service/AWSClientContext.m; sourceTree = "<group>"; };
-		11EDEFEDFA365D9648D81979FF0CF2BA /* AWSSynchronizedMutableDictionary.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSynchronizedMutableDictionary.m; path = AWSCore/Utility/AWSSynchronizedMutableDictionary.m; sourceTree = "<group>"; };
-		12163530DDDEF249BE3C311D0ED23327 /* CwlPreconditionTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlPreconditionTesting.h; path = Sources/CwlPreconditionTesting/include/CwlPreconditionTesting.h; sourceTree = "<group>"; };
-		12B99B810FB2E25531E1E4F2CAF6AABD /* AWSMTLJSONAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLJSONAdapter.m; path = AWSCore/Mantle/AWSMTLJSONAdapter.m; sourceTree = "<group>"; };
-		12D212D94038E4481D8C3C8043590F7C /* AWSCancellationTokenSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationTokenSource.h; path = AWSCore/Bolts/AWSCancellationTokenSource.h; sourceTree = "<group>"; };
-		12DBB62EC989FA364779063935663723 /* AWSUICKeyChainStore.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSUICKeyChainStore.m; path = AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m; sourceTree = "<group>"; };
-		13A27886A2A2BD9BDC18D4AA06E0BE8D /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h"; sourceTree = "<group>"; };
-		13A6AC4F2598B540AB29DEA12B8DA004 /* AWSCredentialsProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCredentialsProvider.h; path = AWSCore/Authentication/AWSCredentialsProvider.h; sourceTree = "<group>"; };
-		13A70D9A2492A9A41C2BC8FDDE0C6707 /* AWSDDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDAbstractDatabaseLogger.m; path = AWSCore/Logging/AWSDDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
-		13F6EC075EF080997FC5EAA557A51049 /* AWSSignInManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSignInManager.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInManager.m; sourceTree = "<group>"; };
+		1213A5418927CFBA7E61F3972A32D352 /* AWSCancellationToken.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationToken.m; path = AWSCore/Bolts/AWSCancellationToken.m; sourceTree = "<group>"; };
+		1251F545E945C3264EA3F89BA9BA3878 /* AWSMobileClient-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSMobileClient-dummy.m"; sourceTree = "<group>"; };
+		1364C2E6FFB3D6CA23B8E4F7EA192804 /* AWSDDTTYLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDTTYLogger.m; path = AWSCore/Logging/AWSDDTTYLogger.m; sourceTree = "<group>"; };
 		14469F121FFD84334E39499AEA8DBAE8 /* Pods-AmplifyTestApp-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-AmplifyTestApp-frameworks.sh"; sourceTree = "<group>"; };
+		14CA4F275A4357515EA6ADABFF873C9F /* CwlPreconditionTesting-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlPreconditionTesting-prefix.pch"; sourceTree = "<group>"; };
+		158BDE967B7C9FFF98317A8A1AF47B24 /* AWSSignature.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignature.h; path = AWSCore/Authentication/AWSSignature.h; sourceTree = "<group>"; };
 		1668BE896BD53109C08AF7DC22CF4EB7 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		168E7EDD61CE770FCEEFF271776BDD39 /* AWSURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLRequestSerialization.h; path = AWSCore/Serialization/AWSURLRequestSerialization.h; sourceTree = "<group>"; };
-		16A649B28EBAF292512D8F10FD00EEC0 /* AWSEXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTKeyPathCoding.h; path = AWSCore/Mantle/extobjc/AWSEXTKeyPathCoding.h; sourceTree = "<group>"; };
+		16A162C41F0549F96E8E860FE210AFBF /* AWSTMCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMCache.m; path = AWSCore/TMCache/AWSTMCache.m; sourceTree = "<group>"; };
 		16B0120C1306E487433FCA2B1B0D2673 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-umbrella.h"; sourceTree = "<group>"; };
+		16C1587C7AC8C56C77374B292761DEB6 /* AWSClientContext.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSClientContext.m; path = AWSCore/Service/AWSClientContext.m; sourceTree = "<group>"; };
+		174B19F5C049FC2721C627519446CAC4 /* AWSServiceEnum.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSServiceEnum.h; path = AWSCore/Service/AWSServiceEnum.h; sourceTree = "<group>"; };
 		17C7782F05A2504AD7615DC3ECD11FE5 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.debug.xcconfig"; sourceTree = "<group>"; };
-		1853077C437335F8E40E76858B148CE5 /* AWSDDLog.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDLog.m; path = AWSCore/Logging/AWSDDLog.m; sourceTree = "<group>"; };
-		185F0DC6368FA1D4547527B451DB8EB9 /* AWSCognitoIdentityResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityResources.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityResources.m; sourceTree = "<group>"; };
 		189C8021820D164FA9236F1D27850C3F /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-umbrella.h"; sourceTree = "<group>"; };
-		18F8E4C791238DE2BC89F84EF383A00D /* AWSMTLModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLModel.m; path = AWSCore/Mantle/AWSMTLModel.m; sourceTree = "<group>"; };
-		1A60E93D25B2C3C212B4679F93F75755 /* AWSMTLReflection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLReflection.h; path = AWSCore/Mantle/AWSMTLReflection.h; sourceTree = "<group>"; };
-		1B0AAF84EC698F11CC63045004A9ED58 /* AWSCognitoIdentityProviderHKDF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderHKDF.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderHKDF.h; sourceTree = "<group>"; };
-		1B1415B741EF9175334EEB8D7110C62F /* DeviceOperations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeviceOperations.swift; path = AWSAuthSDK/Sources/AWSMobileClient/DeviceOperations.swift; sourceTree = "<group>"; };
-		1B7083ED686E473C67DDF5D1E86E724C /* AWSCognitoAuthUICKeyChainStore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuthUICKeyChainStore.h; path = AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.h; sourceTree = "<group>"; };
+		1A374AD7C7E8F04E05236562AE54228F /* AWSUserPoolOperationsHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSUserPoolOperationsHandler.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift; sourceTree = "<group>"; };
+		1A4BE50365F0355639CFCCDE678470A0 /* AWSCognitoIdentityUser_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUser_Internal.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityUser_Internal.h; sourceTree = "<group>"; };
+		1B5A27D1F00D26D77D2F1FB2BED6F0A8 /* AWSMTLModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLModel.h; path = AWSCore/Mantle/AWSMTLModel.h; sourceTree = "<group>"; };
 		1BB9D281CBBD8B4517D1F76CCC30FC7B /* Pods-AmplifyTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-AmplifyTestApp.debug.xcconfig"; sourceTree = "<group>"; };
-		1CB773EA726322B9A2CD42FF90D4DD17 /* AWSGeneric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSGeneric.h; path = AWSCore/Bolts/AWSGeneric.h; sourceTree = "<group>"; };
+		1BBE4054B04F674C1F60D31FA106362C /* AWSMTLModel+NSCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSMTLModel+NSCoding.h"; path = "AWSCore/Mantle/AWSMTLModel+NSCoding.h"; sourceTree = "<group>"; };
+		1CAB5F26082AF7C2C342C8BF2B511189 /* AWSSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSerialization.m; path = AWSCore/Serialization/AWSSerialization.m; sourceTree = "<group>"; };
 		1D87F3274BC9EDCF528FEDC7945B146C /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-Info.plist"; sourceTree = "<group>"; };
-		1E2AEE92884E8A3660E2A5C368A9D134 /* AWSNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSNetworking.h; path = AWSCore/Networking/AWSNetworking.h; sourceTree = "<group>"; };
-		1E93344537320B3C5EB8604688C8560C /* AWSDDContextFilterLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDContextFilterLogFormatter.m; path = AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter.m; sourceTree = "<group>"; };
-		1EEAEFF4390C69F3ED0B2E72D09E4966 /* AWSCognitoIdentityProviderASF.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCognitoIdentityProviderASF.xcconfig; sourceTree = "<group>"; };
-		25B48B5E2F240D5C178AEC37739F47BD /* AWSTaskCompletionSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTaskCompletionSource.m; path = AWSCore/Bolts/AWSTaskCompletionSource.m; sourceTree = "<group>"; };
-		25DFBB76C1BF492E05A46B34178281AD /* AWSAuthCore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSAuthCore.xcconfig; sourceTree = "<group>"; };
+		1E77E16BC664FA930B5F100306836D97 /* AWSDDContextFilterLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDContextFilterLogFormatter.h; path = AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter.h; sourceTree = "<group>"; };
+		1E9CFEC86D03F8A1BE4DBB1CC4A7D751 /* CwlCatchException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchException.swift; path = Sources/CwlCatchException/CwlCatchException.swift; sourceTree = "<group>"; };
+		1F48EA94451797FD4F975F332D56208F /* AWSMTLReflection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLReflection.h; path = AWSCore/Mantle/AWSMTLReflection.h; sourceTree = "<group>"; };
+		1F4EBC18983124FC057E4F6DF2898A82 /* AWSXMLWriter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSXMLWriter.h; path = AWSCore/XMLWriter/AWSXMLWriter.h; sourceTree = "<group>"; };
+		1FBB9B4EF0162E7673ABC89B53F82D1F /* CwlPreconditionTesting.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CwlPreconditionTesting.xcconfig; sourceTree = "<group>"; };
+		20C60E4B329922D1F91D8DC3DE396DA6 /* AWSMTLManagedObjectAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLManagedObjectAdapter.m; path = AWSCore/Mantle/AWSMTLManagedObjectAdapter.m; sourceTree = "<group>"; };
+		2121A06D4729CB181DA9851CB038F767 /* AWSDDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDAbstractDatabaseLogger.m; path = AWSCore/Logging/AWSDDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
+		21C34EBC5C70F3BE92D67784FE6DABC7 /* AWSCognitoIdentityProviderASF.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCognitoIdentityProviderASF.modulemap; sourceTree = "<group>"; };
+		237C34B9822D7E7B6E0CEF798C76A4F9 /* AWSEXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTScope.h; path = AWSCore/Mantle/extobjc/AWSEXTScope.h; sourceTree = "<group>"; };
+		23B3726BA8188C858679F4A62BC5CBE9 /* AWSJKBigDecimal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSJKBigDecimal.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigDecimal.h; sourceTree = "<group>"; };
+		246BFE14AB5D33D83D1677B7CAABB010 /* AWSMobileClient-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSMobileClient-prefix.pch"; sourceTree = "<group>"; };
 		2610F9ADBE599E1ACDCAC688B21F3A61 /* Pods-Amplify-AWSPluginsCore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore.release.xcconfig"; sourceTree = "<group>"; };
-		26844A716609D618B953ADCC3477A9C2 /* AWSSynchronizedMutableDictionary.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSynchronizedMutableDictionary.h; path = AWSCore/Utility/AWSSynchronizedMutableDictionary.h; sourceTree = "<group>"; };
-		27556645674390E079A50FAE1D38FFF1 /* AWSCognitoIdentityProviderService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderService.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderService.m; sourceTree = "<group>"; };
-		2791EB61C4AFF9075545494144A5BD95 /* aws_tommath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath.h; sourceTree = "<group>"; };
-		281AC237A5385219FDCE6717E9C69709 /* AWSCancellationTokenRegistration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationTokenRegistration.m; path = AWSCore/Bolts/AWSCancellationTokenRegistration.m; sourceTree = "<group>"; };
-		285440696A5920B5E6B03DE8351989B8 /* AWSNetworkingHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSNetworkingHelpers.h; path = AWSCore/Networking/AWSNetworkingHelpers.h; sourceTree = "<group>"; };
-		2B531E9546AD9DB8A58EDF26D38A9FE1 /* AWSCognitoIdentityProviderSrpHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderSrpHelper.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderSrpHelper.h; sourceTree = "<group>"; };
-		2C5FAED483BFCC2F6ED318BFC0A89612 /* AWSInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSInfo.m; path = AWSCore/Service/AWSInfo.m; sourceTree = "<group>"; };
-		2C69D27D99AAF70EBC5392FB14C7B7DA /* NSArray+AWSMTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+AWSMTLManipulationAdditions.m"; path = "AWSCore/Mantle/NSArray+AWSMTLManipulationAdditions.m"; sourceTree = "<group>"; };
-		2EDE3BF19468DE4E9605AD1B08021DF4 /* AWSURLRequestRetryHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLRequestRetryHandler.m; path = AWSCore/Serialization/AWSURLRequestRetryHandler.m; sourceTree = "<group>"; };
-		2F6A9E75313D30A2B28F68110FF230A2 /* CwlCatchException-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlCatchException-prefix.pch"; sourceTree = "<group>"; };
-		2F8E1C643E55898382E15AC05AA7365E /* AWSMobileResults.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileResults.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileResults.swift; sourceTree = "<group>"; };
+		26124B8EBEDB7DD09D52BF33E2E59931 /* AWSMobileClient-Mixed-Swift.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSMobileClient-Mixed-Swift.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSMobileClient-Mixed-Swift.h"; sourceTree = "<group>"; };
+		271C0F2E4B66427F654937124F663CAE /* NSDictionary+AWSMTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+AWSMTLManipulationAdditions.h"; path = "AWSCore/Mantle/NSDictionary+AWSMTLManipulationAdditions.h"; sourceTree = "<group>"; };
+		275D383DC4EE5627ABFC1F7CC9BC1128 /* CwlCatchException-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlCatchException-prefix.pch"; sourceTree = "<group>"; };
+		2836D98A865986A534EDB5C920AF2460 /* AWSCognitoIdentityUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUser.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h; sourceTree = "<group>"; };
+		2837F1492EC2CEC5B9DD4352EF5BDE5C /* AWSCognitoIdentityProvider-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProvider-umbrella.h"; sourceTree = "<group>"; };
+		2941F0841B1124B775BC2CCF8C3FB149 /* AWSSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSerialization.h; path = AWSCore/Serialization/AWSSerialization.h; sourceTree = "<group>"; };
+		2B2E251F1BA7B31D4A6B515A842E4660 /* AWSMTLValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLValueTransformer.h; path = AWSCore/Mantle/AWSMTLValueTransformer.h; sourceTree = "<group>"; };
+		2B34DD7531CB06921522A0A382644596 /* FABKitProtocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FABKitProtocol.h; path = AWSCore/Fabric/FABKitProtocol.h; sourceTree = "<group>"; };
+		2BD4DFC991FF667DD0B733C2E0885AA7 /* CwlPreconditionTesting-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "CwlPreconditionTesting-Info.plist"; sourceTree = "<group>"; };
+		2C441590C7A204DED15D0F8637E15D83 /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
+		2CA9718A32A9D07BB92F38401873C8E5 /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
+		2DD2592DCF2D49C44E2F6C0F36299584 /* AWSCognitoIdentityProvider-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProvider-prefix.pch"; sourceTree = "<group>"; };
+		2E45CDF781E122D5B0032D5E10259043 /* AWSCognitoIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProvider.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityProvider.h; sourceTree = "<group>"; };
+		2E8A8CA0DDD90CB39D32CE5FD24DC429 /* NSValueTransformer+AWSMTLInversionAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+AWSMTLInversionAdditions.h"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLInversionAdditions.h"; sourceTree = "<group>"; };
+		2F2C9BD8FD6A62BE547C156A2CB4555A /* AWSDDLegacyMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLegacyMacros.h; path = AWSCore/Logging/AWSDDLegacyMacros.h; sourceTree = "<group>"; };
 		2F99AE9B0E76188538C212C2BB77D456 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-Info.plist"; sourceTree = "<group>"; };
-		30642F131CF85895AB20D4764112A7B1 /* AWSTaskCompletionSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTaskCompletionSource.h; path = AWSCore/Bolts/AWSTaskCompletionSource.h; sourceTree = "<group>"; };
-		316D632308F1EFBC2C0DF047773030DF /* AWSSignInProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInProvider.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInProvider.h; sourceTree = "<group>"; };
 		31ACD2A46D4B2806FEF94323C827E97C /* Pods-AmplifyTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-AmplifyTestApp.release.xcconfig"; sourceTree = "<group>"; };
+		33E7E7A2DD1B06B19C2F0B2B692890C2 /* AWSCognitoAuth_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuth_Internal.h; path = AWSCognitoAuth/Internal/AWSCognitoAuth_Internal.h; sourceTree = "<group>"; };
+		34E76DC27A81691F88AF5806683ADEF0 /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
+		3514C8A4F0642770992CBA9207EA5342 /* AWSMobileOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileOptions.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileOptions.swift; sourceTree = "<group>"; };
+		351B029C4F1BEDEA7476F09758D57E5D /* AWSFMDatabaseQueue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabaseQueue.m; path = AWSCore/FMDB/AWSFMDatabaseQueue.m; sourceTree = "<group>"; };
 		356316C4DFEB6875A03C1B1AC2F84026 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-frameworks.sh"; sourceTree = "<group>"; };
 		36BDAD0F29489ADEBD0B1E3648F2A317 /* Pods-Amplify-AWSPluginsCore-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AWSPluginsCore-acknowledgements.markdown"; sourceTree = "<group>"; };
-		37E8F49480EF8060BB37B26F5BC5DF99 /* AWSSTS.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTS.h; path = AWSCore/STS/AWSSTS.h; sourceTree = "<group>"; };
-		3802AAD88A0ED5ABF4155747E2EC95BC /* NSValueTransformer+AWSMTLInversionAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+AWSMTLInversionAdditions.m"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLInversionAdditions.m"; sourceTree = "<group>"; };
-		3844849C30D28B47FF9C3DD61529455D /* AWSIdentityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSIdentityManager.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSIdentityManager.m; sourceTree = "<group>"; };
-		388680EB7CAF4AB53E3DD89E2CC90F2E /* aws_tommath_class.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath_class.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath_class.h; sourceTree = "<group>"; };
-		38B52AFD8824D96B30C353421A67E04F /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
-		38C24E5DB4B1C541A80CDFF1952C4545 /* AWSFMDB+AWSHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSFMDB+AWSHelpers.h"; path = "AWSCore/FMDB/AWSFMDB+AWSHelpers.h"; sourceTree = "<group>"; };
+		377507ABBE77D13266D4692188AC4A90 /* NSDictionary+AWSMTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+AWSMTLManipulationAdditions.m"; path = "AWSCore/Mantle/NSDictionary+AWSMTLManipulationAdditions.m"; sourceTree = "<group>"; };
+		38643E84B084A0BEB5CED73C2759B5BF /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
 		38C6AD3DCE09BA628BA94A834905BFA2 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.release.xcconfig"; sourceTree = "<group>"; };
 		38FF9DA450E0F55F72749EB00C3E4C06 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.release.xcconfig"; sourceTree = "<group>"; };
-		390C1B329BDBA41B75D7590CFC85F033 /* AWSDDContextFilterLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDContextFilterLogFormatter.h; path = AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter.h; sourceTree = "<group>"; };
-		3965E8754824714C58065089218E87C4 /* AWSDDMultiFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDMultiFormatter.h; path = AWSCore/Logging/Extensions/AWSDDMultiFormatter.h; sourceTree = "<group>"; };
-		3A3C4EF0A54DFF8F64748AB9A6E364E0 /* AWSClientContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSClientContext.h; path = AWSCore/Service/AWSClientContext.h; sourceTree = "<group>"; };
 		3A7A8A66EAE3CF28E4545528AD125CFC /* Pods-Amplify.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify.release.xcconfig"; sourceTree = "<group>"; };
-		3A9A9123BBE11A58771EB87A087316B6 /* CwlCatchException.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CwlCatchException.modulemap; sourceTree = "<group>"; };
-		3B109D739CFC883289A6548766B8B7DD /* AWSSignature.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSignature.m; path = AWSCore/Authentication/AWSSignature.m; sourceTree = "<group>"; };
+		3B13015BDFD766A5AA586CA772B1E3EF /* NSObject+AWSMTLComparisonAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+AWSMTLComparisonAdditions.h"; path = "AWSCore/Mantle/NSObject+AWSMTLComparisonAdditions.h"; sourceTree = "<group>"; };
+		3B680E6B9305CB9D4018616634665303 /* AWSCognitoIdentityProviderASF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderASF.h; path = AWSCognitoIdentityProviderASF/AWSCognitoIdentityProviderASF.h; sourceTree = "<group>"; };
 		3BF5B6D3E0339165EB3C15592888ACB3 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.debug.xcconfig"; sourceTree = "<group>"; };
-		3CE55D53ECA949420B445EF748A6B476 /* SwiftLint.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLint.xcconfig; sourceTree = "<group>"; };
-		3D02469A819F1238BA748181F1265632 /* AWSMTLJSONAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLJSONAdapter.h; path = AWSCore/Mantle/AWSMTLJSONAdapter.h; sourceTree = "<group>"; };
-		3D7AD3753C2B976519ABD2B870B1AAF5 /* AWSAuthUIHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSAuthUIHelper.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.m; sourceTree = "<group>"; };
-		3D98814487113FC0451682BF2CA928D0 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m"; sourceTree = "<group>"; };
+		3C4303F39E4BFB31F28AB5CE5FEEC723 /* AWSFMDatabaseAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabaseAdditions.m; path = AWSCore/FMDB/AWSFMDatabaseAdditions.m; sourceTree = "<group>"; };
+		3CEA978C394A670DE913406DF84C37B3 /* NSError+AWSMTLModelException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSError+AWSMTLModelException.m"; path = "AWSCore/Mantle/NSError+AWSMTLModelException.m"; sourceTree = "<group>"; };
+		3E125CA7F667A530C30603C40C195AD9 /* AWSBolts.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSBolts.m; path = AWSCore/Bolts/AWSBolts.m; sourceTree = "<group>"; };
 		3E93CB74B9F5DE129151102493A989CB /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsTestCommon.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsTestCommon.framework; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		3F3CA727772902D38F633984F132084D /* AWSDDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDAbstractDatabaseLogger.h; path = AWSCore/Logging/AWSDDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
+		3F05F078F444866691A7A4F880388E71 /* AWSMobileResults.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileResults.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileResults.swift; sourceTree = "<group>"; };
+		3F56C406427AA446ED6AC850F1D11F5C /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
 		3F8DD9A4C98BD4C5E30943C049E35926 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		3FB6BA58A3DC5A5334029E7C6BBF6990 /* AWSDDLog+LOGV.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSDDLog+LOGV.h"; path = "AWSCore/Logging/AWSDDLog+LOGV.h"; sourceTree = "<group>"; };
 		40363564952E7B989CC8FD137DFC0347 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-Info.plist"; sourceTree = "<group>"; };
-		40D3E2ACC250193E898393BB5E5B0FAD /* AWSXMLWriter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSXMLWriter.m; path = AWSCore/XMLWriter/AWSXMLWriter.m; sourceTree = "<group>"; };
-		4108872B2D9F35982F849D20935EFE58 /* AWSCognitoIdentityProviderASF.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderASF.m; path = AWSCognitoIdentityProviderASF/AWSCognitoIdentityProviderASF.m; sourceTree = "<group>"; };
-		41F1BA5E8793C8CC6222D85413CE4C4A /* AWSFMDatabaseQueue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabaseQueue.h; path = AWSCore/FMDB/AWSFMDatabaseQueue.h; sourceTree = "<group>"; };
-		42BB3C6979837861377DA5A89549AE64 /* AWSNetworkingHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSNetworkingHelpers.m; path = AWSCore/Networking/AWSNetworkingHelpers.m; sourceTree = "<group>"; };
+		407114E9393182165733176F6B463C75 /* AWSCategory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCategory.h; path = AWSCore/Utility/AWSCategory.h; sourceTree = "<group>"; };
+		410EA7B41FE060205FC4011920FA6597 /* AWSDDMultiFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDMultiFormatter.m; path = AWSCore/Logging/AWSDDMultiFormatter.m; sourceTree = "<group>"; };
+		41594B5134424E94E3C96777AA52D60A /* AWSCancellationToken.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationToken.h; path = AWSCore/Bolts/AWSCancellationToken.h; sourceTree = "<group>"; };
+		41AAC3F5C52861B3D940EF01D950DDD5 /* _AWSMobileClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = _AWSMobileClient.h; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.h; sourceTree = "<group>"; };
+		41F8F2B38046526CF3AC8DF1690BE9CF /* AWSBolts.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSBolts.h; path = AWSCore/Bolts/AWSBolts.h; sourceTree = "<group>"; };
+		422FA242D9F5ED9C37F90A6FD2FF2225 /* AWSIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSIdentityProvider.h; path = AWSCore/Authentication/AWSIdentityProvider.h; sourceTree = "<group>"; };
+		42717ACF4DB5B4F7156A4B027BEEEEC9 /* AWSCognitoIdentityProvider.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCognitoIdentityProvider.xcconfig; sourceTree = "<group>"; };
+		42C4CB6E6E4C46091EEC21ACAA570A13 /* AWSAuthCore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSAuthCore.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSAuthCore.h; sourceTree = "<group>"; };
 		42F9974C1E644CB8D99A4CE7C7E2CA56 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-acknowledgements.markdown"; sourceTree = "<group>"; };
 		430811562C2E438327AA9EA8436484D5 /* Pods-AmplifyTestApp-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-AmplifyTestApp-Info.plist"; sourceTree = "<group>"; };
-		46873E29496F81BE8EB8FC668D31C366 /* AWSNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSNetworking.m; path = AWSCore/Networking/AWSNetworking.m; sourceTree = "<group>"; };
+		438977A2FC2F79FA90059803F47E7388 /* AWSKSReachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSKSReachability.m; path = AWSCore/KSReachability/AWSKSReachability.m; sourceTree = "<group>"; };
+		43E405F1885C7685937FDD90D8A25963 /* CwlCatchException.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CwlCatchException.xcconfig; sourceTree = "<group>"; };
+		440558432306D065896EAE19BE1FDCF2 /* NSError+AWSMTLModelException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSError+AWSMTLModelException.h"; path = "AWSCore/Mantle/NSError+AWSMTLModelException.h"; sourceTree = "<group>"; };
+		45976F280C6328A4C07F4BD4C4EC5932 /* AWSDDLogMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLogMacros.h; path = AWSCore/Logging/AWSDDLogMacros.h; sourceTree = "<group>"; };
+		45C8E5D78BC076CF097C783401D30675 /* AWSURLRequestRetryHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLRequestRetryHandler.m; path = AWSCore/Serialization/AWSURLRequestRetryHandler.m; sourceTree = "<group>"; };
+		465060C70F108952D6A6D0B6B0B85133 /* AWSSignInManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSignInManager.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInManager.m; sourceTree = "<group>"; };
+		46855F19A1FA6C383444A696F925A3C2 /* AWSModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSModel.h; path = AWSCore/Utility/AWSModel.h; sourceTree = "<group>"; };
+		46FB3D57F1B7BFC2E0DECB2BD2A0E07B /* CwlPreconditionTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlPreconditionTesting.h; path = Sources/CwlPreconditionTesting/include/CwlPreconditionTesting.h; sourceTree = "<group>"; };
+		4776EB5C7291FE4BC37305AA93543C01 /* AWSInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSInfo.m; path = AWSCore/Service/AWSInfo.m; sourceTree = "<group>"; };
 		47D46D2BEC1D90EDAE4F1B547348EEFB /* AWSCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		47DF5785EA91BD8744624AB4E432880D /* AWSIdentityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSIdentityManager.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSIdentityManager.m; sourceTree = "<group>"; };
+		4840EABAFD9EACE0BD6B3FFF209208C0 /* AWSCognitoIdentityUserPool+Extension.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoIdentityUserPool+Extension.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoIdentityUserPool+Extension.h"; sourceTree = "<group>"; };
+		4857CE19C8C5F2FBCD5D178C8925E32F /* AWSAuthCore-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSAuthCore-umbrella.h"; sourceTree = "<group>"; };
 		48B10C571F93314CED282170847D63D8 /* Pods-AmplifyTestApp.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-AmplifyTestApp.modulemap"; sourceTree = "<group>"; };
-		49C1DACDE13725ACAFADE7825739F218 /* AWSXMLDictionary.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSXMLDictionary.h; path = AWSCore/XMLDictionary/AWSXMLDictionary.h; sourceTree = "<group>"; };
-		4BD2BB7E9FDBD0CD5EBDDACD4E5589AF /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
-		4D18BB847E2E5CA341022508986C0EA8 /* AWSFMDatabasePool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabasePool.m; path = AWSCore/FMDB/AWSFMDatabasePool.m; sourceTree = "<group>"; };
-		4D3E0FBF0A1B96D9B0A1670BC8C4117E /* AWSCognitoIdentityUserPool+Extension.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoIdentityUserPool+Extension.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoIdentityUserPool+Extension.h"; sourceTree = "<group>"; };
-		4E04EDF5782C184E748B3557700E2640 /* AWSCognitoIdentityProviderASF.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCognitoIdentityProviderASF.modulemap; sourceTree = "<group>"; };
-		4E57BA4A95EE17DEB99ECB5EBFC44EA9 /* AWSCognitoIdentityModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityModel.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityModel.h; sourceTree = "<group>"; };
-		506993FFD5E43321C8EE111378E6B6C5 /* AWSCognitoIdentityUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUser.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h; sourceTree = "<group>"; };
-		5085A6145D46202038A579642BB3B761 /* libAWSCognitoIdentityProviderASFBinary.a */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = archive.ar; name = libAWSCognitoIdentityProviderASFBinary.a; path = AWSCognitoIdentityProviderASF/Internal/libAWSCognitoIdentityProviderASFBinary.a; sourceTree = "<group>"; };
-		51F546FB05338188F9D16DCA20239565 /* AWSCore-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCore-dummy.m"; sourceTree = "<group>"; };
-		5292499829C37C41F261711AC72F7168 /* CwlCatchException.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CwlCatchException.xcconfig; sourceTree = "<group>"; };
-		52E8B5E00968480B2775F83181520231 /* NSDictionary+AWSMTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+AWSMTLManipulationAdditions.m"; path = "AWSCore/Mantle/NSDictionary+AWSMTLManipulationAdditions.m"; sourceTree = "<group>"; };
+		493DA8219B45D565C4ECC2D16A23529F /* AWSCognitoIdentityProviderHKDF.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderHKDF.m; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderHKDF.m; sourceTree = "<group>"; };
+		49DDC8B4B8A0008C33DC34FFEE3FC90F /* AWSFMDatabase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabase.m; path = AWSCore/FMDB/AWSFMDatabase.m; sourceTree = "<group>"; };
+		4AEEB68BA19668B4D0FE9A705816EF70 /* AWSAuthUIHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSAuthUIHelper.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.h; sourceTree = "<group>"; };
+		4BBBDFD5123F98E66123D0B84A133851 /* AWSCognitoIdentityProviderASF.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCognitoIdentityProviderASF.xcconfig; sourceTree = "<group>"; };
+		4BD20C472C43A246A6F2434B9E704BA3 /* CwlCatchException-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CwlCatchException-dummy.m"; sourceTree = "<group>"; };
+		4C609A14E1972EE2654C9EA40769F3AE /* AWSDDTTYLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDTTYLogger.h; path = AWSCore/Logging/AWSDDTTYLogger.h; sourceTree = "<group>"; };
+		4C6E66CCCA2AE2C466B9B3E4E7E352DE /* AWSSignature.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSignature.m; path = AWSCore/Authentication/AWSSignature.m; sourceTree = "<group>"; };
+		4D19419CD1FDE6E7301BE69ABC646C3F /* AWSCognitoIdentityProvider-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCognitoIdentityProvider-Info.plist"; sourceTree = "<group>"; };
+		4D71720CED398A05A893DF8906571124 /* NSData+AWSCognitoIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+AWSCognitoIdentityProvider.h"; path = "AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.h"; sourceTree = "<group>"; };
+		4D7A492EE74C55BEA2FD7E94061D172A /* Fabric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Fabric.h; path = AWSCore/Fabric/Fabric.h; sourceTree = "<group>"; };
+		4EB7448C2B60EDE6846DFA0806F4639D /* AWSTMMemoryCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMMemoryCache.h; path = AWSCore/TMCache/AWSTMMemoryCache.h; sourceTree = "<group>"; };
+		5310AD54B79AE33BED07FE6266C6C464 /* AWSJKBigInteger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSJKBigInteger.m; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.m; sourceTree = "<group>"; };
+		538DAF67D15820217B1911184A939AE2 /* AWSCognitoIdentityUser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityUser.m; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m; sourceTree = "<group>"; };
+		53E4CFA427DABB6BABEB4642C3CAB55E /* AWSXMLDictionary.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSXMLDictionary.m; path = AWSCore/XMLDictionary/AWSXMLDictionary.m; sourceTree = "<group>"; };
 		540B0D26F5B613408E8F5D94A66B5C28 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-acknowledgements.markdown"; sourceTree = "<group>"; };
-		5410D8EAB2C72480C6D03EAC64799186 /* AWSDDASLLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDASLLogger.h; path = AWSCore/Logging/AWSDDASLLogger.h; sourceTree = "<group>"; };
-		557CB74CF255046C393A564440AE135F /* AWSCognitoIdentityProviderModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderModel.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderModel.m; sourceTree = "<group>"; };
+		547C3C8BF2543737907362529ADFF79F /* AWSClientContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSClientContext.h; path = AWSCore/Service/AWSClientContext.h; sourceTree = "<group>"; };
 		5609021041C2F48853430E0091C5BB5A /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-Info.plist"; sourceTree = "<group>"; };
 		5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		57E610DB1C9834B93B86B32AE203D34B /* AWSCognitoAuth_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuth_Internal.h; path = AWSCognitoAuth/Internal/AWSCognitoAuth_Internal.h; sourceTree = "<group>"; };
-		58C89AD838EDC38CC8C7DBB462B82E56 /* AWSCognitoIdentityProviderService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderService.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderService.h; sourceTree = "<group>"; };
+		5917F431683B8C300E8F61292DB9C977 /* NSArray+AWSMTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+AWSMTLManipulationAdditions.h"; path = "AWSCore/Mantle/NSArray+AWSMTLManipulationAdditions.h"; sourceTree = "<group>"; };
 		592313CB94B49286EEF277EA91D3D95A /* AWSCognitoIdentityProviderASF.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AWSCognitoIdentityProviderASF.framework; path = AWSCognitoIdentityProviderASF.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		59A459A5BE87F0DADD67EBB169FFF49A /* AWSGZIP.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSGZIP.h; path = AWSCore/GZIP/AWSGZIP.h; sourceTree = "<group>"; };
 		59AD6B8077039CA78508DA2892FE480F /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.modulemap"; sourceTree = "<group>"; };
-		5AF033D372099B17E4AD1ECEF2388C74 /* FABAttributes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FABAttributes.h; path = AWSCore/Fabric/FABAttributes.h; sourceTree = "<group>"; };
+		5C5C76E4BCB1631B533E28A1DA95403A /* AWSMobileClientExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClientExtensions.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift; sourceTree = "<group>"; };
 		5C6DDDDA1D966AED315AB70664004815 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-umbrella.h"; sourceTree = "<group>"; };
 		5CC60529D233360B1F356DC750E15164 /* Pods-AmplifyTestApp-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-AmplifyTestApp-dummy.m"; sourceTree = "<group>"; };
-		5CDCA759E2B524AD0D5B0529F695A28C /* AWSJKBigDecimal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSJKBigDecimal.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigDecimal.h; sourceTree = "<group>"; };
 		5E7D5AC68E43CA3768505A58681304E1 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-umbrella.h"; sourceTree = "<group>"; };
-		5EDFE115C3392FB9863659189DFA9FD0 /* AWSCognitoIdentityProvider.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCognitoIdentityProvider.xcconfig; sourceTree = "<group>"; };
 		5FA201FD7F04844F9B9C1F2974AD9B46 /* AWSCognitoIdentityProvider.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AWSCognitoIdentityProvider.framework; path = AWSCognitoIdentityProvider.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		60F4BE632949FAE284F63F70D7952C60 /* AWSTMMemoryCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMMemoryCache.m; path = AWSCore/TMCache/AWSTMMemoryCache.m; sourceTree = "<group>"; };
-		63558BCBF0A625B52BCB547CD0DFB1BA /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
+		5FD575266288E008C6989EF6E2A2AC9C /* AWSFMDatabasePool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabasePool.h; path = AWSCore/FMDB/AWSFMDatabasePool.h; sourceTree = "<group>"; };
+		611E4441D39C5B5170F8B169E0740B35 /* AWSLogging.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSLogging.m; path = AWSCore/Utility/AWSLogging.m; sourceTree = "<group>"; };
+		61FFB55F7016DCDE8C2FB463C98FADB8 /* AWSKSReachability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSKSReachability.h; path = AWSCore/KSReachability/AWSKSReachability.h; sourceTree = "<group>"; };
+		628F229771BD6D9333C17BA8DE3BBC71 /* AWSDDOSLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDOSLogger.m; path = AWSCore/Logging/AWSDDOSLogger.m; sourceTree = "<group>"; };
+		62CA243C98F405F83294789351907442 /* aws_tommath_superclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath_superclass.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath_superclass.h; sourceTree = "<group>"; };
+		6334474AFC15E10B8E910D351C5379B5 /* AWSNetworkingHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSNetworkingHelpers.h; path = AWSCore/Networking/AWSNetworkingHelpers.h; sourceTree = "<group>"; };
 		636498E92402BEB2BB38D02D7EC74238 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-acknowledgements.plist"; sourceTree = "<group>"; };
-		64477AF05BB569C283F8CA75DC186B39 /* AWSCognitoIdentityProviderModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderModel.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderModel.h; sourceTree = "<group>"; };
+		6460C32B00D43D9E0499355B51800A75 /* AWSTMCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMCache.h; path = AWSCore/TMCache/AWSTMCache.h; sourceTree = "<group>"; };
 		64802F2E333FD29A93B939784FB965FE /* Pods-Amplify-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-umbrella.h"; sourceTree = "<group>"; };
-		65A25F6FD0D61706F9535950AFC406E4 /* AWSService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSService.m; path = AWSCore/Service/AWSService.m; sourceTree = "<group>"; };
+		64967ADE10969F821252AEE23895E34E /* AWSCognitoIdentityResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityResources.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityResources.h; sourceTree = "<group>"; };
+		64F1263957BE1770DED0ABCC5F3872D8 /* AWSSignInManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInManager.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInManager.h; sourceTree = "<group>"; };
+		652A923CAFD818E22258CB6520F566F6 /* AWSAuthCore-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSAuthCore-prefix.pch"; sourceTree = "<group>"; };
+		65A614203886ABADE199A0B800ECEE41 /* AWSService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSService.m; path = AWSCore/Service/AWSService.m; sourceTree = "<group>"; };
 		66112A1C75E7120538B03A9B1914DB4A /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-Info.plist"; sourceTree = "<group>"; };
-		66931E8F9AFA69143E52E4F621951059 /* AWSCore.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCore.modulemap; sourceTree = "<group>"; };
-		66B10363FF226628014BC9AA0109E500 /* AWSCognitoIdentity.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentity.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentity.h; sourceTree = "<group>"; };
-		66D34A65BD719CA839A366AED5ACE1F2 /* CwlCatchException-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlCatchException-umbrella.h"; sourceTree = "<group>"; };
-		673FC21F904E05922260C6F6C1055044 /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
-		679BE254CFCDEE26015A8539E066D54F /* AWSMTLModel+NSCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSMTLModel+NSCoding.h"; path = "AWSCore/Mantle/AWSMTLModel+NSCoding.h"; sourceTree = "<group>"; };
-		6A425EA2780C3972162FA364B8134591 /* AWSDDLog.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLog.h; path = AWSCore/Logging/AWSDDLog.h; sourceTree = "<group>"; };
-		6B78D374D0A051D9C447BCFAE475F4E2 /* AWSCancellationToken.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationToken.m; path = AWSCore/Bolts/AWSCancellationToken.m; sourceTree = "<group>"; };
-		6BCC572FE610F38AA38FE89EDDD3EDEE /* AWSCore-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCore-prefix.pch"; sourceTree = "<group>"; };
-		6C401F43F3647CFB1A04369928781E0E /* AWSSignature.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignature.h; path = AWSCore/Authentication/AWSSignature.h; sourceTree = "<group>"; };
+		661CA20D4112179C1D8140902C0FA46C /* AWSCognitoIdentityProviderASF-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCognitoIdentityProviderASF-dummy.m"; sourceTree = "<group>"; };
+		683B6C1E23EACE20AD23E1EE20C1F0E2 /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
+		68D965159C213A311C522050217704B2 /* AWSFMDB+AWSHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSFMDB+AWSHelpers.h"; path = "AWSCore/FMDB/AWSFMDB+AWSHelpers.h"; sourceTree = "<group>"; };
+		6988CED39EF50031FDCFEF5E9848AFB6 /* AWSCognitoIdentityUserPool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityUserPool.m; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m; sourceTree = "<group>"; };
+		6A1AD2ECB0B52C7FE0EBCA97ABAE4F7F /* NSData+AWSCognitoIdentityProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+AWSCognitoIdentityProvider.m"; path = "AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.m"; sourceTree = "<group>"; };
+		6A6A68B009E67D316D46E77E899DFD30 /* libAWSCognitoIdentityProviderASFBinary.a */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = archive.ar; name = libAWSCognitoIdentityProviderASFBinary.a; path = AWSCognitoIdentityProviderASF/Internal/libAWSCognitoIdentityProviderASFBinary.a; sourceTree = "<group>"; };
+		6AB1E6FA5B776255F1A3537BE9AA357E /* AWSDDLog+LOGV.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSDDLog+LOGV.h"; path = "AWSCore/Logging/AWSDDLog+LOGV.h"; sourceTree = "<group>"; };
+		6ACF3192254D1F9DBD26D5576A8893F5 /* AWSCore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCore.xcconfig; sourceTree = "<group>"; };
 		6C5ECBC402A49A42921C8BA77F0A19C5 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-acknowledgements.plist"; sourceTree = "<group>"; };
 		6C81CC0258D4E4C6230E583C79613573 /* AWSAuthCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AWSAuthCore.framework; path = AWSAuthCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C836C6AB96168F166B40979832ABA3F /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-frameworks.sh"; sourceTree = "<group>"; };
-		6D2101718310C6801E3A00062C07C39C /* AWSTask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTask.h; path = AWSCore/Bolts/AWSTask.h; sourceTree = "<group>"; };
-		70B3F537BC06A2190DBA5545CA3BC9D1 /* AWSSTSModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSModel.h; path = AWSCore/STS/AWSSTSModel.h; sourceTree = "<group>"; };
-		70BCFF3866799D2A76B86625EB6F94A7 /* CwlPreconditionTesting-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlPreconditionTesting-prefix.pch"; sourceTree = "<group>"; };
+		6D7ED8661EF857706C34D2758977F62B /* AWSMTLModel+NSCoding.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSMTLModel+NSCoding.m"; path = "AWSCore/Mantle/AWSMTLModel+NSCoding.m"; sourceTree = "<group>"; };
+		6E25299C3E7143DC12BA797151D05C86 /* AWSDDLog.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDLog.m; path = AWSCore/Logging/AWSDDLog.m; sourceTree = "<group>"; };
+		6EDDFBA65505F58B53C44E3ADE1B7525 /* AWSDDASLLogCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDASLLogCapture.m; path = AWSCore/Logging/AWSDDASLLogCapture.m; sourceTree = "<group>"; };
+		703E3BD1050E13C9D54DD0E20BE74878 /* AWSMobileClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClient.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift; sourceTree = "<group>"; };
 		70EF68EF61C4587DEC5119A866265B57 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-dummy.m"; sourceTree = "<group>"; };
+		70FB430AE49A1B952C747843DEDD64D0 /* AWSSTSResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSResources.m; path = AWSCore/STS/AWSSTSResources.m; sourceTree = "<group>"; };
+		710605340E5A8DDE7D63BD3EBD553A7E /* AWSTask.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTask.m; path = AWSCore/Bolts/AWSTask.m; sourceTree = "<group>"; };
 		71803B908C82923324FBC55B50603420 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-umbrella.h"; sourceTree = "<group>"; };
-		722FB0BF2F494C956CD49C0C75A2FDC0 /* AWSLogging.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSLogging.m; path = AWSCore/Utility/AWSLogging.m; sourceTree = "<group>"; };
-		7257E001ABB1CC1EF9EE34046FC8BCD2 /* AWSCognitoIdentityProvider.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCognitoIdentityProvider.modulemap; sourceTree = "<group>"; };
-		7281DA57E485275E8A49803FCDED939E /* AWSExecutor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSExecutor.h; path = AWSCore/Bolts/AWSExecutor.h; sourceTree = "<group>"; };
-		72AF9BE763154EB3F8872F62553004E1 /* AWSDDAssertMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDAssertMacros.h; path = AWSCore/Logging/AWSDDAssertMacros.h; sourceTree = "<group>"; };
-		73D6A1A96394F99C88C2D192F6EE2472 /* AWSUICKeyChainStore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSUICKeyChainStore.h; path = AWSCore/UICKeyChainStore/AWSUICKeyChainStore.h; sourceTree = "<group>"; };
-		745068DD32DDB8617322A32B3A678DDD /* AWSDDOSLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDOSLogger.h; path = AWSCore/Logging/AWSDDOSLogger.h; sourceTree = "<group>"; };
-		76183A993DAA4D030DEB79B1EE231C3C /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
+		71A5378770579FD27A792236232E25FC /* AWSCognitoIdentityProvider.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCognitoIdentityProvider.modulemap; sourceTree = "<group>"; };
+		7246F3143227F49E0D69F318896E3F0A /* AWSAuthCore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSAuthCore.xcconfig; sourceTree = "<group>"; };
+		741F49C40E6FA66D5CD23136107A9A2C /* AWSGZIP.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSGZIP.m; path = AWSCore/GZIP/AWSGZIP.m; sourceTree = "<group>"; };
+		76E072AC48744E37B1968B34E9FB8990 /* AWSCancellationTokenSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationTokenSource.m; path = AWSCore/Bolts/AWSCancellationTokenSource.m; sourceTree = "<group>"; };
 		77145BB1E378943FCB981368F4B9E771 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests.release.xcconfig"; sourceTree = "<group>"; };
-		7771C2DFE4AD99CD3A269C7ADB017DAA /* AWSCognitoIdentityService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityService.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityService.h; sourceTree = "<group>"; };
-		795169AE5537F5799BCDE954951A68F6 /* AWSCognitoIdentityProviderASF-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProviderASF-prefix.pch"; sourceTree = "<group>"; };
-		79F8F7318B8DE19209DA9DDF5193FC01 /* AWSURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLRequestSerialization.m; path = AWSCore/Serialization/AWSURLRequestSerialization.m; sourceTree = "<group>"; };
-		7A8546CE0DBDFE5D38B2046606E4B7CE /* AWSFMResultSet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMResultSet.h; path = AWSCore/FMDB/AWSFMResultSet.h; sourceTree = "<group>"; };
-		7AA514D521D364F474E1B819D72E6CA6 /* CwlPreconditionTesting-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "CwlPreconditionTesting-Info.plist"; sourceTree = "<group>"; };
-		7AB1A2F26FDFD8E1CCDB36F0FFD0FDA0 /* AWSEXTScope.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSEXTScope.m; path = AWSCore/Mantle/extobjc/AWSEXTScope.m; sourceTree = "<group>"; };
-		7B5D74163C65BA45F129C2F75A244A26 /* AWSCognitoIdentityUserPool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUserPool.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h; sourceTree = "<group>"; };
-		7B69116025E7AE4E03FD9CB6AE7D4A79 /* AWSmetamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSmetamacros.h; path = AWSCore/Mantle/extobjc/AWSmetamacros.h; sourceTree = "<group>"; };
+		77F4A236D1F851232D48EBDF90147885 /* FABAttributes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FABAttributes.h; path = AWSCore/Fabric/FABAttributes.h; sourceTree = "<group>"; };
+		7861A4ABA0A851F8F55F302EBCA9588A /* AWSUIConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSUIConfiguration.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSUIConfiguration.h; sourceTree = "<group>"; };
+		795B8F8866B38DB939E35FDBA96AF27E /* AWSFMDatabaseQueue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabaseQueue.h; path = AWSCore/FMDB/AWSFMDatabaseQueue.h; sourceTree = "<group>"; };
+		798076C68A26DEC9A47A7EF5AA795AD8 /* AWSMobileClient-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSMobileClient-Info.plist"; sourceTree = "<group>"; };
+		7A7150AD06A15FFA3B7777DE68DE4842 /* AWSTask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTask.h; path = AWSCore/Bolts/AWSTask.h; sourceTree = "<group>"; };
+		7B9AA17ED6E6A642F5E8474D94DA778C /* Fabric+FABKits.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Fabric+FABKits.h"; path = "AWSCore/Fabric/Fabric+FABKits.h"; sourceTree = "<group>"; };
+		7BF3F861431F5E73FB97B7D8762C387A /* AWSCore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCore.h; path = AWSCore/AWSCore.h; sourceTree = "<group>"; };
+		7C51B363039417DEAD5F8456DEE3B877 /* AWSCancellationTokenRegistration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationTokenRegistration.h; path = AWSCore/Bolts/AWSCancellationTokenRegistration.h; sourceTree = "<group>"; };
+		7C7C8994C24425413D1870B567869C47 /* AWSJKBigDecimal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSJKBigDecimal.m; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigDecimal.m; sourceTree = "<group>"; };
+		7D722FE0E92693EA328A01D0C30DE69C /* AWSUICKeyChainStore.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSUICKeyChainStore.m; path = AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m; sourceTree = "<group>"; };
 		7E95AAB996428D7874DB2E4B93260F35 /* CwlCatchException.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CwlCatchException.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		80C849937AD2C88BA17636FFE3EEE60C /* AWSCore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCore.xcconfig; sourceTree = "<group>"; };
+		7F73B91A2BBEF91A3BA691AF03391D24 /* AWSFMDB.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDB.h; path = AWSCore/FMDB/AWSFMDB.h; sourceTree = "<group>"; };
+		80009A829D5F19DFB029CD1074D46FD4 /* AWSTMCacheBackgroundTaskManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMCacheBackgroundTaskManager.h; path = AWSCore/TMCache/AWSTMCacheBackgroundTaskManager.h; sourceTree = "<group>"; };
 		80DF1944FBE1C02C0D19FA556279CF7A /* Pods_Amplify.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify.framework; path = "Pods-Amplify.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		810E6C0AEAF81CEF142AD224BC9FA4D7 /* AWSFMDatabaseAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabaseAdditions.h; path = AWSCore/FMDB/AWSFMDatabaseAdditions.h; sourceTree = "<group>"; };
-		81685F61C04386054C6EB486CE045EB4 /* AWSFMDatabaseQueue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabaseQueue.m; path = AWSCore/FMDB/AWSFMDatabaseQueue.m; sourceTree = "<group>"; };
-		82AE0D4FE2C5DA296BA6072367A2F9F6 /* AWSCognitoIdentityProvider-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProvider-umbrella.h"; sourceTree = "<group>"; };
-		856B9460EE390E948E972BC937AD38F4 /* AWSJKBigInteger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSJKBigInteger.m; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.m; sourceTree = "<group>"; };
-		85B16C1BEED6DAD6A2AB160002933CDA /* AWSJKBigDecimal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSJKBigDecimal.m; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigDecimal.m; sourceTree = "<group>"; };
-		86BE6A81DB57EC1FEA08B44FDD69B10E /* AWSDDMultiFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDMultiFormatter.m; path = AWSCore/Logging/AWSDDMultiFormatter.m; sourceTree = "<group>"; };
-		8712DFDF41458E13CDE557E792397356 /* AWSCognitoIdentity+Fabric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoIdentity+Fabric.h"; path = "AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.h"; sourceTree = "<group>"; };
+		815CCB2AE451A2908705CF17B1B45765 /* AWSAuthUIHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSAuthUIHelper.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.m; sourceTree = "<group>"; };
+		821D30FC1FA05A779392557905809822 /* AWSFMDatabaseAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabaseAdditions.h; path = AWSCore/FMDB/AWSFMDatabaseAdditions.h; sourceTree = "<group>"; };
+		84CC2DC999F384730595ACA3B9CB0A55 /* AWSCognitoIdentityUserPool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUserPool.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h; sourceTree = "<group>"; };
+		881C4F7AD68CE9C1D2FF602B2C79FA9A /* AWSCognitoIdentityProviderASF.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderASF.m; path = AWSCognitoIdentityProviderASF/AWSCognitoIdentityProviderASF.m; sourceTree = "<group>"; };
 		8866A6188CF9937D30E31F9C3AF4744D /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests.modulemap"; sourceTree = "<group>"; };
 		88B5B053284A3CD214CB2345BB04C33F /* AWSMobileClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AWSMobileClient.framework; path = AWSMobileClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		897BE0E1152364146DF9E84966A20D23 /* AWSCognitoIdentityProvider.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSCognitoIdentityProvider.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A0ADFA07325170FDC5BB0CE2DB1EBA9 /* AWSURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLResponseSerialization.m; path = AWSCore/Serialization/AWSURLResponseSerialization.m; sourceTree = "<group>"; };
-		8A5462580CC9DC68AF7075ACA8844031 /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
-		8A6AB7B64F3EA49D82336E6F2342E8F4 /* AWSSTSResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSResources.h; path = AWSCore/STS/AWSSTSResources.h; sourceTree = "<group>"; };
 		8A7F5959C56A2F6E93DDA0D9EB3274DE /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-dummy.m"; sourceTree = "<group>"; };
+		8B09EDE3A624F7ABBDC0599DB913A0F8 /* AWSDDASLLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDASLLogger.m; path = AWSCore/Logging/AWSDDASLLogger.m; sourceTree = "<group>"; };
 		8B37EE7562B33B09D027EE4A0B32AA75 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.release.xcconfig"; sourceTree = "<group>"; };
-		8CAB3BD92207D2E252347FD79A669516 /* NSError+AWSMTLModelException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSError+AWSMTLModelException.h"; path = "AWSCore/Mantle/NSError+AWSMTLModelException.h"; sourceTree = "<group>"; };
-		8CEEBBC83FB1A93562327EAFF615AA6B /* Fabric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Fabric.h; path = AWSCore/Fabric/Fabric.h; sourceTree = "<group>"; };
+		8C4A50FCDF3A84042BAA7731E75F07F3 /* AWSCore-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCore-Info.plist"; sourceTree = "<group>"; };
+		8C768E0E6854399915626CEF3A4AD186 /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
+		8D169BC3B420EB3E0536F23B34963823 /* AWSCognitoIdentityASF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityASF.h; path = AWSCognitoIdentityProviderASF/Internal/AWSCognitoIdentityASF.h; sourceTree = "<group>"; };
+		8DC83450666908D92C002EA49A394A08 /* AWSEXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTKeyPathCoding.h; path = AWSCore/Mantle/extobjc/AWSEXTKeyPathCoding.h; sourceTree = "<group>"; };
+		8F06DA83B9E53426EF78C32536C25671 /* AWSEXTScope.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSEXTScope.m; path = AWSCore/Mantle/extobjc/AWSEXTScope.m; sourceTree = "<group>"; };
 		9000133D745E33FE1ED02390F5F7E717 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
 		9022B9B1EE62A9406A47544AF1A9A60A /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		906357A4C1AA3FE5689B0E940D3D91F2 /* NSData+AWSCognitoIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+AWSCognitoIdentityProvider.h"; path = "AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.h"; sourceTree = "<group>"; };
-		9109D53E30C8C4C64FBC39ECF60C179E /* AWSCancellationTokenRegistration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationTokenRegistration.h; path = AWSCore/Bolts/AWSCancellationTokenRegistration.h; sourceTree = "<group>"; };
-		9176A30EF537A984349EF0941C29042B /* AWSFMResultSet.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMResultSet.m; path = AWSCore/FMDB/AWSFMResultSet.m; sourceTree = "<group>"; };
-		91C2094C059BAFFFFBC229AC5C0F9CEF /* AWSCognitoIdentityModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityModel.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityModel.m; sourceTree = "<group>"; };
-		920863BE9A25A6D24A89E4889EE0A014 /* FABKitProtocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FABKitProtocol.h; path = AWSCore/Fabric/FABKitProtocol.h; sourceTree = "<group>"; };
-		92A43858635F9C27ED94A05763E2521E /* AWSDDASLLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDASLLogger.m; path = AWSCore/Logging/AWSDDASLLogger.m; sourceTree = "<group>"; };
-		9348F3E0355579436D403C96DB0D7EF4 /* AWSCocoaLumberjack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCocoaLumberjack.h; path = AWSCore/Logging/AWSCocoaLumberjack.h; sourceTree = "<group>"; };
-		94327DFA9363831CE32D78455D699B69 /* AWSEXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTScope.h; path = AWSCore/Mantle/extobjc/AWSEXTScope.h; sourceTree = "<group>"; };
-		94701E2D8BEB1ECDDF758D0719854FAF /* AWSTMMemoryCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMMemoryCache.h; path = AWSCore/TMCache/AWSTMMemoryCache.h; sourceTree = "<group>"; };
-		96A2D651BCE8019612EBFDAB5CBD48F2 /* AWSAuthCore-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSAuthCore-prefix.pch"; sourceTree = "<group>"; };
-		98015366A1F6CDB77D29D5B2458E7056 /* AWSDDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDDispatchQueueLogFormatter.m; path = AWSCore/Logging/Extensions/AWSDDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
-		983EDE1A47AA1B93CFCC5C3B7E1E5678 /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
-		98EBAF29DC4D794957822E239F9C944B /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
-		98FCA979D8A8822E734476B6E58B8ED4 /* AWSDDFileLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDFileLogger.h; path = AWSCore/Logging/AWSDDFileLogger.h; sourceTree = "<group>"; };
-		99B54D708FFA50347BEFA9AD8730A8AA /* AWSCore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCore.h; path = AWSCore/AWSCore.h; sourceTree = "<group>"; };
-		9ADAC8F37FB83D9A1FAE60863BAE22A2 /* JSONHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JSONHelper.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/JSONHelper.swift; sourceTree = "<group>"; };
-		9C738EC7E8D4A0BF95B09336DEDB98B1 /* AWSURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLSessionManager.m; path = AWSCore/Networking/AWSURLSessionManager.m; sourceTree = "<group>"; };
-		9CACA599E066FECF7765E60FB671E1A8 /* AWSCognitoIdentity+Fabric.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSCognitoIdentity+Fabric.m"; path = "AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.m"; sourceTree = "<group>"; };
-		9CC392531C7DC92AB41B16939E55FBAC /* AWSCredentialsProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCredentialsProvider.m; path = AWSCore/Authentication/AWSCredentialsProvider.m; sourceTree = "<group>"; };
-		9D814B6AF5A67FF1828ECF314845D1BD /* AWSFMDatabase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabase.m; path = AWSCore/FMDB/AWSFMDatabase.m; sourceTree = "<group>"; };
+		91C2B142988FBE04C888E53876BA2642 /* AWSValidation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSValidation.h; path = AWSCore/Serialization/AWSValidation.h; sourceTree = "<group>"; };
+		929336265CFD5286CD800DF27904879E /* AWSCognitoIdentityProviderResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderResources.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderResources.m; sourceTree = "<group>"; };
+		9319B5648119778AC2F13F3A9EEC73B2 /* AWSFMDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabase.h; path = AWSCore/FMDB/AWSFMDatabase.h; sourceTree = "<group>"; };
+		943F781A6406C3C665785C8FC7D0B20C /* AWSCognitoIdentityProviderResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderResources.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderResources.h; sourceTree = "<group>"; };
+		94434239E6D897885741EAF1FDEE3EDC /* AWSJKBigInteger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSJKBigInteger.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.h; sourceTree = "<group>"; };
+		9493D78EBBFA335F5E10EF8CF66548EF /* AWSModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSModel.m; path = AWSCore/Utility/AWSModel.m; sourceTree = "<group>"; };
+		953D7D189B0B0AA34FE2A00F7B1580B3 /* AWSNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSNetworking.m; path = AWSCore/Networking/AWSNetworking.m; sourceTree = "<group>"; };
+		963946810229E66761E9B42375D1CF97 /* AWSMobileClient.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSMobileClient.xcconfig; sourceTree = "<group>"; };
+		97E3422FF53B92A9D5AFEA9D66AAA4F6 /* AWSGZIP.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSGZIP.h; path = AWSCore/GZIP/AWSGZIP.h; sourceTree = "<group>"; };
+		981624D41E118BC6DCD0A92016B8CF43 /* AWSAuthCore-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSAuthCore-Info.plist"; sourceTree = "<group>"; };
+		98B91CEED15E36B9E7F022C5FEFB9FE8 /* tommath.c */ = {isa = PBXFileReference; includeInIndex = 1; name = tommath.c; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/tommath.c; sourceTree = "<group>"; };
+		9949A94419F2281C1EF0E2EC108965FF /* AWSCognitoIdentityResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityResources.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityResources.m; sourceTree = "<group>"; };
+		9968838C214BDC48C6247783D9B28594 /* AWSCognitoIdentityProviderService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderService.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderService.m; sourceTree = "<group>"; };
+		99BA5D0889BB958E0926C060B9649DAA /* JSONHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JSONHelper.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/JSONHelper.swift; sourceTree = "<group>"; };
+		99BC7FA61E5480A10F9CC2701F43B9A3 /* AWSMTLManagedObjectAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLManagedObjectAdapter.h; path = AWSCore/Mantle/AWSMTLManagedObjectAdapter.h; sourceTree = "<group>"; };
+		9A4B58BC9B812E6EFFD4E6FE0BA16141 /* AWSCognitoIdentityProviderSrpHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderSrpHelper.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderSrpHelper.h; sourceTree = "<group>"; };
+		9A549DBDF126AD830CF93ABF538B614D /* AWSSynchronizedMutableDictionary.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSynchronizedMutableDictionary.m; path = AWSCore/Utility/AWSSynchronizedMutableDictionary.m; sourceTree = "<group>"; };
+		9A6D7B33D949723B982647BA1085C343 /* AWSDDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDDispatchQueueLogFormatter.m; path = AWSCore/Logging/Extensions/AWSDDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
+		9CF10481CDDC747914614A828F8E73CD /* AWSCognitoIdentityProvider-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCognitoIdentityProvider-dummy.m"; sourceTree = "<group>"; };
+		9D241CB74335071761B49679EA021634 /* AWSCognitoAuth+Extensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSCognitoAuth+Extensions.m"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.m"; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		9DAF63CB3927C45D2346F11705E3AFA7 /* AWSCognitoIdentityProviderASF-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProviderASF-umbrella.h"; sourceTree = "<group>"; };
-		9DD919F5D40936CBB175BC18C0CC012A /* aws_tommath_superclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath_superclass.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath_superclass.h; sourceTree = "<group>"; };
-		9F110F53CAAF1AB03CE1CA851F85859F /* NSDictionary+AWSMTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+AWSMTLManipulationAdditions.h"; path = "AWSCore/Mantle/NSDictionary+AWSMTLManipulationAdditions.h"; sourceTree = "<group>"; };
-		9F45A88D28CED0D57D7F1D7138D0CDFF /* NSData+AWSCognitoIdentityProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+AWSCognitoIdentityProvider.m"; path = "AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.m"; sourceTree = "<group>"; };
-		9FCBEE62A3337BC2F65D83AF4E6B900F /* AWSModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSModel.h; path = AWSCore/Utility/AWSModel.h; sourceTree = "<group>"; };
-		9FEEDF39BB2522F1F1564847E3D9021A /* AWSMobileClient.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSMobileClient.modulemap; sourceTree = "<group>"; };
-		9FF7C8B2AC413711B14A91BC15CD8431 /* AWSKSReachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSKSReachability.m; path = AWSCore/KSReachability/AWSKSReachability.m; sourceTree = "<group>"; };
-		A077A3D16945E07EBB64DF9B37B77A62 /* AWSCognitoIdentityProvider-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCognitoIdentityProvider-dummy.m"; sourceTree = "<group>"; };
-		A1163FE82E3D89D2C4D5F59685F700D0 /* AWSCognitoIdentityUserPool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityUserPool.m; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m; sourceTree = "<group>"; };
-		A160B41090A56C0EFD3C4DF8921A1539 /* AWSInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSInfo.h; path = AWSCore/Service/AWSInfo.h; sourceTree = "<group>"; };
-		A1D9BE851096D333C6BCF3DCC3CB8685 /* AWSCognitoIdentityProviderHKDF.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderHKDF.m; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderHKDF.m; sourceTree = "<group>"; };
-		A30C60B5CD0C127A0F791708CFE9B42D /* AWSDDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDDispatchQueueLogFormatter.h; path = AWSCore/Logging/Extensions/AWSDDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
-		A46B3233721574887E89B7E89E73CB49 /* AWSAuthCore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSAuthCore.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSAuthCore.h; sourceTree = "<group>"; };
+		9E167C8879A46B30A2FDB093B65ADCBE /* aws_tommath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath.h; sourceTree = "<group>"; };
+		9EC8D9E31650B69ACA6F529EE143216D /* AWSURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLResponseSerialization.h; path = AWSCore/Serialization/AWSURLResponseSerialization.h; sourceTree = "<group>"; };
+		9EF046703AE413CFEFDEA5EE438FF370 /* AWSCognitoIdentityService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityService.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityService.m; sourceTree = "<group>"; };
+		9F5251F3952F1FA41D25883D9DB6C8C0 /* AWSCocoaLumberjack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCocoaLumberjack.h; path = AWSCore/Logging/AWSCocoaLumberjack.h; sourceTree = "<group>"; };
+		9F9B0BE3560BA877F8EEDC69DDD37534 /* AWSDDFileLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDFileLogger.m; path = AWSCore/Logging/AWSDDFileLogger.m; sourceTree = "<group>"; };
+		9FBA19C6EAB6B5D35D98981B307131F4 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h"; sourceTree = "<group>"; };
+		A042B28A3C211CA9A4F74DAF7311F33D /* AWSNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSNetworking.h; path = AWSCore/Networking/AWSNetworking.h; sourceTree = "<group>"; };
+		A34C3FFA168434E053A947A44448184E /* AWSTMDiskCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMDiskCache.m; path = AWSCore/TMCache/AWSTMDiskCache.m; sourceTree = "<group>"; };
+		A45E4C5772CFEFFC6E77C0624C651A0E /* AWSAuthCore-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSAuthCore-dummy.m"; sourceTree = "<group>"; };
 		A483C9091059B80817F2F1D6E7F4ADC0 /* Pods-Amplify-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-acknowledgements.markdown"; sourceTree = "<group>"; };
 		A4B8551213E176E1C8DC109BF5957DD3 /* Pods_Amplify_AmplifyTestConfigs_AmplifyTestCommon.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AmplifyTestConfigs_AmplifyTestCommon.framework; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		A4F18ECC77B90BCC7C16CD58FFCA677C /* SwiftFormat.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftFormat.xcconfig; sourceTree = "<group>"; };
-		A52145D6322955C0D6C6F09871F24741 /* AWSFMDB+AWSHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSFMDB+AWSHelpers.m"; path = "AWSCore/FMDB/AWSFMDB+AWSHelpers.m"; sourceTree = "<group>"; };
+		A5C4755E18CF7D73FD5757B42817C8A7 /* AWSCognitoIdentityUserPool_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUserPool_Internal.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityUserPool_Internal.h; sourceTree = "<group>"; };
+		A6784ED93641EB4F41049EFBFAE024D1 /* AWSCore-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCore-umbrella.h"; sourceTree = "<group>"; };
+		A6EA21687C72BE41C8EB5778B6F7D519 /* AWSCognitoIdentityProviderService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderService.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderService.h; sourceTree = "<group>"; };
 		A70C7A2407B818ECD1C5D3D6EF9E6781 /* Pods-Amplify-AWSPluginsCore-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-Info.plist"; sourceTree = "<group>"; };
-		A7521733F008AF096D52D74AF5F36981 /* AWSMobileClient-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSMobileClient-dummy.m"; sourceTree = "<group>"; };
-		ACA1E3EBBEA1F5D3160841769800B0DC /* AWSCognitoIdentityUser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityUser.m; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m; sourceTree = "<group>"; };
-		ACCDCDE3D9BB24C9A28284F325A016D5 /* AWSAuthCore.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSAuthCore.modulemap; sourceTree = "<group>"; };
-		ACCDDF8A621C80784B35192C5C55D9ED /* Fabric+FABKits.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Fabric+FABKits.h"; path = "AWSCore/Fabric/Fabric+FABKits.h"; sourceTree = "<group>"; };
-		AD1FFEF90711E0EC311224E066703638 /* AWSValidation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSValidation.h; path = AWSCore/Serialization/AWSValidation.h; sourceTree = "<group>"; };
-		AE43657F8C0C1405A6F48A02C31C2CF5 /* AWSTMCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMCache.m; path = AWSCore/TMCache/AWSTMCache.m; sourceTree = "<group>"; };
+		A8598EE9DFBE20826EC5C647B287555D /* AWSCognitoIdentityModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityModel.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityModel.h; sourceTree = "<group>"; };
+		AB46ADB2B0FACE56687DD120B4D5EDEF /* AWSTaskCompletionSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTaskCompletionSource.h; path = AWSCore/Bolts/AWSTaskCompletionSource.h; sourceTree = "<group>"; };
+		AB967F9CFF776884A5B3215E374A1B1D /* AWSDDOSLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDOSLogger.h; path = AWSCore/Logging/AWSDDOSLogger.h; sourceTree = "<group>"; };
+		ABC5884D8B8D580C98E6127C4041BEB3 /* AWSMobileClient-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSMobileClient-umbrella.h"; sourceTree = "<group>"; };
+		AD933820BDEA1EDFE966D94B6B13DDC5 /* SwiftFormat.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftFormat.xcconfig; sourceTree = "<group>"; };
+		AEE0DFAEAE5810A498869F32312A98CC /* AWSURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLSessionManager.m; path = AWSCore/Networking/AWSURLSessionManager.m; sourceTree = "<group>"; };
 		AF9100203F45E4A2CE2EE987A561A14F /* Pods-AmplifyTestApp-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-AmplifyTestApp-acknowledgements.plist"; sourceTree = "<group>"; };
-		AF9B52768BC4CE65526EAB63E2E75880 /* AWSDDTTYLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDTTYLogger.m; path = AWSCore/Logging/AWSDDTTYLogger.m; sourceTree = "<group>"; };
-		AFE6CA3E54E94B93879D0415A2FA535C /* AWSCognitoAuth+Extensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSCognitoAuth+Extensions.m"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.m"; sourceTree = "<group>"; };
-		B0F9182481E43628F757BAFB64AD0B54 /* NSObject+AWSMTLComparisonAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+AWSMTLComparisonAdditions.m"; path = "AWSCore/Mantle/NSObject+AWSMTLComparisonAdditions.m"; sourceTree = "<group>"; };
-		B105C48272F594AC5233F7320470A5B7 /* AWSTMCacheBackgroundTaskManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMCacheBackgroundTaskManager.h; path = AWSCore/TMCache/AWSTMCacheBackgroundTaskManager.h; sourceTree = "<group>"; };
-		B11D75C0DCD9FF11DB626B078823A733 /* AWSMantle.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMantle.h; path = AWSCore/Mantle/AWSMantle.h; sourceTree = "<group>"; };
-		B1E046FABC7AEB1DDEAF83E80E8A23E5 /* AWSMobileClientUserDetails.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClientUserDetails.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSMobileClientUserDetails.swift; sourceTree = "<group>"; };
-		B22773A61D27574942BD3C76F4C90814 /* AWSTask.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTask.m; path = AWSCore/Bolts/AWSTask.m; sourceTree = "<group>"; };
+		B03BF899ECCAE4CE7E3DAD96B6066B3D /* AWSXMLWriter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSXMLWriter.m; path = AWSCore/XMLWriter/AWSXMLWriter.m; sourceTree = "<group>"; };
+		B113FF367E590A74DFC88C56C2CAF166 /* AWSCategory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCategory.m; path = AWSCore/Utility/AWSCategory.m; sourceTree = "<group>"; };
+		B12E7C422FC9A1B35382A270A70BBAC8 /* AWSDDASLLogCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDASLLogCapture.h; path = AWSCore/Logging/AWSDDASLLogCapture.h; sourceTree = "<group>"; };
+		B1F0999944AEC4156AD5258F82068B0A /* AWSCancellationTokenRegistration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationTokenRegistration.m; path = AWSCore/Bolts/AWSCancellationTokenRegistration.m; sourceTree = "<group>"; };
+		B1FE6F1140144DE02164800F5A36634D /* AWSCognitoIdentityService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityService.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityService.h; sourceTree = "<group>"; };
+		B2467B4C12BFB43EE82B2C9FCCA58B4E /* AWSMobileClientUserDetails.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClientUserDetails.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSMobileClientUserDetails.swift; sourceTree = "<group>"; };
 		B270484543DC97A2E5759EB4E30E0E90 /* Pods_Amplify_AmplifyTestConfigs_AmplifyTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AmplifyTestConfigs_AmplifyTests.framework; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		B2DB7B9AA67A4C2901A501179E35FDC8 /* AWSCognitoIdentityResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityResources.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityResources.h; sourceTree = "<group>"; };
-		B3AE5FD3791D0D949459393DD40CD3DF /* AWSMobileClient-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSMobileClient-umbrella.h"; sourceTree = "<group>"; };
+		B3CA7B68BCCBF9C94B7209BDD71BBDB3 /* AWSURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLResponseSerialization.m; path = AWSCore/Serialization/AWSURLResponseSerialization.m; sourceTree = "<group>"; };
 		B4144DE60EA249CC4A98549069F402FB /* AWSCognitoIdentityProviderASF.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSCognitoIdentityProviderASF.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B4E599012C75D7A133B5D77EB7591134 /* AWSAuthCore-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSAuthCore-umbrella.h"; sourceTree = "<group>"; };
-		B5FA5040145A5FC42FC743FA56514940 /* AWSUserPoolOperationsHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSUserPoolOperationsHandler.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift; sourceTree = "<group>"; };
-		B6F8E974D59BB2C71C3998C162816143 /* AWSBolts.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSBolts.h; path = AWSCore/Bolts/AWSBolts.h; sourceTree = "<group>"; };
-		B785B0927F487DA24F8777BAA7C3FD3E /* AWSCognitoCredentialsProvider+Extension.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoCredentialsProvider+Extension.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoCredentialsProvider+Extension.h"; sourceTree = "<group>"; };
-		B8785DC9A87864D9C1FDCB43C2469B74 /* AWSSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSerialization.m; path = AWSCore/Serialization/AWSSerialization.m; sourceTree = "<group>"; };
+		B4E133BDBC60371D1C4C31859E4C8C7A /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
+		B6277D3F2C6FEE504D3735AE99072576 /* AWSXMLDictionary.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSXMLDictionary.h; path = AWSCore/XMLDictionary/AWSXMLDictionary.h; sourceTree = "<group>"; };
+		B6C416894DABEDED0EA160A85B935848 /* AWSDDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDDispatchQueueLogFormatter.h; path = AWSCore/Logging/Extensions/AWSDDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
+		B6D8BE1666950E8A45057CC6666024C2 /* AWSTMDiskCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMDiskCache.h; path = AWSCore/TMCache/AWSTMDiskCache.h; sourceTree = "<group>"; };
+		B8892F2ADBD009DECB8C1D0B654A930D /* AWSDDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDAbstractDatabaseLogger.h; path = AWSCore/Logging/AWSDDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
 		B8A667E74EC0A8A4EDFB8F2D2364FC92 /* Pods-Amplify-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-dummy.m"; sourceTree = "<group>"; };
-		B9A3E48A5EBDD64DAE2ECD9EE0D19659 /* AWSCognitoIdentityUserPool_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUserPool_Internal.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityUserPool_Internal.h; sourceTree = "<group>"; };
-		BB402C47244C897CE7236FE13AD98752 /* AWSMobileClient-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSMobileClient-Info.plist"; sourceTree = "<group>"; };
-		BB55B2CB2AA26552F0C51813928696F6 /* AWSDDLegacyMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLegacyMacros.h; path = AWSCore/Logging/AWSDDLegacyMacros.h; sourceTree = "<group>"; };
+		B912B8BDF2CFA91469BBC9485DA7EEC3 /* AWSCognitoIdentityProviderModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderModel.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderModel.m; sourceTree = "<group>"; };
+		BA0CC7A8195152F4DDF67D0A4D7C2283 /* AWSMTLReflection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLReflection.m; path = AWSCore/Mantle/AWSMTLReflection.m; sourceTree = "<group>"; };
+		BA53451B0AAF0009E78D037F9A02F878 /* AWSCognitoAuthUICKeyChainStore.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoAuthUICKeyChainStore.m; path = AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.m; sourceTree = "<group>"; };
+		BAD9B4CDCA171522E97D8BA20564EFB8 /* AWSIdentityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSIdentityManager.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSIdentityManager.h; sourceTree = "<group>"; };
+		BB9D98357DCFDB3958EE3BB3E35D948F /* AWSCognitoIdentityProviderASF-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProviderASF-umbrella.h"; sourceTree = "<group>"; };
 		BBCCE722E2FD574C72320E1D0DFA805A /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-acknowledgements.plist"; sourceTree = "<group>"; };
-		BC067900E6CC27C9DAEE297A89AD2D0F /* AWSMTLModel+NSCoding.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSMTLModel+NSCoding.m"; path = "AWSCore/Mantle/AWSMTLModel+NSCoding.m"; sourceTree = "<group>"; };
+		BBFE758649A0AFC2A4DFF34C4B5AB080 /* AWSSTS.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTS.h; path = AWSCore/STS/AWSSTS.h; sourceTree = "<group>"; };
 		BC0AAAB222E3424AB42C3968AE2DD9F7 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests.debug.xcconfig"; sourceTree = "<group>"; };
-		BC78A1BE3112CD63FB79FC0D632C08AD /* AWSSTSService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSService.m; path = AWSCore/STS/AWSSTSService.m; sourceTree = "<group>"; };
-		BD6402601C3C46495B29A0B51C537439 /* AWSMTLManagedObjectAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLManagedObjectAdapter.h; path = AWSCore/Mantle/AWSMTLManagedObjectAdapter.h; sourceTree = "<group>"; };
+		BC18EC7B6416CEED09F73528AE71AA31 /* AWSDDContextFilterLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDContextFilterLogFormatter.m; path = AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter.m; sourceTree = "<group>"; };
+		BC715587BE425079FAA4305951B22D71 /* AWSSTSModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSModel.m; path = AWSCore/STS/AWSSTSModel.m; sourceTree = "<group>"; };
+		BDDF6B882BD969BB837E4A5A683B83C7 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m"; sourceTree = "<group>"; };
 		BDE3D242E320015920FF9968B3B82469 /* Pods-Amplify-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-Info.plist"; sourceTree = "<group>"; };
 		BE3DBB67EEF91BEAEEF0780F753CCB8E /* Pods-Amplify-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-acknowledgements.plist"; sourceTree = "<group>"; };
-		BE4816820DBD8AD200627DBCE6504789 /* AWSMobileClient-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSMobileClient-prefix.pch"; sourceTree = "<group>"; };
+		BEB8D765884E650AFA25EB7CB3820CAB /* AWSCognitoAuth.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoAuth.m; path = AWSCognitoAuth/AWSCognitoAuth.m; sourceTree = "<group>"; };
+		BECA5D4C0B1E2BE1E29EFA8A6FD6DF19 /* AWSURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLRequestSerialization.h; path = AWSCore/Serialization/AWSURLRequestSerialization.h; sourceTree = "<group>"; };
 		BF3EC1DB119CD6294BF8B76C95215B6E /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.modulemap"; sourceTree = "<group>"; };
-		BFCEEE328F910F62BBDE90665F16FD72 /* AWSLogging.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSLogging.h; path = AWSCore/Utility/AWSLogging.h; sourceTree = "<group>"; };
 		C0764D426402BEC77DB42BBD5102F91F /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-acknowledgements.plist"; sourceTree = "<group>"; };
-		C0B03B2C8F2862CAF77DEFE91DF50641 /* AWSURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLSessionManager.h; path = AWSCore/Networking/AWSURLSessionManager.h; sourceTree = "<group>"; };
-		C0DB0C0B9E1C812A42914C8AA7BF1A8D /* AWSGZIP.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSGZIP.m; path = AWSCore/GZIP/AWSGZIP.m; sourceTree = "<group>"; };
-		C163507295304A519E85051ED74A6209 /* AWSTMDiskCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMDiskCache.m; path = AWSCore/TMCache/AWSTMDiskCache.m; sourceTree = "<group>"; };
-		C212D282C3A3524B1011E30E0E313E1C /* AWSDDASLLogCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDASLLogCapture.m; path = AWSCore/Logging/AWSDDASLLogCapture.m; sourceTree = "<group>"; };
+		C0F9349245E10F2DAF7ACDFFC42876BE /* AWSmetamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSmetamacros.h; path = AWSCore/Mantle/extobjc/AWSmetamacros.h; sourceTree = "<group>"; };
+		C113662AE6AF834F148159C71FB3E942 /* AWSSTSService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSService.h; path = AWSCore/STS/AWSSTSService.h; sourceTree = "<group>"; };
+		C2F60A5A19FDE9D43EC3A8800F3192D6 /* AWSSTSModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSModel.h; path = AWSCore/STS/AWSSTSModel.h; sourceTree = "<group>"; };
+		C2F7721C7D4AB4BD517C4A7A90EC2AF7 /* AWSFMResultSet.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMResultSet.m; path = AWSCore/FMDB/AWSFMResultSet.m; sourceTree = "<group>"; };
+		C44C1B8D58F0B38ADB731A5082B0CAB0 /* AWSSTSService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSService.m; path = AWSCore/STS/AWSSTSService.m; sourceTree = "<group>"; };
 		C49CC694143B932ACAEDAB2B998DE32A /* AWSAuthCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSAuthCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C5C34C491A183A09D49EF0138F8202FE /* AWSIdentityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSIdentityManager.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSIdentityManager.h; sourceTree = "<group>"; };
-		C6FB30955DA68107EDEF56A9A1344D17 /* AWSMobileClient.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSMobileClient.xcconfig; sourceTree = "<group>"; };
-		C751FB32301C38302A2EC137BA70D3EC /* AWSCognitoIdentityProviderSrpHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderSrpHelper.m; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderSrpHelper.m; sourceTree = "<group>"; };
+		C5E6F0C0A4A580010558CD9BF7B954F5 /* AWSFMDB+AWSHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSFMDB+AWSHelpers.m"; path = "AWSCore/FMDB/AWSFMDB+AWSHelpers.m"; sourceTree = "<group>"; };
+		C77683D48729E6AB6FA9EB8451E29E32 /* AWSMantle.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMantle.h; path = AWSCore/Mantle/AWSMantle.h; sourceTree = "<group>"; };
+		C80E1BAEA00F8C1A39BB5BFAFEB0F909 /* AWSEXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTRuntimeExtensions.h; path = AWSCore/Mantle/extobjc/AWSEXTRuntimeExtensions.h; sourceTree = "<group>"; };
 		C8D22E6E639FD8B2AA18F007DEDB51F7 /* Pods-Amplify.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify.debug.xcconfig"; sourceTree = "<group>"; };
-		C9022B2A001A348E8DEDD1296B5E0716 /* NSError+AWSMTLModelException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSError+AWSMTLModelException.m"; path = "AWSCore/Mantle/NSError+AWSMTLModelException.m"; sourceTree = "<group>"; };
-		CA7B6E7179083414E201D1859C9528EB /* AWSCognitoIdentityProvider-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProvider-prefix.pch"; sourceTree = "<group>"; };
-		CA847668DCC864011A6F5E61B5B8F788 /* AWSCognitoIdentityProvider-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCognitoIdentityProvider-Info.plist"; sourceTree = "<group>"; };
-		CA9BF82B9D49B3E34E31C82200838ACE /* AWSMobileClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMobileClient.h; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.h; sourceTree = "<group>"; };
+		C9C7A3FBCE1D43323505FAAA796042CB /* AWSCognitoIdentity+Fabric.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSCognitoIdentity+Fabric.m"; path = "AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.m"; sourceTree = "<group>"; };
+		CA2C71AB4AF430CD7C3F0BBFA980970B /* AWSCognitoIdentityProviderSrpHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderSrpHelper.m; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderSrpHelper.m; sourceTree = "<group>"; };
+		CA996DE4D8F1EF552C13984CECAD7D4B /* NSValueTransformer+AWSMTLInversionAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+AWSMTLInversionAdditions.m"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLInversionAdditions.m"; sourceTree = "<group>"; };
 		CAB297499AF600870ECB83BC5970DED8 /* Pods-AmplifyTestApp-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-AmplifyTestApp-acknowledgements.markdown"; sourceTree = "<group>"; };
-		CAB31BB0CB1979BC02AE603D4C767273 /* AWSXMLWriter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSXMLWriter.h; path = AWSCore/XMLWriter/AWSXMLWriter.h; sourceTree = "<group>"; };
-		CB5F5DD200C1796E0CD90E3B92A8DB28 /* AWSURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLResponseSerialization.h; path = AWSCore/Serialization/AWSURLResponseSerialization.h; sourceTree = "<group>"; };
+		CAEB52D72F180BE2D87F708E35A82DA1 /* AWSCognitoIdentityProviderHKDF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderHKDF.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderHKDF.h; sourceTree = "<group>"; };
+		CBC63B38BFED9913CCC459F4312FC6EB /* AWSService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSService.h; path = AWSCore/Service/AWSService.h; sourceTree = "<group>"; };
 		CBED44CF131280494DBEBD7CF2B56150 /* Pods_Amplify_AWSPluginsCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AWSPluginsCore.framework; path = "Pods-Amplify-AWSPluginsCore.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC46A423E858362387E2F494BE58A39B /* Pods-Amplify.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify.modulemap"; sourceTree = "<group>"; };
 		CC56497384E780278F916D6C57EA4951 /* CwlPreconditionTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = CwlPreconditionTesting.framework; path = CwlPreconditionTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCFB8F03867DB892EFC47B53186590C4 /* AWSCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AWSCore.framework; path = AWSCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CD4393963F8EEB81AD47AEF6938B3646 /* CwlPreconditionTesting.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CwlPreconditionTesting.modulemap; sourceTree = "<group>"; };
-		CD9504574C2BEA74886D0BA7A7E51BE6 /* AWSFMDatabasePool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabasePool.h; path = AWSCore/FMDB/AWSFMDatabasePool.h; sourceTree = "<group>"; };
-		CDA38353C499EAFBF0C7F4C481DB06D1 /* AWSCognitoIdentityProviderASF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderASF.h; path = AWSCognitoIdentityProviderASF/AWSCognitoIdentityProviderASF.h; sourceTree = "<group>"; };
-		CEAA8CF19472EC4ACF9D738F775FC832 /* AWSJKBigInteger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSJKBigInteger.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.h; sourceTree = "<group>"; };
-		CF52B59CF212AEF5EF49ED0B7A9E02C1 /* AWSService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSService.h; path = AWSCore/Service/AWSService.h; sourceTree = "<group>"; };
-		D0E94613A5F8B0E8267BE68F25F2F8CD /* AWSServiceEnum.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSServiceEnum.h; path = AWSCore/Service/AWSServiceEnum.h; sourceTree = "<group>"; };
+		CE10F2C9689101DC708A3559492AFAB3 /* AWSCognitoAuthUICKeyChainStore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuthUICKeyChainStore.h; path = AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.h; sourceTree = "<group>"; };
+		CF059F400C23E801FC3E8CADBC196680 /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
+		CFE581CE7FF366A7AA6702AB8C3EBF43 /* CwlPreconditionTesting.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CwlPreconditionTesting.modulemap; sourceTree = "<group>"; };
+		D04928F7B7DF5814379C4B5B12F50A99 /* _AWSMobileClient.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = _AWSMobileClient.m; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.m; sourceTree = "<group>"; };
+		D08680B5CB880D99A30DF2ABB5ABB192 /* AWSCore-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCore-dummy.m"; sourceTree = "<group>"; };
+		D0E83F4975799D8D677867E97B00A081 /* CwlPreconditionTesting-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlPreconditionTesting-umbrella.h"; sourceTree = "<group>"; };
+		D2069E3BA0CE303E2ACED88BB858900C /* AWSNetworkingHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSNetworkingHelpers.m; path = AWSCore/Networking/AWSNetworkingHelpers.m; sourceTree = "<group>"; };
 		D278F5748D57849269D3BC19FE845B99 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.release.xcconfig"; sourceTree = "<group>"; };
-		D29FE4BBF56788C9AC325256DFB9A156 /* AWSCancellationTokenSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationTokenSource.m; path = AWSCore/Bolts/AWSCancellationTokenSource.m; sourceTree = "<group>"; };
+		D283F1B77F53E197BA10ED0DAB9F2445 /* AWSDDASLLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDASLLogger.h; path = AWSCore/Logging/AWSDDASLLogger.h; sourceTree = "<group>"; };
 		D2FC9F4ECE3B1251F36F9AC548B8969B /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.modulemap"; sourceTree = "<group>"; };
-		D30FB1471BD4A7F0CE23217C25A286D6 /* AWSEXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTRuntimeExtensions.h; path = AWSCore/Mantle/extobjc/AWSEXTRuntimeExtensions.h; sourceTree = "<group>"; };
-		D3E5DF2CC49F1C2A673519ADB5D725BE /* AWSExecutor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSExecutor.m; path = AWSCore/Bolts/AWSExecutor.m; sourceTree = "<group>"; };
+		D34262BF92ECE4D3009E5F09892D60F0 /* aws_tommath_class.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath_class.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath_class.h; sourceTree = "<group>"; };
+		D47F25C2F5ACF88B85C501564465245F /* AWSCognitoIdentityProviderASF-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCognitoIdentityProviderASF-Info.plist"; sourceTree = "<group>"; };
+		D51BF6733A6A0E115157B9762902702F /* AWSCognitoIdentityModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityModel.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityModel.m; sourceTree = "<group>"; };
+		D615C7B77855CCD54C6919CCA2017839 /* CwlCatchException.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CwlCatchException.modulemap; sourceTree = "<group>"; };
+		D7166CDD70AFA0C6433623748FD475E9 /* AWSGeneric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSGeneric.h; path = AWSCore/Bolts/AWSGeneric.h; sourceTree = "<group>"; };
 		D745E2A5C3D7BB82BB00BA0C3CD9A56C /* Pods_Amplify_AmplifyTestConfigs_AmplifyFunctionalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AmplifyTestConfigs_AmplifyFunctionalTests.framework; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D76FC53C6B0339CBD0396CA7E9736905 /* CwlCatchException-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "CwlCatchException-Info.plist"; sourceTree = "<group>"; };
 		D7E43FB42F81273FADA2B41F8A59397E /* Pods-AmplifyTestApp-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-AmplifyTestApp-umbrella.h"; sourceTree = "<group>"; };
-		D7E8BDCF5CB5DF64785E0DE7EDD5371A /* CwlPreconditionTesting-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlPreconditionTesting-umbrella.h"; sourceTree = "<group>"; };
-		D7E963C4F0D7D073D7546DDC482E53FD /* AWSMTLValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLValueTransformer.h; path = AWSCore/Mantle/AWSMTLValueTransformer.h; sourceTree = "<group>"; };
-		D87BBA54881BE0850CBFFDC4D8114FCA /* AWSBolts.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSBolts.m; path = AWSCore/Bolts/AWSBolts.m; sourceTree = "<group>"; };
+		D83E7FD2A0F668DD364117F3A03DDD21 /* AWSCore-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCore-prefix.pch"; sourceTree = "<group>"; };
+		D9223D3012D6A3F0E45D477716FC783A /* AWSCredentialsProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCredentialsProvider.h; path = AWSCore/Authentication/AWSCredentialsProvider.h; sourceTree = "<group>"; };
 		D9D21961D651909C5E5D1161C7FF4859 /* Pods-Amplify-AWSPluginsCore-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-acknowledgements.plist"; sourceTree = "<group>"; };
-		DA93AD0D291E93447CCCCCEFD85708BB /* AWSCognitoIdentityProviderResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderResources.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderResources.m; sourceTree = "<group>"; };
-		DAA8BB0506C2E9D42D5AED09D74156A6 /* AWSTMDiskCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMDiskCache.h; path = AWSCore/TMCache/AWSTMDiskCache.h; sourceTree = "<group>"; };
-		DAD1437F5D9BFFE96ADE2AC63A18703F /* AWSAuthCore-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSAuthCore-Info.plist"; sourceTree = "<group>"; };
-		DADB698FF6F0FE317C721CB8277E3306 /* AWSCognitoIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProvider.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityProvider.h; sourceTree = "<group>"; };
-		DBF4A88D5942D7C441128C119BAF0999 /* AWSCognitoAuth+Extensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoAuth+Extensions.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h"; sourceTree = "<group>"; };
-		DCE1BA35810587B99C58F0FED53ABAC3 /* AWSCognitoIdentityService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityService.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityService.m; sourceTree = "<group>"; };
-		DD0529F2FD94E94EE9F9F9EA3B418E22 /* AWSCognitoIdentityProviderASF-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCognitoIdentityProviderASF-Info.plist"; sourceTree = "<group>"; };
-		DE52C631AAD1F37EC85940B309484450 /* AWSTMCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMCache.h; path = AWSCore/TMCache/AWSTMCache.h; sourceTree = "<group>"; };
 		DEC3E3C3510C8A55F95F909E0207C7DD /* Pods-Amplify-AWSPluginsCore-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AWSPluginsCore-dummy.m"; sourceTree = "<group>"; };
+		DEE1DCA4A5FB0656C92086E64BA674E8 /* AWSEXTRuntimeExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSEXTRuntimeExtensions.m; path = AWSCore/Mantle/extobjc/AWSEXTRuntimeExtensions.m; sourceTree = "<group>"; };
+		DF3BBE962830C1EDC2E1806CFDFE0272 /* AWSSignInProviderApplicationIntercept.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInProviderApplicationIntercept.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInProviderApplicationIntercept.h; sourceTree = "<group>"; };
 		E0BC8BB0FE4725CF87EB0A9F5D400FD6 /* CwlCatchException.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = CwlCatchException.framework; path = CwlCatchException.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E128D8EF93BA4D893F0117811A205D83 /* AWSCategory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCategory.m; path = AWSCore/Utility/AWSCategory.m; sourceTree = "<group>"; };
-		E1EC8C3E16C71BF25AA7F00CDEF6C1DE /* AWSCancellationToken.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationToken.h; path = AWSCore/Bolts/AWSCancellationToken.h; sourceTree = "<group>"; };
-		E727F698E5184B8A8F0AEF9CAF632FA8 /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
-		E7EC8830B686D3AA9F8A5EC5559D133E /* AWSCognitoIdentityUser_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUser_Internal.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityUser_Internal.h; sourceTree = "<group>"; };
-		E8B5FDB178DA118BA766982955206D30 /* AWSFMDatabase+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSFMDatabase+Private.h"; path = "AWSCore/FMDB/AWSFMDatabase+Private.h"; sourceTree = "<group>"; };
-		E8D2519C6A2A39EC2767637F8B899FDB /* AWSCognitoAuthUICKeyChainStore.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoAuthUICKeyChainStore.m; path = AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.m; sourceTree = "<group>"; };
-		E946D357D1B824535DF21C71A74F7306 /* AWSEXTRuntimeExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSEXTRuntimeExtensions.m; path = AWSCore/Mantle/extobjc/AWSEXTRuntimeExtensions.m; sourceTree = "<group>"; };
-		EA5ACF18886A4FF581354E7504E25CCD /* AWSSignInButtonView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInButtonView.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInButtonView.h; sourceTree = "<group>"; };
-		EAB2EC18E32F6E2FCA424AE80D8412DB /* AWSCognitoIdentityASF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityASF.h; path = AWSCognitoIdentityProviderASF/Internal/AWSCognitoIdentityASF.h; sourceTree = "<group>"; };
-		EB037FE1BB0944A9A0396B42155C798B /* AWSUIConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSUIConfiguration.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSUIConfiguration.h; sourceTree = "<group>"; };
-		EB3B13702A64602EEE8777F3A9C91B70 /* AWSValidation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSValidation.m; path = AWSCore/Serialization/AWSValidation.m; sourceTree = "<group>"; };
-		ED595581B874044815E93AAC0D4FB3A4 /* AWSIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSIdentityProvider.h; path = AWSCore/Authentication/AWSIdentityProvider.h; sourceTree = "<group>"; };
-		EE13CC64B7D51AA8D246157E67E7DDB0 /* AWSMobileClientExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClientExtensions.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift; sourceTree = "<group>"; };
+		E20654D1C7C32E38165102AE5ABFB0F0 /* AWSURLRequestRetryHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLRequestRetryHandler.h; path = AWSCore/Serialization/AWSURLRequestRetryHandler.h; sourceTree = "<group>"; };
+		E25D5299C21355193D7C2A76F8CEEFDD /* DeviceOperations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeviceOperations.swift; path = AWSAuthSDK/Sources/AWSMobileClient/DeviceOperations.swift; sourceTree = "<group>"; };
+		E3532D3DEC3B3B7120EC060FE9C7499B /* AWSCognitoAuth.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuth.h; path = AWSCognitoAuth/AWSCognitoAuth.h; sourceTree = "<group>"; };
+		E41A4F6C5931A151F14ADD44D2C53F73 /* AWSCognitoIdentity.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentity.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentity.h; sourceTree = "<group>"; };
+		E57C86135FE3E1EB1A2782F47F0B61E1 /* AWSDDMultiFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDMultiFormatter.h; path = AWSCore/Logging/Extensions/AWSDDMultiFormatter.h; sourceTree = "<group>"; };
+		E6C6A920327206592931F16DBEE69BE2 /* AWSCognitoIdentityProviderASF-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProviderASF-prefix.pch"; sourceTree = "<group>"; };
+		E6FDC0CFF3356A4962E09D5E960ABB17 /* AWSURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLRequestSerialization.m; path = AWSCore/Serialization/AWSURLRequestSerialization.m; sourceTree = "<group>"; };
+		E8E35E59E39195095F41E8723BD20312 /* AWSCore.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCore.modulemap; sourceTree = "<group>"; };
+		E8F6A95D7BE53B66C196833D9CA26FA9 /* AWSExecutor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSExecutor.h; path = AWSCore/Bolts/AWSExecutor.h; sourceTree = "<group>"; };
+		E93D888F2358613A1772D77597C493E9 /* AWSMTLModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLModel.m; path = AWSCore/Mantle/AWSMTLModel.m; sourceTree = "<group>"; };
+		EA8CCC92D9F0AC3169E2EB6118110571 /* CwlCatchException-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlCatchException-umbrella.h"; sourceTree = "<group>"; };
+		EC6A357AB15EB63B0204FADCF79A97F8 /* AWSCancellationTokenSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationTokenSource.h; path = AWSCore/Bolts/AWSCancellationTokenSource.h; sourceTree = "<group>"; };
+		EDE35F033F8789A514C6E98B2E720923 /* AWSDDAssertMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDAssertMacros.h; path = AWSCore/Logging/AWSDDAssertMacros.h; sourceTree = "<group>"; };
 		EE377F76EBC89AD773429D3EBE8EF8D5 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.modulemap"; sourceTree = "<group>"; };
 		EE49F6473631850D3EC76C328D5772CB /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		EF561B1B40611C880C1A51E5F00A234D /* AWSInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSInfo.h; path = AWSCore/Service/AWSInfo.h; sourceTree = "<group>"; };
+		EFAE02E7CEADBC4AB4A4F59052C630F4 /* AWSCredentialsProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCredentialsProvider.m; path = AWSCore/Authentication/AWSCredentialsProvider.m; sourceTree = "<group>"; };
 		EFD2AEC8F92F60614948319DA39DDA2C /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-dummy.m"; sourceTree = "<group>"; };
-		EFEA0F24602DFAEAAC189215C3C59E39 /* AWSCategory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCategory.h; path = AWSCore/Utility/AWSCategory.h; sourceTree = "<group>"; };
 		F046E64EB8EA7F1638E89AFEA89BD856 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-acknowledgements.plist"; sourceTree = "<group>"; };
-		F14752C7AAF0C272D64F8DB9DB35D1FB /* CwlPreconditionTesting-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CwlPreconditionTesting-dummy.m"; sourceTree = "<group>"; };
 		F15EBDBF674EB1666EE4635030DAB0DE /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.debug.xcconfig"; sourceTree = "<group>"; };
-		F170E6A7DDECEFE5838C092C79B21FDA /* AWSMTLReflection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLReflection.m; path = AWSCore/Mantle/AWSMTLReflection.m; sourceTree = "<group>"; };
 		F1B77771753AD2D834119C6AF9F65C72 /* Pods-Amplify-AWSPluginsCore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore.debug.xcconfig"; sourceTree = "<group>"; };
-		F271D7B7BA1C38C1E117F07AA0BB9E42 /* AWSCognitoAuth.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoAuth.m; path = AWSCognitoAuth/AWSCognitoAuth.m; sourceTree = "<group>"; };
-		F2F95957A8A28F91A1A0FE2164F2234D /* AWSSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSerialization.h; path = AWSCore/Serialization/AWSSerialization.h; sourceTree = "<group>"; };
-		F3CB9777F44C0BDB4C2F7226731D7A17 /* AWSFMDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabase.h; path = AWSCore/FMDB/AWSFMDatabase.h; sourceTree = "<group>"; };
-		F427531291DB1D1C9D8F6A709F1BBD2A /* NSValueTransformer+AWSMTLInversionAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+AWSMTLInversionAdditions.h"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLInversionAdditions.h"; sourceTree = "<group>"; };
-		F512671A8CA89ACEF7575B062F6AD0DC /* AWSDDASLLogCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDASLLogCapture.h; path = AWSCore/Logging/AWSDDASLLogCapture.h; sourceTree = "<group>"; };
-		F5D4071126A64D42B2F302F608505CE9 /* AWSUserPoolCustomAuthHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSUserPoolCustomAuthHandler.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSUserPoolCustomAuthHandler.swift; sourceTree = "<group>"; };
-		F5DABEBB1A7AE30FC002FA9F7D7C32BC /* _AWSMobileClient.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = _AWSMobileClient.m; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.m; sourceTree = "<group>"; };
-		F739532763F64777B91327F4DD6E9AB0 /* AWSMTLValueTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLValueTransformer.m; path = AWSCore/Mantle/AWSMTLValueTransformer.m; sourceTree = "<group>"; };
-		F752DCF3576E6E8F2191593BA7C6F05A /* AWSSignInProviderApplicationIntercept.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInProviderApplicationIntercept.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInProviderApplicationIntercept.h; sourceTree = "<group>"; };
-		F7BD476B02A70C2CA36E64D4DDF32DAD /* AWSURLRequestRetryHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLRequestRetryHandler.h; path = AWSCore/Serialization/AWSURLRequestRetryHandler.h; sourceTree = "<group>"; };
-		F7D6FB7A816C9E5F5B9FD5344DFA7EA6 /* CwlCatchException-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "CwlCatchException-Info.plist"; sourceTree = "<group>"; };
-		F917BC5B219C19085ED19ED90CB19D15 /* CwlCatchException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchException.swift; path = Sources/CwlCatchException/CwlCatchException.swift; sourceTree = "<group>"; };
-		F95F5D2719024ECC7BF03F6832F6944E /* AWSFMDatabaseAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabaseAdditions.m; path = AWSCore/FMDB/AWSFMDatabaseAdditions.m; sourceTree = "<group>"; };
+		F291DBE453B14BE33FD687E62A995465 /* CwlPreconditionTesting-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CwlPreconditionTesting-dummy.m"; sourceTree = "<group>"; };
+		F2F0FD149643708FDA4C151010A65162 /* AWSFMDatabase+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSFMDatabase+Private.h"; path = "AWSCore/FMDB/AWSFMDatabase+Private.h"; sourceTree = "<group>"; };
+		F315E4DD3CDFF2005E5797FC3DA761A8 /* AWSCognitoIdentityProviderModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderModel.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderModel.h; sourceTree = "<group>"; };
+		F468789ADD71CDF2D656C188FC55C800 /* AWSCognitoCredentialsProvider+Extension.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoCredentialsProvider+Extension.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoCredentialsProvider+Extension.h"; sourceTree = "<group>"; };
+		F5E803FC9650596AEA2F9A353BE31401 /* AWSURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLSessionManager.h; path = AWSCore/Networking/AWSURLSessionManager.h; sourceTree = "<group>"; };
+		F7FC9BE173B3AAD3825EA854C06AB75E /* AWSSynchronizedMutableDictionary.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSynchronizedMutableDictionary.h; path = AWSCore/Utility/AWSSynchronizedMutableDictionary.h; sourceTree = "<group>"; };
+		F8841AFA6EEBA04ED1A278D30AB02563 /* AWSSignInProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInProvider.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInProvider.h; sourceTree = "<group>"; };
+		F981B395491B56FA08162A83B12AC098 /* AWSAuthCore.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSAuthCore.modulemap; sourceTree = "<group>"; };
 		F9918FB3EA173FD1AC5374D0FE2A4C3D /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.debug.xcconfig"; sourceTree = "<group>"; };
 		F9B0E837F8889C0E70E3B3CAD7D9D949 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-frameworks.sh"; sourceTree = "<group>"; };
-		F9E0D46A0F53CEF014CB608689479F5A /* AWSMTLModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLModel.h; path = AWSCore/Mantle/AWSMTLModel.h; sourceTree = "<group>"; };
-		FABA1EBEF087305EAED9649E53354E5E /* AWSCognitoIdentityProviderResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderResources.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderResources.h; sourceTree = "<group>"; };
-		FB67317B1299EE3D2F425CDDD6AFEEC0 /* AWSMobileClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClient.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift; sourceTree = "<group>"; };
-		FC3DCF579216C793C1D5986A399A2417 /* AWSCognitoIdentityProviderASF-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCognitoIdentityProviderASF-dummy.m"; sourceTree = "<group>"; };
-		FF9CFC24BCA0B14493B8518376969BEC /* AWSDDFileLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDFileLogger.m; path = AWSCore/Logging/AWSDDFileLogger.m; sourceTree = "<group>"; };
-		FFCB4AAE367BAD78D9C6A46083E63014 /* CwlCatchException-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CwlCatchException-dummy.m"; sourceTree = "<group>"; };
+		FC341DFA15E436E927491FB260311C9B /* AWSMTLJSONAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLJSONAdapter.h; path = AWSCore/Mantle/AWSMTLJSONAdapter.h; sourceTree = "<group>"; };
+		FD90263907B9BD577E7F0850F86817D0 /* AWSDDLog.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLog.h; path = AWSCore/Logging/AWSDDLog.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1210,21 +1212,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3E145C62E18EB143A9D5C8EB279CC99A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				589B4BDB54D0D172D532FC88D5D7C953 /* AWSAuthCore.framework in Frameworks */,
+				900EB0A2321005B91FC71C7F8C7B92ED /* AWSCognitoIdentityProvider.framework in Frameworks */,
+				58F513DBEC30590405F5B3CDC4C472B2 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4A76839E88FACA782C1C6CF90585C55D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				D76CECDB2FAB94F3D8DD51B54EA7F510 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8DD65B45F2688280FD422D5D7364A10A /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				46818E554C7902ABE93D24966BB50EE3 /* AWSAuthCore.framework in Frameworks */,
-				AD223728D8DFA18B28E0340459453763 /* AWSCognitoIdentityProvider.framework in Frameworks */,
-				5D97CDAB82AF5231ACF2D62F75FB4F55 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1317,191 +1319,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		02D3095C4836936A4D26CFDAAA5A29E8 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				1811ACAB11403C7A7936597C357FA33F /* AWSAuthCore */,
-				2C6A834CCAE8EB26259C71E30848F767 /* AWSCognitoIdentityProvider */,
-				F54394C431F5EB529A6160FB3E437E7F /* AWSCognitoIdentityProviderASF */,
-				06C6A85FC6C767AFBB8E17BA37379CD0 /* AWSCore */,
-				BA904E8F7807E5CC859BDDBE0BAA43C5 /* AWSMobileClient */,
-				1E39A2F1394B55C0C838F5202B7F2C7C /* CwlCatchException */,
-				412F96643FE3AE1A69F36120130ADBF5 /* CwlPreconditionTesting */,
-				E9B1820AFEA9222E5AE6AF00D1419B29 /* SwiftFormat */,
-				7F1BD4DAED83CA45AC39DEDEB8F26247 /* SwiftLint */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		06C6A85FC6C767AFBB8E17BA37379CD0 /* AWSCore */ = {
-			isa = PBXGroup;
-			children = (
-				B6F8E974D59BB2C71C3998C162816143 /* AWSBolts.h */,
-				D87BBA54881BE0850CBFFDC4D8114FCA /* AWSBolts.m */,
-				E1EC8C3E16C71BF25AA7F00CDEF6C1DE /* AWSCancellationToken.h */,
-				6B78D374D0A051D9C447BCFAE475F4E2 /* AWSCancellationToken.m */,
-				9109D53E30C8C4C64FBC39ECF60C179E /* AWSCancellationTokenRegistration.h */,
-				281AC237A5385219FDCE6717E9C69709 /* AWSCancellationTokenRegistration.m */,
-				12D212D94038E4481D8C3C8043590F7C /* AWSCancellationTokenSource.h */,
-				D29FE4BBF56788C9AC325256DFB9A156 /* AWSCancellationTokenSource.m */,
-				EFEA0F24602DFAEAAC189215C3C59E39 /* AWSCategory.h */,
-				E128D8EF93BA4D893F0117811A205D83 /* AWSCategory.m */,
-				3A3C4EF0A54DFF8F64748AB9A6E364E0 /* AWSClientContext.h */,
-				11981CE8441163483F737D85DE32B1CE /* AWSClientContext.m */,
-				9348F3E0355579436D403C96DB0D7EF4 /* AWSCocoaLumberjack.h */,
-				66B10363FF226628014BC9AA0109E500 /* AWSCognitoIdentity.h */,
-				8712DFDF41458E13CDE557E792397356 /* AWSCognitoIdentity+Fabric.h */,
-				9CACA599E066FECF7765E60FB671E1A8 /* AWSCognitoIdentity+Fabric.m */,
-				4E57BA4A95EE17DEB99ECB5EBFC44EA9 /* AWSCognitoIdentityModel.h */,
-				91C2094C059BAFFFFBC229AC5C0F9CEF /* AWSCognitoIdentityModel.m */,
-				B2DB7B9AA67A4C2901A501179E35FDC8 /* AWSCognitoIdentityResources.h */,
-				185F0DC6368FA1D4547527B451DB8EB9 /* AWSCognitoIdentityResources.m */,
-				7771C2DFE4AD99CD3A269C7ADB017DAA /* AWSCognitoIdentityService.h */,
-				DCE1BA35810587B99C58F0FED53ABAC3 /* AWSCognitoIdentityService.m */,
-				99B54D708FFA50347BEFA9AD8730A8AA /* AWSCore.h */,
-				13A6AC4F2598B540AB29DEA12B8DA004 /* AWSCredentialsProvider.h */,
-				9CC392531C7DC92AB41B16939E55FBAC /* AWSCredentialsProvider.m */,
-				3F3CA727772902D38F633984F132084D /* AWSDDAbstractDatabaseLogger.h */,
-				13A70D9A2492A9A41C2BC8FDDE0C6707 /* AWSDDAbstractDatabaseLogger.m */,
-				F512671A8CA89ACEF7575B062F6AD0DC /* AWSDDASLLogCapture.h */,
-				C212D282C3A3524B1011E30E0E313E1C /* AWSDDASLLogCapture.m */,
-				5410D8EAB2C72480C6D03EAC64799186 /* AWSDDASLLogger.h */,
-				92A43858635F9C27ED94A05763E2521E /* AWSDDASLLogger.m */,
-				72AF9BE763154EB3F8872F62553004E1 /* AWSDDAssertMacros.h */,
-				390C1B329BDBA41B75D7590CFC85F033 /* AWSDDContextFilterLogFormatter.h */,
-				1E93344537320B3C5EB8604688C8560C /* AWSDDContextFilterLogFormatter.m */,
-				A30C60B5CD0C127A0F791708CFE9B42D /* AWSDDDispatchQueueLogFormatter.h */,
-				98015366A1F6CDB77D29D5B2458E7056 /* AWSDDDispatchQueueLogFormatter.m */,
-				98FCA979D8A8822E734476B6E58B8ED4 /* AWSDDFileLogger.h */,
-				FF9CFC24BCA0B14493B8518376969BEC /* AWSDDFileLogger.m */,
-				BB55B2CB2AA26552F0C51813928696F6 /* AWSDDLegacyMacros.h */,
-				6A425EA2780C3972162FA364B8134591 /* AWSDDLog.h */,
-				1853077C437335F8E40E76858B148CE5 /* AWSDDLog.m */,
-				3FB6BA58A3DC5A5334029E7C6BBF6990 /* AWSDDLog+LOGV.h */,
-				076B6FA2F32A84341788F1C2E42A79CA /* AWSDDLogMacros.h */,
-				3965E8754824714C58065089218E87C4 /* AWSDDMultiFormatter.h */,
-				86BE6A81DB57EC1FEA08B44FDD69B10E /* AWSDDMultiFormatter.m */,
-				745068DD32DDB8617322A32B3A678DDD /* AWSDDOSLogger.h */,
-				0831B18334CCA361EBE774FCE1C79065 /* AWSDDOSLogger.m */,
-				0E02F91D7B07EC8FC39A4CAF40D39746 /* AWSDDTTYLogger.h */,
-				AF9B52768BC4CE65526EAB63E2E75880 /* AWSDDTTYLogger.m */,
-				7281DA57E485275E8A49803FCDED939E /* AWSExecutor.h */,
-				D3E5DF2CC49F1C2A673519ADB5D725BE /* AWSExecutor.m */,
-				16A649B28EBAF292512D8F10FD00EEC0 /* AWSEXTKeyPathCoding.h */,
-				D30FB1471BD4A7F0CE23217C25A286D6 /* AWSEXTRuntimeExtensions.h */,
-				E946D357D1B824535DF21C71A74F7306 /* AWSEXTRuntimeExtensions.m */,
-				94327DFA9363831CE32D78455D699B69 /* AWSEXTScope.h */,
-				7AB1A2F26FDFD8E1CCDB36F0FFD0FDA0 /* AWSEXTScope.m */,
-				F3CB9777F44C0BDB4C2F7226731D7A17 /* AWSFMDatabase.h */,
-				9D814B6AF5A67FF1828ECF314845D1BD /* AWSFMDatabase.m */,
-				E8B5FDB178DA118BA766982955206D30 /* AWSFMDatabase+Private.h */,
-				810E6C0AEAF81CEF142AD224BC9FA4D7 /* AWSFMDatabaseAdditions.h */,
-				F95F5D2719024ECC7BF03F6832F6944E /* AWSFMDatabaseAdditions.m */,
-				CD9504574C2BEA74886D0BA7A7E51BE6 /* AWSFMDatabasePool.h */,
-				4D18BB847E2E5CA341022508986C0EA8 /* AWSFMDatabasePool.m */,
-				41F1BA5E8793C8CC6222D85413CE4C4A /* AWSFMDatabaseQueue.h */,
-				81685F61C04386054C6EB486CE045EB4 /* AWSFMDatabaseQueue.m */,
-				07ECE90907BE180F6A539BF08715EDE3 /* AWSFMDB.h */,
-				38C24E5DB4B1C541A80CDFF1952C4545 /* AWSFMDB+AWSHelpers.h */,
-				A52145D6322955C0D6C6F09871F24741 /* AWSFMDB+AWSHelpers.m */,
-				7A8546CE0DBDFE5D38B2046606E4B7CE /* AWSFMResultSet.h */,
-				9176A30EF537A984349EF0941C29042B /* AWSFMResultSet.m */,
-				1CB773EA726322B9A2CD42FF90D4DD17 /* AWSGeneric.h */,
-				59A459A5BE87F0DADD67EBB169FFF49A /* AWSGZIP.h */,
-				C0DB0C0B9E1C812A42914C8AA7BF1A8D /* AWSGZIP.m */,
-				ED595581B874044815E93AAC0D4FB3A4 /* AWSIdentityProvider.h */,
-				0A1CD521E28948276DB6DF5C1CEBC2C1 /* AWSIdentityProvider.m */,
-				A160B41090A56C0EFD3C4DF8921A1539 /* AWSInfo.h */,
-				2C5FAED483BFCC2F6ED318BFC0A89612 /* AWSInfo.m */,
-				0D58BF63FD36A36860F5EB44E38DD099 /* AWSKSReachability.h */,
-				9FF7C8B2AC413711B14A91BC15CD8431 /* AWSKSReachability.m */,
-				BFCEEE328F910F62BBDE90665F16FD72 /* AWSLogging.h */,
-				722FB0BF2F494C956CD49C0C75A2FDC0 /* AWSLogging.m */,
-				B11D75C0DCD9FF11DB626B078823A733 /* AWSMantle.h */,
-				7B69116025E7AE4E03FD9CB6AE7D4A79 /* AWSmetamacros.h */,
-				9FCBEE62A3337BC2F65D83AF4E6B900F /* AWSModel.h */,
-				115578294D5785F67A4164B425F3D299 /* AWSModel.m */,
-				3D02469A819F1238BA748181F1265632 /* AWSMTLJSONAdapter.h */,
-				12B99B810FB2E25531E1E4F2CAF6AABD /* AWSMTLJSONAdapter.m */,
-				BD6402601C3C46495B29A0B51C537439 /* AWSMTLManagedObjectAdapter.h */,
-				0E3D65FEA8DF69AB59F24058F42DCED6 /* AWSMTLManagedObjectAdapter.m */,
-				F9E0D46A0F53CEF014CB608689479F5A /* AWSMTLModel.h */,
-				18F8E4C791238DE2BC89F84EF383A00D /* AWSMTLModel.m */,
-				679BE254CFCDEE26015A8539E066D54F /* AWSMTLModel+NSCoding.h */,
-				BC067900E6CC27C9DAEE297A89AD2D0F /* AWSMTLModel+NSCoding.m */,
-				1A60E93D25B2C3C212B4679F93F75755 /* AWSMTLReflection.h */,
-				F170E6A7DDECEFE5838C092C79B21FDA /* AWSMTLReflection.m */,
-				D7E963C4F0D7D073D7546DDC482E53FD /* AWSMTLValueTransformer.h */,
-				F739532763F64777B91327F4DD6E9AB0 /* AWSMTLValueTransformer.m */,
-				1E2AEE92884E8A3660E2A5C368A9D134 /* AWSNetworking.h */,
-				46873E29496F81BE8EB8FC668D31C366 /* AWSNetworking.m */,
-				285440696A5920B5E6B03DE8351989B8 /* AWSNetworkingHelpers.h */,
-				42BB3C6979837861377DA5A89549AE64 /* AWSNetworkingHelpers.m */,
-				F2F95957A8A28F91A1A0FE2164F2234D /* AWSSerialization.h */,
-				B8785DC9A87864D9C1FDCB43C2469B74 /* AWSSerialization.m */,
-				CF52B59CF212AEF5EF49ED0B7A9E02C1 /* AWSService.h */,
-				65A25F6FD0D61706F9535950AFC406E4 /* AWSService.m */,
-				D0E94613A5F8B0E8267BE68F25F2F8CD /* AWSServiceEnum.h */,
-				6C401F43F3647CFB1A04369928781E0E /* AWSSignature.h */,
-				3B109D739CFC883289A6548766B8B7DD /* AWSSignature.m */,
-				37E8F49480EF8060BB37B26F5BC5DF99 /* AWSSTS.h */,
-				70B3F537BC06A2190DBA5545CA3BC9D1 /* AWSSTSModel.h */,
-				0C7EFC1FA0A94BB3040D38C1BBFCF76E /* AWSSTSModel.m */,
-				8A6AB7B64F3EA49D82336E6F2342E8F4 /* AWSSTSResources.h */,
-				0A3B34FAA9B84A5377B2D5C709DA6B92 /* AWSSTSResources.m */,
-				009CACF5738D03F5B64F3EF3C99FB61E /* AWSSTSService.h */,
-				BC78A1BE3112CD63FB79FC0D632C08AD /* AWSSTSService.m */,
-				26844A716609D618B953ADCC3477A9C2 /* AWSSynchronizedMutableDictionary.h */,
-				11EDEFEDFA365D9648D81979FF0CF2BA /* AWSSynchronizedMutableDictionary.m */,
-				6D2101718310C6801E3A00062C07C39C /* AWSTask.h */,
-				B22773A61D27574942BD3C76F4C90814 /* AWSTask.m */,
-				30642F131CF85895AB20D4764112A7B1 /* AWSTaskCompletionSource.h */,
-				25B48B5E2F240D5C178AEC37739F47BD /* AWSTaskCompletionSource.m */,
-				DE52C631AAD1F37EC85940B309484450 /* AWSTMCache.h */,
-				AE43657F8C0C1405A6F48A02C31C2CF5 /* AWSTMCache.m */,
-				B105C48272F594AC5233F7320470A5B7 /* AWSTMCacheBackgroundTaskManager.h */,
-				DAA8BB0506C2E9D42D5AED09D74156A6 /* AWSTMDiskCache.h */,
-				C163507295304A519E85051ED74A6209 /* AWSTMDiskCache.m */,
-				94701E2D8BEB1ECDDF758D0719854FAF /* AWSTMMemoryCache.h */,
-				60F4BE632949FAE284F63F70D7952C60 /* AWSTMMemoryCache.m */,
-				73D6A1A96394F99C88C2D192F6EE2472 /* AWSUICKeyChainStore.h */,
-				12DBB62EC989FA364779063935663723 /* AWSUICKeyChainStore.m */,
-				F7BD476B02A70C2CA36E64D4DDF32DAD /* AWSURLRequestRetryHandler.h */,
-				2EDE3BF19468DE4E9605AD1B08021DF4 /* AWSURLRequestRetryHandler.m */,
-				168E7EDD61CE770FCEEFF271776BDD39 /* AWSURLRequestSerialization.h */,
-				79F8F7318B8DE19209DA9DDF5193FC01 /* AWSURLRequestSerialization.m */,
-				CB5F5DD200C1796E0CD90E3B92A8DB28 /* AWSURLResponseSerialization.h */,
-				8A0ADFA07325170FDC5BB0CE2DB1EBA9 /* AWSURLResponseSerialization.m */,
-				C0B03B2C8F2862CAF77DEFE91DF50641 /* AWSURLSessionManager.h */,
-				9C738EC7E8D4A0BF95B09336DEDB98B1 /* AWSURLSessionManager.m */,
-				AD1FFEF90711E0EC311224E066703638 /* AWSValidation.h */,
-				EB3B13702A64602EEE8777F3A9C91B70 /* AWSValidation.m */,
-				49C1DACDE13725ACAFADE7825739F218 /* AWSXMLDictionary.h */,
-				0ADFD7E42BE139F259349496AA57A0A2 /* AWSXMLDictionary.m */,
-				CAB31BB0CB1979BC02AE603D4C767273 /* AWSXMLWriter.h */,
-				40D3E2ACC250193E898393BB5E5B0FAD /* AWSXMLWriter.m */,
-				5AF033D372099B17E4AD1ECEF2388C74 /* FABAttributes.h */,
-				920863BE9A25A6D24A89E4889EE0A014 /* FABKitProtocol.h */,
-				8CEEBBC83FB1A93562327EAFF615AA6B /* Fabric.h */,
-				ACCDDF8A621C80784B35192C5C55D9ED /* Fabric+FABKits.h */,
-				0A075F8FA03A8A6E504C77FC33DE7E6D /* NSArray+AWSMTLManipulationAdditions.h */,
-				2C69D27D99AAF70EBC5392FB14C7B7DA /* NSArray+AWSMTLManipulationAdditions.m */,
-				9F110F53CAAF1AB03CE1CA851F85859F /* NSDictionary+AWSMTLManipulationAdditions.h */,
-				52E8B5E00968480B2775F83181520231 /* NSDictionary+AWSMTLManipulationAdditions.m */,
-				8CAB3BD92207D2E252347FD79A669516 /* NSError+AWSMTLModelException.h */,
-				C9022B2A001A348E8DEDD1296B5E0716 /* NSError+AWSMTLModelException.m */,
-				0CF40D7AF9CA3F2F9A410759AE391171 /* NSObject+AWSMTLComparisonAdditions.h */,
-				B0F9182481E43628F757BAFB64AD0B54 /* NSObject+AWSMTLComparisonAdditions.m */,
-				F427531291DB1D1C9D8F6A709F1BBD2A /* NSValueTransformer+AWSMTLInversionAdditions.h */,
-				3802AAD88A0ED5ABF4155747E2EC95BC /* NSValueTransformer+AWSMTLInversionAdditions.m */,
-				13A27886A2A2BD9BDC18D4AA06E0BE8D /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */,
-				3D98814487113FC0451682BF2CA928D0 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */,
-				F1190B5C3CF3ED79D80F706422B61756 /* Support Files */,
-			);
-			name = AWSCore;
-			path = AWSCore;
-			sourceTree = "<group>";
-		};
 		07B15F0B0839BB873BF49FF0A5A12925 /* Pods-Amplify-AWSPluginsCore */ = {
 			isa = PBXGroup;
 			children = (
@@ -1516,6 +1333,20 @@
 			);
 			name = "Pods-Amplify-AWSPluginsCore";
 			path = "Target Support Files/Pods-Amplify-AWSPluginsCore";
+			sourceTree = "<group>";
+		};
+		097E04C4D5D1E846CC912F69B80EA246 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				CFE581CE7FF366A7AA6702AB8C3EBF43 /* CwlPreconditionTesting.modulemap */,
+				1FBB9B4EF0162E7673ABC89B53F82D1F /* CwlPreconditionTesting.xcconfig */,
+				F291DBE453B14BE33FD687E62A995465 /* CwlPreconditionTesting-dummy.m */,
+				2BD4DFC991FF667DD0B733C2E0885AA7 /* CwlPreconditionTesting-Info.plist */,
+				14CA4F275A4357515EA6ADABFF873C9F /* CwlPreconditionTesting-prefix.pch */,
+				D0E83F4975799D8D677867E97B00A081 /* CwlPreconditionTesting-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/CwlPreconditionTesting";
 			sourceTree = "<group>";
 		};
 		09AD8BEF7343A541603839F476C7F70E /* Targets Support Files */ = {
@@ -1563,33 +1394,16 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		0D8EAE8D0C82066F079BBE49527FC539 /* Support Files */ = {
+		0D914FA08BBB7F3FEBB9225468EA36A4 /* CwlCatchException */ = {
 			isa = PBXGroup;
 			children = (
-				3CE55D53ECA949420B445EF748A6B476 /* SwiftLint.xcconfig */,
+				8C768E0E6854399915626CEF3A4AD186 /* CwlCatchException.h */,
+				38643E84B084A0BEB5CED73C2759B5BF /* CwlCatchException.m */,
+				1E9CFEC86D03F8A1BE4DBB1CC4A7D751 /* CwlCatchException.swift */,
+				343DD7303322B9506CE7B41BEC44F37C /* Support Files */,
 			);
-			name = "Support Files";
-			path = "../Target Support Files/SwiftLint";
-			sourceTree = "<group>";
-		};
-		1811ACAB11403C7A7936597C357FA33F /* AWSAuthCore */ = {
-			isa = PBXGroup;
-			children = (
-				A46B3233721574887E89B7E89E73CB49 /* AWSAuthCore.h */,
-				00ED9F12F787409584FD64E63CB00BFA /* AWSAuthUIHelper.h */,
-				3D7AD3753C2B976519ABD2B870B1AAF5 /* AWSAuthUIHelper.m */,
-				C5C34C491A183A09D49EF0138F8202FE /* AWSIdentityManager.h */,
-				3844849C30D28B47FF9C3DD61529455D /* AWSIdentityManager.m */,
-				EA5ACF18886A4FF581354E7504E25CCD /* AWSSignInButtonView.h */,
-				04F94581174EDFD77DD77D64E573D786 /* AWSSignInManager.h */,
-				13F6EC075EF080997FC5EAA557A51049 /* AWSSignInManager.m */,
-				316D632308F1EFBC2C0DF047773030DF /* AWSSignInProvider.h */,
-				F752DCF3576E6E8F2191593BA7C6F05A /* AWSSignInProviderApplicationIntercept.h */,
-				EB037FE1BB0944A9A0396B42155C798B /* AWSUIConfiguration.h */,
-				F7A91B718564D779417F4BAA7812A5AE /* Support Files */,
-			);
-			name = AWSAuthCore;
-			path = AWSAuthCore;
+			name = CwlCatchException;
+			path = CwlCatchException;
 			sourceTree = "<group>";
 		};
 		1AEAD31DC1C1DD9F4F43BEB61EDEB4C2 /* Pods-AmplifyTestApp */ = {
@@ -1609,106 +1423,101 @@
 			path = "Target Support Files/Pods-AmplifyTestApp";
 			sourceTree = "<group>";
 		};
-		1E39A2F1394B55C0C838F5202B7F2C7C /* CwlCatchException */ = {
+		24077C0DEBDAC1C508738332CBE213CE /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				E727F698E5184B8A8F0AEF9CAF632FA8 /* CwlCatchException.h */,
-				673FC21F904E05922260C6F6C1055044 /* CwlCatchException.m */,
-				F917BC5B219C19085ED19ED90CB19D15 /* CwlCatchException.swift */,
-				8D46555916756E76EC60CB6B102FADD4 /* Support Files */,
+				B974F83B9F263B1C286C97BEEE558C89 /* AWSAuthCore */,
+				2A2D8411673AA19732C5BC36DBC9512F /* AWSCognitoIdentityProvider */,
+				AFB9B1D3506E642246BC0282677D999C /* AWSCognitoIdentityProviderASF */,
+				92B4F9E0D4852314E90F8BA2889254FE /* AWSCore */,
+				7D7A394803578A4B9B4C966AD076FCA4 /* AWSMobileClient */,
+				0D914FA08BBB7F3FEBB9225468EA36A4 /* CwlCatchException */,
+				966E7781FA3F109D8D4A71FCF5F8E64A /* CwlPreconditionTesting */,
+				3DFE20995C616365418B72A5A4AB9464 /* SwiftFormat */,
+				C3949CE1130B1883629D695D71A69DC0 /* SwiftLint */,
 			);
-			name = CwlCatchException;
-			path = CwlCatchException;
+			name = Pods;
 			sourceTree = "<group>";
 		};
-		2798668B9A1CF9575742CF07A8B1C114 /* Support Files */ = {
+		2A2D8411673AA19732C5BC36DBC9512F /* AWSCognitoIdentityProvider */ = {
 			isa = PBXGroup;
 			children = (
-				9FEEDF39BB2522F1F1564847E3D9021A /* AWSMobileClient.modulemap */,
-				C6FB30955DA68107EDEF56A9A1344D17 /* AWSMobileClient.xcconfig */,
-				A7521733F008AF096D52D74AF5F36981 /* AWSMobileClient-dummy.m */,
-				BB402C47244C897CE7236FE13AD98752 /* AWSMobileClient-Info.plist */,
-				BE4816820DBD8AD200627DBCE6504789 /* AWSMobileClient-prefix.pch */,
-				B3AE5FD3791D0D949459393DD40CD3DF /* AWSMobileClient-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/AWSMobileClient";
-			sourceTree = "<group>";
-		};
-		2C6A834CCAE8EB26259C71E30848F767 /* AWSCognitoIdentityProvider */ = {
-			isa = PBXGroup;
-			children = (
-				2791EB61C4AFF9075545494144A5BD95 /* aws_tommath.h */,
-				388680EB7CAF4AB53E3DD89E2CC90F2E /* aws_tommath_class.h */,
-				9DD919F5D40936CBB175BC18C0CC012A /* aws_tommath_superclass.h */,
-				DADB698FF6F0FE317C721CB8277E3306 /* AWSCognitoIdentityProvider.h */,
-				1B0AAF84EC698F11CC63045004A9ED58 /* AWSCognitoIdentityProviderHKDF.h */,
-				A1D9BE851096D333C6BCF3DCC3CB8685 /* AWSCognitoIdentityProviderHKDF.m */,
-				64477AF05BB569C283F8CA75DC186B39 /* AWSCognitoIdentityProviderModel.h */,
-				557CB74CF255046C393A564440AE135F /* AWSCognitoIdentityProviderModel.m */,
-				FABA1EBEF087305EAED9649E53354E5E /* AWSCognitoIdentityProviderResources.h */,
-				DA93AD0D291E93447CCCCCEFD85708BB /* AWSCognitoIdentityProviderResources.m */,
-				58C89AD838EDC38CC8C7DBB462B82E56 /* AWSCognitoIdentityProviderService.h */,
-				27556645674390E079A50FAE1D38FFF1 /* AWSCognitoIdentityProviderService.m */,
-				2B531E9546AD9DB8A58EDF26D38A9FE1 /* AWSCognitoIdentityProviderSrpHelper.h */,
-				C751FB32301C38302A2EC137BA70D3EC /* AWSCognitoIdentityProviderSrpHelper.m */,
-				506993FFD5E43321C8EE111378E6B6C5 /* AWSCognitoIdentityUser.h */,
-				ACA1E3EBBEA1F5D3160841769800B0DC /* AWSCognitoIdentityUser.m */,
-				E7EC8830B686D3AA9F8A5EC5559D133E /* AWSCognitoIdentityUser_Internal.h */,
-				7B5D74163C65BA45F129C2F75A244A26 /* AWSCognitoIdentityUserPool.h */,
-				A1163FE82E3D89D2C4D5F59685F700D0 /* AWSCognitoIdentityUserPool.m */,
-				B9A3E48A5EBDD64DAE2ECD9EE0D19659 /* AWSCognitoIdentityUserPool_Internal.h */,
-				5CDCA759E2B524AD0D5B0529F695A28C /* AWSJKBigDecimal.h */,
-				85B16C1BEED6DAD6A2AB160002933CDA /* AWSJKBigDecimal.m */,
-				CEAA8CF19472EC4ACF9D738F775FC832 /* AWSJKBigInteger.h */,
-				856B9460EE390E948E972BC937AD38F4 /* AWSJKBigInteger.m */,
-				906357A4C1AA3FE5689B0E940D3D91F2 /* NSData+AWSCognitoIdentityProvider.h */,
-				9F45A88D28CED0D57D7F1D7138D0CDFF /* NSData+AWSCognitoIdentityProvider.m */,
-				0F18885B0C226C01535E4BC473565790 /* tommath.c */,
-				42851DE6B2F6C93AEDE5F7352627E5B4 /* Support Files */,
+				9E167C8879A46B30A2FDB093B65ADCBE /* aws_tommath.h */,
+				D34262BF92ECE4D3009E5F09892D60F0 /* aws_tommath_class.h */,
+				62CA243C98F405F83294789351907442 /* aws_tommath_superclass.h */,
+				2E45CDF781E122D5B0032D5E10259043 /* AWSCognitoIdentityProvider.h */,
+				CAEB52D72F180BE2D87F708E35A82DA1 /* AWSCognitoIdentityProviderHKDF.h */,
+				493DA8219B45D565C4ECC2D16A23529F /* AWSCognitoIdentityProviderHKDF.m */,
+				F315E4DD3CDFF2005E5797FC3DA761A8 /* AWSCognitoIdentityProviderModel.h */,
+				B912B8BDF2CFA91469BBC9485DA7EEC3 /* AWSCognitoIdentityProviderModel.m */,
+				943F781A6406C3C665785C8FC7D0B20C /* AWSCognitoIdentityProviderResources.h */,
+				929336265CFD5286CD800DF27904879E /* AWSCognitoIdentityProviderResources.m */,
+				A6EA21687C72BE41C8EB5778B6F7D519 /* AWSCognitoIdentityProviderService.h */,
+				9968838C214BDC48C6247783D9B28594 /* AWSCognitoIdentityProviderService.m */,
+				9A4B58BC9B812E6EFFD4E6FE0BA16141 /* AWSCognitoIdentityProviderSrpHelper.h */,
+				CA2C71AB4AF430CD7C3F0BBFA980970B /* AWSCognitoIdentityProviderSrpHelper.m */,
+				2836D98A865986A534EDB5C920AF2460 /* AWSCognitoIdentityUser.h */,
+				538DAF67D15820217B1911184A939AE2 /* AWSCognitoIdentityUser.m */,
+				1A4BE50365F0355639CFCCDE678470A0 /* AWSCognitoIdentityUser_Internal.h */,
+				84CC2DC999F384730595ACA3B9CB0A55 /* AWSCognitoIdentityUserPool.h */,
+				6988CED39EF50031FDCFEF5E9848AFB6 /* AWSCognitoIdentityUserPool.m */,
+				A5C4755E18CF7D73FD5757B42817C8A7 /* AWSCognitoIdentityUserPool_Internal.h */,
+				23B3726BA8188C858679F4A62BC5CBE9 /* AWSJKBigDecimal.h */,
+				7C7C8994C24425413D1870B567869C47 /* AWSJKBigDecimal.m */,
+				94434239E6D897885741EAF1FDEE3EDC /* AWSJKBigInteger.h */,
+				5310AD54B79AE33BED07FE6266C6C464 /* AWSJKBigInteger.m */,
+				4D71720CED398A05A893DF8906571124 /* NSData+AWSCognitoIdentityProvider.h */,
+				6A1AD2ECB0B52C7FE0EBCA97ABAE4F7F /* NSData+AWSCognitoIdentityProvider.m */,
+				98B91CEED15E36B9E7F022C5FEFB9FE8 /* tommath.c */,
+				B9EE08F142D930FBD8162E72B64BE34A /* Support Files */,
 			);
 			name = AWSCognitoIdentityProvider;
 			path = AWSCognitoIdentityProvider;
 			sourceTree = "<group>";
 		};
-		412F96643FE3AE1A69F36120130ADBF5 /* CwlPreconditionTesting */ = {
+		3016B275C979EB0DDC039F99E88FCCFD /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				38B52AFD8824D96B30C353421A67E04F /* CwlBadInstructionException.swift */,
-				983EDE1A47AA1B93CFCC5C3B7E1E5678 /* CwlCatchBadInstruction.swift */,
-				76183A993DAA4D030DEB79B1EE231C3C /* CwlDarwinDefinitions.swift */,
-				98EBAF29DC4D794957822E239F9C944B /* CwlMachBadInstructionHandler.h */,
-				63558BCBF0A625B52BCB547CD0DFB1BA /* CwlMachBadInstructionHandler.m */,
-				12163530DDDEF249BE3C311D0ED23327 /* CwlPreconditionTesting.h */,
-				8A5462580CC9DC68AF7075ACA8844031 /* mach_excServer.c */,
-				4BD2BB7E9FDBD0CD5EBDDACD4E5589AF /* mach_excServer.h */,
-				4EBF2523AEF0E390C69D94209C884745 /* Support Files */,
-			);
-			name = CwlPreconditionTesting;
-			path = CwlPreconditionTesting;
-			sourceTree = "<group>";
-		};
-		42851DE6B2F6C93AEDE5F7352627E5B4 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				7257E001ABB1CC1EF9EE34046FC8BCD2 /* AWSCognitoIdentityProvider.modulemap */,
-				5EDFE115C3392FB9863659189DFA9FD0 /* AWSCognitoIdentityProvider.xcconfig */,
-				A077A3D16945E07EBB64DF9B37B77A62 /* AWSCognitoIdentityProvider-dummy.m */,
-				CA847668DCC864011A6F5E61B5B8F788 /* AWSCognitoIdentityProvider-Info.plist */,
-				CA7B6E7179083414E201D1859C9528EB /* AWSCognitoIdentityProvider-prefix.pch */,
-				82AE0D4FE2C5DA296BA6072367A2F9F6 /* AWSCognitoIdentityProvider-umbrella.h */,
+				E8E35E59E39195095F41E8723BD20312 /* AWSCore.modulemap */,
+				6ACF3192254D1F9DBD26D5576A8893F5 /* AWSCore.xcconfig */,
+				D08680B5CB880D99A30DF2ABB5ABB192 /* AWSCore-dummy.m */,
+				8C4A50FCDF3A84042BAA7731E75F07F3 /* AWSCore-Info.plist */,
+				D83E7FD2A0F668DD364117F3A03DDD21 /* AWSCore-prefix.pch */,
+				A6784ED93641EB4F41049EFBFAE024D1 /* AWSCore-umbrella.h */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/AWSCognitoIdentityProvider";
+			path = "../Target Support Files/AWSCore";
 			sourceTree = "<group>";
 		};
-		4389FF4A5297B305E2B3B22BF5E9A6A3 /* Support Files */ = {
+		343DD7303322B9506CE7B41BEC44F37C /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				A4F18ECC77B90BCC7C16CD58FFCA677C /* SwiftFormat.xcconfig */,
+				D615C7B77855CCD54C6919CCA2017839 /* CwlCatchException.modulemap */,
+				43E405F1885C7685937FDD90D8A25963 /* CwlCatchException.xcconfig */,
+				4BD20C472C43A246A6F2434B9E704BA3 /* CwlCatchException-dummy.m */,
+				D76FC53C6B0339CBD0396CA7E9736905 /* CwlCatchException-Info.plist */,
+				275D383DC4EE5627ABFC1F7CC9BC1128 /* CwlCatchException-prefix.pch */,
+				EA8CCC92D9F0AC3169E2EB6118110571 /* CwlCatchException-umbrella.h */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/SwiftFormat";
+			path = "../Target Support Files/CwlCatchException";
+			sourceTree = "<group>";
+		};
+		3DFE20995C616365418B72A5A4AB9464 /* SwiftFormat */ = {
+			isa = PBXGroup;
+			children = (
+				E26223C0CC50857A04F61D6F1E9200B8 /* Support Files */,
+			);
+			name = SwiftFormat;
+			path = SwiftFormat;
+			sourceTree = "<group>";
+		};
+		4A213C96B899FCA620B6F8B755A93F85 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				6A6A68B009E67D316D46E77E899DFD30 /* libAWSCognitoIdentityProviderASFBinary.a */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		4E14FB6CA44176BC9D0444841C733692 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests */ = {
@@ -1728,18 +1537,32 @@
 			path = "Target Support Files/Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests";
 			sourceTree = "<group>";
 		};
-		4EBF2523AEF0E390C69D94209C884745 /* Support Files */ = {
+		589CB92F54D2041425943A4CB360B974 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				CD4393963F8EEB81AD47AEF6938B3646 /* CwlPreconditionTesting.modulemap */,
-				0E4D66772DCE19A7404EF983F3D98759 /* CwlPreconditionTesting.xcconfig */,
-				F14752C7AAF0C272D64F8DB9DB35D1FB /* CwlPreconditionTesting-dummy.m */,
-				7AA514D521D364F474E1B819D72E6CA6 /* CwlPreconditionTesting-Info.plist */,
-				70BCFF3866799D2A76B86625EB6F94A7 /* CwlPreconditionTesting-prefix.pch */,
-				D7E8BDCF5CB5DF64785E0DE7EDD5371A /* CwlPreconditionTesting-umbrella.h */,
+				21C34EBC5C70F3BE92D67784FE6DABC7 /* AWSCognitoIdentityProviderASF.modulemap */,
+				4BBBDFD5123F98E66123D0B84A133851 /* AWSCognitoIdentityProviderASF.xcconfig */,
+				661CA20D4112179C1D8140902C0FA46C /* AWSCognitoIdentityProviderASF-dummy.m */,
+				D47F25C2F5ACF88B85C501564465245F /* AWSCognitoIdentityProviderASF-Info.plist */,
+				E6C6A920327206592931F16DBEE69BE2 /* AWSCognitoIdentityProviderASF-prefix.pch */,
+				BB9D98357DCFDB3958EE3BB3E35D948F /* AWSCognitoIdentityProviderASF-umbrella.h */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/CwlPreconditionTesting";
+			path = "../Target Support Files/AWSCognitoIdentityProviderASF";
+			sourceTree = "<group>";
+		};
+		6B1392041AFF5FF97AE0A98B211C056C /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				1133E0EC9A119ECACA5D55C5DC030291 /* AWSMobileClient.modulemap */,
+				963946810229E66761E9B42375D1CF97 /* AWSMobileClient.xcconfig */,
+				1251F545E945C3264EA3F89BA9BA3878 /* AWSMobileClient-dummy.m */,
+				798076C68A26DEC9A47A7EF5AA795AD8 /* AWSMobileClient-Info.plist */,
+				246BFE14AB5D33D83D1677B7CAABB010 /* AWSMobileClient-prefix.pch */,
+				ABC5884D8B8D580C98E6127C4041BEB3 /* AWSMobileClient-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/AWSMobileClient";
 			sourceTree = "<group>";
 		};
 		7849ED9E3F18FE1FE213C9FB97D7F75F /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests */ = {
@@ -1759,13 +1582,35 @@
 			path = "Target Support Files/Pods-Amplify-AmplifyTestConfigs-AmplifyTests";
 			sourceTree = "<group>";
 		};
-		7F1BD4DAED83CA45AC39DEDEB8F26247 /* SwiftLint */ = {
+		7D7A394803578A4B9B4C966AD076FCA4 /* AWSMobileClient */ = {
 			isa = PBXGroup;
 			children = (
-				0D8EAE8D0C82066F079BBE49527FC539 /* Support Files */,
+				41AAC3F5C52861B3D940EF01D950DDD5 /* _AWSMobileClient.h */,
+				D04928F7B7DF5814379C4B5B12F50A99 /* _AWSMobileClient.m */,
+				E3532D3DEC3B3B7120EC060FE9C7499B /* AWSCognitoAuth.h */,
+				BEB8D765884E650AFA25EB7CB3820CAB /* AWSCognitoAuth.m */,
+				087170046A46680BA6789BBA5A452CED /* AWSCognitoAuth+Extensions.h */,
+				9D241CB74335071761B49679EA021634 /* AWSCognitoAuth+Extensions.m */,
+				33E7E7A2DD1B06B19C2F0B2B692890C2 /* AWSCognitoAuth_Internal.h */,
+				CE10F2C9689101DC708A3559492AFAB3 /* AWSCognitoAuthUICKeyChainStore.h */,
+				BA53451B0AAF0009E78D037F9A02F878 /* AWSCognitoAuthUICKeyChainStore.m */,
+				F468789ADD71CDF2D656C188FC55C800 /* AWSCognitoCredentialsProvider+Extension.h */,
+				4840EABAFD9EACE0BD6B3FFF209208C0 /* AWSCognitoIdentityUserPool+Extension.h */,
+				1005679B00726AC1ED9911E5237C9C36 /* AWSMobileClient.h */,
+				703E3BD1050E13C9D54DD0E20BE74878 /* AWSMobileClient.swift */,
+				26124B8EBEDB7DD09D52BF33E2E59931 /* AWSMobileClient-Mixed-Swift.h */,
+				5C5C76E4BCB1631B533E28A1DA95403A /* AWSMobileClientExtensions.swift */,
+				B2467B4C12BFB43EE82B2C9FCCA58B4E /* AWSMobileClientUserDetails.swift */,
+				3514C8A4F0642770992CBA9207EA5342 /* AWSMobileOptions.swift */,
+				3F05F078F444866691A7A4F880388E71 /* AWSMobileResults.swift */,
+				0B1E9500E2EA7365DD37F18E40DB00C5 /* AWSUserPoolCustomAuthHandler.swift */,
+				1A374AD7C7E8F04E05236562AE54228F /* AWSUserPoolOperationsHandler.swift */,
+				E25D5299C21355193D7C2A76F8CEEFDD /* DeviceOperations.swift */,
+				99BA5D0889BB958E0926C060B9649DAA /* JSONHelper.swift */,
+				6B1392041AFF5FF97AE0A98B211C056C /* Support Files */,
 			);
-			name = SwiftLint;
-			path = SwiftLint;
+			name = AWSMobileClient;
+			path = AWSMobileClient;
 			sourceTree = "<group>";
 		};
 		8B4308E9F48A6891A7915CA1BC478FDA /* Products */ = {
@@ -1790,32 +1635,203 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		8D46555916756E76EC60CB6B102FADD4 /* Support Files */ = {
+		92B4F9E0D4852314E90F8BA2889254FE /* AWSCore */ = {
 			isa = PBXGroup;
 			children = (
-				3A9A9123BBE11A58771EB87A087316B6 /* CwlCatchException.modulemap */,
-				5292499829C37C41F261711AC72F7168 /* CwlCatchException.xcconfig */,
-				FFCB4AAE367BAD78D9C6A46083E63014 /* CwlCatchException-dummy.m */,
-				F7D6FB7A816C9E5F5B9FD5344DFA7EA6 /* CwlCatchException-Info.plist */,
-				2F6A9E75313D30A2B28F68110FF230A2 /* CwlCatchException-prefix.pch */,
-				66D34A65BD719CA839A366AED5ACE1F2 /* CwlCatchException-umbrella.h */,
+				41F8F2B38046526CF3AC8DF1690BE9CF /* AWSBolts.h */,
+				3E125CA7F667A530C30603C40C195AD9 /* AWSBolts.m */,
+				41594B5134424E94E3C96777AA52D60A /* AWSCancellationToken.h */,
+				1213A5418927CFBA7E61F3972A32D352 /* AWSCancellationToken.m */,
+				7C51B363039417DEAD5F8456DEE3B877 /* AWSCancellationTokenRegistration.h */,
+				B1F0999944AEC4156AD5258F82068B0A /* AWSCancellationTokenRegistration.m */,
+				EC6A357AB15EB63B0204FADCF79A97F8 /* AWSCancellationTokenSource.h */,
+				76E072AC48744E37B1968B34E9FB8990 /* AWSCancellationTokenSource.m */,
+				407114E9393182165733176F6B463C75 /* AWSCategory.h */,
+				B113FF367E590A74DFC88C56C2CAF166 /* AWSCategory.m */,
+				547C3C8BF2543737907362529ADFF79F /* AWSClientContext.h */,
+				16C1587C7AC8C56C77374B292761DEB6 /* AWSClientContext.m */,
+				9F5251F3952F1FA41D25883D9DB6C8C0 /* AWSCocoaLumberjack.h */,
+				E41A4F6C5931A151F14ADD44D2C53F73 /* AWSCognitoIdentity.h */,
+				079B74F72A04181513C47299DF1DE291 /* AWSCognitoIdentity+Fabric.h */,
+				C9C7A3FBCE1D43323505FAAA796042CB /* AWSCognitoIdentity+Fabric.m */,
+				A8598EE9DFBE20826EC5C647B287555D /* AWSCognitoIdentityModel.h */,
+				D51BF6733A6A0E115157B9762902702F /* AWSCognitoIdentityModel.m */,
+				64967ADE10969F821252AEE23895E34E /* AWSCognitoIdentityResources.h */,
+				9949A94419F2281C1EF0E2EC108965FF /* AWSCognitoIdentityResources.m */,
+				B1FE6F1140144DE02164800F5A36634D /* AWSCognitoIdentityService.h */,
+				9EF046703AE413CFEFDEA5EE438FF370 /* AWSCognitoIdentityService.m */,
+				7BF3F861431F5E73FB97B7D8762C387A /* AWSCore.h */,
+				D9223D3012D6A3F0E45D477716FC783A /* AWSCredentialsProvider.h */,
+				EFAE02E7CEADBC4AB4A4F59052C630F4 /* AWSCredentialsProvider.m */,
+				B8892F2ADBD009DECB8C1D0B654A930D /* AWSDDAbstractDatabaseLogger.h */,
+				2121A06D4729CB181DA9851CB038F767 /* AWSDDAbstractDatabaseLogger.m */,
+				B12E7C422FC9A1B35382A270A70BBAC8 /* AWSDDASLLogCapture.h */,
+				6EDDFBA65505F58B53C44E3ADE1B7525 /* AWSDDASLLogCapture.m */,
+				D283F1B77F53E197BA10ED0DAB9F2445 /* AWSDDASLLogger.h */,
+				8B09EDE3A624F7ABBDC0599DB913A0F8 /* AWSDDASLLogger.m */,
+				EDE35F033F8789A514C6E98B2E720923 /* AWSDDAssertMacros.h */,
+				1E77E16BC664FA930B5F100306836D97 /* AWSDDContextFilterLogFormatter.h */,
+				BC18EC7B6416CEED09F73528AE71AA31 /* AWSDDContextFilterLogFormatter.m */,
+				B6C416894DABEDED0EA160A85B935848 /* AWSDDDispatchQueueLogFormatter.h */,
+				9A6D7B33D949723B982647BA1085C343 /* AWSDDDispatchQueueLogFormatter.m */,
+				0816FEAC15987BEA5F0AAC291F36AF7F /* AWSDDFileLogger.h */,
+				9F9B0BE3560BA877F8EEDC69DDD37534 /* AWSDDFileLogger.m */,
+				2F2C9BD8FD6A62BE547C156A2CB4555A /* AWSDDLegacyMacros.h */,
+				FD90263907B9BD577E7F0850F86817D0 /* AWSDDLog.h */,
+				6E25299C3E7143DC12BA797151D05C86 /* AWSDDLog.m */,
+				6AB1E6FA5B776255F1A3537BE9AA357E /* AWSDDLog+LOGV.h */,
+				45976F280C6328A4C07F4BD4C4EC5932 /* AWSDDLogMacros.h */,
+				E57C86135FE3E1EB1A2782F47F0B61E1 /* AWSDDMultiFormatter.h */,
+				410EA7B41FE060205FC4011920FA6597 /* AWSDDMultiFormatter.m */,
+				AB967F9CFF776884A5B3215E374A1B1D /* AWSDDOSLogger.h */,
+				628F229771BD6D9333C17BA8DE3BBC71 /* AWSDDOSLogger.m */,
+				4C609A14E1972EE2654C9EA40769F3AE /* AWSDDTTYLogger.h */,
+				1364C2E6FFB3D6CA23B8E4F7EA192804 /* AWSDDTTYLogger.m */,
+				E8F6A95D7BE53B66C196833D9CA26FA9 /* AWSExecutor.h */,
+				0BF3152809C0C7F2A37F2AA076B8BD80 /* AWSExecutor.m */,
+				8DC83450666908D92C002EA49A394A08 /* AWSEXTKeyPathCoding.h */,
+				C80E1BAEA00F8C1A39BB5BFAFEB0F909 /* AWSEXTRuntimeExtensions.h */,
+				DEE1DCA4A5FB0656C92086E64BA674E8 /* AWSEXTRuntimeExtensions.m */,
+				237C34B9822D7E7B6E0CEF798C76A4F9 /* AWSEXTScope.h */,
+				8F06DA83B9E53426EF78C32536C25671 /* AWSEXTScope.m */,
+				9319B5648119778AC2F13F3A9EEC73B2 /* AWSFMDatabase.h */,
+				49DDC8B4B8A0008C33DC34FFEE3FC90F /* AWSFMDatabase.m */,
+				F2F0FD149643708FDA4C151010A65162 /* AWSFMDatabase+Private.h */,
+				821D30FC1FA05A779392557905809822 /* AWSFMDatabaseAdditions.h */,
+				3C4303F39E4BFB31F28AB5CE5FEEC723 /* AWSFMDatabaseAdditions.m */,
+				5FD575266288E008C6989EF6E2A2AC9C /* AWSFMDatabasePool.h */,
+				0BB005E4B39B32629A62D3E26272A2DE /* AWSFMDatabasePool.m */,
+				795B8F8866B38DB939E35FDBA96AF27E /* AWSFMDatabaseQueue.h */,
+				351B029C4F1BEDEA7476F09758D57E5D /* AWSFMDatabaseQueue.m */,
+				7F73B91A2BBEF91A3BA691AF03391D24 /* AWSFMDB.h */,
+				68D965159C213A311C522050217704B2 /* AWSFMDB+AWSHelpers.h */,
+				C5E6F0C0A4A580010558CD9BF7B954F5 /* AWSFMDB+AWSHelpers.m */,
+				0D98BF8E4B6395E80EDB1448E308861F /* AWSFMResultSet.h */,
+				C2F7721C7D4AB4BD517C4A7A90EC2AF7 /* AWSFMResultSet.m */,
+				D7166CDD70AFA0C6433623748FD475E9 /* AWSGeneric.h */,
+				97E3422FF53B92A9D5AFEA9D66AAA4F6 /* AWSGZIP.h */,
+				741F49C40E6FA66D5CD23136107A9A2C /* AWSGZIP.m */,
+				422FA242D9F5ED9C37F90A6FD2FF2225 /* AWSIdentityProvider.h */,
+				0738F3F1322771D982BAB3661AE24214 /* AWSIdentityProvider.m */,
+				EF561B1B40611C880C1A51E5F00A234D /* AWSInfo.h */,
+				4776EB5C7291FE4BC37305AA93543C01 /* AWSInfo.m */,
+				61FFB55F7016DCDE8C2FB463C98FADB8 /* AWSKSReachability.h */,
+				438977A2FC2F79FA90059803F47E7388 /* AWSKSReachability.m */,
+				0986180FBBE79C4B527D81D16F04FDBC /* AWSLogging.h */,
+				611E4441D39C5B5170F8B169E0740B35 /* AWSLogging.m */,
+				C77683D48729E6AB6FA9EB8451E29E32 /* AWSMantle.h */,
+				C0F9349245E10F2DAF7ACDFFC42876BE /* AWSmetamacros.h */,
+				46855F19A1FA6C383444A696F925A3C2 /* AWSModel.h */,
+				9493D78EBBFA335F5E10EF8CF66548EF /* AWSModel.m */,
+				FC341DFA15E436E927491FB260311C9B /* AWSMTLJSONAdapter.h */,
+				0A31E6C80451E19FB2CCD3F9E764BB37 /* AWSMTLJSONAdapter.m */,
+				99BC7FA61E5480A10F9CC2701F43B9A3 /* AWSMTLManagedObjectAdapter.h */,
+				20C60E4B329922D1F91D8DC3DE396DA6 /* AWSMTLManagedObjectAdapter.m */,
+				1B5A27D1F00D26D77D2F1FB2BED6F0A8 /* AWSMTLModel.h */,
+				E93D888F2358613A1772D77597C493E9 /* AWSMTLModel.m */,
+				1BBE4054B04F674C1F60D31FA106362C /* AWSMTLModel+NSCoding.h */,
+				6D7ED8661EF857706C34D2758977F62B /* AWSMTLModel+NSCoding.m */,
+				1F48EA94451797FD4F975F332D56208F /* AWSMTLReflection.h */,
+				BA0CC7A8195152F4DDF67D0A4D7C2283 /* AWSMTLReflection.m */,
+				2B2E251F1BA7B31D4A6B515A842E4660 /* AWSMTLValueTransformer.h */,
+				01406D2554960C95060691CFCAA31D92 /* AWSMTLValueTransformer.m */,
+				A042B28A3C211CA9A4F74DAF7311F33D /* AWSNetworking.h */,
+				953D7D189B0B0AA34FE2A00F7B1580B3 /* AWSNetworking.m */,
+				6334474AFC15E10B8E910D351C5379B5 /* AWSNetworkingHelpers.h */,
+				D2069E3BA0CE303E2ACED88BB858900C /* AWSNetworkingHelpers.m */,
+				2941F0841B1124B775BC2CCF8C3FB149 /* AWSSerialization.h */,
+				1CAB5F26082AF7C2C342C8BF2B511189 /* AWSSerialization.m */,
+				CBC63B38BFED9913CCC459F4312FC6EB /* AWSService.h */,
+				65A614203886ABADE199A0B800ECEE41 /* AWSService.m */,
+				174B19F5C049FC2721C627519446CAC4 /* AWSServiceEnum.h */,
+				158BDE967B7C9FFF98317A8A1AF47B24 /* AWSSignature.h */,
+				4C6E66CCCA2AE2C466B9B3E4E7E352DE /* AWSSignature.m */,
+				BBFE758649A0AFC2A4DFF34C4B5AB080 /* AWSSTS.h */,
+				C2F60A5A19FDE9D43EC3A8800F3192D6 /* AWSSTSModel.h */,
+				BC715587BE425079FAA4305951B22D71 /* AWSSTSModel.m */,
+				0886BCD226D6B5190149C85BA3210FCB /* AWSSTSResources.h */,
+				70FB430AE49A1B952C747843DEDD64D0 /* AWSSTSResources.m */,
+				C113662AE6AF834F148159C71FB3E942 /* AWSSTSService.h */,
+				C44C1B8D58F0B38ADB731A5082B0CAB0 /* AWSSTSService.m */,
+				F7FC9BE173B3AAD3825EA854C06AB75E /* AWSSynchronizedMutableDictionary.h */,
+				9A549DBDF126AD830CF93ABF538B614D /* AWSSynchronizedMutableDictionary.m */,
+				7A7150AD06A15FFA3B7777DE68DE4842 /* AWSTask.h */,
+				710605340E5A8DDE7D63BD3EBD553A7E /* AWSTask.m */,
+				AB46ADB2B0FACE56687DD120B4D5EDEF /* AWSTaskCompletionSource.h */,
+				0581448F3A1EE16FE6877A21192B3174 /* AWSTaskCompletionSource.m */,
+				6460C32B00D43D9E0499355B51800A75 /* AWSTMCache.h */,
+				16A162C41F0549F96E8E860FE210AFBF /* AWSTMCache.m */,
+				80009A829D5F19DFB029CD1074D46FD4 /* AWSTMCacheBackgroundTaskManager.h */,
+				B6D8BE1666950E8A45057CC6666024C2 /* AWSTMDiskCache.h */,
+				A34C3FFA168434E053A947A44448184E /* AWSTMDiskCache.m */,
+				4EB7448C2B60EDE6846DFA0806F4639D /* AWSTMMemoryCache.h */,
+				0907C13F03EF67C1D2365ACFD20D38D6 /* AWSTMMemoryCache.m */,
+				073E77A65347582ED7A81E3D956DD22E /* AWSUICKeyChainStore.h */,
+				7D722FE0E92693EA328A01D0C30DE69C /* AWSUICKeyChainStore.m */,
+				E20654D1C7C32E38165102AE5ABFB0F0 /* AWSURLRequestRetryHandler.h */,
+				45C8E5D78BC076CF097C783401D30675 /* AWSURLRequestRetryHandler.m */,
+				BECA5D4C0B1E2BE1E29EFA8A6FD6DF19 /* AWSURLRequestSerialization.h */,
+				E6FDC0CFF3356A4962E09D5E960ABB17 /* AWSURLRequestSerialization.m */,
+				9EC8D9E31650B69ACA6F529EE143216D /* AWSURLResponseSerialization.h */,
+				B3CA7B68BCCBF9C94B7209BDD71BBDB3 /* AWSURLResponseSerialization.m */,
+				F5E803FC9650596AEA2F9A353BE31401 /* AWSURLSessionManager.h */,
+				AEE0DFAEAE5810A498869F32312A98CC /* AWSURLSessionManager.m */,
+				91C2B142988FBE04C888E53876BA2642 /* AWSValidation.h */,
+				0DFE245507CD57FBD4B44DEC84BBF871 /* AWSValidation.m */,
+				B6277D3F2C6FEE504D3735AE99072576 /* AWSXMLDictionary.h */,
+				53E4CFA427DABB6BABEB4642C3CAB55E /* AWSXMLDictionary.m */,
+				1F4EBC18983124FC057E4F6DF2898A82 /* AWSXMLWriter.h */,
+				B03BF899ECCAE4CE7E3DAD96B6066B3D /* AWSXMLWriter.m */,
+				77F4A236D1F851232D48EBDF90147885 /* FABAttributes.h */,
+				2B34DD7531CB06921522A0A382644596 /* FABKitProtocol.h */,
+				4D7A492EE74C55BEA2FD7E94061D172A /* Fabric.h */,
+				7B9AA17ED6E6A642F5E8474D94DA778C /* Fabric+FABKits.h */,
+				5917F431683B8C300E8F61292DB9C977 /* NSArray+AWSMTLManipulationAdditions.h */,
+				02CBA27505E2262F5F64DAEDB8CE8E87 /* NSArray+AWSMTLManipulationAdditions.m */,
+				271C0F2E4B66427F654937124F663CAE /* NSDictionary+AWSMTLManipulationAdditions.h */,
+				377507ABBE77D13266D4692188AC4A90 /* NSDictionary+AWSMTLManipulationAdditions.m */,
+				440558432306D065896EAE19BE1FDCF2 /* NSError+AWSMTLModelException.h */,
+				3CEA978C394A670DE913406DF84C37B3 /* NSError+AWSMTLModelException.m */,
+				3B13015BDFD766A5AA586CA772B1E3EF /* NSObject+AWSMTLComparisonAdditions.h */,
+				0E9E777591741F7713A15CED1A8CC19D /* NSObject+AWSMTLComparisonAdditions.m */,
+				2E8A8CA0DDD90CB39D32CE5FD24DC429 /* NSValueTransformer+AWSMTLInversionAdditions.h */,
+				CA996DE4D8F1EF552C13984CECAD7D4B /* NSValueTransformer+AWSMTLInversionAdditions.m */,
+				9FBA19C6EAB6B5D35D98981B307131F4 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */,
+				BDDF6B882BD969BB837E4A5A683B83C7 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */,
+				3016B275C979EB0DDC039F99E88FCCFD /* Support Files */,
 			);
-			name = "Support Files";
-			path = "../Target Support Files/CwlCatchException";
+			name = AWSCore;
+			path = AWSCore;
 			sourceTree = "<group>";
 		};
-		8F42B06208C9BBA4BF078658353A8926 /* Support Files */ = {
+		966E7781FA3F109D8D4A71FCF5F8E64A /* CwlPreconditionTesting */ = {
 			isa = PBXGroup;
 			children = (
-				4E04EDF5782C184E748B3557700E2640 /* AWSCognitoIdentityProviderASF.modulemap */,
-				1EEAEFF4390C69F3ED0B2E72D09E4966 /* AWSCognitoIdentityProviderASF.xcconfig */,
-				FC3DCF579216C793C1D5986A399A2417 /* AWSCognitoIdentityProviderASF-dummy.m */,
-				DD0529F2FD94E94EE9F9F9EA3B418E22 /* AWSCognitoIdentityProviderASF-Info.plist */,
-				795169AE5537F5799BCDE954951A68F6 /* AWSCognitoIdentityProviderASF-prefix.pch */,
-				9DAF63CB3927C45D2346F11705E3AFA7 /* AWSCognitoIdentityProviderASF-umbrella.h */,
+				2CA9718A32A9D07BB92F38401873C8E5 /* CwlBadInstructionException.swift */,
+				34E76DC27A81691F88AF5806683ADEF0 /* CwlCatchBadInstruction.swift */,
+				3F56C406427AA446ED6AC850F1D11F5C /* CwlDarwinDefinitions.swift */,
+				CF059F400C23E801FC3E8CADBC196680 /* CwlMachBadInstructionHandler.h */,
+				2C441590C7A204DED15D0F8637E15D83 /* CwlMachBadInstructionHandler.m */,
+				46FB3D57F1B7BFC2E0DECB2BD2A0E07B /* CwlPreconditionTesting.h */,
+				683B6C1E23EACE20AD23E1EE20C1F0E2 /* mach_excServer.c */,
+				B4E133BDBC60371D1C4C31859E4C8C7A /* mach_excServer.h */,
+				097E04C4D5D1E846CC912F69B80EA246 /* Support Files */,
 			);
-			name = "Support Files";
-			path = "../Target Support Files/AWSCognitoIdentityProviderASF";
+			name = CwlPreconditionTesting;
+			path = CwlPreconditionTesting;
+			sourceTree = "<group>";
+		};
+		AFB9B1D3506E642246BC0282677D999C /* AWSCognitoIdentityProviderASF */ = {
+			isa = PBXGroup;
+			children = (
+				8D169BC3B420EB3E0536F23B34963823 /* AWSCognitoIdentityASF.h */,
+				3B680E6B9305CB9D4018616634665303 /* AWSCognitoIdentityProviderASF.h */,
+				881C4F7AD68CE9C1D2FF602B2C79FA9A /* AWSCognitoIdentityProviderASF.m */,
+				4A213C96B899FCA620B6F8B755A93F85 /* Frameworks */,
+				589CB92F54D2041425943A4CB360B974 /* Support Files */,
+			);
+			name = AWSCognitoIdentityProviderASF;
+			path = AWSCognitoIdentityProviderASF;
 			sourceTree = "<group>";
 		};
 		B4EABFCFD498135F4126D3A716F7B109 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon */ = {
@@ -1834,34 +1850,47 @@
 			path = "Target Support Files/Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon";
 			sourceTree = "<group>";
 		};
-		BA904E8F7807E5CC859BDDBE0BAA43C5 /* AWSMobileClient */ = {
+		B974F83B9F263B1C286C97BEEE558C89 /* AWSAuthCore */ = {
 			isa = PBXGroup;
 			children = (
-				0CACEC397330066C8C398ECECCE8BD5F /* _AWSMobileClient.h */,
-				F5DABEBB1A7AE30FC002FA9F7D7C32BC /* _AWSMobileClient.m */,
-				04498D780108D3EBDF53FD76FB42D380 /* AWSCognitoAuth.h */,
-				F271D7B7BA1C38C1E117F07AA0BB9E42 /* AWSCognitoAuth.m */,
-				DBF4A88D5942D7C441128C119BAF0999 /* AWSCognitoAuth+Extensions.h */,
-				AFE6CA3E54E94B93879D0415A2FA535C /* AWSCognitoAuth+Extensions.m */,
-				57E610DB1C9834B93B86B32AE203D34B /* AWSCognitoAuth_Internal.h */,
-				1B7083ED686E473C67DDF5D1E86E724C /* AWSCognitoAuthUICKeyChainStore.h */,
-				E8D2519C6A2A39EC2767637F8B899FDB /* AWSCognitoAuthUICKeyChainStore.m */,
-				B785B0927F487DA24F8777BAA7C3FD3E /* AWSCognitoCredentialsProvider+Extension.h */,
-				4D3E0FBF0A1B96D9B0A1670BC8C4117E /* AWSCognitoIdentityUserPool+Extension.h */,
-				CA9BF82B9D49B3E34E31C82200838ACE /* AWSMobileClient.h */,
-				FB67317B1299EE3D2F425CDDD6AFEEC0 /* AWSMobileClient.swift */,
-				EE13CC64B7D51AA8D246157E67E7DDB0 /* AWSMobileClientExtensions.swift */,
-				B1E046FABC7AEB1DDEAF83E80E8A23E5 /* AWSMobileClientUserDetails.swift */,
-				05F0A6A210EDEAFCB636DEF2E8E2C143 /* AWSMobileOptions.swift */,
-				2F8E1C643E55898382E15AC05AA7365E /* AWSMobileResults.swift */,
-				F5D4071126A64D42B2F302F608505CE9 /* AWSUserPoolCustomAuthHandler.swift */,
-				B5FA5040145A5FC42FC743FA56514940 /* AWSUserPoolOperationsHandler.swift */,
-				1B1415B741EF9175334EEB8D7110C62F /* DeviceOperations.swift */,
-				9ADAC8F37FB83D9A1FAE60863BAE22A2 /* JSONHelper.swift */,
-				2798668B9A1CF9575742CF07A8B1C114 /* Support Files */,
+				42C4CB6E6E4C46091EEC21ACAA570A13 /* AWSAuthCore.h */,
+				4AEEB68BA19668B4D0FE9A705816EF70 /* AWSAuthUIHelper.h */,
+				815CCB2AE451A2908705CF17B1B45765 /* AWSAuthUIHelper.m */,
+				BAD9B4CDCA171522E97D8BA20564EFB8 /* AWSIdentityManager.h */,
+				47DF5785EA91BD8744624AB4E432880D /* AWSIdentityManager.m */,
+				0E641F4FC82C85952BAF9B257C40A701 /* AWSSignInButtonView.h */,
+				64F1263957BE1770DED0ABCC5F3872D8 /* AWSSignInManager.h */,
+				465060C70F108952D6A6D0B6B0B85133 /* AWSSignInManager.m */,
+				F8841AFA6EEBA04ED1A278D30AB02563 /* AWSSignInProvider.h */,
+				DF3BBE962830C1EDC2E1806CFDFE0272 /* AWSSignInProviderApplicationIntercept.h */,
+				7861A4ABA0A851F8F55F302EBCA9588A /* AWSUIConfiguration.h */,
+				FD0C00281B2A67D14C2715BBDEFC8C37 /* Support Files */,
 			);
-			name = AWSMobileClient;
-			path = AWSMobileClient;
+			name = AWSAuthCore;
+			path = AWSAuthCore;
+			sourceTree = "<group>";
+		};
+		B9EE08F142D930FBD8162E72B64BE34A /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				71A5378770579FD27A792236232E25FC /* AWSCognitoIdentityProvider.modulemap */,
+				42717ACF4DB5B4F7156A4B027BEEEEC9 /* AWSCognitoIdentityProvider.xcconfig */,
+				9CF10481CDDC747914614A828F8E73CD /* AWSCognitoIdentityProvider-dummy.m */,
+				4D19419CD1FDE6E7301BE69ABC646C3F /* AWSCognitoIdentityProvider-Info.plist */,
+				2DD2592DCF2D49C44E2F6C0F36299584 /* AWSCognitoIdentityProvider-prefix.pch */,
+				2837F1492EC2CEC5B9DD4352EF5BDE5C /* AWSCognitoIdentityProvider-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/AWSCognitoIdentityProvider";
+			sourceTree = "<group>";
+		};
+		C3949CE1130B1883629D695D71A69DC0 /* SwiftLint */ = {
+			isa = PBXGroup;
+			children = (
+				E5F45A2A18BC19E31734A87F653618F3 /* Support Files */,
+			);
+			name = SwiftLint;
+			path = SwiftLint;
 			sourceTree = "<group>";
 		};
 		CF1408CF629C7361332E53B88F7BD30C = {
@@ -1869,18 +1898,10 @@
 			children = (
 				9D940727FF8FB9C785EB98E56350EF41 /* Podfile */,
 				0CEE57DA1055C19A1014C9B885209183 /* Frameworks */,
-				02D3095C4836936A4D26CFDAAA5A29E8 /* Pods */,
+				24077C0DEBDAC1C508738332CBE213CE /* Pods */,
 				8B4308E9F48A6891A7915CA1BC478FDA /* Products */,
 				09AD8BEF7343A541603839F476C7F70E /* Targets Support Files */,
 			);
-			sourceTree = "<group>";
-		};
-		D3577260291B47D9CE68407C73B49CA1 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				5085A6145D46202038A579642BB3B761 /* libAWSCognitoIdentityProviderASFBinary.a */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		D5CE6FD3F74C74F66A240B353AF7E722 /* iOS */ = {
@@ -1911,27 +1932,22 @@
 			path = "Target Support Files/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon";
 			sourceTree = "<group>";
 		};
-		E9B1820AFEA9222E5AE6AF00D1419B29 /* SwiftFormat */ = {
+		E26223C0CC50857A04F61D6F1E9200B8 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				4389FF4A5297B305E2B3B22BF5E9A6A3 /* Support Files */,
-			);
-			name = SwiftFormat;
-			path = SwiftFormat;
-			sourceTree = "<group>";
-		};
-		F1190B5C3CF3ED79D80F706422B61756 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				66931E8F9AFA69143E52E4F621951059 /* AWSCore.modulemap */,
-				80C849937AD2C88BA17636FFE3EEE60C /* AWSCore.xcconfig */,
-				51F546FB05338188F9D16DCA20239565 /* AWSCore-dummy.m */,
-				0D9574530C129769D1D1F03203C85D7C /* AWSCore-Info.plist */,
-				6BCC572FE610F38AA38FE89EDDD3EDEE /* AWSCore-prefix.pch */,
-				017996FA9F98A7E1AC8B1FB672D4E557 /* AWSCore-umbrella.h */,
+				AD933820BDEA1EDFE966D94B6B13DDC5 /* SwiftFormat.xcconfig */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/AWSCore";
+			path = "../Target Support Files/SwiftFormat";
+			sourceTree = "<group>";
+		};
+		E5F45A2A18BC19E31734A87F653618F3 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				064ADE545B584F856974A8D04E6DDED1 /* SwiftLint.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/SwiftLint";
 			sourceTree = "<group>";
 		};
 		F317EA87105ABDAE64570CCCC20B5912 /* Pods-Amplify */ = {
@@ -1950,28 +1966,15 @@
 			path = "Target Support Files/Pods-Amplify";
 			sourceTree = "<group>";
 		};
-		F54394C431F5EB529A6160FB3E437E7F /* AWSCognitoIdentityProviderASF */ = {
+		FD0C00281B2A67D14C2715BBDEFC8C37 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				EAB2EC18E32F6E2FCA424AE80D8412DB /* AWSCognitoIdentityASF.h */,
-				CDA38353C499EAFBF0C7F4C481DB06D1 /* AWSCognitoIdentityProviderASF.h */,
-				4108872B2D9F35982F849D20935EFE58 /* AWSCognitoIdentityProviderASF.m */,
-				D3577260291B47D9CE68407C73B49CA1 /* Frameworks */,
-				8F42B06208C9BBA4BF078658353A8926 /* Support Files */,
-			);
-			name = AWSCognitoIdentityProviderASF;
-			path = AWSCognitoIdentityProviderASF;
-			sourceTree = "<group>";
-		};
-		F7A91B718564D779417F4BAA7812A5AE /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				ACCDCDE3D9BB24C9A28284F325A016D5 /* AWSAuthCore.modulemap */,
-				25DFBB76C1BF492E05A46B34178281AD /* AWSAuthCore.xcconfig */,
-				0AEEFB1F4D4875A426FBE8C5C6D76AB1 /* AWSAuthCore-dummy.m */,
-				DAD1437F5D9BFFE96ADE2AC63A18703F /* AWSAuthCore-Info.plist */,
-				96A2D651BCE8019612EBFDAB5CBD48F2 /* AWSAuthCore-prefix.pch */,
-				B4E599012C75D7A133B5D77EB7591134 /* AWSAuthCore-umbrella.h */,
+				F981B395491B56FA08162A83B12AC098 /* AWSAuthCore.modulemap */,
+				7246F3143227F49E0D69F318896E3F0A /* AWSAuthCore.xcconfig */,
+				A45E4C5772CFEFFC6E77C0624C651A0E /* AWSAuthCore-dummy.m */,
+				981624D41E118BC6DCD0A92016B8CF43 /* AWSAuthCore-Info.plist */,
+				652A923CAFD818E22258CB6520F566F6 /* AWSAuthCore-prefix.pch */,
+				4857CE19C8C5F2FBCD5D178C8925E32F /* AWSAuthCore-umbrella.h */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/AWSAuthCore";
@@ -1991,27 +1994,28 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		1C6362B963B51C00EB918F5486B46BEA /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC33B5AE93CAD05125F41344A7DC295C /* _AWSMobileClient.h in Headers */,
+				29F001B4F1F5D8369E7793F2E2C7518E /* AWSCognitoAuth+Extensions.h in Headers */,
+				54D6C81AB4089CE00C5F58D243DCC8FA /* AWSCognitoAuth.h in Headers */,
+				5E64CCB1D7FC10661B116F8ED8819648 /* AWSCognitoAuth_Internal.h in Headers */,
+				2861A1716ABD10B59138E0608BE1C775 /* AWSCognitoAuthUICKeyChainStore.h in Headers */,
+				E2C09DB09ACE2CA2677337DB8BD28CF9 /* AWSCognitoCredentialsProvider+Extension.h in Headers */,
+				8ED2F8EE57C9042901D80E722D41AC0D /* AWSCognitoIdentityUserPool+Extension.h in Headers */,
+				4589F69C4934F11F1A17ACA1B08BC0E0 /* AWSMobileClient-Mixed-Swift.h in Headers */,
+				FD3A3329F3101AF1F8969EA38080957E /* AWSMobileClient-umbrella.h in Headers */,
+				408E26270F1ADEBB526CEDF85AD131DC /* AWSMobileClient.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		490B1475EE35A1DFF2E34F4E0B863549 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				9D914E2C5BB01F438CE2CEFAF3518D6F /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4FA2461680E769976C4D06608A2A9004 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				3CA6B00BEC52629874A59C4425B040FF /* _AWSMobileClient.h in Headers */,
-				5D1E1ED20C02309D4897C489A4FF1385 /* AWSCognitoAuth+Extensions.h in Headers */,
-				4DF330318C6863C9A9457AB6A0D931AC /* AWSCognitoAuth.h in Headers */,
-				080A963CA88B480650FFE9DA4C1FB652 /* AWSCognitoAuth_Internal.h in Headers */,
-				FF5A3D0068C906E484D9FB5CC613556E /* AWSCognitoAuthUICKeyChainStore.h in Headers */,
-				06286FFF5F9A837D882033756A51BA6F /* AWSCognitoCredentialsProvider+Extension.h in Headers */,
-				4B0A6C1C5E40CA5991F72FE870380789 /* AWSCognitoIdentityUserPool+Extension.h in Headers */,
-				51250616CA565F13AACEBE3D53B538A9 /* AWSMobileClient-umbrella.h in Headers */,
-				2D0A57953832EF83AD2FA1511820B602 /* AWSMobileClient.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2352,18 +2356,18 @@
 		};
 		6428ED7DAC8003D918A4F549769F079D /* AWSMobileClient */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 6C1B0082F55622F61D55E4DF5F89B58D /* Build configuration list for PBXNativeTarget "AWSMobileClient" */;
+			buildConfigurationList = 8303AF580CB32D93D56CB25771284834 /* Build configuration list for PBXNativeTarget "AWSMobileClient" */;
 			buildPhases = (
-				4FA2461680E769976C4D06608A2A9004 /* Headers */,
-				49C4F997373C728DF83F55FD7FCCB1A8 /* Sources */,
-				8DD65B45F2688280FD422D5D7364A10A /* Frameworks */,
-				B219A243F752A8EC273DCB0D9186D7C0 /* Resources */,
+				1C6362B963B51C00EB918F5486B46BEA /* Headers */,
+				6207831AD768716452B1848E61EEAF65 /* Sources */,
+				3E145C62E18EB143A9D5C8EB279CC99A /* Frameworks */,
+				BF5B87B637529AE68F42AD7B3D225C41 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				06729402D244E9B3898403BE3BECA781 /* PBXTargetDependency */,
-				3956B7AEEEE178E01F0DEA935F7D7E02 /* PBXTargetDependency */,
+				5667EF0F959239F15E58BB582963AE92 /* PBXTargetDependency */,
+				F5B0421585F0FF6459D4B846436CD62B /* PBXTargetDependency */,
 			);
 			name = AWSMobileClient;
 			productName = AWSMobileClient;
@@ -2677,13 +2681,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B219A243F752A8EC273DCB0D9186D7C0 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		B417A984DF6BABD8867BB25AD9BC1503 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2699,6 +2696,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		B9311AFD8AC2DD0D5BABA9D418762F1D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BF5B87B637529AE68F42AD7B3D225C41 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2808,24 +2812,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		49C4F997373C728DF83F55FD7FCCB1A8 /* Sources */ = {
+		6207831AD768716452B1848E61EEAF65 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6A6F7F27DCCF6D5F73EA43FCCA1DAB92 /* _AWSMobileClient.m in Sources */,
-				0DC60DC3F6A7EDA73648721C422359A7 /* AWSCognitoAuth+Extensions.m in Sources */,
-				6026B603F1245AD52915F34CA6A83CC5 /* AWSCognitoAuth.m in Sources */,
-				5296910C64F9CFF68149C484D4FCB927 /* AWSCognitoAuthUICKeyChainStore.m in Sources */,
-				37899F8A7B0ED0B72C99334BAA54CEAB /* AWSMobileClient-dummy.m in Sources */,
-				FEBDB02A795559B8678FF609BD63DC5D /* AWSMobileClient.swift in Sources */,
-				9C756224993E158189C803D1CF6DB659 /* AWSMobileClientExtensions.swift in Sources */,
-				67D8229426E3B531C446102C3F290D63 /* AWSMobileClientUserDetails.swift in Sources */,
-				BE7ADABCCDB533FDC0433D0D631EF85E /* AWSMobileOptions.swift in Sources */,
-				CD670349157D1CC299C595DBC118D553 /* AWSMobileResults.swift in Sources */,
-				D0008DB1D694408559F50AD06E9DCF00 /* AWSUserPoolCustomAuthHandler.swift in Sources */,
-				CCF3D812222A96CB42B542F4D68A6B3F /* AWSUserPoolOperationsHandler.swift in Sources */,
-				35A9EDB5F19A0AA37CFAC061744C58A4 /* DeviceOperations.swift in Sources */,
-				97C52BFCC42E09EEE37E0F079375C892 /* JSONHelper.swift in Sources */,
+				941E42D1D509D1F582000664CD91E228 /* _AWSMobileClient.m in Sources */,
+				CE96BB65FD82A94CC9C9BBE2FEDC0872 /* AWSCognitoAuth+Extensions.m in Sources */,
+				DD391DA8A4F2D8D3EFA2387964725A24 /* AWSCognitoAuth.m in Sources */,
+				A16C4E9390E6BB2980D939DC8E65B67C /* AWSCognitoAuthUICKeyChainStore.m in Sources */,
+				D543D7550F4B79012301D277113C1132 /* AWSMobileClient-dummy.m in Sources */,
+				FB10B80CC418942706405C6FDA423234 /* AWSMobileClient.swift in Sources */,
+				5B96288E92790AC284A258082D40A1C9 /* AWSMobileClientExtensions.swift in Sources */,
+				774615D361214800A581F3588FB96E5A /* AWSMobileClientUserDetails.swift in Sources */,
+				899F3EC9E3871788006C0546EBC03291 /* AWSMobileOptions.swift in Sources */,
+				6F173BDEC3D52002ECE0AFF78D666654 /* AWSMobileResults.swift in Sources */,
+				66F79AA0A7BADE7040571FBA367C4239 /* AWSUserPoolCustomAuthHandler.swift in Sources */,
+				2914C15AB2C025430066747BE42F6A39 /* AWSUserPoolOperationsHandler.swift in Sources */,
+				601D294DEA3B5DA9613371722EAB154D /* DeviceOperations.swift in Sources */,
+				3B34E32ACD49583FA677CE0E51257228 /* JSONHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2962,12 +2966,6 @@
 			target = 52B60EC2A583F24ACBB69C113F5488B9 /* SwiftLint */;
 			targetProxy = D39665078EF67EB882056A22CF65FE80 /* PBXContainerItemProxy */;
 		};
-		06729402D244E9B3898403BE3BECA781 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = AWSAuthCore;
-			target = 8042F2B0721B13AEDEB81F058C2B2125 /* AWSAuthCore */;
-			targetProxy = ABF241B4BEC3E8ADB5E0B8D8BB34B97C /* PBXContainerItemProxy */;
-		};
 		0677872B62BA77DECE8C9125D7C238B1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = SwiftLint;
@@ -3040,12 +3038,6 @@
 			target = 1CD0618C486973D5588EF20D2E8C0AEA /* SwiftFormat */;
 			targetProxy = B74E5D04FC60F052519803DF490FA801 /* PBXContainerItemProxy */;
 		};
-		3956B7AEEEE178E01F0DEA935F7D7E02 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = AWSCognitoIdentityProvider;
-			target = 29212B2F049288E035AB98405A23E41E /* AWSCognitoIdentityProvider */;
-			targetProxy = 808E02155DEA9FFFA7AB26A41DE112FA /* PBXContainerItemProxy */;
-		};
 		3D8B7F3F5BB71669A7C025928D1072D2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = AWSAuthCore;
@@ -3081,6 +3073,12 @@
 			name = SwiftFormat;
 			target = 1CD0618C486973D5588EF20D2E8C0AEA /* SwiftFormat */;
 			targetProxy = 0B15C6B49EE32852CECA199085B40CF5 /* PBXContainerItemProxy */;
+		};
+		5667EF0F959239F15E58BB582963AE92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AWSAuthCore;
+			target = 8042F2B0721B13AEDEB81F058C2B2125 /* AWSAuthCore */;
+			targetProxy = 5E6F9F34B5C8CFC5E5A1534148440CAD /* PBXContainerItemProxy */;
 		};
 		56727A38DC5793FCE8DCF48D44EFC2AA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3352,6 +3350,12 @@
 			target = 52B60EC2A583F24ACBB69C113F5488B9 /* SwiftLint */;
 			targetProxy = 00EEF00846B79EED10A448BF95960D73 /* PBXContainerItemProxy */;
 		};
+		F5B0421585F0FF6459D4B846436CD62B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AWSCognitoIdentityProvider;
+			target = 29212B2F049288E035AB98405A23E41E /* AWSCognitoIdentityProvider */;
+			targetProxy = 93D132FE40403BE2D60EC7A29146AB21 /* PBXContainerItemProxy */;
+		};
 		FB1CAB383ACC481695189C429B46C7F4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = AWSCore;
@@ -3484,7 +3488,7 @@
 		};
 		0AB23DA2C855470186D5B8116100B50B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 80C849937AD2C88BA17636FFE3EEE60C /* AWSCore.xcconfig */;
+			baseConfigurationReference = 6ACF3192254D1F9DBD26D5576A8893F5 /* AWSCore.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3809,41 +3813,6 @@
 			};
 			name = Release;
 		};
-		40FB7DF87715899C41DE4BFC0E32DCA3 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C6FB30955DA68107EDEF56A9A1344D17 /* AWSMobileClient.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/AWSMobileClient/AWSMobileClient-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient.modulemap";
-				PRODUCT_MODULE_NAME = AWSMobileClient;
-				PRODUCT_NAME = AWSMobileClient;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		48F6A6E15897D3D8C499170A423CFE8F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3BF5B6D3E0339165EB3C15592888ACB3 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.debug.xcconfig */;
@@ -3921,9 +3890,44 @@
 			};
 			name = Release;
 		};
+		53EFB213B545096B2630366CA992D0DA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 963946810229E66761E9B42375D1CF97 /* AWSMobileClient.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/AWSMobileClient/AWSMobileClient-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient.modulemap";
+				PRODUCT_MODULE_NAME = AWSMobileClient;
+				PRODUCT_NAME = AWSMobileClient;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		61D16562C88F67A248B236668FAC8E96 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A4F18ECC77B90BCC7C16CD58FFCA677C /* SwiftFormat.xcconfig */;
+			baseConfigurationReference = AD933820BDEA1EDFE966D94B6B13DDC5 /* SwiftFormat.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -3978,7 +3982,7 @@
 		};
 		64A9859A733876E4E55A5B60695C5E4B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 25DFBB76C1BF492E05A46B34178281AD /* AWSAuthCore.xcconfig */;
+			baseConfigurationReference = 7246F3143227F49E0D69F318896E3F0A /* AWSAuthCore.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4013,7 +4017,7 @@
 		};
 		84D7C4574E8F0F3095623F0E06F5B402 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3CE55D53ECA949420B445EF748A6B476 /* SwiftLint.xcconfig */;
+			baseConfigurationReference = 064ADE545B584F856974A8D04E6DDED1 /* SwiftLint.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -4030,7 +4034,7 @@
 		};
 		928A9CF8F7DC9E60D390F3E0FCC0717D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5292499829C37C41F261711AC72F7168 /* CwlCatchException.xcconfig */;
+			baseConfigurationReference = 43E405F1885C7685937FDD90D8A25963 /* CwlCatchException.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4064,45 +4068,9 @@
 			};
 			name = Release;
 		};
-		9582552BB2F8FFE35DD0951280A2C193 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C6FB30955DA68107EDEF56A9A1344D17 /* AWSMobileClient.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/AWSMobileClient/AWSMobileClient-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient.modulemap";
-				PRODUCT_MODULE_NAME = AWSMobileClient;
-				PRODUCT_NAME = AWSMobileClient;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 		97FC9D3288E512074D4653E6D51CCA73 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 80C849937AD2C88BA17636FFE3EEE60C /* AWSCore.xcconfig */;
+			baseConfigurationReference = 6ACF3192254D1F9DBD26D5576A8893F5 /* AWSCore.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4177,7 +4145,7 @@
 		};
 		A4A57FD36DD30772507B9A3AD28CB752 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0E4D66772DCE19A7404EF983F3D98759 /* CwlPreconditionTesting.xcconfig */;
+			baseConfigurationReference = 1FBB9B4EF0162E7673ABC89B53F82D1F /* CwlPreconditionTesting.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4212,7 +4180,7 @@
 		};
 		A54E9CD02041BDE6A02174EE5A58EA97 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 25DFBB76C1BF492E05A46B34178281AD /* AWSAuthCore.xcconfig */;
+			baseConfigurationReference = 7246F3143227F49E0D69F318896E3F0A /* AWSAuthCore.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4248,7 +4216,7 @@
 		};
 		A82ABF3A5034931D5FB9563326AFB8E3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5EDFE115C3392FB9863659189DFA9FD0 /* AWSCognitoIdentityProvider.xcconfig */;
+			baseConfigurationReference = 42717ACF4DB5B4F7156A4B027BEEEEC9 /* AWSCognitoIdentityProvider.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4283,7 +4251,7 @@
 		};
 		A8A39F86ED80874B567AC60703BA6FA1 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A4F18ECC77B90BCC7C16CD58FFCA677C /* SwiftFormat.xcconfig */;
+			baseConfigurationReference = AD933820BDEA1EDFE966D94B6B13DDC5 /* SwiftFormat.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -4297,9 +4265,45 @@
 			};
 			name = Debug;
 		};
+		A959515D58376A70191613342929CC0D /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 963946810229E66761E9B42375D1CF97 /* AWSMobileClient.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/AWSMobileClient/AWSMobileClient-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient.modulemap";
+				PRODUCT_MODULE_NAME = AWSMobileClient;
+				PRODUCT_NAME = AWSMobileClient;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		AA5A2AABF10AA289D052CC2477A1DDF5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5EDFE115C3392FB9863659189DFA9FD0 /* AWSCognitoIdentityProvider.xcconfig */;
+			baseConfigurationReference = 42717ACF4DB5B4F7156A4B027BEEEEC9 /* AWSCognitoIdentityProvider.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4335,7 +4339,7 @@
 		};
 		AB8EA580E69DD4917550E086C71FFCBA /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1EEAEFF4390C69F3ED0B2E72D09E4966 /* AWSCognitoIdentityProviderASF.xcconfig */;
+			baseConfigurationReference = 4BBBDFD5123F98E66123D0B84A133851 /* AWSCognitoIdentityProviderASF.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4371,7 +4375,7 @@
 		};
 		BF762AF3FA0BD3A6F21E92E355CE0648 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1EEAEFF4390C69F3ED0B2E72D09E4966 /* AWSCognitoIdentityProviderASF.xcconfig */;
+			baseConfigurationReference = 4BBBDFD5123F98E66123D0B84A133851 /* AWSCognitoIdentityProviderASF.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4483,7 +4487,7 @@
 		};
 		D2F61928062703C27432E49CB425D03D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0E4D66772DCE19A7404EF983F3D98759 /* CwlPreconditionTesting.xcconfig */;
+			baseConfigurationReference = 1FBB9B4EF0162E7673ABC89B53F82D1F /* CwlPreconditionTesting.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4583,7 +4587,7 @@
 		};
 		DEED47E09AF743F48544C1C4FEADEF47 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3CE55D53ECA949420B445EF748A6B476 /* SwiftLint.xcconfig */;
+			baseConfigurationReference = 064ADE545B584F856974A8D04E6DDED1 /* SwiftLint.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -4599,7 +4603,7 @@
 		};
 		DFA2EA1406BE3C6CCAD3F47AFCEA53A2 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5292499829C37C41F261711AC72F7168 /* CwlCatchException.xcconfig */;
+			baseConfigurationReference = 43E405F1885C7685937FDD90D8A25963 /* CwlCatchException.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4727,20 +4731,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		6C1B0082F55622F61D55E4DF5F89B58D /* Build configuration list for PBXNativeTarget "AWSMobileClient" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				40FB7DF87715899C41DE4BFC0E32DCA3 /* Debug */,
-				9582552BB2F8FFE35DD0951280A2C193 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		7C3B83A384027AAE79E0A6C8D268CC69 /* Build configuration list for PBXNativeTarget "Pods-AmplifyTestApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				018A6D71EC5BCAC6F0A37D87974E596D /* Debug */,
 				9DEEE6868679007B228157ABEE9989F3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8303AF580CB32D93D56CB25771284834 /* Build configuration list for PBXNativeTarget "AWSMobileClient" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				53EFB213B545096B2630366CA992D0DA /* Debug */,
+				A959515D58376A70191613342929CC0D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
This updates the AWS_SDK_VERSION to 2.12.7 across all Podfiles. Currently the process is manual and in the future, heard that @kneekey23 may be picking up something down the road to automatically do this. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
