### PR TITLE
Propagate connection status up, wait on subscription init, fix unit tests

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
@@ -24,6 +24,8 @@ extension RemoteSyncEngine {
 
             case (.initializeSubscriptions, .initializedSubscriptions):
                 return .performInitialSync
+            case (.initializeSubscriptions, .errored(let error)):
+                return .cleanup(error)
 
             case (.performInitialSync, .performedInitialSync):
                 return .activateCloudSubscriptions

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -198,8 +198,8 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
             receiveCompletion: onReceiveCompletion(receiveCompletion:),
             receiveValue: onReceive(receiveValue:))
 
-        remoteSyncTopicPublisher.send(.subscriptionsInitialized)
-        stateMachine.notify(action: .initializedSubscriptions)
+        //Notifying the publisher & state machine are handled in:
+        // RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
     }
 
     private func performInitialSync() {
@@ -253,8 +253,10 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     }
 
     private func cleanup(error: AmplifyError?) {
-        // TODO:
-        // handle clean up here
+        reconciliationQueue?.cancel()
+        reconciliationQueue = nil
+        outgoingMutationQueue.pauseSyncingToCloud()
+
         remoteSyncTopicPublisher.send(.cleanedUp)
         stateMachine.notify(action: .cleanedUp(error))
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -29,6 +29,7 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
     }
 
     private var reconciliationQueues: [String: ModelReconciliationQueue]
