### PR TITLE
add enum support to DataStore models fixes #111 and #246

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -207,6 +207,8 @@
 		B98E9D122372236300934B51 /* QueryField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98E9D0A2372236200934B51 /* QueryField.swift */; };
 		B98E9D132372236300934B51 /* QueryOperator+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98E9D0B2372236200934B51 /* QueryOperator+Equatable.swift */; };
 		B98E9D142372236300934B51 /* QueryPredicate+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98E9D0C2372236200934B51 /* QueryPredicate+Equatable.swift */; };
+		B9C79A7223F52C3A00ACAA3E /* Model+Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C79A7123F52C3A00ACAA3E /* Model+Enum.swift */; };
+		B9C79A7423F52E1A00ACAA3E /* PostStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C79A7323F52E1A00ACAA3E /* PostStatus.swift */; };
 		B9FAA10B23878122009414B4 /* ModelField+Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FAA10A23878122009414B4 /* ModelField+Association.swift */; };
 		B9FAA10E23878BF3009414B4 /* UserAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FAA10D23878BF3009414B4 /* UserAccount.swift */; };
 		B9FAA11023878C5E009414B4 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FAA10F23878C5E009414B4 /* UserProfile.swift */; };
@@ -834,6 +836,8 @@
 		B98E9D0A2372236200934B51 /* QueryField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryField.swift; sourceTree = "<group>"; };
 		B98E9D0B2372236200934B51 /* QueryOperator+Equatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "QueryOperator+Equatable.swift"; sourceTree = "<group>"; };
 		B98E9D0C2372236200934B51 /* QueryPredicate+Equatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "QueryPredicate+Equatable.swift"; sourceTree = "<group>"; };
+		B9C79A7123F52C3A00ACAA3E /* Model+Enum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Model+Enum.swift"; sourceTree = "<group>"; };
+		B9C79A7323F52E1A00ACAA3E /* PostStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostStatus.swift; sourceTree = "<group>"; };
 		B9FAA10A23878122009414B4 /* ModelField+Association.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModelField+Association.swift"; sourceTree = "<group>"; };
 		B9FAA10D23878BF3009414B4 /* UserAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAccount.swift; sourceTree = "<group>"; };
 		B9FAA10F23878C5E009414B4 /* UserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
@@ -1723,6 +1727,7 @@
 				B9FAA17F238FBB5D009414B4 /* Model+Array.swift */,
 				B92E03AC2367CE7A006CEB8D /* Model+Codable.swift */,
 				FACBA78C23949588006349C8 /* Model+DateFormatting.swift */,
+				B9C79A7123F52C3A00ACAA3E /* Model+Enum.swift */,
 				FA8EE778238627040097E4F1 /* Model+ModelName.swift */,
 				B92E03AB2367CE7A006CEB8D /* Model+Schema.swift */,
 				FA8EE77C238627350097E4F1 /* Model+Subscript.swift */,
@@ -1750,6 +1755,7 @@
 				B9521832237E21B900F53237 /* Post.swift */,
 				B9521831237E21B900F53237 /* Post+Schema.swift */,
 				2129BE002394627B006363A1 /* PostCommentModelRegistration.swift */,
+				B9C79A7323F52E1A00ACAA3E /* PostStatus.swift */,
 				B9FAA10C23878BD6009414B4 /* Associations */,
 			);
 			path = Models;
@@ -3604,6 +3610,7 @@
 				FA09337E2384677A00C2FD5F /* AWSUnifiedLoggingPlugin.swift in Sources */,
 				FAF1B88623392F96007F1435 /* SerialDispatcher.swift in Sources */,
 				FAAFAF2D23904ADF002CF932 /* AtomicValue+Numeric.swift in Sources */,
+				B9C79A7223F52C3A00ACAA3E /* Model+Enum.swift in Sources */,
 				FA09B94B2322CBEB000E064D /* LoggingCategoryConfiguration.swift in Sources */,
 				2129BE512395A66F006363A1 /* AmplifyModelRegistration.swift in Sources */,
 				210922572359693900CEC295 /* BasicAnalyticsEvent.swift in Sources */,
@@ -3832,6 +3839,7 @@
 				FA176ED7238503C200C5C5F9 /* HubListenerTestUtilities.swift in Sources */,
 				21F40A3A23A294770074678E /* TestConfigHelper.swift in Sources */,
 				B4BD6B3723708C6700A1F0A7 /* MockPredictionsCategoryPlugin.swift in Sources */,
