### PR TITLE
[DO NOT COMMIT] Hacks used to test remote sync engine restarting

### DIFF
--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLSubscriptionOperation.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLSubscriptionOperation.swift
@@ -46,6 +46,7 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
         } else {
             super.cancel()
         }
+        subscriptionConnectionFactory.cancel()
     }
 
     override public func main() {

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/SubscriptionConnection/AppSyncSubscriptionConnection+EventHandler.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/SubscriptionConnection/AppSyncSubscriptionConnection+EventHandler.swift
@@ -65,6 +65,9 @@ extension AppSyncSubscriptionConnection {
             serialSubscriptionQueue.async {[weak self] in
                 // Move all subscriptionItems to disconnected but keep them in memory.
                 self?.subscriptionItems.forEach { _, subscriptionItem in
+                    if let error = error {
+                       subscriptionItem.dispatch(error: .networkError("", nil, error))
+                    }
                     switch subscriptionItem.subscriptionConnectionState {
                     case .connecting, .connected:
                         subscriptionItem.setState(.disconnected)

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/SubscriptionConnectionFactory/AWSSubscriptionConnectionFactory.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/SubscriptionConnectionFactory/AWSSubscriptionConnectionFactory.swift
@@ -20,7 +20,9 @@ class AWSSubscriptionConnectionFactory: SubscriptionConnectionFactory {
     init(retryStrategy: AWSAppSyncRetryStrategy = .exponential) {
         self.retryStrategy = retryStrategy
     }
-
+    func cancel() {
+        apiToSubscriptionConnections = [:]
+    }
     func getOrCreateConnection(for endpointConfig: AWSAPICategoryPluginConfiguration.EndpointConfig,
                                authService: AWSAuthServiceBehavior) throws -> SubscriptionConnection {
         return try concurrencyQueue.sync {

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/SubscriptionConnectionFactory/SubscriptionConnectionFactory.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Subscription/SubscriptionConnectionFactory/SubscriptionConnectionFactory.swift
@@ -8,7 +8,7 @@
 import AWSPluginsCore
 
 protocol SubscriptionConnectionFactory {
-
+    func cancel()
     func getOrCreateConnection(for endpointConfiguration: AWSAPICategoryPluginConfiguration.EndpointConfig,
                                authService: AWSAuthServiceBehavior) throws -> SubscriptionConnection
 }


### PR DESCRIPTION
This is probably not useful, as you could probably imagine the code i used to hack API to work on the restarting of the remote sync engine, but i figure i give this to you just in case you were curious how I hacked up API.

I'm hoping we can come up with something similar so that
1.  Errors are passed back to the data store category
2. Sockets are destroyed upon no other operations are using that particular socket

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