+    private var reconciliationQueueConnectionStatus: [String: Bool]
 
     init(modelTypes: [Model.Type],
          api: APICategoryGraphQLBehavior,
@@ -36,7 +37,7 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
         self.modelReconciliationQueueSinks = [:]
         self.eventReconciliationQueueTopic = PassthroughSubject<IncomingEventReconciliationQueueEvent, DataStoreError>()
         self.reconciliationQueues = [:]
-
+        self.reconciliationQueueConnectionStatus = [:]
         for modelType in modelTypes {
             let modelName = modelType.modelName
             let queue = AWSModelReconciliationQueue(modelType: modelType,
@@ -74,6 +75,7 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
     }
 
     private func onReceiveCompletion(completed: Subscribers.Completion<DataStoreError>) {
+        reconciliationQueueConnectionStatus = [:]
         switch completed {
         case .failure(let error):
             eventReconciliationQueueTopic.send(completion: .failure(error))
@@ -83,8 +85,16 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
     }
 
     private func onRecieveValue(receiveValue: ModelReconciliationQueueEvent) {
-        if case .mutationEvent(let event) = receiveValue {
-            self.eventReconciliationQueueTopic.send(.mutationEvent(event))
+        switch receiveValue {
+        case .mutationEvent(let event):
+            eventReconciliationQueueTopic.send(.mutationEvent(event))
+        case .connected(let modelName):
+            reconciliationQueueConnectionStatus[modelName] = true
+            if reconciliationQueueConnectionStatus.count == reconciliationQueues.count {
+                eventReconciliationQueueTopic.send(.initialized)
+            }
+        default:
+            break
         }
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -36,12 +36,15 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
     }
 
     private func onReceiveCompletion(receiveCompletion: Subscribers.Completion<DataStoreError>) {
-
         subscriptionEventSubject.send(completion: receiveCompletion)
     }
 
-    private func onReceive(receiveValue: MutationSync<AnyModel>) {
-        subscriptionEventSubject.send(.mutationEvent(receiveValue))
+    private func onReceive(receiveValue: IncomingAsyncSubscriptionEvent) {
+        if case .connectionConnected = receiveValue {
+            subscriptionEventSubject.send(.connectionConnected)
+        } else if case .payload(let mutationSyncAnyModel) = receiveValue {
+            subscriptionEventSubject.send(.mutationEvent(mutationSyncAnyModel))
+        }
     }
 
     func cancel() {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
@@ -9,6 +9,12 @@ import Amplify
 import AWSPluginsCore
 import Combine
 
+enum IncomingAsyncSubscriptionEvent {
+    case payload(MutationSync<AnyModel>)
+    case connectionConnected
+    case connectionDisconnected
+}
+
 // swiftlint:disable type_name
 /// Subscribes to an IncomingSubscriptionAsyncEventQueue, and publishes AnyModel
 @available(iOS 13.0, *)
@@ -21,14 +27,14 @@ final class IncomingAsyncSubscriptionEventToAnyModelMapper: Subscriber {
 
     var subscription: Subscription?
 
-    private let modelsFromSubscription: PassthroughSubject<Payload, DataStoreError>
+    private let modelsFromSubscription: PassthroughSubject<IncomingAsyncSubscriptionEvent, DataStoreError>
 
-    var publisher: AnyPublisher<Payload, DataStoreError> {
+    var publisher: AnyPublisher<IncomingAsyncSubscriptionEvent, DataStoreError> {
         modelsFromSubscription.eraseToAnyPublisher()
     }
 
     init() {
-        self.modelsFromSubscription = PassthroughSubject<Payload, DataStoreError>()
+        self.modelsFromSubscription = PassthroughSubject<IncomingAsyncSubscriptionEvent, DataStoreError>()
     }
 
     // MARK: - Subscriber
@@ -71,6 +77,14 @@ final class IncomingAsyncSubscriptionEventToAnyModelMapper: Subscriber {
             // Connection events are informational only at this level. The terminal state is represented at the
             // AsyncEvent Completion/Error
             log.info("connectionState now \(connectionState)")
+            switch connectionState {
+            case .connected:
+                modelsFromSubscription.send(.connectionConnected)
+            case .disconnected:
+                modelsFromSubscription.send(.connectionDisconnected)
+            default:
+                break
+            }
         case .data(let graphQLResponse):
             dispose(of: graphQLResponse)
         }
@@ -80,7 +94,7 @@ final class IncomingAsyncSubscriptionEventToAnyModelMapper: Subscriber {
         log.verbose("dispose(of graphQLResponse): \(graphQLResponse)")
         switch graphQLResponse {
         case .success(let mutationSync):
-            modelsFromSubscription.send(mutationSync)
+            modelsFromSubscription.send(.payload(mutationSync))
         case .failure(let failure):
             log.error(error: failure)
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
@@ -10,6 +10,7 @@ import AWSPluginsCore
 import Combine
 
 enum IncomingEventReconciliationQueueEvent {
+    case initialized
     case started
     case paused
     case mutationEvent(MutationEvent)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
@@ -10,6 +10,7 @@ import AWSPluginsCore
 import Combine
 
 enum IncomingSubscriptionEventPublisherEvent {
+    case connectionConnected
     case mutationEvent(MutationSync<AnyModel>)
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
@@ -12,6 +12,7 @@ import Combine
 enum ModelReconciliationQueueEvent {
     case started
     case paused
+    case connected(String)
     case mutationEvent(MutationEvent)
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSyncEngineTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSyncEngineTests.swift
@@ -83,6 +83,9 @@ class RemoteSyncEngineTests: XCTestCase {
                     currCount = self.checkAndFulfill(currCount, 2, expectation: subscriptionsPaused)
                 case .mutationsPaused:
                     currCount = self.checkAndFulfill(currCount, 3, expectation: mutationsPaused)
+                    DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
+                        MockAWSIncomingEventReconciliationQueue.mockSend(event: .initialized)
+                    }
                 case .subscriptionsInitialized:
                     currCount = self.checkAndFulfill(currCount, 4, expectation: subscriptionsInitialized)
                 case .performedInitialSync:
@@ -130,6 +133,9 @@ class RemoteSyncEngineTests: XCTestCase {
                     currCount = self.checkAndFulfill(currCount, 2, expectation: subscriptionsPaused)
                 case .mutationsPaused:
                     currCount = self.checkAndFulfill(currCount, 3, expectation: mutationsPaused)
+                    DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
+                        MockAWSIncomingEventReconciliationQueue.mockSend(event: .initialized)
+                    }
                 case .subscriptionsInitialized:
                     currCount = self.checkAndFulfill(currCount, 4, expectation: subscriptionsInitialized)
                 case .performedInitialSync:
@@ -186,6 +192,9 @@ class RemoteSyncEngineTests: XCTestCase {
                     currCount = self.checkAndFulfill(currCount, 2, expectation: subscriptionsPaused)
                 case .mutationsPaused:
                     currCount = self.checkAndFulfill(currCount, 3, expectation: mutationsPaused)
+                    DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
+                        MockAWSIncomingEventReconciliationQueue.mockSend(event: .initialized)
+                    }
                 case .subscriptionsInitialized:
                     currCount = self.checkAndFulfill(currCount, 4, expectation: subscriptionsInitialized)
                 case .performedInitialSync:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
@@ -48,6 +48,11 @@ class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue 
     static func mockSendCompletion(completion: Subscribers.Completion<DataStoreError>) {
         lastInstance?.incomingEventSubject.send(completion: completion)
     }
+
+    static func mockSend(event: IncomingEventReconciliationQueueEvent) {
+        lastInstance?.incomingEventSubject.send(event)
+    }
+
     func cancel() {
         //no-op for mock
     }


### PR DESCRIPTION
In this case we are waiting for the subscriptions to properly initialize the subscriptions, which means, we have the need to make sure that the sockets are connected, prior to doing our initial sync.

I'm not particularly proud how we are handling connected sockets & propagating that status up -- I will be refactoring this shortly -- but the good news is that if i explicitly kill sockets in API, this code seems to allow us to bring and remote sync engine up and down! :)

Known issues
. API is not passing back errors (working with lawmicha@ on this.)
. API is storing connections and not killing them (have some code which cleans the connections on a cancel() of an Amplify API operation) (working with lawmicha@ on this)
. OutgoingMutationQueue occasionally receives and invalid state transition -- Haven't dug into it yet, but I will.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