+				B9C79A7423F52E1A00ACAA3E /* PostStatus.swift in Sources */,
 				FACA361C2327FC7D000E74F6 /* MockHubCategoryPlugin.swift in Sources */,
 				FAD3937F23820DAE00463F5E /* MockDataStoreCategoryPlugin.swift in Sources */,
 				FACA361A2327FC69000E74F6 /* MockStorageCategoryPlugin.swift in Sources */,

--- a/Amplify/Categories/DataStore/Model/Model+Enum.swift
+++ b/Amplify/Categories/DataStore/Model/Model+Enum.swift
@@ -1,0 +1,32 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// Protocol that represents a `Codable` Enum that can be persisted and easily
+/// integrate with remote APIs since it must have a raw `String` value.
+///
+/// That means only simple enums (i.e. the ones that don't have arguments) can be used
+/// as model properties.
+///
+/// - Example:
+///
+/// ```swift
+/// public enum PostStatus: String, PersistentEnum {
+///     case draft
+///     case published
+/// }
+/// ```
+public protocol PersistentEnum: Codable {
+
+    /// The `String` representation. Make your enum conform to `String`
+    /// to get an automatic `rawValue`.
+    /// See the [Enumeration Language Guide](https://docs.swift.org/swift-book/LanguageGuide/Enumerations.html#ID149)
+    /// for details on enum with raw values.
+    var rawValue: String { get }
+
+}

