### PR TITLE
Switch mutex to serial work queue & remove unused serial queue

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -33,7 +33,6 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     }
 
     /// Synchronizes startup operations
-    private let syncQueue: OperationQueue
     private let workQueue = DispatchQueue(label: "com.amazonaws.RemoteSyncEngineOperationQueue",
                                           target: DispatchQueue.global())
 
@@ -100,10 +99,6 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         self.remoteSyncTopicPublisher = PassthroughSubject<RemoteSyncEngineEvent, DataStoreError>()
         self.networkReachabilityPublisher = networkReachabilityPublisher
         self.requestRetryablePolicy = requestRetryablePolicy
-
-        self.syncQueue = OperationQueue()
-        syncQueue.name = "com.amazonaws.Amplify.\(AWSDataStorePlugin.self).CloudSyncEngine"
-        syncQueue.maxConcurrentOperationCount = 1
 
         self.currentAttemptNumber = 1
 
@@ -268,11 +263,6 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         let group = DispatchGroup()
 
         group.enter()
-
-        DispatchQueue.global().async {
-            self.syncQueue.cancelAllOperations()
-            self.syncQueue.waitUntilAllOperationsAreFinished()
-        }
 
         let mirror = Mirror(reflecting: self)
         for child in mirror.children {


### PR DESCRIPTION
- Minor refactor to avoid using mutex/DispatchSemaphore
- Removed serial operation queue that was no longer being used in RemoteSyncEngine

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
