### PR TITLE
Fix DataStore delete mutation 

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
@@ -92,16 +92,15 @@ class SyncMutationToCloudOperation: Operation {
     func createAPIRequest(mutationType: GraphQLMutationType) -> GraphQLRequest<MutationSync<AnyModel>>? {
         let request: GraphQLRequest<MutationSync<AnyModel>>
         do {
+            let model = try mutationEvent.decodeModel()
             switch mutationType {
             case .delete:
                 request = GraphQLRequest<MutationSyncResult>.deleteMutation(modelName: mutationEvent.modelName,
-                                                                            id: mutationEvent.id,
+                                                                            id: model.id,
                                                                             version: mutationEvent.version)
             case .update:
-                let model = try mutationEvent.decodeModel()
                 request = GraphQLRequest<MutationSyncResult>.updateMutation(of: model, version: mutationEvent.version)
             case .create:
-                let model = try mutationEvent.decodeModel()
                 request = GraphQLRequest<MutationSyncResult>.createMutation(of: model, version: mutationEvent.version)
             }
         } catch {


### PR DESCRIPTION
Fix DataStore delete mutation - pass in model.id. Previously it was passing in mutationEvent.Id which is just a unique identifier for the mutationEvent, not the model instance's identifier

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