--- a/Amplify/Categories/DataStore/Model/Model+Enum.swift
+++ b/Amplify/Categories/DataStore/Model/Model+Enum.swift
@@ -23,8 +23,7 @@ import Foundation
 /// ```
 public protocol PersistentEnum: Codable {
 
-    /// The `String` representation. Make your enum conform to `String`
-    /// to get an automatic `rawValue`.
+    /// The `String` representation. Make your enum conform to `String` to get an automatic `rawValue`.
     /// See the [Enumeration Language Guide](https://docs.swift.org/swift-book/LanguageGuide/Enumerations.html#ID149)
     /// for details on enum with raw values.
     var rawValue: String { get }

--- a/Amplify/Categories/DataStore/Model/ModelRegistry.swift
+++ b/Amplify/Categories/DataStore/Model/ModelRegistry.swift
@@ -16,6 +16,8 @@ public struct ModelRegistry {
 
     private static var modelTypes = [String: Model.Type]()
 
+    private static var enumTypes = [String: PersistentEnum.Type]()
+
     private static var modelDecoders = [String: ModelDecoder]()
 
     public static var models: [Model.Type] {
@@ -37,9 +39,22 @@ public struct ModelRegistry {
         }
     }
 
+    public static func register(enumType: PersistentEnum.Type) {
+        concurrencyQueue.sync {
+            let enumName = String(describing: enumType)
+            enumTypes[enumName] = enumType
+        }
+    }
+
     public static func modelType(from name: String) -> Model.Type? {
         concurrencyQueue.sync {
             modelTypes[name]
+        }
+    }
+
+    public static func enumType(from name: String) -> PersistentEnum.Type? {
+        concurrencyQueue.sync {
+            enumTypes[name]
         }
     }
 
@@ -65,6 +80,7 @@ extension ModelRegistry {
     static func reset() {
         concurrencyQueue.sync {
             modelTypes = [:]
+            enumTypes = [:]
             modelDecoders = [:]
         }
     }

--- a/Amplify/Categories/DataStore/Model/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/ModelSchema+Definition.swift
@@ -18,7 +18,7 @@ public enum ModelFieldType: CustomStringConvertible {
     case dateTime
     case time
     case bool
-    case `enum`(Any.Type)
+    case `enum`(PersistentEnum.Type)
     case model(type: Model.Type)
     case collection(of: Model.Type)
 
@@ -31,7 +31,7 @@ public enum ModelFieldType: CustomStringConvertible {
         case .dateTime: return "AWSDateTime"
         case .time: return "AWSTime"
         case .bool: return "Boolean"
-        case .enum(let anyType): return String(describing: anyType)
+        case .enum(let enumType): return String(describing: enumType)
         case .model(let modelType): return modelType.modelName
         case .collection(let modelType): return modelType.modelName
         }
@@ -58,7 +58,13 @@ extension ModelField {
         case "AWSDate": return .date
         case "AWSDateTime": return .dateTime
         case "AWSTime": return .time
+        // when the type from the schema is not a scalar, it could be a Model, Type or Enum
         default:
+            // is it an Enum?
+            if let enumType = ModelRegistry.enumType(from: type) {
+                return .enum(enumType)
+            }
+            // is it a Model then?
             guard let model = ModelRegistry.modelType(from: type) else {
                 preconditionFailure("Model with name \(type) could not be found.")
             }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -29,6 +29,8 @@ extension Model {
                 } else {
                     input[name] = value
                 }
+            case .enum:
+                input[fieldName] = (value as? PersistentEnum)?.rawValue
             case .model:
                 // For Models, append the model name in front in case a targetName is not provided
                 // e.g. "comment" + "PostId"

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -30,7 +30,7 @@ extension Model {
                     input[name] = value
                 }
             case .enum:
-                input[fieldName] = (value as? PersistentEnum)?.rawValue
+                input[name] = (value as? PersistentEnum)?.rawValue
             case .model:
                 // For Models, append the model name in front in case a targetName is not provided
                 // e.g. "comment" + "PostId"

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
@@ -124,7 +124,7 @@ extension Persistable {
         if let value = value as? String {
             return value
         }
-        
+
         if let value = value as? PersistentEnum {
             return value.rawValue
         }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
@@ -124,6 +124,10 @@ extension Persistable {
         if let value = value as? String {
             return value
         }
+        
+        if let value = value as? PersistentEnum {
+            return value.rawValue
+        }
 
         preconditionFailure("""
         Value \(String(describing: value)) of type \(String(describing: type(of: value)))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
@@ -87,8 +87,10 @@ extension Model {
             // Now `value` is still an Any, but we've assured ourselves that it's not an Optional, which means we can
             // safely attempt a cast to Persistable below.
 
-            // if value is an associated model, get its id
-            if let value = value as? Model, field.isForeignKey {
+            if let value = value as? PersistentEnum {
+                return value.rawValue
+            } else if let value = value as? Model, field.isForeignKey {
+                // if value is an associated model, get its id
                 let associatedModel: Model.Type = type(of: value)
                 return value[associatedModel.schema.primaryKey.name] as? String
             } else if let value = value as? Persistable {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/ModelSchema+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/ModelSchema+SQLite.swift
@@ -117,10 +117,7 @@ extension ModelField: SQLColumn {
                 return value.iso8601Date?.iso8601String
             }
         case .enum:
-            if let value = binding as? String {
-//                return enumType.from(string: value)
-                return value
-            }
+            return binding as? String
         case .collection:
             return binding ?? []
         default:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/ModelSchema+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/ModelSchema+SQLite.swift
@@ -116,6 +116,11 @@ extension ModelField: SQLColumn {
                 // values we accept, but always output the same format.
                 return value.iso8601Date?.iso8601String
             }
+        case .enum:
+            if let value = binding as? String {
+//                return enumType.from(string: value)
+                return value
+            }
         case .collection:
             return binding ?? []
         default:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
@@ -20,6 +20,7 @@ class SQLStatementTests: XCTestCase {
         // one-to-many/many-to-one association
         ModelRegistry.register(modelType: Post.self)
         ModelRegistry.register(modelType: Comment.self)
+        ModelRegistry.register(enumType: PostStatus.self)
 
         // one-to-one association
         ModelRegistry.register(modelType: UserAccount.self)
@@ -49,6 +50,7 @@ class SQLStatementTests: XCTestCase {
           "createdAt" text not null,
           "draft" integer,
           "rating" real,
+          "status" text,
           "title" text not null,
           "updatedAt" text
         );
@@ -136,14 +138,14 @@ class SQLStatementTests: XCTestCase {
         let statement = InsertStatement(model: post)
 
         let expectedStatement = """
-        insert into Post ("id", "content", "createdAt", "draft", "rating", "title", "updatedAt")
-        values (?, ?, ?, ?, ?, ?, ?)
+        insert into Post ("id", "content", "createdAt", "draft", "rating", "status", "title", "updatedAt")
+        values (?, ?, ?, ?, ?, ?, ?, ?)
         """
         XCTAssertEqual(statement.stringValue, expectedStatement)
 
         let variables = statement.variables
         XCTAssertEqual(variables[1] as? String, "content")
-        XCTAssertEqual(variables[5] as? String, "title")
+        XCTAssertEqual(variables[6] as? String, "title")
     }
 
     /// - Given: a `Model` instance
@@ -189,6 +191,7 @@ class SQLStatementTests: XCTestCase {
           "createdAt" = ?,
           "draft" = ?,
           "rating" = ?,
+          "status" = ?,
           "title" = ?,
           "updatedAt" = ?
         where "id" = ?
@@ -197,8 +200,8 @@ class SQLStatementTests: XCTestCase {
 
         let variables = statement.variables
         XCTAssertEqual(variables[0] as? String, "content")
-        XCTAssertEqual(variables[4] as? String, "title")
-        XCTAssertEqual(variables[6] as? String, post.id)
+        XCTAssertEqual(variables[5] as? String, "title")
+        XCTAssertEqual(variables[7] as? String, post.id)
     }
 
     // MARK: - Delete Statements
@@ -236,8 +239,8 @@ class SQLStatementTests: XCTestCase {
         let expectedStatement = """
         select
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
-          "root"."draft" as "draft", "root"."rating" as "rating", "root"."title" as "title",
-          "root"."updatedAt" as "updatedAt"
+          "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
+          "root"."title" as "title", "root"."updatedAt" as "updatedAt"
         from Post as root
         """
         XCTAssertEqual(statement.stringValue, expectedStatement)
@@ -257,8 +260,8 @@ class SQLStatementTests: XCTestCase {
         let expectedStatement = """
         select
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
-          "root"."draft" as "draft", "root"."rating" as "rating", "root"."title" as "title",
-          "root"."updatedAt" as "updatedAt"
+          "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
+          "root"."title" as "title", "root"."updatedAt" as "updatedAt"
         from Post as root
         where 1 = 1
           and "root"."draft" = ?
@@ -284,7 +287,7 @@ class SQLStatementTests: XCTestCase {
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
           "root"."commentPostId" as "commentPostId", "post"."id" as "post.id", "post"."content" as "post.content",
           "post"."createdAt" as "post.createdAt", "post"."draft" as "post.draft", "post"."rating" as "post.rating",
-          "post"."title" as "post.title", "post"."updatedAt" as "post.updatedAt"
+          "post"."status" as "post.status", "post"."title" as "post.title", "post"."updatedAt" as "post.updatedAt"
         from Comment as root
         inner join Post as post
           on "post"."id" = "root"."commentPostId"

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -23,7 +23,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             description: "it should save and select a Post from the database")
 
         // insert a post
-        let post = Post(title: "title", content: "content", createdAt: Date())
+        let post = Post(title: "title", content: "content", createdAt: Date(), status: .draft)
         storageAdapter.save(post) { saveResult in
             switch saveResult {
             case .success:
@@ -31,10 +31,11 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                     switch queryResult {
                     case .success(let posts):
                         XCTAssert(posts.count == 1)
-                        if let post = posts.first {
-                            XCTAssert(post.id == post.id)
-                            XCTAssert(post.title == post.title)
-                            XCTAssert(post.content == post.content)
+                        if let savedPost = posts.first {
+                            XCTAssert(post.id == savedPost.id)
+                            XCTAssert(post.title == savedPost.title)
+                            XCTAssert(post.content == savedPost.content)
+                            XCTAssert(post.status == savedPost.status)
                         }
                         expectation.fulfill()
                     case .failure(let error):
@@ -71,10 +72,10 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                     switch queryResult {
                     case .success(let posts):
                         XCTAssertEqual(posts.count, 1)
-                        if let post = posts.first {
-                            XCTAssert(post.id == post.id)
-                            XCTAssert(post.title == post.title)
-                            XCTAssert(post.content == post.content)
+                        if let savedPost = posts.first {
+                            XCTAssert(post.id == savedPost.id)
+                            XCTAssert(post.title == savedPost.title)
+                            XCTAssert(post.content == savedPost.content)
                         }
                         expectation.fulfill()
                     case .failure(let error):

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
@@ -15,6 +15,7 @@ struct TestModelRegistration: AmplifyModelRegistration {
         // Post and Comment
         registry.register(modelType: Post.self)
         registry.register(modelType: Comment.self)
+        registry.register(enumType: PostStatus.self)
 
         // Mock Models
         registry.register(modelType: MockSynced.self)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -52,6 +52,7 @@ class SyncEngineTestBase: XCTestCase {
     /// `models`.
     func setUpStorageAdapter(preCreating models: [Model.Type] = []) throws {
         models.forEach { ModelRegistry.register(modelType: $0) }
+        ModelRegistry.register(enumType: PostStatus.self)
         let connection = try Connection(.inMemory)
         storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
         try storageAdapter.setUp(models: StorageEngine.systemModels + models)

--- a/AmplifyTestCommon/Models/AmplifyModels.swift
+++ b/AmplifyTestCommon/Models/AmplifyModels.swift
@@ -12,10 +12,13 @@ import Foundation
 // Contains the set of classes that conforms to the `Model` protocol.
 
 final public class AmplifyModels: AmplifyModelRegistration {
-  public let version: String = "46369a50a95486d76713fd33833fb782"
 
-  public func registerModels(registry: ModelRegistry.Type) {
-    ModelRegistry.register(modelType: Post.self)
-    ModelRegistry.register(modelType: Comment.self)
-  }
+    public let version: String = "46369a50a95486d76713fd33833fb782"
+
+    public func registerModels(registry: ModelRegistry.Type) {
+        ModelRegistry.register(modelType: Post.self)
+        ModelRegistry.register(modelType: Comment.self)
+        ModelRegistry.register(enumType: PostStatus.self)
+    }
+
 }

--- a/AmplifyTestCommon/Models/Post+Schema.swift
+++ b/AmplifyTestCommon/Models/Post+Schema.swift
@@ -19,6 +19,7 @@ extension Post {
     case updatedAt
     case draft
     case rating
+    case status
     case comments
   }
 
@@ -38,6 +39,7 @@ extension Post {
       .field(post.updatedAt, is: .optional, ofType: .dateTime),
       .field(post.draft, is: .optional, ofType: .bool),
       .field(post.rating, is: .optional, ofType: .double),
+      .field(post.status, is: .optional, ofType: .enum(PostStatus.self)),
       .hasMany(post.comments, is: .optional, ofType: Comment.self, associatedWith: Comment.keys.post)
     )
     }

--- a/AmplifyTestCommon/Models/Post.swift
+++ b/AmplifyTestCommon/Models/Post.swift
@@ -10,30 +10,34 @@ import Amplify
 import Foundation
 
 public struct Post: Model {
-  public let id: String
-  public var title: String
-  public var content: String
-  public var createdAt: Date
-  public var updatedAt: Date?
-  public var draft: Bool?
-  public var rating: Double?
-  public var comments: List<Comment>?
 
-  public init(id: String = UUID().uuidString,
-      title: String,
-      content: String,
-      createdAt: Date,
-      updatedAt: Date? = nil,
-      draft: Bool? = nil,
-      rating: Double? = nil,
-      comments: List<Comment>? = []) {
-      self.id = id
-      self.title = title
-      self.content = content
-      self.createdAt = createdAt
-      self.updatedAt = updatedAt
-      self.draft = draft
-      self.rating = rating
-      self.comments = comments
-  }
+    public let id: String
+    public var title: String
+    public var content: String
+    public var createdAt: Date
+    public var updatedAt: Date?
+    public var draft: Bool?
+    public var rating: Double?
+    public var status: PostStatus?
+    public var comments: List<Comment>?
+
+    public init(id: String = UUID().uuidString,
+                title: String,
+                content: String,
+                createdAt: Date,
+                updatedAt: Date? = nil,
+                draft: Bool? = nil,
+                rating: Double? = nil,
+                status: PostStatus? = nil,
+                comments: List<Comment>? = []) {
+        self.id = id
+        self.title = title
+        self.content = content
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.draft = draft
+        self.rating = rating
+        self.status = status
+        self.comments = comments
+    }
 }

--- a/AmplifyTestCommon/Models/PostStatus.swift
+++ b/AmplifyTestCommon/Models/PostStatus.swift
@@ -1,0 +1,15 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Foundation
+
+public enum PostStatus: String, PersistentEnum {
+    case deleted
+    case draft
+    case published
+}

--- a/AmplifyTestCommon/Models/schema.graphql
+++ b/AmplifyTestCommon/Models/schema.graphql
@@ -6,6 +6,7 @@ type Post @model {
     updatedAt: AWSDateTime
     draft: Boolean
     rating: Float
+    status: PostStatus
     comments: [Comment] @connection(name: "PostComment")
 }
 
@@ -14,4 +15,10 @@ type Comment @model {
     content: String!
     createdAt: AWSDateTime!
     post: Post @connection(name: "PostComment")
+}
+
+enum PostStatus {
+    deleted
+    draft
+    published
 }


### PR DESCRIPTION
**Notes:**

- introduced a `PersistentEnum` protocol to indicate enums that can be persisted
  - they are `Codable`
  - must provide a `rawValue` String
- changed `ModelRegistry` to accept enum registration
- updated the DataStore plugin to handle `PersistentEnum`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
