### PR TITLE
Add websocket disconnect when all subscriptions are closed

### DIFF
--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		21598CF223A0164A00529F29 /* GraphQLWithUserPoolIntegrationTests-amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21598CF023A0164900529F29 /* GraphQLWithUserPoolIntegrationTests-amplifyconfiguration.json */; };
 		21598CF323A0164A00529F29 /* GraphQLWithUserPoolIntegrationTests-awsconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21598CF123A0164A00529F29 /* GraphQLWithUserPoolIntegrationTests-awsconfiguration.json */; };
 		216201E323920A6200AB2E10 /* GraphQLSyncBasedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216201E223920A6200AB2E10 /* GraphQLSyncBasedTests.swift */; };
+		217180A223FF14CB00E520C9 /* GraphQLModelBasedTests+Subscriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217180A123FF14CB00E520C9 /* GraphQLModelBasedTests+Subscriptions.swift */; };
 		217856632380C60400A30D19 /* GraphQLWithIAMIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217856622380C60400A30D19 /* GraphQLWithIAMIntegrationTests.swift */; };
 		217856652380C60400A30D19 /* AWSAPICategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B478F5FB2374DBF400C4F92B /* AWSAPICategoryPlugin.framework */; };
 		217856742380C73600A30D19 /* AWSAPICategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B478F5FB2374DBF400C4F92B /* AWSAPICategoryPlugin.framework */; };
@@ -281,6 +282,7 @@
 		21598CF023A0164900529F29 /* GraphQLWithUserPoolIntegrationTests-amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GraphQLWithUserPoolIntegrationTests-amplifyconfiguration.json"; sourceTree = "<group>"; };
 		21598CF123A0164A00529F29 /* GraphQLWithUserPoolIntegrationTests-awsconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GraphQLWithUserPoolIntegrationTests-awsconfiguration.json"; sourceTree = "<group>"; };
 		216201E223920A6200AB2E10 /* GraphQLSyncBasedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLSyncBasedTests.swift; sourceTree = "<group>"; };
+		217180A123FF14CB00E520C9 /* GraphQLModelBasedTests+Subscriptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLModelBasedTests+Subscriptions.swift"; sourceTree = "<group>"; };
 		217856602380C60400A30D19 /* GraphQLWithIAMIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GraphQLWithIAMIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		217856622380C60400A30D19 /* GraphQLWithIAMIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLWithIAMIntegrationTests.swift; sourceTree = "<group>"; };
 		217856642380C60400A30D19 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -590,6 +592,7 @@
 			children = (
 				21F40A2D23A0707E0074678E /* GraphQLModelBasedTests-amplifyconfiguration.json */,
 				217856C12383339D00A30D19 /* GraphQLModelBasedTests.swift */,
+				217180A123FF14CB00E520C9 /* GraphQLModelBasedTests+Subscriptions.swift */,
 				21598CEF23A00F8400529F29 /* README.md */,
 			);
 			path = GraphQLModelBased;
@@ -2066,6 +2069,7 @@
 				2178569A2380D1E000A30D19 /* BlogPostCommentGraphQLWithAPIKeyTests.swift in Sources */,
 				216201E323920A6200AB2E10 /* GraphQLSyncBasedTests.swift in Sources */,
 				FA97F5532386CCF500EE9EFE /* AnyModelIntegrationTests.swift in Sources */,
