### PR TITLE
Datastore delete model type with local predciate API w/out predicate on sync

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
@@ -28,6 +28,12 @@ extension DataStoreCategory: DataStoreBaseBehavior {
     }
 
     public func delete<M: Model>(_ modelType: M.Type,
+                                 where predicate: @escaping QueryPredicateFactory,
+                                 completion: @escaping DataStoreCallback<Void>) {
+        plugin.delete(modelType, where: predicate, completion: completion)
+    }
+
+    public func delete<M: Model>(_ modelType: M.Type,
                                  withId id: String,
                                  completion: @escaping DataStoreCallback<Void>) {
         plugin.delete(modelType, withId: id, completion: completion)

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -29,6 +29,10 @@ public protocol DataStoreBaseBehavior {
                           completion: @escaping DataStoreCallback<Void>)
 
     func delete<M: Model>(_ modelType: M.Type,
+                          where predicate: @escaping QueryPredicateFactory,
+                          completion: @escaping DataStoreCallback<Void>)
+
+    func delete<M: Model>(_ modelType: M.Type,
                           withId id: String,
                           completion: @escaping DataStoreCallback<Void>)
 }

--- a/Amplify/Categories/DataStore/Query/QueryPredicate.swift
+++ b/Amplify/Categories/DataStore/Query/QueryPredicate.swift
@@ -23,6 +23,13 @@ public func not<Predicate: QueryPredicate>(_ predicate: Predicate) -> QueryPredi
     return QueryPredicateGroup(type: .not, predicates: [predicate])
 }
 
+/// The case `.all` is a predicate used as an argument to select all of a single modeltype. We
+/// chose `.all` instead of `nil` because we didn't want to use the implicit nature of `nil` to
+/// specify an action applies to an entire data set.
+public enum QueryPredicateConstant: QueryPredicate {
+    case all
+}
+
 public class QueryPredicateGroup: QueryPredicate {
 
     public internal(set) var type: QueryPredicateGroupType

--- a/Amplify/Core/Support/BasicClosure.swift
+++ b/Amplify/Core/Support/BasicClosure.swift
@@ -7,3 +7,5 @@
 
 /// Convenience typealias
 public typealias BasicClosure = () -> Void
+
+public typealias BasicThrowableClosure = () throws -> Void

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -106,6 +106,24 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                completion: publishingCompletion)
     }
 
+    public func delete<M: Model>(_ modelType: M.Type,
+                                 where predicate: @escaping QueryPredicateFactory,
+                                 completion: @escaping DataStoreCallback<Void>) {
+        let onCompletion: DataStoreCallback<[M]> = { result in
+            switch result {
+            case .success(let models):
+                for model in models {
+                    self.publishMutationEvent(from: model, mutationType: .delete)
+                }
+                completion(.emptyResult)
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+        storageEngine.delete(modelType,
+                             predicate: predicate(),
+                             completion: onCompletion)
+    }
     // MARK: Private
 
     private func publishMutationEvent<M: Model>(from model: M,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
@@ -16,6 +16,10 @@ protocol ModelStorageBehavior {
                           withId id: Model.Identifier,
                           completion: @escaping DataStoreCallback<Void>)
 
+    func delete<M: Model>(_ modelType: M.Type,
+                          predicate: QueryPredicate,
+                          completion: @escaping DataStoreCallback<[M]>)
+
     func query<M: Model>(_ modelType: M.Type,
                          predicate: QueryPredicate?,
                          completion: DataStoreCallback<[M]>)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
@@ -49,6 +49,10 @@ private func translateQueryPredicate(from modelType: Model.Type,
                 indentSize -= 1
                 sql.append("\(indent))")
             }
+        } else if let constant = pred as? QueryPredicateConstant {
+            if case .all = constant {
+                sql.append("or 1 = 1")
+            }
         }
     }
     translate(predicate)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -22,6 +22,10 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
                 withId id: Model.Identifier,
                 completion: DataStoreCallback<Void>)
 
+    func delete<M: Model>(_ modelType: M.Type,
+                          predicate: QueryPredicate,
+                          completion: @escaping DataStoreCallback<[M]>)
+
     func query(untypedModel modelType: Model.Type,
                predicate: QueryPredicate?,
                completion: DataStoreCallback<[Model]>)
@@ -43,4 +47,5 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
 
     func queryModelSyncMetadata(for modelType: Model.Type) throws -> ModelSyncMetadata?
 
+    func transaction(_ basicClosure: BasicThrowableClosure) throws
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -67,6 +67,12 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
         XCTFail("Not expected to execute")
     }
 
+    func delete<M: Model>(_ modelType: M.Type,
+                          predicate: QueryPredicate,
+                          completion: @escaping DataStoreCallback<[M]>) {
+        XCTFail("Not expected to execute")
+    }
+
     func delete(untypedModelType modelType: Model.Type,
                 withId id: String,
                 completion: (Result<Void, DataStoreError>) -> Void) {
@@ -151,6 +157,10 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
         listenerForModelSyncMetadata?()
         return resultForQueryModelSyncMetadata
     }
+
+    func transaction(_ basicClosure: () throws -> Void) throws {
+        XCTFail("Not expected to execute")
+    }
 }
 
 class MockStorageEngineBehavior: StorageEngineBehavior {
@@ -177,6 +187,12 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
                           withId id: Model.Identifier,
                           completion: DataStoreCallback<Void>) {
         completion(.successfulVoid)
+    }
+
+    func delete<M: Model>(_ modelType: M.Type,
+                          predicate: QueryPredicate,
+                          completion: @escaping DataStoreCallback<[M]>) {
+        XCTFail("Not expected to execute")
     }
 
     func query<M: Model>(_ modelType: M.Type, predicate: QueryPredicate?, completion: DataStoreCallback<[M]>) {

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -50,6 +50,12 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         notify("deleteById")
     }
 
+    func delete<M: Model>(_ model: M.Type,
+                          where predicate: @escaping QueryPredicateFactory,
+                          completion: @escaping DataStoreCallback<Void>) {
+        notify("deleteByPredicate")
+    }
+
     @available(iOS 13.0, *)
     func publisher<M: Model>(for modelType: M.Type)
         -> AnyPublisher<MutationEvent, DataStoreError> {


### PR DESCRIPTION
This code adds the following concepts:
- sql `transaction` interface to the storageAdapter
- `QueryPredicateConstant.all` to query for all items
- New `delete(type, predicate)` interface for storageEngine/ModelStroageBehavior
- Implementation of transaction-based delete Model.Type w/ predicate
- Submission of individual deleted modelIds to be submitted to the sync engine, but without the predicate.  Deferring submitting the predicate until we can refactor the MutationEvent to two separate classes -- one to notify customers, and one to submit into the SyncEngine

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
