### PR TITLE
Added retry/restart logic to RemoteSyncEngine without cancel downstream components

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
@@ -23,10 +23,12 @@ extension RemoteSyncEngine {
         case activatedCloudSubscriptions(APICategoryGraphQLBehavior, MutationEventPublisher)
         case activatedMutationQueue
         case notifiedSyncStarted
+        case cleanedUp(AmplifyError?)
+        case scheduleRestart(AmplifyError?)
 
         // Terminal actions
         case receivedCancel
-        case errored(AmplifyError)
+        case errored(AmplifyError?)
 
         var displayName: String {
             switch self {
@@ -46,6 +48,10 @@ extension RemoteSyncEngine {
                 return "activatedMutationQueue"
             case .notifiedSyncStarted:
                 return "notifiedSyncStarted"
+            case .cleanedUp:
+                return "cleanedUp"
+            case .scheduleRestart:
+                return "scheduleRestart"
             case .receivedCancel:
                 return "receivedCancel"
             case .errored:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
@@ -13,14 +13,11 @@ import Foundation
 extension RemoteSyncEngine {
     @available(iOS 13.0, *)
     func onReceiveCompletion(receiveCompletion: Subscribers.Completion<DataStoreError>) {
-        if case .failure(let error) = receiveCompletion {
-            remoteSyncTopicPublisher.send(completion: .failure(error))
-        }
-        if case .finished = receiveCompletion {
-            let unexpectedFinishError = DataStoreError.unknown("ReconcilationQueue sent .finished message",
-                                                               AmplifyErrorMessages.shouldNotHappenReportBugToAWS(),
-                                                               nil)
-            remoteSyncTopicPublisher.send(completion: .failure(unexpectedFinishError))
+        switch receiveCompletion {
+        case .failure(let error):
+            stateMachine.notify(action: .errored(error))
+        case .finished:
+            stateMachine.notify(action: .errored(nil))
         }
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
@@ -37,11 +37,21 @@ extension RemoteSyncEngine {
 
             case (.activateMutationQueue, .activatedMutationQueue):
                 return .notifySyncStarted
+
             case (.activateMutationQueue, .errored(let error)):
                 return .cleanup(error)
 
             case (.notifySyncStarted, .notifiedSyncStarted):
                 return .syncEngineActive
+
+            case (.syncEngineActive, .errored(let error)):
+                return .cleanup(error)
+
+            case (.cleanup, .cleanedUp(let error)):
+                return .scheduleRestart(error)
+
+            case (.scheduleRestart, .receivedStart):
+                return .pauseSubscriptions
 
             default:
                 log.warn("Unexpected state transition. In \(currentState.displayName), got \(action.displayName)")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Retryable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Retryable.swift
@@ -1,0 +1,64 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Foundation
+
+@available(iOS 13.0, *)
+extension RemoteSyncEngine {
+
+    func resetCurrentAttemptNumber() {
+        currentAttemptNumber = 1
+    }
+
+    func scheduleRestart(error: AmplifyError?) {
+        let advice = getRetryAdviceIfRetryable(error: error)
+        if advice.shouldRetry {
+            scheduleRestart(advice: advice)
+        } else {
+            if let error = error {
+                remoteSyncTopicPublisher.send(completion: .failure(DataStoreError.api(error)))
+            } else {
+                remoteSyncTopicPublisher.send(completion: .finished)
+            }
+        }
+
+    }
+
+    private func getRetryAdviceIfRetryable(error: Error?) -> RequestRetryAdvice {
+        //TODO: Parse error from the receive completion to use as an input into getting retry advice.
+        //      For now, specifying not connected to internet to force a retry up to our maximum
+        let urlError = URLError(.notConnectedToInternet)
+        let advice = requestRetryablePolicy.retryRequestAdvice(urlError: urlError,
+                                                               httpURLResponse: nil,
+                                                               attemptNumber: currentAttemptNumber)
+        return advice
+    }
+
+    private func scheduleRestart(advice: RequestRetryAdvice) {
+        log.verbose("\(#function) scheduling retry for restarting remote sync engine")
+        resolveReachabilityPublisher()
+        mutationRetryNotifier = MutationRetryNotifier(advice: advice,
+                                                      networkReachabilityPublisher: networkReachabilityPublisher) {
+                                                        self.mutationRetryNotifier = nil
+                                                        self.stateMachine.notify(action: .receivedStart)
+        }
+        currentAttemptNumber += 1
+    }
+
+    private func resolveReachabilityPublisher() {
+        if networkReachabilityPublisher == nil {
+            if let reachability = api as? APICategoryReachabilityBehavior {
+                do {
+                    networkReachabilityPublisher = try reachability.reachabilityPublisher()
+                } catch {
+                    log.error("\(#function): Unable to listen on reachability: \(error)")
+                }
+            }
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+State.swift
@@ -24,7 +24,9 @@ extension RemoteSyncEngine {
 
         case syncEngineActive
 
-        case cleanup(AmplifyError)
+        case cleanup(AmplifyError?)
+        case scheduleRestart(AmplifyError?)
+
         var displayName: String {
             switch self {
             case .notStarted:
@@ -47,6 +49,8 @@ extension RemoteSyncEngine {
                 return "syncEngineActive"
             case .cleanup:
                 return "cleanup"
+            case .scheduleRestart:
+                return "scheduleRestart"
             }
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
@@ -17,6 +17,7 @@ enum RemoteSyncEngineEvent {
     case subscriptionsActivated
     case mutationQueueStarted
     case syncStarted
+    case cleanedUp
     case mutationEvent(MutationEvent)
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
@@ -41,7 +41,9 @@ class LocalSubscriptionTests: XCTestCase {
                                              mutationEventPublisher: awsMutationEventPublisher,
                                              initialSyncOrchestratorFactory: NoOpInitialSyncOrchestrator.factory,
                                              reconciliationQueueFactory: MockAWSIncomingEventReconciliationQueue.factory,
-                                             stateMachine: stateMachine)
+                                             stateMachine: stateMachine,
+                                             networkReachabilityPublisher: nil,
+                                             requestRetryablePolicy: MockRequestRetryablePolicy())
 
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
                                           syncEngine: syncEngine)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -7,6 +7,7 @@
 
 import SQLite
 import XCTest
+import Combine
 
 @testable import Amplify
 @testable import AmplifyTestCommon
@@ -25,6 +26,8 @@ class SyncEngineTestBase: XCTestCase {
     var storageAdapter: SQLiteStorageEngineAdapter!
 
     var stateMachine: StateMachine<RemoteSyncEngine.State, RemoteSyncEngine.Action>!
+
+    var reachabilityPublisher: PassthroughSubject<ReachabilityUpdate, Never>?
 
     // MARK: - Setup
 
@@ -78,7 +81,9 @@ class SyncEngineTestBase: XCTestCase {
                                           mutationEventPublisher: awsMutationEventPublisher,
                                           initialSyncOrchestratorFactory: initialSyncOrchestratorFactory,
                                           reconciliationQueueFactory: AWSIncomingEventReconciliationQueue.factory,
-                                          stateMachine: stateMachine)
+                                          stateMachine: stateMachine,
+                                          networkReachabilityPublisher: reachabilityPublisher?.eraseToAnyPublisher(),
+                                          requestRetryablePolicy: MockRequestRetryablePolicy())
 
         let storageEngine = StorageEngine(storageAdapter: storageAdapter,
                                           syncEngine: syncEngine)

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		6B3CC61523F5E63F0008ECBC /* RemoteSyncEngine+Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC61423F5E63F0008ECBC /* RemoteSyncEngine+Resolver.swift */; };
 		6B3CC61923F5E64F0008ECBC /* RemoteSyncEngine+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC61823F5E64F0008ECBC /* RemoteSyncEngine+State.swift */; };
 		6B3CC67C23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC67B23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift */; };
+		6B3CC68023F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC67F23F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift */; };
 		6B4693E923A5645F006BE2C5 /* MutationRetryNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4693E823A5645F006BE2C5 /* MutationRetryNotifier.swift */; };
 		6B4E3DF42397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E3DF32397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift */; };
 		6B4E3DF62397327E00AD962B /* MockStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E3DF52397327E00AD962B /* MockStateMachine.swift */; };
@@ -63,7 +64,7 @@
 		6B91DEBF238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */; };
 		6BC4FDA823A899180027D20C /* RequestRetryablePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC4FDA723A899180027D20C /* RequestRetryablePolicyTests.swift */; };
 		6BC4FDAA23A899680027D20C /* MockRequestRetryablePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */; };
-		6BDC224023E21A4E007C8410 /* RemoteEngineSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC223F23E21A4E007C8410 /* RemoteEngineSyncTests.swift */; };
+		6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */; };
 		6BDC224223E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */; };
 		9BDB42C47E6D7F9A113AE558 /* Pods_HostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C6448DF009E54C11ACE4515 /* Pods_HostApp.framework */; };
 		B9E010E4239167E000DCE8C8 /* TestModelRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E010E3239167E000DCE8C8 /* TestModelRegistration.swift */; };
