### PR TITLE
Adding cancellable interface to RemoteSyncEngine components

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
@@ -25,6 +25,7 @@ extension RemoteSyncEngine {
         case notifiedSyncStarted
         case cleanedUp(AmplifyError?)
         case scheduleRestart(AmplifyError?)
+        case scheduleRestartFinished
 
         // Terminal actions
         case receivedCancel
@@ -52,6 +53,8 @@ extension RemoteSyncEngine {
                 return "cleanedUp"
             case .scheduleRestart:
                 return "scheduleRestart"
+            case .scheduleRestartFinished:
+                return "scheduleRestartFinished"
             case .receivedCancel:
                 return "receivedCancel"
             case .errored:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
@@ -13,12 +13,17 @@ import Foundation
 extension RemoteSyncEngine {
     @available(iOS 13.0, *)
     func onReceiveCompletion(receiveCompletion: Subscribers.Completion<DataStoreError>) {
-        switch receiveCompletion {
-        case .failure(let error):
-            stateMachine.notify(action: .errored(error))
-        case .finished:
-            stateMachine.notify(action: .errored(nil))
+        let semaphore = DispatchSemaphore(value: 1)
+        semaphore.wait()
+        if case .syncEngineActive = stateMachine.state {
+            switch receiveCompletion {
+            case .failure(let error):
+                stateMachine.notify(action: .errored(error))
+            case .finished:
+                stateMachine.notify(action: .errored(nil))
+            }
         }
+        semaphore.signal()
     }
 
     @available(iOS 13.0, *)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
@@ -50,7 +50,7 @@ extension RemoteSyncEngine {
             case (.cleanup, .cleanedUp(let error)):
                 return .scheduleRestart(error)
 
-            case (.scheduleRestart, .receivedStart):
+            case (.scheduleRestart, .scheduleRestartFinished):
                 return .pauseSubscriptions
 
             default:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Retryable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Retryable.swift
@@ -45,7 +45,7 @@ extension RemoteSyncEngine {
         mutationRetryNotifier = MutationRetryNotifier(advice: advice,
                                                       networkReachabilityPublisher: networkReachabilityPublisher) {
                                                         self.mutationRetryNotifier = nil
-                                                        self.stateMachine.notify(action: .receivedStart)
+                                                        self.stateMachine.notify(action: .scheduleRestartFinished)
         }
         currentAttemptNumber += 1
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -87,6 +87,13 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
             self.eventReconciliationQueueTopic.send(.mutationEvent(event))
         }
     }
+
+    func cancel() {
+        modelReconciliationQueueSinks.values.forEach { $0.cancel() }
+        reconciliationQueues.values.forEach { $0.cancel()}
+        reconciliationQueues = [:]
+        modelReconciliationQueueSinks = [:]
+    }
 }
 
 @available(iOS 13.0, *)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -18,7 +18,7 @@ import Combine
 /// `GraphQLSubscriptionType` and holds a reference to the returned operation. The operations' listeners enqueue
 /// incoming successful events onto a `Publisher`, that queue processors can subscribe to.
 @available(iOS 13.0, *)
-final class IncomingAsyncSubscriptionEventPublisher {
+final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
     typealias Payload = MutationSync<AnyModel>
     typealias Event = AsyncEvent<SubscriptionEvent<GraphQLResponse<Payload>>, Void, APIError>
 
@@ -86,6 +86,17 @@ final class IncomingAsyncSubscriptionEventPublisher {
 
     func subscribe<S: Subscriber>(subscriber: S) where S.Input == Event, S.Failure == DataStoreError {
         incomingSubscriptionEvents.subscribe(subscriber)
+    }
+
+    func cancel() {
+        onCreateOperation?.cancel()
+        onCreateOperation = nil
+
+        onUpdateOperation?.cancel()
+        onUpdateOperation = nil
+
+        onDeleteOperation?.cancel()
+        onDeleteOperation = nil
     }
 
     func reset(onComplete: () -> Void) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
@@ -20,7 +20,7 @@ enum IncomingEventReconciliationQueueEvent {
 /// automatically-configured subscriptions for models, the queue provides an `offer` method for submitting events
 /// directly from other network events such as mutation callbacks or from base/initial sync queries.
 @available(iOS 13.0, *)
-protocol IncomingEventReconciliationQueue: class {
+protocol IncomingEventReconciliationQueue: class, Cancellable {
     func start()
     func pause()
     func offer(_ remoteModel: MutationSync<AnyModel>)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
@@ -9,7 +9,11 @@ import Amplify
 import AWSPluginsCore
 import Combine
 
+enum IncomingSubscriptionEventPublisherEvent {
+    case mutationEvent(MutationSync<AnyModel>)
+}
+
 @available(iOS 13.0, *)
-protocol IncomingSubscriptionEventPublisher {
-    var publisher: AnyPublisher<MutationSync<AnyModel>, DataStoreError> { get }
+protocol IncomingSubscriptionEventPublisher: Cancellable {
+    var publisher: AnyPublisher<IncomingSubscriptionEventPublisherEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Cancellable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Cancellable.swift
@@ -1,0 +1,17 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+//Note: There is already a Cancellable in Core/Support/Cancellable.swift, which does not seem to be
+//       visible to this package.  In any case, the protocol is the exact same.
+
+/// The conforming type supports canceling an in-process operation. The exact semantics of "canceling" are not defined
+/// in the protocol. Specifically, there is no guarantee that a `cancel` results in immediate cessation of activity.
+public protocol Cancellable {
+    func cancel()
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -42,7 +42,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                                                     lastChangedAt: Date().unixSeconds,
                                                     version: 1)
             let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
-            subscriptionEventsSubject.send(mutationSync)
+            subscriptionEventsSubject.send(.mutationEvent(mutationSync))
         }
 
         wait(for: [eventsNotSaved], timeout: 5.0)
@@ -84,7 +84,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                                                     lastChangedAt: Date().unixSeconds,
                                                     version: 1)
             let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
-            subscriptionEventsSubject.send(mutationSync)
+            subscriptionEventsSubject.send(.mutationEvent(mutationSync))
         }
 
         queue.start()
@@ -150,7 +150,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                                                     lastChangedAt: Date().unixSeconds,
                                                     version: 1)
             let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
-            subscriptionEventsSubject.send(mutationSync)
+            subscriptionEventsSubject.send(.mutationEvent(mutationSync))
         }
 
         queue.start()
@@ -195,7 +195,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                                                     lastChangedAt: Date().unixSeconds,
                                                     version: 1)
             let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
-            subscriptionEventsSubject.send(mutationSync)
+            subscriptionEventsSubject.send(.mutationEvent(mutationSync))
         }
 
         queue.start()
@@ -228,7 +228,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                                                 lastChangedAt: Date().unixSeconds,
                                                 version: 1)
         let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
-        subscriptionEventsSubject.send(mutationSync)
+        subscriptionEventsSubject.send(.mutationEvent(mutationSync))
 
         wait(for: [event1ShouldNotBeProcessed, event2ShouldNotBeProcessed, event3ShouldBeProcessed], timeout: 1.0)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/ReconciliationQueueTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/ReconciliationQueueTestBase.swift
@@ -18,7 +18,7 @@ class ReconciliationQueueTestBase: XCTestCase {
     var apiPlugin: MockAPICategoryPlugin!
     var storageAdapter: MockSQLiteStorageEngineAdapter!
     var subscriptionEventsPublisher: MockIncomingSubscriptionEventPublisher!
-    var subscriptionEventsSubject: PassthroughSubject<MutationSync<AnyModel>, DataStoreError>!
+    var subscriptionEventsSubject: PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>!
 
     override func setUp() {
         ModelRegistry.register(modelType: MockSynced.self)
@@ -33,9 +33,13 @@ class ReconciliationQueueTestBase: XCTestCase {
 }
 
 struct MockIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPublisher {
-    let subject = PassthroughSubject<MutationSync<AnyModel>, DataStoreError>()
+    let subject = PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>()
 
-    var publisher: AnyPublisher<MutationSync<AnyModel>, DataStoreError> {
+    var publisher: AnyPublisher<IncomingSubscriptionEventPublisherEvent, DataStoreError> {
         subject.eraseToAnyPublisher()
+    }
+
+    func cancel() {
+        //no-op for mock
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
@@ -48,4 +48,7 @@ class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue 
     static func mockSendCompletion(completion: Subscribers.Completion<DataStoreError>) {
         lastInstance?.incomingEventSubject.send(completion: completion)
     }
+    func cancel() {
+        //no-op for mock
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
@@ -28,4 +28,8 @@ final class MockReconciliationQueue: MessageReporter, IncomingEventReconciliatio
     var publisher: AnyPublisher<IncomingEventReconciliationQueueEvent, DataStoreError> {
         return PassthroughSubject<IncomingEventReconciliationQueueEvent, DataStoreError>().eraseToAnyPublisher()
     }
+
+    func cancel() {
+        //no-op for mock
+    }
 }

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		6B3CC61923F5E64F0008ECBC /* RemoteSyncEngine+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC61823F5E64F0008ECBC /* RemoteSyncEngine+State.swift */; };
 		6B3CC67C23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC67B23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift */; };
 		6B3CC68023F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC67F23F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift */; };
+		6B3CC68223F89EE30008ECBC /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CC68123F89EE30008ECBC /* Cancellable.swift */; };
 		6B4693E923A5645F006BE2C5 /* MutationRetryNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4693E823A5645F006BE2C5 /* MutationRetryNotifier.swift */; };
 		6B4E3DF42397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E3DF32397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift */; };
 		6B4E3DF62397327E00AD962B /* MockStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E3DF52397327E00AD962B /* MockStateMachine.swift */; };
