### PR TITLE
Fix two memory leaks when restarting remote sync engine

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -52,6 +52,7 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
         mapperSink = nil
 
         asyncEvents.cancel()
+        mapper?.cancel()
         mapper = nil
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -149,12 +149,17 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
     func cancel() {
         onCreateOperation?.cancel()
         onCreateOperation = nil
+        onCreateListener = nil
 
         onUpdateOperation?.cancel()
         onUpdateOperation = nil
+        onUpdateListener = nil
+
 
         onDeleteOperation?.cancel()
         onDeleteOperation = nil
+        onDeleteListener = nil
+
     }
 
     func reset(onComplete: () -> Void) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
@@ -18,7 +18,7 @@ enum IncomingAsyncSubscriptionEvent {
 // swiftlint:disable type_name
 /// Subscribes to an IncomingSubscriptionAsyncEventQueue, and publishes AnyModel
 @available(iOS 13.0, *)
-final class IncomingAsyncSubscriptionEventToAnyModelMapper: Subscriber {
+final class IncomingAsyncSubscriptionEventToAnyModelMapper: Subscriber, Cancellable {
     // swiftlint:enable type_name
 
     typealias Input = IncomingAsyncSubscriptionEventPublisher.Event
@@ -98,6 +98,11 @@ final class IncomingAsyncSubscriptionEventToAnyModelMapper: Subscriber {
         case .failure(let failure):
             log.error(error: failure)
         }
+    }
+
+    func cancel() {
+        subscription?.cancel()
+        subscription = nil
     }
 
     func reset(onComplete: () -> Void) {


### PR DESCRIPTION
Found two memory leaks using the memory graph debugger/visualizer.

Repro:
setup a data store app, go into airplane mode to force subscription connections to fail, then go back online to restart subscription connections

Observed behavior:
Instances of AWSIncomingSubscriptionEventPublisher were referencing itself
IncomingAsyncSubscriptionEventToAnyModelMapper references dangling due to subscriptions and.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