@@ -218,6 +219,7 @@
 		6B3CC61423F5E63F0008ECBC /* RemoteSyncEngine+Resolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+Resolver.swift"; sourceTree = "<group>"; };
 		6B3CC61823F5E64F0008ECBC /* RemoteSyncEngine+State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+State.swift"; sourceTree = "<group>"; };
 		6B3CC67B23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift"; sourceTree = "<group>"; };
+		6B3CC67F23F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+Retryable.swift"; sourceTree = "<group>"; };
 		6B4693E823A5645F006BE2C5 /* MutationRetryNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationRetryNotifier.swift; sourceTree = "<group>"; };
 		6B4E3DF32397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingMutationQueueTestsWithMockStateMachine.swift; sourceTree = "<group>"; };
 		6B4E3DF52397327E00AD962B /* MockStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStateMachine.swift; sourceTree = "<group>"; };
@@ -226,7 +228,7 @@
 		6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcileAndLocalSaveOperationTests.swift; sourceTree = "<group>"; };
 		6BC4FDA723A899180027D20C /* RequestRetryablePolicyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestRetryablePolicyTests.swift; sourceTree = "<group>"; };
 		6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRequestRetryablePolicy.swift; sourceTree = "<group>"; };
-		6BDC223F23E21A4E007C8410 /* RemoteEngineSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteEngineSyncTests.swift; sourceTree = "<group>"; };
+		6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSyncEngineTests.swift; sourceTree = "<group>"; };
 		6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSInitialSyncOrchestrator.swift; sourceTree = "<group>"; };
 		6CF3060AE9E227813325029F /* Pods_AWSDataStoreCategoryPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSDataStoreCategoryPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		715777CA4DC182BC96B88C19 /* Pods_HostApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -441,6 +443,7 @@
 				6B3CC61423F5E63F0008ECBC /* RemoteSyncEngine+Resolver.swift */,
 				6B3CC61823F5E64F0008ECBC /* RemoteSyncEngine+State.swift */,
 				6B3CC67B23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift */,