@@ -220,6 +221,7 @@
 		6B3CC61823F5E64F0008ECBC /* RemoteSyncEngine+State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+State.swift"; sourceTree = "<group>"; };
 		6B3CC67B23F86D680008ECBC /* RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift"; sourceTree = "<group>"; };
 		6B3CC67F23F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSyncEngine+Retryable.swift"; sourceTree = "<group>"; };
+		6B3CC68123F89EE30008ECBC /* Cancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
 		6B4693E823A5645F006BE2C5 /* MutationRetryNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationRetryNotifier.swift; sourceTree = "<group>"; };
 		6B4E3DF32397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingMutationQueueTestsWithMockStateMachine.swift; sourceTree = "<group>"; };
 		6B4E3DF52397327E00AD962B /* MockStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStateMachine.swift; sourceTree = "<group>"; };
@@ -583,6 +585,7 @@
 				FA8F4D1D2395AF7600861D91 /* DataStoreError+Plugin.swift */,
 				FA8F4D212395B11700861D91 /* MutationEvent+Query.swift */,
 				FA3841E823889D440070AD5B /* StateMachine.swift */,
+				6B3CC68123F89EE30008ECBC /* Cancellable.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -1244,6 +1247,7 @@
 				2149E5C82388684F00873955 /* SQLStatement.swift in Sources */,
 				FAED5742238B52CE008EBED8 /* ModelStorageBehavior.swift in Sources */,
 				2149E5C62388684F00873955 /* StorageEngineAdapter.swift in Sources */,
+				6B3CC68223F89EE30008ECBC /* Cancellable.swift in Sources */,
 				FA55A5492391EA89002AFF2D /* MutationEventSubscription.swift in Sources */,
 				FA5D76AB2394752900489864 /* AWSMutationDatabaseAdapter+MutationEventIngester.swift in Sources */,
 				FA0427CA2396C35500D25AB0 /* InitialSyncOrchestrator.swift in Sources */,


### PR DESCRIPTION
In this PR, we are adding a cancellable interface, but still not calling cancel -- that will be done in the next PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
