### PR TITLE
Datastore clear() sync implementation

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
@@ -38,4 +38,8 @@ extension DataStoreCategory: DataStoreBaseBehavior {
                                  completion: @escaping DataStoreCallback<Void>) {
         plugin.delete(modelType, withId: id, completion: completion)
     }
+
+    public func clear(completion: @escaping DataStoreCallback<Void>) {
+        plugin.clear(completion: completion)
+    }
 }

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -35,6 +35,8 @@ public protocol DataStoreBaseBehavior {
     func delete<M: Model>(_ modelType: M.Type,
                           withId id: String,
                           completion: @escaping DataStoreCallback<Void>)
+
+    func clear(completion: @escaping DataStoreCallback<Void>)
 }
 
 public protocol DataStoreSubscribeBehavior {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
@@ -12,6 +12,7 @@ extension AWSDataStorePlugin: DataStoreSubscribeBehavior {
     @available(iOS 13.0, *)
     public func publisher<M: Model>(for modelType: M.Type)
         -> AnyPublisher<MutationEvent, DataStoreError> {
+            reinitStorageEngineIfNeeded()
             // Force-unwrapping: The optional 'dataStorePublisher' is expected
             // to exist for deployment targets >=iOS13.0
             return dataStorePublisher!.publisher(for: modelType)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -279,6 +279,16 @@ final class StorageEngine: StorageEngineBehavior {
         syncEngine?.start(api: Amplify.API)
     }
 
+    func clear(completion: @escaping DataStoreCallback<Void>) {
+        if let syncEngine = syncEngine {
+            syncEngine.stop(completion: { _ in
+                self.storageAdapter.clear(completion: completion)
+            })
+        } else {
+            storageAdapter.clear(completion: completion)
+        }
+    }
+
     func reset(onComplete: () -> Void) {
         // TOOD: Perform cleanup on StorageAdapter, including releasing its `Connection` if needed
         let group = DispatchGroup()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -48,4 +48,6 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
     func queryModelSyncMetadata(for modelType: Model.Type) throws -> ModelSyncMetadata?
 
     func transaction(_ basicClosure: BasicThrowableClosure) throws
+
+    func clear(completion: @escaping DataStoreCallback<Void>)
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineBehavior.swift
@@ -21,4 +21,6 @@ protocol StorageEngineBehavior: class, ModelStorageBehavior {
 
     /// Tells the StorageEngine to begin syncing, if sync is enabled
     func startSync()
+
+    func clear(completion: @escaping DataStoreCallback<Void>)
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/AWSMutationEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/AWSMutationEventPublisher.swift
@@ -34,6 +34,7 @@ final class AWSMutationEventPublisher: Publisher {
 
     func cancel() {
         subscription = nil
+        eventSource = nil
     }
 
     func request(_ demand: Subscribers.Demand) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventPublisher.swift
@@ -10,6 +10,6 @@ import Combine
 
 /// Publishes mutation events to downstream subscribers for subsequent sync to the API.
 @available(iOS 13.0, *)
-protocol MutationEventPublisher: class {
+protocol MutationEventPublisher: class, Cancellable {
     var publisher: AnyPublisher<MutationEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -144,7 +144,7 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
             let dataStoreError = DataStoreError.configuration(
                 "API is unexpectedly nil",
                 """
-                The reference to storageAdapter has been released while an ongoing mutation was being processed.
+                The reference to api has been released while an ongoing mutation was being processed.
                 \(AmplifyErrorMessages.reportBugToAWS())
                 """
             )

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
@@ -23,8 +23,9 @@ extension RemoteSyncEngine {
         case activatedCloudSubscriptions(APICategoryGraphQLBehavior, MutationEventPublisher)
         case activatedMutationQueue
         case notifiedSyncStarted
-        case cleanedUp(AmplifyError?)
-        case scheduleRestart(AmplifyError?)
+        case cleanedUp(AmplifyError)
+        case cleanedUpForTermination
+        case scheduleRestart(AmplifyError)
         case scheduleRestartFinished
 
         // Terminal actions
@@ -52,6 +53,8 @@ extension RemoteSyncEngine {
                 return "notifiedSyncStarted"
             case .cleanedUp:
                 return "cleanedUp"
+            case .cleanedUpForTermination:
+                return "cleanedUpForTermination"
             case .scheduleRestart:
                 return "scheduleRestart"
             case .scheduleRestartFinished:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
@@ -27,42 +27,35 @@ extension RemoteSyncEngine {
                 return .performingInitialSync
             case (.initializingSubscriptions, .errored(let error)):
                 return .cleaningUp(error)
-            case (.initializingSubscriptions, .finished):
-                return .cleaningUp(nil)
-
 
             case (.performingInitialSync, .performedInitialSync):
                 return .activatingCloudSubscriptions
             case (.performingInitialSync, .errored(let error)):
                 return .cleaningUp(error)
-            case (.performingInitialSync, .finished):
-                return .cleaningUp(nil)
-
 
             case (.activatingCloudSubscriptions, .activatedCloudSubscriptions(let api, let mutationEventPublisher)):
                 return .activatingMutationQueue(api, mutationEventPublisher)
             case (.activatingCloudSubscriptions, .errored(let error)):
                 return .cleaningUp(error)
-            case (.activatingCloudSubscriptions, .finished):
-                return .cleaningUp(nil)
 
             case (.activatingMutationQueue, .activatedMutationQueue):
                 return .notifyingSyncStarted
             case (.activatingMutationQueue, .errored(let error)):
                 return .cleaningUp(error)
-            case (.activatingMutationQueue, .finished):
-                return .cleaningUp(nil)
 
             case (.notifyingSyncStarted, .notifiedSyncStarted):
                 return .syncEngineActive
 
             case (.syncEngineActive, .errored(let error)):
                 return .cleaningUp(error)
-            case (.syncEngineActive, .finished):
-                return .cleaningUp(nil)
+
+            case (_, .finished):
+                return .cleaningUpForTermination
 
             case (.cleaningUp, .cleanedUp(let error)):
                 return .schedulingRestart(error)
+            case (.cleaningUpForTermination, .cleanedUpForTermination):
+                return .terminate
 
             case (.schedulingRestart, .scheduleRestartFinished):
                 return .pausingSubscriptions

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+State.swift
@@ -24,8 +24,11 @@ extension RemoteSyncEngine {
 
         case syncEngineActive
 
-        case cleaningUp(AmplifyError?)
-        case schedulingRestart(AmplifyError?)
+        case cleaningUp(AmplifyError)
+        case cleaningUpForTermination
+
+        case schedulingRestart(AmplifyError)
+        case terminate
 
         var displayName: String {
             switch self {
@@ -49,8 +52,12 @@ extension RemoteSyncEngine {
                 return "syncEngineActive"
             case .cleaningUp:
                 return "cleaningUp"
+            case .cleaningUpForTermination:
+                return "cleaningUpForTermination"
             case .schedulingRestart:
                 return "schedulingRestart"
+            case .terminate:
+                return "terminate"
             }
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
@@ -18,6 +18,7 @@ enum RemoteSyncEngineEvent {
     case mutationQueueStarted
     case syncStarted
     case cleanedUp
+    case cleanedUpForTermination
     case mutationEvent(MutationEvent)
 }
 
@@ -35,6 +36,8 @@ protocol RemoteSyncEngineBehavior: class {
     /// 1. Mutation processor drains messages off the queue in serial and sends to the service, invoking
     ///    any local callbacks on error if necessary
     func start(api: APICategoryGraphQLBehavior)
+
+    func stop(completion: @escaping DataStoreCallback<Void>)
 
     /// Submits a new mutation for synchronization to the remote API. The response will be handled by the appropriate
     /// reconciliation queue

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSyncEngineTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSyncEngineTests.swift
@@ -229,6 +229,78 @@ class RemoteSyncEngineTests: XCTestCase {
                    forceFailToNotRestartSyncEngine], timeout: defaultAsyncWaitTimeout)
     }
 
+    func testStopEndsRemoteSyncEngine() throws {
+        let storageAdapterAvailable = expectation(description: "storageAdapterAvailable")
+        let subscriptionsPaused = expectation(description: "subscriptionsPaused")
+        let mutationsPaused = expectation(description: "mutationsPaused")
+        let subscriptionsInitialized = expectation(description: "subscriptionsInitialized")
+        let performedInitialSync = expectation(description: "performedInitialSync")
+        let subscriptionActivation = expectation(description: "failureOnSubscriptionActivation")
+        let mutationQueueStarted = expectation(description: "mutationQueueStarted")
+        let syncStarted = expectation(description: "syncStarted")
+        let cleanedUpForTermination = expectation(description: "cleanedUpForTermination")
+        let forceFailToNotRestartSyncEngine = expectation(description: "forceFailToNotRestartSyncEngine")
+        let completionBlockCalled = expectation(description: "Completion block is called")
+
+        var currCount = 1
+
+        let advice = RequestRetryAdvice.init(shouldRetry: false)
+        mockRequestRetryablePolicy.pushOnRetryRequestAdvice(response: advice)
+
+        let remoteSyncEngineSink = remoteSyncEngine
+            .publisher
+            .sink(receiveCompletion: { _ in
+                currCount = self.checkAndFulfill(currCount, 10, expectation: forceFailToNotRestartSyncEngine)
+            }, receiveValue: { event in
+                switch event {
+                case .storageAdapterAvailable:
+                    currCount = self.checkAndFulfill(currCount, 1, expectation: storageAdapterAvailable)
+                case .subscriptionsPaused:
+                    currCount = self.checkAndFulfill(currCount, 2, expectation: subscriptionsPaused)
+                case .mutationsPaused:
+                    currCount = self.checkAndFulfill(currCount, 3, expectation: mutationsPaused)
+                    DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
+                        MockAWSIncomingEventReconciliationQueue.mockSend(event: .initialized)
+                    }
+                case .subscriptionsInitialized:
+                    currCount = self.checkAndFulfill(currCount, 4, expectation: subscriptionsInitialized)
+                case .performedInitialSync:
+                    currCount = self.checkAndFulfill(currCount, 5, expectation: performedInitialSync)
+                case .subscriptionsActivated:
+                    currCount = self.checkAndFulfill(currCount, 6, expectation: subscriptionActivation)
+                case .mutationQueueStarted:
+                    currCount = self.checkAndFulfill(currCount, 7, expectation: mutationQueueStarted)
+                case .syncStarted:
+                    currCount = self.checkAndFulfill(currCount, 8, expectation: syncStarted)
+                    DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
+                        self.remoteSyncEngine.stop(completion: { result in
+                            if case .success = result {
+                                currCount = self.checkAndFulfill(currCount, 11, expectation: completionBlockCalled)
+                            }
+                        })
+                    }
+                case .cleanedUpForTermination:
+                    currCount = self.checkAndFulfill(currCount, 9, expectation: cleanedUpForTermination)
+                default:
+                    XCTFail("unexpected call")
+                }
+            })
+
+        remoteSyncEngine.start()
+
+        wait(for: [storageAdapterAvailable,
+                   subscriptionsPaused,
+                   mutationsPaused,
+                   subscriptionsInitialized,
+                   performedInitialSync,
+                   subscriptionActivation,
+                   mutationQueueStarted,
+                   syncStarted,
+                   cleanedUpForTermination,
+                   completionBlockCalled,
+                   forceFailToNotRestartSyncEngine], timeout: defaultAsyncWaitTimeout)
+    }
+
     private func checkAndFulfill(_ currCount: Int, _ expectedCount: Int, expectation: XCTestExpectation) -> Int {
         if currCount == expectedCount {
             expectation.fulfill()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -161,6 +161,9 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
     func transaction(_ basicClosure: () throws -> Void) throws {
         XCTFail("Not expected to execute")
     }
+    func clear(completion: @escaping DataStoreCallback<Void>) {
+        XCTFail("Not expected to execute")
+    }
 }
 
 class MockStorageEngineBehavior: StorageEngineBehavior {
@@ -196,6 +199,10 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
     }
 
     func query<M: Model>(_ modelType: M.Type, predicate: QueryPredicate?, completion: DataStoreCallback<[M]>) {
+        //TODO: Find way to mock this
+    }
+
+    func clear(completion: @escaping DataStoreCallback<Void>) {
         //TODO: Find way to mock this
     }
 }

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -56,6 +56,10 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         notify("deleteByPredicate")
     }
 
+    func clear(completion: @escaping DataStoreCallback<Void>) {
+        notify("clear")
+    }
+
     @available(iOS 13.0, *)
     func publisher<M: Model>(for modelType: M.Type)
         -> AnyPublisher<MutationEvent, DataStoreError> {


### PR DESCRIPTION
. clear() is an async interface
. After calling clear() on DataStore, the datastore is in an idle state -- that is, the remote sync engine has stopped, all subscriptions have been severed and any publishers the customer may have been listening were called with receiveCompletion() (meaning, they will need to re-subscribe)
. Any subsequent call to query, save, delete, publisher() will restart the sync engine and publishers, mirroring JS's behavior

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