+				6B3CC67F23F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift */,
 				FAF7CECE238C93A50095547B /* RemoteSyncEngineBehavior.swift */,
 				6B01B71E23A4672500AD0E97 /* RequestRetryable.swift */,
 				6B01B71F23A4672500AD0E97 /* RequestRetryablePolicy.swift */,
@@ -615,7 +618,7 @@
 				2149E5F1238869CF00873955 /* APICategoryDependencyTests.swift */,
 				FA0427CF2396CDD800D25AB0 /* DataStoreHubTests.swift */,
 				2149E5F3238869CF00873955 /* LocalSubscriptionTests.swift */,
-				6BDC223F23E21A4E007C8410 /* RemoteEngineSyncTests.swift */,
+				6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */,
 				6BC4FDA723A899180027D20C /* RequestRetryablePolicyTests.swift */,
 				FAE01F9923997BD900B468DA /* InitialSync */,
 				FAE01F9823997B7600B468DA /* MutationQueue */,
@@ -1248,6 +1251,7 @@
 				FACBA78F23949C75006349C8 /* AWSMutationDatabaseAdapter.swift in Sources */,
 				FA55A54D2391F96E002AFF2D /* AWSMutationDatabaseAdapter+MutationEventSource.swift in Sources */,
 				2149E5CE2388684F00873955 /* SQLStatement+CreateTable.swift in Sources */,
+				6B3CC68023F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift in Sources */,
 				FACBB2AE238AFAE800C29602 /* AWSDataStorePlugin+DataStoreBaseBehavior.swift in Sources */,
 				6B3CC61523F5E63F0008ECBC /* RemoteSyncEngine+Resolver.swift in Sources */,
 				2149E5D32388684F00873955 /* Statement+Model.swift in Sources */,
@@ -1276,7 +1280,7 @@
 				6B64027923E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift in Sources */,
 				FA0427D02396CDD800D25AB0 /* DataStoreHubTests.swift in Sources */,
 				FA3B3F09238F39DE002EFDB3 /* AWSMutationEventIngesterTests.swift in Sources */,
-				6BDC224023E21A4E007C8410 /* RemoteEngineSyncTests.swift in Sources */,
+				6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */,
 				FA4B8E962391C609009FC10F /* XCTest+AmplifyExtensions.swift in Sources */,
 				FAE4146C239AA40600CE94C2 /* MockSQLiteStorageEngineAdapter.swift in Sources */,
 				FA8D932F239EA5C4001ED336 /* NoOpInitialSyncOrchestrator.swift in Sources */,


### PR DESCRIPTION
This handles logic to restart the remote sync engine, without actually canceling downstream components.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