+				217180A223FF14CB00E520C9 /* GraphQLModelBasedTests+Subscriptions.swift in Sources */,
 				217856C22383339D00A30D19 /* GraphQLModelBasedTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLModelBasedTests+Subscriptions.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLModelBasedTests+Subscriptions.swift
@@ -1,0 +1,149 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AWSMobileClient
+@testable import AWSAPICategoryPlugin
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSAPICategoryPluginTestCommon
+@testable import AppSyncSubscriptionClient
+
+/// Subscription related stress/load tests
+extension GraphQLModelBasedTests {
+
+    /// Ensure that the underlying websocket socket is disconnected when the number of subscriptions on the socket
+    /// reaches zero. This test first creates multiple subscriptions, does a mutation to make sure data is flowing,
+    /// cancel the operations, and makes sure the underlying socket is disconnected. Given this new state of the system
+    /// where there is an existing connection provider, run a similar test by create a new subscription, which in turn
+    /// uses the same connection provider instance but will create a new websocket connection.
+    ///
+    /// - Given: Connected subscriptions
+    /// - When:
+    ///    - All subscription operations are cancelled
+    /// - Then:
+    ///    - Underlying websocket is disconnected
+    func testAllSubscriptionsCancelledShouldDisconnectTheWebsocket() {
+        let connectedInvoked = expectation(description: "Connection established")
+        connectedInvoked.expectedFulfillmentCount = 3
+        let disconnectedInvoked = expectation(description: "Connection disconnected")
+        disconnectedInvoked.expectedFulfillmentCount = 3
+        let completedInvoked = expectation(description: "Completed invoked")
+        completedInvoked.expectedFulfillmentCount = 3
+        let progressInvoked = expectation(description: "progress invoked")
+        progressInvoked.expectedFulfillmentCount = 3
+
+        let operation1 = Amplify.API.subscribe(from: Post.self, type: .onCreate) { event in
+            if case let .inProcess(response) = event, case let .connection(state) = response {
+                if case .connected = state {
+                    connectedInvoked.fulfill()
+                }
+                if case .disconnected = state {
+                    disconnectedInvoked.fulfill()
+                }
+            }
+
+            if case .completed = event {
+                completedInvoked.fulfill()
+            }
+
+            if case let .inProcess(response) = event, case .data = response {
+                progressInvoked.fulfill()
+            }
+        }
+        let operation2 = Amplify.API.subscribe(from: Post.self, type: .onCreate) { event in
+            if case let .inProcess(response) = event, case let .connection(state) = response {
+                if case .connected = state {
+                    connectedInvoked.fulfill()
+                }
+                if case .disconnected = state {
+                    disconnectedInvoked.fulfill()
+                }
+            }
+
+            if case .completed = event {
+                completedInvoked.fulfill()
+            }
+
+            if case let .inProcess(response) = event, case .data = response {
+                progressInvoked.fulfill()
+            }
+        }
+        let operation3 = Amplify.API.subscribe(from: Post.self, type: .onCreate) { event in
+            if case let .inProcess(response) = event, case let .connection(state) = response {
+                if case .connected = state {
+                    connectedInvoked.fulfill()
+                }
+                if case .disconnected = state {
+                    disconnectedInvoked.fulfill()
+                }
+            }
+
+            if case .completed = event {
+                completedInvoked.fulfill()
+            }
+
+            if case let .inProcess(response) = event, case .data = response {
+                progressInvoked.fulfill()
+            }
+        }
+
+        XCTAssertNotNil(operation1)
+        XCTAssertNotNil(operation2)
+        XCTAssertNotNil(operation3)
+        wait(for: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+
+        guard let awsOp = operation1 as? AWSGraphQLSubscriptionOperation,
+            let factory = awsOp.subscriptionConnectionFactory as? AWSSubscriptionConnectionFactory,
+            let singleConnectionProvider = factory.apiToConnectionProvider.first,
+            let connectionProvider = singleConnectionProvider.value as? RealtimeConnectionProvider else {
+                XCTFail("Failed to retrieve the underlying connection provider that interfaces with the websocket.")
+                return
+        }
+        XCTAssertEqual(connectionProvider.status, .connected)
+
+        let uuid = UUID().uuidString
+        let testMethodName = String("\(#function)".dropLast(2))
+        let title = testMethodName + "Title"
+
+        guard createPost(id: uuid, title: title) != nil else {
+            XCTFail("Failed to create post")
+            return
+        }
+        wait(for: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        XCTAssertEqual(connectionProvider.status, .connected)
+
+        operation1.cancel()
+        operation2.cancel()
+        operation3.cancel()
+
+        wait(for: [disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
+        XCTAssertTrue(operation1.isFinished)
+        XCTAssertTrue(operation2.isFinished)
+        XCTAssertTrue(operation3.isFinished)
+        XCTAssertEqual(connectionProvider.status, .notConnected)
+
+        let newConnectedInvoked = expectation(description: "Connection established")
+        let newDisconnectedInvoked = expectation(description: "Disconnected established")
+        let newOperation = Amplify.API.subscribe(from: Post.self, type: .onCreate) { event in
+            if case let .inProcess(response) = event, case let .connection(state) = response {
+                if case .connected = state {
+                    newConnectedInvoked.fulfill()
+                }
+                if case .disconnected = state {
+                    newDisconnectedInvoked.fulfill()
+                }
+            }
+        }
+        wait(for: [newConnectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        XCTAssertEqual(connectionProvider.status, .connected)
+        newOperation.cancel()
+        wait(for: [newDisconnectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        XCTAssertTrue(newOperation.isFinished)
+        XCTAssertEqual(connectionProvider.status, .notConnected)
+    }
+}

--- a/AppSyncSubscriptionClient/AppSyncSubscriptionClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+Websocket.swift
+++ b/AppSyncSubscriptionClient/AppSyncSubscriptionClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider+Websocket.swift
@@ -10,11 +10,11 @@ import Foundation
 extension RealtimeConnectionProvider: AppSyncWebsocketDelegate {
 
     public func websocketDidConnect(provider: AppSyncWebsocketProvider) {
+        lastKeepAliveTime = DispatchTime.now()
         // Call the ack to finish the connection handshake
         // Inform the callback when ack gives back a response.
         AppSyncLogger.debug("WebsocketDidConnect, sending init message...")
         sendConnectionInitMessage()
-        disconnectIfStale()
     }
 
     public func websocketDidDisconnect(provider: AppSyncWebsocketProvider, error: Error?) {

--- a/AppSyncSubscriptionClient/AppSyncSubscriptionClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncSubscriptionClient/AppSyncSubscriptionClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -31,6 +31,7 @@ public class RealtimeConnectionProvider: ConnectionProvider {
     public init(for url: URL, websocket: AppSyncWebsocketProvider) {
         self.url = url
         self.websocket = websocket
+        disconnectIfStale()
     }
 
     // MARK: - ConnectionProvider methods

--- a/AppSyncSubscriptionClient/AppSyncSubscriptionClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
+++ b/AppSyncSubscriptionClient/AppSyncSubscriptionClient/ConnectionProvider/AppsyncRealtimeConnection/RealtimeConnectionProvider.swift
@@ -97,6 +97,10 @@ public class RealtimeConnectionProvider: ConnectionProvider {
     public func removeListener(identifier: String) {
         serialCallbackQueue.async {
             self.listeners.removeValue(forKey: identifier)
+            if self.listeners.count == 0 {
+                self.status = .notConnected
+                self.websocket.disconnect()
+            }
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
An underlying websocket remains open even after all subscriptions are closed. 

*Description of changes:*
Forcefully close the websocket connection when there are no more subscriptions on the socket, by 
1. setting internal state of the connection provider to disconnected
2. call socket.disconnect (Starscream method).

We had decided on this approach of cleaning up the socket so that new subscriptions will trigger fresh instantiations of the socket, and thus connection handshake process. That way, the internal state of the connection provider is more often than not synchronzied to the actual state of the socket connection.

Take internet connectivity for an example. If the socket gets into a bad state while the connection provider does not receive a disconnect event, then our internal state maintains a connected state. We then rely on the keep alive to check the staleness of the connection which will take 5 minutes before the internal state is deemed not connected.

Now let's assume a new subscription is attempted on the existing broken socket which has an internal state of connected, we simply write a message on the socket and react to the callbacks such as `didReceiveMessage`. It's not clear exactly what the behavior is for Starscream socket implementation and if we never get a message back, the subscription remains in a connecting state and never transitions to connected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
