### PR TITLE
[WIP] Remote sync revamp

### DIFF
--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/SubscriptionConnection/AppSyncSubscriptionConnection+EventHandler.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/SubscriptionConnection/AppSyncSubscriptionConnection+EventHandler.swift
@@ -65,6 +65,9 @@ extension AppSyncSubscriptionConnection {
             serialSubscriptionQueue.async {[weak self] in
                 // Move all subscriptionItems to disconnected but keep them in memory.
                 self?.subscriptionItems.forEach { _, subscriptionItem in
+                    if let error = error {
+                       subscriptionItem.dispatch(error: .networkError("", nil, error))
+                    }
                     switch subscriptionItem.subscriptionConnectionState {
                     case .connecting, .connected:
                         subscriptionItem.setState(.disconnected)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
@@ -23,10 +23,12 @@ extension RemoteSyncEngine {
         case activatedCloudSubscriptions(APICategoryGraphQLBehavior, MutationEventPublisher)
         case activatedMutationQueue
         case notifiedSyncStarted
+        case cleanedUp(AmplifyError?)
+        case scheduleRestart(AmplifyError?)
 
         // Terminal actions
         case receivedCancel
-        case errored(AmplifyError)
+        case errored(AmplifyError?)
 
         var displayName: String {
             switch self {
@@ -46,6 +48,10 @@ extension RemoteSyncEngine {
                 return "activatedMutationQueue"
             case .notifiedSyncStarted:
                 return "notifiedSyncStarted"
+            case .cleanedUp:
+                return "cleanedUp"
+            case .scheduleRestart:
+                return "scheduleRestart"
             case .receivedCancel:
                 return "receivedCancel"
             case .errored:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
@@ -1,0 +1,57 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Combine
+
+@available(iOS 13.0, *)
+extension RemoteSyncEngine {
+
+    /// Actions are declarative, they say what I just did
+    enum Action {
+        // Startup/config actions
+        case receivedStart
+
+        case pausedSubscriptions
+        case pausedMutationQueue(APICategoryGraphQLBehavior, StorageEngineAdapter)
+        case initializedSubscriptions
+        case performedInitialSync
+        case activatedCloudSubscriptions(APICategoryGraphQLBehavior, MutationEventPublisher)
+        case activatedMutationQueue
+        case notifiedSyncStarted
+
+        // Terminal actions
+        case receivedCancel
+        case errored(AmplifyError)
+
+        var displayName: String {
+            switch self {
+            case .receivedStart:
+                return "receivedStart"
+            case .pausedSubscriptions:
+                return "pausedSubscriptions"
+            case .pausedMutationQueue:
+                return "pausedMutationQueue"
+            case .initializedSubscriptions:
+                return "initializedSubscriptions"
+            case .performedInitialSync:
+                return "performedInitialSync"
+            case .activatedCloudSubscriptions:
+                return "activatedCloudSubscriptions"
+            case .activatedMutationQueue:
+                return "activatedMutationQueue"
+            case .notifiedSyncStarted:
+                return "notifiedSyncStarted"
+            case .receivedCancel:
+                return "receivedCancel"
+            case .errored:
+                return "errored"
+            }
+
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
@@ -25,6 +25,7 @@ extension RemoteSyncEngine {
         case notifiedSyncStarted
         case cleanedUp(AmplifyError?)
         case scheduleRestart(AmplifyError?)
+        case scheduleRestartFinished
 
         // Terminal actions
         case receivedCancel
@@ -52,6 +53,8 @@ extension RemoteSyncEngine {
                 return "cleanedUp"
             case .scheduleRestart:
                 return "scheduleRestart"
+            case .scheduleRestartFinished:
+                return "scheduleRestartFinished"
             case .receivedCancel:
                 return "receivedCancel"
             case .errored:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
@@ -1,0 +1,41 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Combine
+import Foundation
+
+@available(iOS 13.0, *)
+extension RemoteSyncEngine {
+    @available(iOS 13.0, *)
+    func onReceiveCompletion(receiveCompletion: Subscribers.Completion<DataStoreError>) {
+        if case .failure(let error) = receiveCompletion {
+            remoteSyncTopicPublisher.send(completion: .failure(error))
+        }
+        if case .finished = receiveCompletion {
+            let unexpectedFinishError = DataStoreError.unknown("ReconcilationQueue sent .finished message",
+                                                               AmplifyErrorMessages.shouldNotHappenReportBugToAWS(),
+                                                               nil)
+            remoteSyncTopicPublisher.send(completion: .failure(unexpectedFinishError))
+        }
+    }
+
+    @available(iOS 13.0, *)
+    func onReceive(receiveValue: IncomingEventReconciliationQueueEvent) {
+        switch receiveValue {
+        case .started:
+            remoteSyncTopicPublisher.send(.subscriptionsActivated)
+            if let api = self.api {
+                stateMachine.notify(action: .activatedCloudSubscriptions(api, mutationEventPublisher))
+            }
+        case .paused:
+            remoteSyncTopicPublisher.send(.subscriptionsPaused)
+        case .mutationEvent(let mutationEvent):
+            remoteSyncTopicPublisher.send(.mutationEvent(mutationEvent))
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
@@ -13,22 +13,17 @@ import Foundation
 extension RemoteSyncEngine {
     @available(iOS 13.0, *)
     func onReceiveCompletion(receiveCompletion: Subscribers.Completion<DataStoreError>) {
-        switch receiveCompletion {
-        case .failure(let error):
-            stateMachine.notify(action: .errored(error))
-        case .finished:
-            stateMachine.notify(action: .errored(nil))
+        let semaphore = DispatchSemaphore(value: 1)
+        semaphore.wait()
+        if case .syncEngineActive = stateMachine.state {
+            switch receiveCompletion {
+            case .failure(let error):
+                stateMachine.notify(action: .errored(error))
+            case .finished:
+                stateMachine.notify(action: .errored(nil))
+            }
         }
-        /*
-        if case .failure(let error) = receiveCompletion {
-            remoteSyncTopicPublisher.send(completion: .failure(error))
-        }
-        if case .finished = receiveCompletion {
-            let unexpectedFinishError = DataStoreError.unknown("ReconcilationQueue sent .finished message",
-                                                               AmplifyErrorMessages.shouldNotHappenReportBugToAWS(),
-                                                               nil)
-            remoteSyncTopicPublisher.send(completion: .failure(unexpectedFinishError))
-        }*/
+        semaphore.signal()
     }
 
     @available(iOS 13.0, *)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
@@ -13,6 +13,13 @@ import Foundation
 extension RemoteSyncEngine {
     @available(iOS 13.0, *)
     func onReceiveCompletion(receiveCompletion: Subscribers.Completion<DataStoreError>) {
+        switch receiveCompletion {
+        case .failure(let error):
+            stateMachine.notify(action: .errored(error))
+        case .finished:
+            stateMachine.notify(action: .errored(nil))
+        }
+        /*
         if case .failure(let error) = receiveCompletion {
             remoteSyncTopicPublisher.send(completion: .failure(error))
         }
@@ -21,7 +28,7 @@ extension RemoteSyncEngine {
                                                                AmplifyErrorMessages.shouldNotHappenReportBugToAWS(),
                                                                nil)
             remoteSyncTopicPublisher.send(completion: .failure(unexpectedFinishError))
-        }
+        }*/
     }
 
     @available(iOS 13.0, *)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
@@ -15,20 +15,33 @@ extension RemoteSyncEngine {
     func onReceiveCompletion(receiveCompletion: Subscribers.Completion<DataStoreError>) {
         let semaphore = DispatchSemaphore(value: 1)
         semaphore.wait()
-        if case .syncEngineActive = stateMachine.state {
-            switch receiveCompletion {
-            case .failure(let error):
-                stateMachine.notify(action: .errored(error))
-            case .finished:
-                stateMachine.notify(action: .errored(nil))
-            }
+        switch stateMachine.state {
+        case .initializeSubscriptions:
+            notifyError(receiveCompletion: receiveCompletion)
+        case .syncEngineActive:
+            notifyError(receiveCompletion: receiveCompletion)
+        default:
+            break
         }
         semaphore.signal()
     }
 
     @available(iOS 13.0, *)
+    func notifyError(receiveCompletion: Subscribers.Completion<DataStoreError>) {
+        switch receiveCompletion {
+        case .failure(let error):
+            stateMachine.notify(action: .errored(error))
+        case .finished:
+            stateMachine.notify(action: .errored(nil))
+        }
+    }
+
+    @available(iOS 13.0, *)
     func onReceive(receiveValue: IncomingEventReconciliationQueueEvent) {
         switch receiveValue {
+        case .initialized:
+            remoteSyncTopicPublisher.send(.subscriptionsInitialized)
+            stateMachine.notify(action: .initializedSubscriptions)
         case .started:
             remoteSyncTopicPublisher.send(.subscriptionsActivated)
             if let api = self.api {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
@@ -1,0 +1,53 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Combine
+
+@available(iOS 13.0, *)
+extension RemoteSyncEngine {
+    struct Resolver {
+        static func resolve(currentState: State, action: Action) -> State {
+            switch (currentState, action) {
+            case (.notStarted, .receivedStart):
+                return .pauseSubscriptions
+
+            case (.pauseSubscriptions, .pausedSubscriptions):
+                return .pauseMutationQueue
+
+            case (.pauseMutationQueue, .pausedMutationQueue(let api, let storageEngineAdapter)):
+                return .initializeSubscriptions(api, storageEngineAdapter)
+
+            case (.initializeSubscriptions, .initializedSubscriptions):
+                return .performInitialSync
+
+            case (.performInitialSync, .performedInitialSync):
+                return .activateCloudSubscriptions
+            case (.performInitialSync, .errored(let error)):
+                return .cleanup(error)
+
+            case (.activateCloudSubscriptions, .activatedCloudSubscriptions(let api, let mutationEventPublisher)):
+                return .activateMutationQueue(api, mutationEventPublisher)
+            case (.activateCloudSubscriptions, .errored(let error)):
+                return .cleanup(error)
+
+            case (.activateMutationQueue, .activatedMutationQueue):
+                return .notifySyncStarted
+            case (.activateMutationQueue, .errored(let error)):
+                return .cleanup(error)
+
+            case (.notifySyncStarted, .notifiedSyncStarted):
+                return .syncEngineActive
+
+            default:
+                log.warn("Unexpected state transition. In \(currentState.displayName), got \(action.displayName)")
+                log.verbose("Unexpected state transition. In \(currentState), got \(action)")
+                return currentState
+            }
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
@@ -50,7 +50,7 @@ extension RemoteSyncEngine {
             case (.cleanup, .cleanedUp(let error)):
                 return .scheduleRestart(error)
 
-            case (.scheduleRestart, .receivedStart):
+            case (.scheduleRestart, .scheduleRestartFinished):
                 return .pauseSubscriptions
 
             default:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
@@ -24,6 +24,8 @@ extension RemoteSyncEngine {
 
             case (.initializeSubscriptions, .initializedSubscriptions):
                 return .performInitialSync
+            case (.initializeSubscriptions, .errored(let error)):
+                return .cleanup(error)
 
             case (.performInitialSync, .performedInitialSync):
                 return .activateCloudSubscriptions

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
@@ -37,13 +37,26 @@ extension RemoteSyncEngine {
 
             case (.activateMutationQueue, .activatedMutationQueue):
                 return .notifySyncStarted
+
             case (.activateMutationQueue, .errored(let error)):
                 return .cleanup(error)
 
             case (.notifySyncStarted, .notifiedSyncStarted):
                 return .syncEngineActive
 
+            case (.syncEngineActive, .errored(let error)):
+                return .cleanup(error)
+
+            case (.cleanup, .cleanedUp(let error)):
+                return .scheduleRestart(error)
+
+            case (.scheduleRestart, .receivedStart):
+                return .pauseSubscriptions
+
             default:
+                print("Unexpected state transition. In \(currentState.displayName), got \(action.displayName)")
+                print("Unexpected state transition. In \(currentState), got \(action)")
+
                 log.warn("Unexpected state transition. In \(currentState.displayName), got \(action.displayName)")
                 log.verbose("Unexpected state transition. In \(currentState), got \(action)")
                 return currentState

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Retryable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Retryable.swift
@@ -45,7 +45,7 @@ extension RemoteSyncEngine {
         mutationRetryNotifier = MutationRetryNotifier(advice: advice,
                                                       networkReachabilityPublisher: networkReachabilityPublisher) {
                                                         self.mutationRetryNotifier = nil
-                                                        self.stateMachine.notify(action: .receivedStart)
+                                                        self.stateMachine.notify(action: .scheduleRestartFinished)
         }
         currentAttemptNumber += 1
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Retryable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Retryable.swift
@@ -1,0 +1,64 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Foundation
+
+@available(iOS 13.0, *)
+extension RemoteSyncEngine {
+
+    func resetCurrentAttemptNumber() {
+        currentAttemptNumber = 1
+    }
+
+    func scheduleRestart(error: AmplifyError?) {
+        let advice = getRetryAdviceIfRetryable(error: error)
+        if advice.shouldRetry {
+            scheduleRestart(advice: advice)
+        } else {
+            if let error = error {
+                remoteSyncTopicPublisher.send(completion: .failure(DataStoreError.api(error)))
+            } else {
+                remoteSyncTopicPublisher.send(completion: .finished)
+            }
+        }
+
+    }
+
+    private func getRetryAdviceIfRetryable(error: Error?) -> RequestRetryAdvice {
+        //TODO: Parse error from the receive completion to use as an input into getting retry advice.
+        //      For now, specifying not connected to internet to force a retry up to our maximum
+        let urlError = URLError(.notConnectedToInternet)
+        let advice = requestRetryablePolicy.retryRequestAdvice(urlError: urlError,
+                                                               httpURLResponse: nil,
+                                                               attemptNumber: currentAttemptNumber)
+        return advice
+    }
+
+    private func scheduleRestart(advice: RequestRetryAdvice) {
+        log.verbose("\(#function) scheduling retry for restarting remote sync engine")
+        resolveReachabilityPublisher()
+        mutationRetryNotifier = MutationRetryNotifier(advice: advice,
+                                                      networkReachabilityPublisher: networkReachabilityPublisher) {
+                                                        self.mutationRetryNotifier = nil
+                                                        self.stateMachine.notify(action: .receivedStart)
+        }
+        currentAttemptNumber += 1
+    }
+
+    private func resolveReachabilityPublisher() {
+        if networkReachabilityPublisher == nil {
+            if let reachability = api as? APICategoryReachabilityBehavior {
+                do {
+                    networkReachabilityPublisher = try reachability.reachabilityPublisher()
+                } catch {
+                    log.error("\(#function): Unable to listen on reachability: \(error)")
+                }
+            }
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+State.swift
@@ -24,7 +24,9 @@ extension RemoteSyncEngine {
 
         case syncEngineActive
 
-        case cleanup(AmplifyError)
+        case cleanup(AmplifyError?)
+        case scheduleRestart(AmplifyError?)
+
         var displayName: String {
             switch self {
             case .notStarted:
@@ -47,6 +49,8 @@ extension RemoteSyncEngine {
                 return "syncEngineActive"
             case .cleanup:
                 return "cleanup"
+            case .scheduleRestart:
+                return "scheduleRestart"
             }
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+State.swift
@@ -1,0 +1,53 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Combine
+@available(iOS 13.0, *)
+extension RemoteSyncEngine {
+
+    /// States are descriptive, they say what is happening in the system right now
+    enum State {
+        case notStarted
+
+        case pauseSubscriptions
+        case pauseMutationQueue
+        case initializeSubscriptions(APICategoryGraphQLBehavior, StorageEngineAdapter)
+        case performInitialSync
+        case activateCloudSubscriptions
+        case activateMutationQueue(APICategoryGraphQLBehavior, MutationEventPublisher)
+        case notifySyncStarted
+
+        case syncEngineActive
+
+        case cleanup(AmplifyError)
+        var displayName: String {
+            switch self {
+            case .notStarted:
+                return "notStarted"
+            case .pauseSubscriptions:
+                return "pauseCloudSubscriptions"
+            case .pauseMutationQueue:
+                return "pauseMutationQueue"
+            case .initializeSubscriptions:
+                return "initializeSubscriptions"
+            case .performInitialSync:
+                return "performInitialSync"
+            case .activateCloudSubscriptions:
+                return "activateCloudSubscriptions"
+            case .activateMutationQueue:
+                return "activateMutationQueue"
+            case .notifySyncStarted:
+                return "notifySyncStarted"
+            case .syncEngineActive:
+                return "syncEngineActive"
+            case .cleanup:
+                return "cleanup"
+            }
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -198,8 +198,8 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
             receiveCompletion: onReceiveCompletion(receiveCompletion:),
             receiveValue: onReceive(receiveValue:))
 
-        remoteSyncTopicPublisher.send(.subscriptionsInitialized)
-        stateMachine.notify(action: .initializedSubscriptions)
+        //Notifying the publisher & state machine are handled in:
+        // RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
     }
 
     private func performInitialSync() {
@@ -253,8 +253,9 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     }
 
     private func cleanup(error: AmplifyError?) {
-        //todo:
-        //Remote sync publisher -- kill.  Serially.  seriously.
+        reconciliationQueue?.cancel()
+        reconciliationQueue = nil
+
         remoteSyncTopicPublisher.send(.cleanedUp)
         stateMachine.notify(action: .cleanedUp(error))
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -44,6 +44,11 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     let stateMachine: StateMachine<State, Action>
     private var stateMachineSink: AnyCancellable?
 
+    var networkReachabilityPublisher: AnyPublisher<ReachabilityUpdate, Never>?
+    var mutationRetryNotifier: MutationRetryNotifier?
+    let requestRetryablePolicy: RequestRetryablePolicy
+    var currentAttemptNumber: Int
+
     /// Initializes the CloudSyncEngine with the specified storageAdapter as the provider for persistence of
     /// MutationEvents, sync metadata, and conflict resolution metadata. Immediately initializes the incoming mutation
     /// queue so it can begin accepting incoming mutations from DataStore.
@@ -51,7 +56,9 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
                      outgoingMutationQueue: OutgoingMutationQueueBehavior? = nil,
                      initialSyncOrchestratorFactory: InitialSyncOrchestratorFactory? = nil,
                      reconciliationQueueFactory: IncomingEventReconciliationQueueFactory? = nil,
-                     stateMachine: StateMachine<State, Action>? = nil) throws {
+                     stateMachine: StateMachine<State, Action>? = nil,
+                     networkReachabilityPublisher: AnyPublisher<ReachabilityUpdate, Never>? = nil,
+                     requestRetryablePolicy: RequestRetryablePolicy? = nil) throws {
         let mutationDatabaseAdapter = try AWSMutationDatabaseAdapter(storageAdapter: storageAdapter)
         let awsMutationEventPublisher = AWSMutationEventPublisher(eventSource: mutationDatabaseAdapter)
         let outgoingMutationQueue = outgoingMutationQueue ?? OutgoingMutationQueue()
@@ -61,6 +68,8 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
             AWSInitialSyncOrchestrator.init(api:reconciliationQueue:storageAdapter:)
         let stateMachine = stateMachine ?? StateMachine(initialState: .notStarted,
                                                         resolver: RemoteSyncEngine.Resolver.resolve(currentState:action:))
+        let requestRetryablePolicy = requestRetryablePolicy ?? RequestRetryablePolicy()
+
 
         self.init(storageAdapter: storageAdapter,
                   outgoingMutationQueue: outgoingMutationQueue,
@@ -68,7 +77,9 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
                   mutationEventPublisher: awsMutationEventPublisher,
                   initialSyncOrchestratorFactory: initialSyncOrchestratorFactory,
                   reconciliationQueueFactory: reconciliationQueueFactory,
-                  stateMachine: stateMachine)
+                  stateMachine: stateMachine,
+                  networkReachabilityPublisher: networkReachabilityPublisher,
+                  requestRetryablePolicy: requestRetryablePolicy)
     }
 
     init(storageAdapter: StorageEngineAdapter,
@@ -77,7 +88,9 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
          mutationEventPublisher: MutationEventPublisher,
          initialSyncOrchestratorFactory: @escaping InitialSyncOrchestratorFactory,
          reconciliationQueueFactory: @escaping IncomingEventReconciliationQueueFactory,
-         stateMachine: StateMachine<State, Action>) {
+         stateMachine: StateMachine<State, Action>,
+         networkReachabilityPublisher: AnyPublisher<ReachabilityUpdate, Never>?,
+         requestRetryablePolicy: RequestRetryablePolicy) {
         self.storageAdapter = storageAdapter
         self.mutationEventIngester = mutationEventIngester
         self.mutationEventPublisher = mutationEventPublisher
@@ -85,10 +98,14 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         self.initialSyncOrchestratorFactory = initialSyncOrchestratorFactory
         self.reconciliationQueueFactory = reconciliationQueueFactory
         self.remoteSyncTopicPublisher = PassthroughSubject<RemoteSyncEngineEvent, DataStoreError>()
+        self.networkReachabilityPublisher = networkReachabilityPublisher
+        self.requestRetryablePolicy = requestRetryablePolicy
 
         self.syncQueue = OperationQueue()
         syncQueue.name = "com.amazonaws.Amplify.\(AWSDataStorePlugin.self).CloudSyncEngine"
         syncQueue.maxConcurrentOperationCount = 1
+
+        self.currentAttemptNumber = 1
 
         self.stateMachine = stateMachine
         self.stateMachineSink = self.stateMachine
@@ -128,10 +145,11 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         case .syncEngineActive:
             break
 
-        case .cleanup(let amplifyError):
-            //todo
-            print("error: \(amplifyError)")
+        case .cleanup(let error):
+            cleanup(error: error)
 
+        case .scheduleRestart(let error):
+            scheduleRestart(error: error)
         }
     }
 
@@ -217,7 +235,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     private func activateCloudSubscriptions() {
         log.debug(#function)
         reconciliationQueue?.start()
-        
+
         //Notifying the publisher & state machine are handled in:
         // RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
     }
@@ -231,10 +249,20 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         stateMachine.notify(action: .activatedMutationQueue)
     }
 
+    private func cleanup(error: AmplifyError?) {
+        //todo:
+        //Remote sync publisher -- kill.  Serially.  seriously.
+        remoteSyncTopicPublisher.send(.cleanedUp)
+        stateMachine.notify(action: .cleanedUp(error))
+    }
+
     private func notifySyncStarted() {
+        resetCurrentAttemptNumber()
         Amplify.Hub.dispatch(to: .dataStore,
                              payload: HubPayload(eventName: HubPayload.EventName.DataStore.syncStarted))
+
         remoteSyncTopicPublisher.send(.syncStarted)
+        stateMachine.notify(action: .notifiedSyncStarted)
     }
 
     func reset(onComplete: () -> Void) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
@@ -17,6 +17,7 @@ enum RemoteSyncEngineEvent {
     case subscriptionsActivated
     case mutationQueueStarted
     case syncStarted
+    case cleanedUp
     case mutationEvent(MutationEvent)
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
@@ -7,7 +7,7 @@
 
 import Amplify
 import Combine
-
+//How much of this we will use vs trash, i have no idea
 enum RemoteSyncEngineEvent {
     case storageAdapterAvailable
     case subscriptionsPaused

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -87,6 +87,13 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
             self.eventReconciliationQueueTopic.send(.mutationEvent(event))
         }
     }
+
+    func cancel() {
+        modelReconciliationQueueSinks.values.forEach { $0.cancel() }
+        reconciliationQueues.values.forEach { $0.cancel()}
+        reconciliationQueues = [:]
+        modelReconciliationQueueSinks = [:]
+    }
 }
 
 @available(iOS 13.0, *)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -15,13 +15,15 @@ import Combine
 final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPublisher {
 
     private let asyncEvents: IncomingAsyncSubscriptionEventPublisher
-    private let mapper: IncomingAsyncSubscriptionEventToAnyModelMapper
-
-    var publisher: AnyPublisher<MutationSync<AnyModel>, DataStoreError> {
-        mapper.publisher
+    private var mapper: IncomingAsyncSubscriptionEventToAnyModelMapper?
+    private let subscriptionEventSubject: PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>
+    private var mapperSink: AnyCancellable?
+    var publisher: AnyPublisher<IncomingSubscriptionEventPublisherEvent, DataStoreError> {
+        return subscriptionEventSubject.eraseToAnyPublisher()
     }
 
     init(modelType: Model.Type, api: APICategoryGraphQLBehavior) {
+        self.subscriptionEventSubject = PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>()
         self.asyncEvents = IncomingAsyncSubscriptionEventPublisher(modelType: modelType,
                                                                    api: api)
 
@@ -29,8 +31,25 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
         self.mapper = mapper
 
         asyncEvents.subscribe(subscriber: mapper)
+        self.mapperSink = mapper.publisher.sink(receiveCompletion: onReceiveCompletion(receiveCompletion:),
+                                                receiveValue: onReceive(receiveValue:))
     }
 
+    private func onReceiveCompletion(receiveCompletion: Subscribers.Completion<DataStoreError>) {
+        subscriptionEventSubject.send(completion: receiveCompletion)
+    }
+
+    private func onReceive(receiveValue: MutationSync<AnyModel>) {
+        subscriptionEventSubject.send(.mutationEvent(receiveValue))
+    }
+
+    func cancel() {
+        mapperSink?.cancel()
+        mapperSink = nil
+
+        asyncEvents.cancel()
+        mapper = nil
+    }
 }
 
 @available(iOS 13.0, *)
@@ -46,7 +65,7 @@ extension AWSIncomingSubscriptionEventPublisher: Resettable {
 
         group.enter()
         DispatchQueue.global().async {
-            self.mapper.reset { group.leave() }
+            self.mapper?.reset { group.leave() }
         }
 
         group.wait()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -36,6 +36,7 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
     }
 
     private func onReceiveCompletion(receiveCompletion: Subscribers.Completion<DataStoreError>) {
+
         subscriptionEventSubject.send(completion: receiveCompletion)
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -18,7 +18,7 @@ import Combine
 /// `GraphQLSubscriptionType` and holds a reference to the returned operation. The operations' listeners enqueue
 /// incoming successful events onto a `Publisher`, that queue processors can subscribe to.
 @available(iOS 13.0, *)
-final class IncomingAsyncSubscriptionEventPublisher {
+final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
     typealias Payload = MutationSync<AnyModel>
     typealias Event = AsyncEvent<SubscriptionEvent<GraphQLResponse<Payload>>, Void, APIError>
 
@@ -86,6 +86,17 @@ final class IncomingAsyncSubscriptionEventPublisher {
 
     func subscribe<S: Subscriber>(subscriber: S) where S.Input == Event, S.Failure == DataStoreError {
         incomingSubscriptionEvents.subscribe(subscriber)
+    }
+
+    func cancel() {
+        onCreateOperation?.cancel()
+        onCreateOperation = nil
+
+        onUpdateOperation?.cancel()
+        onUpdateOperation = nil
+
+        onDeleteOperation?.cancel()
+        onDeleteOperation = nil
     }
 
     func reset(onComplete: () -> Void) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
@@ -9,6 +9,12 @@ import Amplify
 import AWSPluginsCore
 import Combine
 
+enum IncomingAsyncSubscriptionEvent {
+    case payload(MutationSync<AnyModel>)
+    case connectionConnected
+    case connectionDisconnected
+}
+
 // swiftlint:disable type_name
 /// Subscribes to an IncomingSubscriptionAsyncEventQueue, and publishes AnyModel
 @available(iOS 13.0, *)
@@ -21,14 +27,14 @@ final class IncomingAsyncSubscriptionEventToAnyModelMapper: Subscriber {
 
     var subscription: Subscription?
 
-    private let modelsFromSubscription: PassthroughSubject<Payload, DataStoreError>
+    private let modelsFromSubscription: PassthroughSubject<IncomingAsyncSubscriptionEvent, DataStoreError>
 
-    var publisher: AnyPublisher<Payload, DataStoreError> {
+    var publisher: AnyPublisher<IncomingAsyncSubscriptionEvent, DataStoreError> {
         modelsFromSubscription.eraseToAnyPublisher()
     }
 
     init() {
-        self.modelsFromSubscription = PassthroughSubject<Payload, DataStoreError>()
+        self.modelsFromSubscription = PassthroughSubject<IncomingAsyncSubscriptionEvent, DataStoreError>()
     }
 
     // MARK: - Subscriber
@@ -71,6 +77,14 @@ final class IncomingAsyncSubscriptionEventToAnyModelMapper: Subscriber {
             // Connection events are informational only at this level. The terminal state is represented at the
             // AsyncEvent Completion/Error
             log.info("connectionState now \(connectionState)")
+            switch connectionState {
+            case .connected:
+                modelsFromSubscription.send(.connectionConnected)
+            case .disconnected:
+                modelsFromSubscription.send(.connectionDisconnected)
+            default:
+                break
+            }
         case .data(let graphQLResponse):
             dispose(of: graphQLResponse)
         }
@@ -80,7 +94,7 @@ final class IncomingAsyncSubscriptionEventToAnyModelMapper: Subscriber {
         log.verbose("dispose(of graphQLResponse): \(graphQLResponse)")
         switch graphQLResponse {
         case .success(let mutationSync):
-            modelsFromSubscription.send(mutationSync)
+            modelsFromSubscription.send(.payload(mutationSync))
         case .failure(let failure):
             log.error(error: failure)
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
@@ -20,7 +20,7 @@ enum IncomingEventReconciliationQueueEvent {
 /// automatically-configured subscriptions for models, the queue provides an `offer` method for submitting events
 /// directly from other network events such as mutation callbacks or from base/initial sync queries.
 @available(iOS 13.0, *)
-protocol IncomingEventReconciliationQueue: class {
+protocol IncomingEventReconciliationQueue: class, Cancellable {
     func start()
     func pause()
     func offer(_ remoteModel: MutationSync<AnyModel>)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
@@ -10,6 +10,7 @@ import AWSPluginsCore
 import Combine
 
 enum IncomingEventReconciliationQueueEvent {
+    case initialized
     case started
     case paused
     case mutationEvent(MutationEvent)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
@@ -9,7 +9,11 @@ import Amplify
 import AWSPluginsCore
 import Combine
 
+enum IncomingSubscriptionEventPublisherEvent {
+    case mutationEvent(MutationSync<AnyModel>)
+}
+
 @available(iOS 13.0, *)
-protocol IncomingSubscriptionEventPublisher {
-    var publisher: AnyPublisher<MutationSync<AnyModel>, DataStoreError> { get }
+protocol IncomingSubscriptionEventPublisher: Cancellable {
+    var publisher: AnyPublisher<IncomingSubscriptionEventPublisherEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
@@ -10,6 +10,7 @@ import AWSPluginsCore
 import Combine
 
 enum IncomingSubscriptionEventPublisherEvent {
+    case connectionConnected
     case mutationEvent(MutationSync<AnyModel>)
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -93,11 +93,7 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
             .sink(receiveCompletion: { [weak self] completion in
                 self?.receiveCompletion(completion)
                 }, receiveValue: { [weak self] receiveValue in
-                    if case .mutationEvent(let remoteModel) = receiveValue {
-                        self?.incomingSubscriptionEventQueue.addOperation(CancelAwareBlockOperation {
-                            self?.enqueue(remoteModel)
-                        })
-                    }
+                    self?.receive(receiveValue)
                 })
     }
 
@@ -134,6 +130,16 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
         reconcileAndSaveQueue.addOperation(reconcileOp)
     }
 
+    private func receive(_ receive: IncomingSubscriptionEventPublisherEvent) {
+        switch receive {
+        case .mutationEvent(let remoteModel):
+            incomingSubscriptionEventQueue.addOperation(CancelAwareBlockOperation {
+                self.enqueue(remoteModel)
+            })
+        case .connectionConnected:
+            modelReconciliationQueueSubject.send(.connected)
+        }
+    }
     private func receiveCompletion(_ completion: Subscribers.Completion<DataStoreError>) {
         switch completion {
         case .finished:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
@@ -12,6 +12,7 @@ import Combine
 enum ModelReconciliationQueueEvent {
     case started
     case paused
+    case connected
     case mutationEvent(MutationEvent)
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Cancellable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Cancellable.swift
@@ -1,0 +1,17 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+//Note: There is already a Cancellable in Core/Support/Cancellable.swift, which does not seem to be
+//       visible to this package.  In any case, the protocol is the exact same.
+
+/// The conforming type supports canceling an in-process operation. The exact semantics of "canceling" are not defined
+/// in the protocol. Specifically, there is no guarantee that a `cancel` results in immediate cessation of activity.
+public protocol Cancellable {
+    func cancel()
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
@@ -41,7 +41,9 @@ class LocalSubscriptionTests: XCTestCase {
                                              mutationEventPublisher: awsMutationEventPublisher,
                                              initialSyncOrchestratorFactory: NoOpInitialSyncOrchestrator.factory,
                                              reconciliationQueueFactory: MockAWSIncomingEventReconciliationQueue.factory,
-                                             stateMachine: stateMachine)
+                                             stateMachine: stateMachine,
+                                             networkReachabilityPublisher: nil,
+                                             requestRetryablePolicy: MockRequestRetryablePolicy())
 
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
                                           syncEngine: syncEngine)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteEngineSyncTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteEngineSyncTests.swift
@@ -56,6 +56,7 @@ class RemoteEngineSyncTests: XCTestCase {
 
     func testFailureOnInitialSync() throws {
         let storageAdapterAvailable = expectation(description: "storageAdapterAvailable")
+        let subscriptionsPaused = expectation(description: "subscriptionsPaused")
         let mutationsPaused = expectation(description: "mutationsPaused")
         let subscriptionsInitialized = expectation(description: "subscriptionsInitialized")
         let failureOnInitialSync = expectation(description: "failureOnInitialSync")
@@ -69,7 +70,7 @@ class RemoteEngineSyncTests: XCTestCase {
                 case .storageAdapterAvailable:
                     storageAdapterAvailable.fulfill()
                 case .subscriptionsPaused:
-                    XCTFail("subscriptions have not been created, so they are not paused")
+                    subscriptionsPaused.fulfill()
                 case .mutationsPaused:
                     mutationsPaused.fulfill()
                 case .subscriptionsInitialized:
@@ -86,12 +87,15 @@ class RemoteEngineSyncTests: XCTestCase {
         remoteSyncEngine.start()
 
         wait(for: [storageAdapterAvailable,
-                   mutationsPaused, subscriptionsInitialized,
+                   subscriptionsPaused,
+                   mutationsPaused,
+                   subscriptionsInitialized,
                    failureOnInitialSync], timeout: defaultAsyncWaitTimeout)
     }
 
     func testRemoteSyncEngineHappyPath() throws {
         let storageAdapterAvailable = expectation(description: "storageAdapterAvailable")
+        let subscriptionsPaused = expectation(description: "subscriptionsPaused")
         let mutationsPaused = expectation(description: "mutationsPaused")
         let subscriptionsInitialized = expectation(description: "subscriptionsInitialized")
         let performedInitialSync = expectation(description: "performedInitialSync")
@@ -108,7 +112,7 @@ class RemoteEngineSyncTests: XCTestCase {
                 case .storageAdapterAvailable:
                     storageAdapterAvailable.fulfill()
                 case .subscriptionsPaused:
-                    XCTFail("subscriptions have not been created, so they are not paused")
+                    subscriptionsPaused.fulfill()
                 case .mutationsPaused:
                     mutationsPaused.fulfill()
                 case .subscriptionsInitialized:
@@ -129,6 +133,7 @@ class RemoteEngineSyncTests: XCTestCase {
         remoteSyncEngine.start()
 
         wait(for: [storageAdapterAvailable,
+                   subscriptionsPaused,
                    mutationsPaused,
                    subscriptionsInitialized,
                    performedInitialSync,
@@ -139,6 +144,7 @@ class RemoteEngineSyncTests: XCTestCase {
 
     func testFailsAfterSyncStarted() throws {
         let storageAdapterAvailable = expectation(description: "storageAdapterAvailable")
+        let subscriptionsPaused = expectation(description: "subscriptionsPaused")
         let mutationsPaused = expectation(description: "mutationsPaused")
         let subscriptionsInitialized = expectation(description: "subscriptionsInitialized")
         let performedInitialSync = expectation(description: "performedInitialSync")
@@ -156,7 +162,7 @@ class RemoteEngineSyncTests: XCTestCase {
                 case .storageAdapterAvailable:
                     storageAdapterAvailable.fulfill()
                 case .subscriptionsPaused:
-                    XCTFail("subscriptions have not been created, so they are not paused")
+                    subscriptionsPaused.fulfill()
                 case .mutationsPaused:
                     mutationsPaused.fulfill()
                 case .subscriptionsInitialized:
@@ -178,6 +184,7 @@ class RemoteEngineSyncTests: XCTestCase {
         remoteSyncEngine.start()
 
         wait(for: [storageAdapterAvailable,
+                   subscriptionsPaused,
                    mutationsPaused,
                    subscriptionsInitialized,
                    performedInitialSync,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSyncEngineTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSyncEngineTests.swift
@@ -83,6 +83,9 @@ class RemoteSyncEngineTests: XCTestCase {
                     currCount = self.checkAndFulfill(currCount, 2, expectation: subscriptionsPaused)
                 case .mutationsPaused:
                     currCount = self.checkAndFulfill(currCount, 3, expectation: mutationsPaused)
+                    DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
+                        MockAWSIncomingEventReconciliationQueue.mockSend(event: .initialized)
+                    }
                 case .subscriptionsInitialized:
                     currCount = self.checkAndFulfill(currCount, 4, expectation: subscriptionsInitialized)
                 case .performedInitialSync:
@@ -130,6 +133,9 @@ class RemoteSyncEngineTests: XCTestCase {
                     currCount = self.checkAndFulfill(currCount, 2, expectation: subscriptionsPaused)
                 case .mutationsPaused:
                     currCount = self.checkAndFulfill(currCount, 3, expectation: mutationsPaused)
+                    DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
+                        MockAWSIncomingEventReconciliationQueue.mockSend(event: .initialized)
+                    }
                 case .subscriptionsInitialized:
                     currCount = self.checkAndFulfill(currCount, 4, expectation: subscriptionsInitialized)
                 case .performedInitialSync:
@@ -186,6 +192,9 @@ class RemoteSyncEngineTests: XCTestCase {
                     currCount = self.checkAndFulfill(currCount, 2, expectation: subscriptionsPaused)
                 case .mutationsPaused:
                     currCount = self.checkAndFulfill(currCount, 3, expectation: mutationsPaused)
+                    DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
+                        MockAWSIncomingEventReconciliationQueue.mockSend(event: .initialized)
+                    }
                 case .subscriptionsInitialized:
                     currCount = self.checkAndFulfill(currCount, 4, expectation: subscriptionsInitialized)
                 case .performedInitialSync:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -42,7 +42,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                                                     lastChangedAt: Date().unixSeconds,
                                                     version: 1)
             let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
-            subscriptionEventsSubject.send(mutationSync)
+            subscriptionEventsSubject.send(.mutationEvent(mutationSync))
         }
 
         wait(for: [eventsNotSaved], timeout: 5.0)
@@ -84,7 +84,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                                                     lastChangedAt: Date().unixSeconds,
                                                     version: 1)
             let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
-            subscriptionEventsSubject.send(mutationSync)
+            subscriptionEventsSubject.send(.mutationEvent(mutationSync))
         }
 
         queue.start()
@@ -150,7 +150,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                                                     lastChangedAt: Date().unixSeconds,
                                                     version: 1)
             let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
-            subscriptionEventsSubject.send(mutationSync)
+            subscriptionEventsSubject.send(.mutationEvent(mutationSync))
         }
 
         queue.start()
@@ -195,7 +195,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                                                     lastChangedAt: Date().unixSeconds,
                                                     version: 1)
             let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
-            subscriptionEventsSubject.send(mutationSync)
+            subscriptionEventsSubject.send(.mutationEvent(mutationSync))
         }
 
         queue.start()
@@ -228,7 +228,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                                                 lastChangedAt: Date().unixSeconds,
                                                 version: 1)
         let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
-        subscriptionEventsSubject.send(mutationSync)
+        subscriptionEventsSubject.send(.mutationEvent(mutationSync))
 
         wait(for: [event1ShouldNotBeProcessed, event2ShouldNotBeProcessed, event3ShouldBeProcessed], timeout: 1.0)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/ReconciliationQueueTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/ReconciliationQueueTestBase.swift
@@ -18,7 +18,7 @@ class ReconciliationQueueTestBase: XCTestCase {
     var apiPlugin: MockAPICategoryPlugin!
     var storageAdapter: MockSQLiteStorageEngineAdapter!
     var subscriptionEventsPublisher: MockIncomingSubscriptionEventPublisher!
-    var subscriptionEventsSubject: PassthroughSubject<MutationSync<AnyModel>, DataStoreError>!
+    var subscriptionEventsSubject: PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>!
 
     override func setUp() {
         ModelRegistry.register(modelType: MockSynced.self)
@@ -33,9 +33,13 @@ class ReconciliationQueueTestBase: XCTestCase {
 }
 
 struct MockIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPublisher {
-    let subject = PassthroughSubject<MutationSync<AnyModel>, DataStoreError>()
+    let subject = PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>()
 
-    var publisher: AnyPublisher<MutationSync<AnyModel>, DataStoreError> {
+    var publisher: AnyPublisher<IncomingSubscriptionEventPublisherEvent, DataStoreError> {
         subject.eraseToAnyPublisher()
+    }
+
+    func cancel() {
+        //no-op for mock
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
@@ -48,4 +48,7 @@ class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue 
     static func mockSendCompletion(completion: Subscribers.Completion<DataStoreError>) {
         lastInstance?.incomingEventSubject.send(completion: completion)
     }
+    func cancel() {
+        //no-op for mock
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
@@ -48,6 +48,11 @@ class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue 
     static func mockSendCompletion(completion: Subscribers.Completion<DataStoreError>) {
         lastInstance?.incomingEventSubject.send(completion: completion)
     }
+
+    static func mockSend(event: IncomingEventReconciliationQueueEvent) {
+        lastInstance?.incomingEventSubject.send(event)
+    }
+
     func cancel() {
         //no-op for mock
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
@@ -28,4 +28,8 @@ final class MockReconciliationQueue: MessageReporter, IncomingEventReconciliatio
     var publisher: AnyPublisher<IncomingEventReconciliationQueueEvent, DataStoreError> {
         return PassthroughSubject<IncomingEventReconciliationQueueEvent, DataStoreError>().eraseToAnyPublisher()
     }
+
+    func cancel() {
+        //no-op for mock
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -7,6 +7,7 @@
 
 import SQLite
 import XCTest
+import Combine
 
 @testable import Amplify
 @testable import AmplifyTestCommon
@@ -25,6 +26,8 @@ class SyncEngineTestBase: XCTestCase {
     var storageAdapter: SQLiteStorageEngineAdapter!
 
     var stateMachine: StateMachine<RemoteSyncEngine.State, RemoteSyncEngine.Action>!
+
+    var reachabilityPublisher: PassthroughSubject<ReachabilityUpdate, Never>?
 
     // MARK: - Setup
 
@@ -78,7 +81,9 @@ class SyncEngineTestBase: XCTestCase {
                                           mutationEventPublisher: awsMutationEventPublisher,
                                           initialSyncOrchestratorFactory: initialSyncOrchestratorFactory,
                                           reconciliationQueueFactory: AWSIncomingEventReconciliationQueue.factory,
-                                          stateMachine: stateMachine)
+                                          stateMachine: stateMachine,
+                                          networkReachabilityPublisher: reachabilityPublisher?.eraseToAnyPublisher(),
+                                          requestRetryablePolicy: MockRequestRetryablePolicy())
 
         let storageEngine = StorageEngine(storageAdapter: storageAdapter,
                                           syncEngine: syncEngine)

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		6B3CC61923F5E64F0008ECBC /* RemoteSyncEngine+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC61823F5E64F0008ECBC /* RemoteSyncEngine+State.swift */; };
 		6B3CC67C23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC67B23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift */; };
 		6B3CC68023F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC67F23F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift */; };
+		6B3CC68223F89EE30008ECBC /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC68123F89EE30008ECBC /* Cancellable.swift */; };
 		6B4693E923A5645F006BE2C5 /* MutationRetryNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4693E823A5645F006BE2C5 /* MutationRetryNotifier.swift */; };
 		6B4E3DF42397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E3DF32397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift */; };
 		6B4E3DF62397327E00AD962B /* MockStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E3DF52397327E00AD962B /* MockStateMachine.swift */; };
@@ -220,6 +221,7 @@
 		6B3CC61823F5E64F0008ECBC /* RemoteSyncEngine+State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+State.swift"; sourceTree = "<group>"; };
 		6B3CC67B23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift"; sourceTree = "<group>"; };
 		6B3CC67F23F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+Retryable.swift"; sourceTree = "<group>"; };
+		6B3CC68123F89EE30008ECBC /* Cancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
 		6B4693E823A5645F006BE2C5 /* MutationRetryNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationRetryNotifier.swift; sourceTree = "<group>"; };
 		6B4E3DF32397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingMutationQueueTestsWithMockStateMachine.swift; sourceTree = "<group>"; };
 		6B4E3DF52397327E00AD962B /* MockStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStateMachine.swift; sourceTree = "<group>"; };
@@ -583,6 +585,7 @@
 				FA8F4D1D2395AF7600861D91 /* DataStoreError+Plugin.swift */,
 				FA8F4D212395B11700861D91 /* MutationEvent+Query.swift */,
 				FA3841E823889D440070AD5B /* StateMachine.swift */,
+				6B3CC68123F89EE30008ECBC /* Cancellable.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -1244,6 +1247,7 @@
 				2149E5C82388684F00873955 /* SQLStatement.swift in Sources */,
 				FAED5742238B52CE008EBED8 /* ModelStorageBehavior.swift in Sources */,
 				2149E5C62388684F00873955 /* StorageEngineAdapter.swift in Sources */,
+				6B3CC68223F89EE30008ECBC /* Cancellable.swift in Sources */,
 				FA55A5492391EA89002AFF2D /* MutationEventSubscription.swift in Sources */,
 				FA5D76AB2394752900489864 /* AWSMutationDatabaseAdapter+MutationEventIngester.swift in Sources */,
 				FA0427CA2396C35500D25AB0 /* InitialSyncOrchestrator.swift in Sources */,

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -51,6 +51,10 @@
 		6B01B72023A4672500AD0E97 /* RequestRetryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B01B71E23A4672500AD0E97 /* RequestRetryable.swift */; };
 		6B01B72223A4672500AD0E97 /* RequestRetryablePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B01B71F23A4672500AD0E97 /* RequestRetryablePolicy.swift */; };
 		6B3381BC239778E90036F046 /* AWSMutationDatabaseAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3381BB239778E90036F046 /* AWSMutationDatabaseAdapterTests.swift */; };
+		6B3CC61123F5E6210008ECBC /* RemoteSyncEngine+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC61023F5E6210008ECBC /* RemoteSyncEngine+Action.swift */; };
+		6B3CC61523F5E63F0008ECBC /* RemoteSyncEngine+Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC61423F5E63F0008ECBC /* RemoteSyncEngine+Resolver.swift */; };
+		6B3CC61923F5E64F0008ECBC /* RemoteSyncEngine+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC61823F5E64F0008ECBC /* RemoteSyncEngine+State.swift */; };
+		6B3CC67C23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC67B23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift */; };
 		6B4693E923A5645F006BE2C5 /* MutationRetryNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4693E823A5645F006BE2C5 /* MutationRetryNotifier.swift */; };
 		6B4E3DF42397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E3DF32397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift */; };
 		6B4E3DF62397327E00AD962B /* MockStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E3DF52397327E00AD962B /* MockStateMachine.swift */; };
@@ -210,6 +214,10 @@
 		6B01B71E23A4672500AD0E97 /* RequestRetryable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestRetryable.swift; sourceTree = "<group>"; };
 		6B01B71F23A4672500AD0E97 /* RequestRetryablePolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestRetryablePolicy.swift; sourceTree = "<group>"; };
 		6B3381BB239778E90036F046 /* AWSMutationDatabaseAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMutationDatabaseAdapterTests.swift; sourceTree = "<group>"; };
+		6B3CC61023F5E6210008ECBC /* RemoteSyncEngine+Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+Action.swift"; sourceTree = "<group>"; };
+		6B3CC61423F5E63F0008ECBC /* RemoteSyncEngine+Resolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+Resolver.swift"; sourceTree = "<group>"; };
+		6B3CC61823F5E64F0008ECBC /* RemoteSyncEngine+State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+State.swift"; sourceTree = "<group>"; };
+		6B3CC67B23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift"; sourceTree = "<group>"; };
 		6B4693E823A5645F006BE2C5 /* MutationRetryNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationRetryNotifier.swift; sourceTree = "<group>"; };
 		6B4E3DF32397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingMutationQueueTestsWithMockStateMachine.swift; sourceTree = "<group>"; };
 		6B4E3DF52397327E00AD962B /* MockStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStateMachine.swift; sourceTree = "<group>"; };
@@ -429,6 +437,10 @@
 			isa = PBXGroup;
 			children = (
 				2149E5BE2388684F00873955 /* RemoteSyncEngine.swift */,
+				6B3CC61023F5E6210008ECBC /* RemoteSyncEngine+Action.swift */,
+				6B3CC61423F5E63F0008ECBC /* RemoteSyncEngine+Resolver.swift */,
+				6B3CC61823F5E64F0008ECBC /* RemoteSyncEngine+State.swift */,
+				6B3CC67B23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift */,
 				FAF7CECE238C93A50095547B /* RemoteSyncEngineBehavior.swift */,
 				6B01B71E23A4672500AD0E97 /* RequestRetryable.swift */,
 				6B01B71F23A4672500AD0E97 /* RequestRetryablePolicy.swift */,
@@ -1176,6 +1188,7 @@
 			files = (
 				2149E5DE2388684F00873955 /* AWSDataStorePlugin.swift in Sources */,
 				FAC010EC23956D5800FCE7BB /* ReconcileAndLocalSaveOperation+Resolver.swift in Sources */,
+				6B3CC61923F5E64F0008ECBC /* RemoteSyncEngine+State.swift in Sources */,
 				FA6C3FEC23988D0900A73110 /* AWSIncomingEventReconciliationQueue.swift in Sources */,
 				6B01B72023A4672500AD0E97 /* RequestRetryable.swift in Sources */,
 				6B01B72223A4672500AD0E97 /* RequestRetryablePolicy.swift in Sources */,
@@ -1196,6 +1209,7 @@
 				FA55A54B2391EAB5002AFF2D /* MutationEventSubscriber.swift in Sources */,
 				FA3B3F07238F23CA002EFDB3 /* OutgoingMutationQueue+Resolver.swift in Sources */,
 				2149E5D22388684F00873955 /* SQLStatement+Condition.swift in Sources */,
+				6B3CC61123F5E6210008ECBC /* RemoteSyncEngine+Action.swift in Sources */,
 				FAED573C238B4B03008EBED8 /* Statement+AnyModel.swift in Sources */,
 				FA1AE9BC23988BE100DE396D /* AWSModelReconciliationQueue.swift in Sources */,
 				2149E5C52388684F00873955 /* StorageEngineBehavior.swift in Sources */,
@@ -1209,6 +1223,7 @@
 				FACBA78B2394950C006349C8 /* MutationEventSource.swift in Sources */,
 				FAC010E823956CF400FCE7BB /* ReconcileAndLocalSaveOperation+State.swift in Sources */,
 				FA60461323980A75009E4B97 /* InitialSyncOperation.swift in Sources */,
+				6B3CC67C23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift in Sources */,
 				2149E5C72388684F00873955 /* StorageEngine.swift in Sources */,
 				FA3B3F05238F22F5002EFDB3 /* OutgoingMutationQueue+Action.swift in Sources */,
 				FAED573E238B4C2F008EBED8 /* StorageEngineAdapter+UntypedModel.swift in Sources */,
@@ -1234,6 +1249,7 @@
 				FA55A54D2391F96E002AFF2D /* AWSMutationDatabaseAdapter+MutationEventSource.swift in Sources */,
 				2149E5CE2388684F00873955 /* SQLStatement+CreateTable.swift in Sources */,
 				FACBB2AE238AFAE800C29602 /* AWSDataStorePlugin+DataStoreBaseBehavior.swift in Sources */,
+				6B3CC61523F5E63F0008ECBC /* RemoteSyncEngine+Resolver.swift in Sources */,
 				2149E5D32388684F00873955 /* Statement+Model.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		6B3CC61523F5E63F0008ECBC /* RemoteSyncEngine+Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC61423F5E63F0008ECBC /* RemoteSyncEngine+Resolver.swift */; };
 		6B3CC61923F5E64F0008ECBC /* RemoteSyncEngine+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC61823F5E64F0008ECBC /* RemoteSyncEngine+State.swift */; };
 		6B3CC67C23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC67B23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift */; };
+		6B3CC68023F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC67F23F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift */; };
 		6B4693E923A5645F006BE2C5 /* MutationRetryNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4693E823A5645F006BE2C5 /* MutationRetryNotifier.swift */; };
 		6B4E3DF42397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E3DF32397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift */; };
 		6B4E3DF62397327E00AD962B /* MockStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E3DF52397327E00AD962B /* MockStateMachine.swift */; };
@@ -63,7 +64,7 @@
 		6B91DEBF238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */; };
 		6BC4FDA823A899180027D20C /* RequestRetryablePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC4FDA723A899180027D20C /* RequestRetryablePolicyTests.swift */; };
 		6BC4FDAA23A899680027D20C /* MockRequestRetryablePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */; };
-		6BDC224023E21A4E007C8410 /* RemoteEngineSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC223F23E21A4E007C8410 /* RemoteEngineSyncTests.swift */; };
+		6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */; };
 		6BDC224223E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */; };
 		9BDB42C47E6D7F9A113AE558 /* Pods_HostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C6448DF009E54C11ACE4515 /* Pods_HostApp.framework */; };
 		B9E010E4239167E000DCE8C8 /* TestModelRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E010E3239167E000DCE8C8 /* TestModelRegistration.swift */; };
@@ -218,6 +219,7 @@
 		6B3CC61423F5E63F0008ECBC /* RemoteSyncEngine+Resolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+Resolver.swift"; sourceTree = "<group>"; };
 		6B3CC61823F5E64F0008ECBC /* RemoteSyncEngine+State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+State.swift"; sourceTree = "<group>"; };
 		6B3CC67B23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift"; sourceTree = "<group>"; };
+		6B3CC67F23F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+Retryable.swift"; sourceTree = "<group>"; };
 		6B4693E823A5645F006BE2C5 /* MutationRetryNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationRetryNotifier.swift; sourceTree = "<group>"; };
 		6B4E3DF32397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingMutationQueueTestsWithMockStateMachine.swift; sourceTree = "<group>"; };
 		6B4E3DF52397327E00AD962B /* MockStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStateMachine.swift; sourceTree = "<group>"; };
@@ -226,7 +228,7 @@
 		6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcileAndLocalSaveOperationTests.swift; sourceTree = "<group>"; };
 		6BC4FDA723A899180027D20C /* RequestRetryablePolicyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestRetryablePolicyTests.swift; sourceTree = "<group>"; };
 		6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRequestRetryablePolicy.swift; sourceTree = "<group>"; };
-		6BDC223F23E21A4E007C8410 /* RemoteEngineSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteEngineSyncTests.swift; sourceTree = "<group>"; };
+		6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSyncEngineTests.swift; sourceTree = "<group>"; };
 		6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSInitialSyncOrchestrator.swift; sourceTree = "<group>"; };
 		6CF3060AE9E227813325029F /* Pods_AWSDataStoreCategoryPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSDataStoreCategoryPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		715777CA4DC182BC96B88C19 /* Pods_HostApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -441,6 +443,7 @@
 				6B3CC61423F5E63F0008ECBC /* RemoteSyncEngine+Resolver.swift */,
 				6B3CC61823F5E64F0008ECBC /* RemoteSyncEngine+State.swift */,
 				6B3CC67B23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift */,
+				6B3CC67F23F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift */,
 				FAF7CECE238C93A50095547B /* RemoteSyncEngineBehavior.swift */,
 				6B01B71E23A4672500AD0E97 /* RequestRetryable.swift */,
 				6B01B71F23A4672500AD0E97 /* RequestRetryablePolicy.swift */,
@@ -615,7 +618,7 @@
 				2149E5F1238869CF00873955 /* APICategoryDependencyTests.swift */,
 				FA0427CF2396CDD800D25AB0 /* DataStoreHubTests.swift */,
 				2149E5F3238869CF00873955 /* LocalSubscriptionTests.swift */,
-				6BDC223F23E21A4E007C8410 /* RemoteEngineSyncTests.swift */,
+				6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */,
 				6BC4FDA723A899180027D20C /* RequestRetryablePolicyTests.swift */,
 				FAE01F9923997BD900B468DA /* InitialSync */,
 				FAE01F9823997B7600B468DA /* MutationQueue */,
@@ -1248,6 +1251,7 @@
 				FACBA78F23949C75006349C8 /* AWSMutationDatabaseAdapter.swift in Sources */,
 				FA55A54D2391F96E002AFF2D /* AWSMutationDatabaseAdapter+MutationEventSource.swift in Sources */,
 				2149E5CE2388684F00873955 /* SQLStatement+CreateTable.swift in Sources */,
+				6B3CC68023F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift in Sources */,
 				FACBB2AE238AFAE800C29602 /* AWSDataStorePlugin+DataStoreBaseBehavior.swift in Sources */,
 				6B3CC61523F5E63F0008ECBC /* RemoteSyncEngine+Resolver.swift in Sources */,
 				2149E5D32388684F00873955 /* Statement+Model.swift in Sources */,
@@ -1276,7 +1280,7 @@
 				6B64027923E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift in Sources */,
 				FA0427D02396CDD800D25AB0 /* DataStoreHubTests.swift in Sources */,
 				FA3B3F09238F39DE002EFDB3 /* AWSMutationEventIngesterTests.swift in Sources */,
-				6BDC224023E21A4E007C8410 /* RemoteEngineSyncTests.swift in Sources */,
+				6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */,
 				FA4B8E962391C609009FC10F /* XCTest+AmplifyExtensions.swift in Sources */,
 				FAE4146C239AA40600CE94C2 /* MockSQLiteStorageEngineAdapter.swift in Sources */,
 				FA8D932F239EA5C4001ED336 /* NoOpInitialSyncOrchestrator.swift in Sources */,


### PR DESCRIPTION
Don't review this.  This is actually four separate commits I will be splitting up in the very near future.

Uploading this to a branch in the event my computer gets hit by a bus.

Notable updates:
- remote sync engine was moved to a serial statemachine
- handle a sendCompletion (failure) in order to kick the state machine to an errored/clean up restart 
- Added cancel interface to cancel event reconciliation queue, model reconciliation queue, listeners, mappers, etc.
- Added sending connection information from API in order to decide when subscribeInitialization succeeds (e.g., if we can't make a subscription connection, then we shouldn't be doing an initialSync)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
