### PR TITLE
Use AppSyncRealTimeClient 1.1.0

### DIFF
--- a/AmplifyPlugins.podspec
+++ b/AmplifyPlugins.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
     ss.source_files = 'AmplifyPlugins/API/AWSAPICategoryPlugin/**/*.swift'
     ss.dependency 'AWSPluginsCore', AMPLIFY_VERSION
     ss.dependency 'ReachabilitySwift', '~> 5.0.0'
-    ss.dependency 'AppSyncRealTimeClient', "~> 1.0.2"
+    ss.dependency 'AppSyncRealTimeClient', "~> 1.1.0"
   end
 
   s.subspec 'AWSDataStorePlugin' do |ss|

--- a/AmplifyPlugins/API/Podfile
+++ b/AmplifyPlugins/API/Podfile
@@ -10,7 +10,7 @@ target 'AWSAPICategoryPlugin' do
 	pod 'Amplify', :path => '../../'
   pod 'AWSPluginsCore', :path => '../../'
   pod "ReachabilitySwift", "~> 5.0.0"
-  pod "AppSyncRealTimeClient", "~> 1.0.2"
+  pod "AppSyncRealTimeClient", "~> 1.1.0"
 
   target "AWSAPICategoryPluginTests" do
     inherit! :complete


### PR DESCRIPTION
*Description of changes:*
Looks like 1.0.2 removed interceptors while current version takes ~1.0.0 which will pulls in 1.0.2 and has some classes missing like RealtimeGatewayURLInterceptor. I published 1.1.0 and need to bump the version of the consumers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
