### PR TITLE
Upgrade SDK dependency to 2.13.0

### DIFF
--- a/AWSPluginsCore.podspec
+++ b/AWSPluginsCore.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   
   s.requires_arc = true
   
-  AWS_SDK_VERSION = "~> 2.12.6"
+  AWS_SDK_VERSION = "~> 2.13.0"
 
   s.source_files = 'AmplifyPlugins/Core/AWSPluginsCore/**/*.swift'
   s.dependency 'Amplify', '0.10.0'

--- a/AWSPredictionsPlugin.podspec
+++ b/AWSPredictionsPlugin.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     
     s.requires_arc = true
 
-    AWS_SDK_VERSION = '~> 2.12.6'
+    AWS_SDK_VERSION = '~> 2.13.0'
     AMPLIFY_VERSION = '0.10.0'
     
     s.source_files = 'AmplifyPlugins/Predictions/AWSPredictionsPlugin/**/*.swift'

--- a/AmplifyPlugins.podspec
+++ b/AmplifyPlugins.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   
   s.requires_arc = true 
 
-  AWS_SDK_VERSION = '~> 2.12.6'
+  AWS_SDK_VERSION = '~> 2.13.0'
   AMPLIFY_VERSION = '0.10.0'
   
   s.subspec 'AWSAPIPlugin' do |ss|

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
@@ -70,9 +70,11 @@ class IAMAuthInterceptor: AuthInterceptor {
         guard let date = amzDate.aws_stringValue(AWSDateISO8601DateFormat2) else {
             return nil
         }
-        let awsEndpoint = AWSEndpoint(region: region,
-                                      serviceName: SubscriptionConstants.appsyncServiceName,
-                                      url: endpoint)
+        guard let awsEndpoint = AWSEndpoint(region: region,
+                                            serviceName: SubscriptionConstants.appsyncServiceName,
+                                            url: endpoint) else {
+            return nil
+        }
         let signer: AWSSignatureV4Signer = AWSSignatureV4Signer(credentialsProvider: authProvider,
                                                                 endpoint: awsEndpoint)
         let semaphore = DispatchSemaphore(value: 0)

--- a/AmplifyPlugins/API/Podfile
+++ b/AmplifyPlugins/API/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '11.0'
 use_frameworks!
 
-AWS_SDK_VERSION = "2.12.6"
+AWS_SDK_VERSION = "2.13.0"
 
 pod 'SwiftFormat/CLI'
 pod 'SwiftLint'

--- a/AmplifyPlugins/Analytics/Podfile
+++ b/AmplifyPlugins/Analytics/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '12.0'
 use_frameworks!
 
-AWS_SDK_VERSION = "2.12.2"
+AWS_SDK_VERSION = "2.13.0"
 
 pod 'SwiftFormat/CLI'
 pod 'SwiftLint'

--- a/AmplifyPlugins/DataStore/Podfile
+++ b/AmplifyPlugins/DataStore/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '11.0'
 use_frameworks!
 
-AWS_SDK_VERSION = "2.12.2"
+AWS_SDK_VERSION = "2.13.0"
 
 pod 'SwiftFormat/CLI'
 pod 'SwiftLint'

--- a/AmplifyPlugins/Predictions/Podfile
+++ b/AmplifyPlugins/Predictions/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '13.0'
 use_frameworks!
 
-AWS_SDK_VERSION = "2.12.6"
+AWS_SDK_VERSION = "2.13.0"
 
 pod 'SwiftFormat/CLI'
 pod 'SwiftLint'

--- a/AmplifyPlugins/Storage/Podfile
+++ b/AmplifyPlugins/Storage/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '12.0'
 use_frameworks!
 
-AWS_SDK_VERSION = "2.12.5"
+AWS_SDK_VERSION = "2.13.0"
 
 pod 'SwiftFormat/CLI'
 pod 'SwiftLint'

--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 # Uncomment the next line to define a global platform for your project
 platform :ios, "11.0"
 
-AWS_SDK_VERSION = "2.12.6"
+AWS_SDK_VERSION = "2.13.0"
 
 target "Amplify" do
   # Comment the next line if you"re not using Swift and don"t want to use dynamic frameworks

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - AWSAuthCore (2.12.6):
-    - AWSCore (= 2.12.6)
-  - AWSCognitoIdentityProvider (2.12.6):
+  - AWSAuthCore (2.13.0):
+    - AWSCore (= 2.13.0)
+  - AWSCognitoIdentityProvider (2.13.0):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.12.6)
+    - AWSCore (= 2.13.0)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.12.6)
-  - AWSMobileClient (2.12.6):
-    - AWSAuthCore (= 2.12.6)
-    - AWSCognitoIdentityProvider (= 2.12.6)
+  - AWSCore (2.13.0)
+  - AWSMobileClient (2.13.0):
+    - AWSAuthCore (= 2.13.0)
+    - AWSCognitoIdentityProvider (= 2.13.0)
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
@@ -16,7 +16,7 @@ PODS:
   - SwiftLint (0.37.0)
 
 DEPENDENCIES:
-  - AWSMobileClient (~> 2.12.6)
+  - AWSMobileClient (~> 2.13.0)
   - CwlCatchException (from `https://github.com/mattgallagher/CwlCatchException.git`, tag `1.2.0`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `1.2.0`)
   - SwiftFormat/CLI
@@ -49,16 +49,16 @@ CHECKOUT OPTIONS:
     :tag: 1.2.0
 
 SPEC CHECKSUMS:
-  AWSAuthCore: d981abe8fb987a1caa7ac6c76c428de12387dcf4
-  AWSCognitoIdentityProvider: 9502438e528185a2c61b97baf66e2fd2ac6833f3
+  AWSAuthCore: 8fa7f8a8ddd6b0922d9989d8eaa8e7bac87b02fc
+  AWSCognitoIdentityProvider: 9ea197104d3425eed78c58d122190217f2b0cee2
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: 48bb8d477d8137377e86b2ade9eb34a761f42df5
-  AWSMobileClient: d752ed540a75d45516c8d5b2054b3f3b6b9e7e65
+  AWSCore: 167aba8cdaff6873193a66f062f41749c6c6a3d3
+  AWSMobileClient: e8922b6abcafa01d0fb630a93f64397f3bc73079
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 5faa819600268dfaa5c19f1359730883db151678
   SwiftLint: c078a14d7d7ade75e5507795d185e3da41d844d2
 
-PODFILE CHECKSUM: 052b557087c76e48d6c09130d48e484e6b7ed701
+PODFILE CHECKSUM: 1c22fd7e8ddadfe26bb643a7d7ebf74f24d85950
 
 COCOAPODS: 1.9.0

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -1,14 +1,14 @@
 PODS:
-  - AWSAuthCore (2.12.6):
-    - AWSCore (= 2.12.6)
-  - AWSCognitoIdentityProvider (2.12.6):
+  - AWSAuthCore (2.13.0):
+    - AWSCore (= 2.13.0)
+  - AWSCognitoIdentityProvider (2.13.0):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.12.6)
+    - AWSCore (= 2.13.0)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.12.6)
-  - AWSMobileClient (2.12.6):
-    - AWSAuthCore (= 2.12.6)
-    - AWSCognitoIdentityProvider (= 2.12.6)
+  - AWSCore (2.13.0)
+  - AWSMobileClient (2.13.0):
+    - AWSAuthCore (= 2.13.0)
+    - AWSCognitoIdentityProvider (= 2.13.0)
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
@@ -16,7 +16,7 @@ PODS:
   - SwiftLint (0.37.0)
 
 DEPENDENCIES:
-  - AWSMobileClient (~> 2.12.6)
+  - AWSMobileClient (~> 2.13.0)
   - CwlCatchException (from `https://github.com/mattgallagher/CwlCatchException.git`, tag `1.2.0`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `1.2.0`)
   - SwiftFormat/CLI
@@ -49,16 +49,16 @@ CHECKOUT OPTIONS:
     :tag: 1.2.0
 
 SPEC CHECKSUMS:
-  AWSAuthCore: d981abe8fb987a1caa7ac6c76c428de12387dcf4
-  AWSCognitoIdentityProvider: 9502438e528185a2c61b97baf66e2fd2ac6833f3
+  AWSAuthCore: 8fa7f8a8ddd6b0922d9989d8eaa8e7bac87b02fc
+  AWSCognitoIdentityProvider: 9ea197104d3425eed78c58d122190217f2b0cee2
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: 48bb8d477d8137377e86b2ade9eb34a761f42df5
-  AWSMobileClient: d752ed540a75d45516c8d5b2054b3f3b6b9e7e65
+  AWSCore: 167aba8cdaff6873193a66f062f41749c6c6a3d3
+  AWSMobileClient: e8922b6abcafa01d0fb630a93f64397f3bc73079
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 5faa819600268dfaa5c19f1359730883db151678
   SwiftLint: c078a14d7d7ade75e5507795d185e3da41d844d2
 
-PODFILE CHECKSUM: 052b557087c76e48d6c09130d48e484e6b7ed701
+PODFILE CHECKSUM: 1c22fd7e8ddadfe26bb643a7d7ebf74f24d85950
 
 COCOAPODS: 1.9.0

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -28,296 +28,297 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		00245045D5E45577751253E413EB5A41 /* AWSCancellationToken.m in Sources */ = {isa = PBXBuildFile; fileRef = E391A6CDBB25CD9CD616C8379AC49870 /* AWSCancellationToken.m */; };
-		00F52188FE076B3977A110330D3A48C7 /* AWSCognitoIdentityProviderResources.h in Headers */ = {isa = PBXBuildFile; fileRef = 12BA902F81D3D089ACEDE790A2838040 /* AWSCognitoIdentityProviderResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		014D5B8A4928C9A387534875206E8AFE /* AWSDDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 88E787B8E15B912AC396282DC00F1F4E /* AWSDDASLLogCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		016F99722715BF88A9636B87434EA4F8 /* AWSSignature.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B23FCA3582BFF3C7711AF1C1630BCB4 /* AWSSignature.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		06286FFF5F9A837D882033756A51BA6F /* AWSCognitoCredentialsProvider+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = F2106BBD2524DBF1B3BEC5103CF2259F /* AWSCognitoCredentialsProvider+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		06920E9A30F8C694426F31326AEC669F /* AWSDDOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 77151F54F4FB266CE6A2D7162F277D21 /* AWSDDOSLogger.m */; };
-		07C22CB8F0D5D1D155E99E7FAA03E922 /* AWSSTSService.h in Headers */ = {isa = PBXBuildFile; fileRef = 044F723309888175C12015B0DF8AC9D5 /* AWSSTSService.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		07E00EE1AEB8DB9013DC357339E01573 /* AWSJKBigInteger.h in Headers */ = {isa = PBXBuildFile; fileRef = 3530F941D0991933A79B9D55F929710A /* AWSJKBigInteger.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		080A963CA88B480650FFE9DA4C1FB652 /* AWSCognitoAuth_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 010075438C45B44D020D0DEC44200331 /* AWSCognitoAuth_Internal.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		090E87DED2A7E745AB4B80D9D40A3B0F /* Fabric+FABKits.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A8D66842538327815F5470D8B00AB5E /* Fabric+FABKits.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		00245045D5E45577751253E413EB5A41 /* AWSCancellationToken.m in Sources */ = {isa = PBXBuildFile; fileRef = E5B9725E282813EE09B00F8FFC242521 /* AWSCancellationToken.m */; };
+		00F52188FE076B3977A110330D3A48C7 /* AWSCognitoIdentityProviderResources.h in Headers */ = {isa = PBXBuildFile; fileRef = 0488FA91ED857D8097EC068E16175D50 /* AWSCognitoIdentityProviderResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		014D5B8A4928C9A387534875206E8AFE /* AWSDDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = EFCBD8953313EA0478E2ABBBEAAE5DE8 /* AWSDDASLLogCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		016F99722715BF88A9636B87434EA4F8 /* AWSSignature.h in Headers */ = {isa = PBXBuildFile; fileRef = E4003F52E2BBF00826A847B636581208 /* AWSSignature.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		06920E9A30F8C694426F31326AEC669F /* AWSDDOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 87621921A248C6EF6BF53C7D51B346DA /* AWSDDOSLogger.m */; };
+		07C22CB8F0D5D1D155E99E7FAA03E922 /* AWSSTSService.h in Headers */ = {isa = PBXBuildFile; fileRef = 55FFA9C0CA0B27CD56EFC5882E49685B /* AWSSTSService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		07E00EE1AEB8DB9013DC357339E01573 /* AWSJKBigInteger.h in Headers */ = {isa = PBXBuildFile; fileRef = 697C4DC3BEEA6233CCA378E1675B85A3 /* AWSJKBigInteger.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		090E87DED2A7E745AB4B80D9D40A3B0F /* Fabric+FABKits.h in Headers */ = {isa = PBXBuildFile; fileRef = 62CC145608B6C86186B3A54AB9FA6498 /* Fabric+FABKits.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0B2EFA3514269B1827188E84004105AD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
 		0BE7171684CA5D10C9831EC4DFF28406 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		0D975819F09C9DCD588638EC7D2C3C91 /* AWSIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 822AFB1D38A97E144B98521D98A44F0C /* AWSIdentityProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0DA5E07E1BA323EEA73D7E1675363EA2 /* AWSCognitoIdentityUserPool.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C1A67C9050CCB40F2F72D8A032AF67D /* AWSCognitoIdentityUserPool.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0DC60DC3F6A7EDA73648721C422359A7 /* AWSCognitoAuth+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = AFB5BF50AD93515A92630A2145F8DDE2 /* AWSCognitoAuth+Extensions.m */; };
-		0F7ABBD637E331A9CA9F514904C5EF64 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE333F7C6ACC595DEBC08E6B8A5E5C9 /* CwlCatchBadInstruction.swift */; };
-		1060FCAC1ACCA3BA3F7B2B266177E21D /* AWSDDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = E3896A3F2C482FFBC76D016CCEE102D7 /* AWSDDLog.m */; };
-		11D1DF9ADBCB93C6643F9C14E8E5ABF6 /* AWSCore.h in Headers */ = {isa = PBXBuildFile; fileRef = CA4FA7BEDE7F4F5A4F52727D799961AC /* AWSCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		11E98BE334C469A1C9694F6891B2119D /* AWSDDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CFCA5D85B002DD014B94FF35A27A47E /* AWSDDDispatchQueueLogFormatter.m */; };
-		121B62241BE1752EA25A5BA6E017616A /* AWSFMDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C89B5E8C8653EF6D614F1BE244FAE98 /* AWSFMDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		13603B0B004ADA8FA4C6A29F8C255F00 /* AWSEXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E497CA1D2B416C4AF9A01F578B63DD3 /* AWSEXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		13E1E9094F5329494002200340B1AF65 /* NSData+AWSCognitoIdentityProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 290CB885A0DA80E2C91393B784C70837 /* NSData+AWSCognitoIdentityProvider.m */; };
-		1443F4986172D7C166827E3E8CDAA21D /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46988F326C331492F52C9FAC76BC0841 /* CwlDarwinDefinitions.swift */; };
+		0D975819F09C9DCD588638EC7D2C3C91 /* AWSIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D568287CCF8F49059025CA6EAC9A858 /* AWSIdentityProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0DA5E07E1BA323EEA73D7E1675363EA2 /* AWSCognitoIdentityUserPool.h in Headers */ = {isa = PBXBuildFile; fileRef = 944F5689ABB43BAA26EF5E6C8EF89444 /* AWSCognitoIdentityUserPool.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F7ABBD637E331A9CA9F514904C5EF64 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB02F82D35F0C4356FB9F0B429AB99B /* CwlCatchBadInstruction.swift */; };
+		1060FCAC1ACCA3BA3F7B2B266177E21D /* AWSDDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = B1D278448B10A80E29C4434D94F1C76C /* AWSDDLog.m */; };
+		11D1DF9ADBCB93C6643F9C14E8E5ABF6 /* AWSCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CAC325F4C19790A3C2A4947CFE9E363 /* AWSCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		11E98BE334C469A1C9694F6891B2119D /* AWSDDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 52760804261C891A3DD97614D8925107 /* AWSDDDispatchQueueLogFormatter.m */; };
+		121B62241BE1752EA25A5BA6E017616A /* AWSFMDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 428D3EA4240F70D5F918C0CB986F3528 /* AWSFMDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		13603B0B004ADA8FA4C6A29F8C255F00 /* AWSEXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = E7EFD0A7EF3677CE21C15C2F9A4E64E3 /* AWSEXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		13E1E9094F5329494002200340B1AF65 /* NSData+AWSCognitoIdentityProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = C9C84929EC5363F579A75A9F5043F686 /* NSData+AWSCognitoIdentityProvider.m */; };
+		1443F4986172D7C166827E3E8CDAA21D /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B751B97A2DDD0C9910C8F55261DE9 /* CwlDarwinDefinitions.swift */; };
 		14BB10E6F64439F078229540A0807EE6 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8DB7849FE18394F4C1421ABE0CEA2E /* Security.framework */; };
-		15558E6E6B5B340AE9A56594910085DC /* AWSCancellationTokenRegistration.m in Sources */ = {isa = PBXBuildFile; fileRef = B7ADE5543A95AE17B1E9115EC5CDF0CC /* AWSCancellationTokenRegistration.m */; };
+		15558E6E6B5B340AE9A56594910085DC /* AWSCancellationTokenRegistration.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BC4FCA3F9BDAE1F28A5E3EF4A14C418 /* AWSCancellationTokenRegistration.m */; };
 		176EE1FC318E9CD5AA1E79B1A79070D7 /* CwlCatchException.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E95AAB996428D7874DB2E4B93260F35 /* CwlCatchException.framework */; };
-		189C52695A137B58704DF3C5BD57BCA7 /* AWSDDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C088E988DA4E79E7D02BF2FF788EDAE /* AWSDDTTYLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1912D9BBE939D40B7F1D5D5006671F32 /* AWSCognitoIdentityProvider-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BC46419BA3507B1B650E2E09B3787EA /* AWSCognitoIdentityProvider-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1A39D1693474EB62977EF09A9433600E /* AWSTaskCompletionSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C68FE2B5EB71F0D9C32F7A1353E1BF9 /* AWSTaskCompletionSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1B3F193F03EA731E027EB54639B9AFAE /* AWSDDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = AE8CC2E06DEBCE5EF191799D1127C5F1 /* AWSDDLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1B4699D8D8A9FA361461FA0918FB1BBD /* AWSDDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = DC848AA86A44B12AA9160C97145E729E /* AWSDDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1B607F8C305C2DDE2170D517993A0542 /* AWSClientContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A4FA38EE0D5F12E02C928F9D0D90AF5 /* AWSClientContext.m */; };
-		1BB794FB213EC4CA73B3C8BC4D05C3A5 /* CwlCatchException-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7799BCB5D7602926CD8534E8D595CD25 /* CwlCatchException-dummy.m */; };
-		1C3989F261B6DEB7427157E58FFAF18E /* AWSCognitoIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C8656F7AC30360AE4D12537118FBDC5 /* AWSCognitoIdentityProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1C458B6D3529A73474CA7ED48C718CEA /* AWSIdentityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = A78730E05ABF4E299EDFBE9D6E383E47 /* AWSIdentityManager.m */; };
-		1CEC54C8680C61BAE07A09608EE075A1 /* AWSDDOSLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = D730CA76B9F5586885C45C8BD0271261 /* AWSDDOSLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		189C52695A137B58704DF3C5BD57BCA7 /* AWSDDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F8DC78698DCFAB9BA43F5468B4A840D /* AWSDDTTYLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1912D9BBE939D40B7F1D5D5006671F32 /* AWSCognitoIdentityProvider-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 061DB1E4B174776DD34B7A1D4026D64B /* AWSCognitoIdentityProvider-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1A39D1693474EB62977EF09A9433600E /* AWSTaskCompletionSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 0187DBE67FCE1366346974DF80312B67 /* AWSTaskCompletionSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1B3F193F03EA731E027EB54639B9AFAE /* AWSDDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 13DDB3FE8723FB5DBF721EFC1C54E8B8 /* AWSDDLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1B4699D8D8A9FA361461FA0918FB1BBD /* AWSDDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 253206CA6FFCBA451A002CD959A8880D /* AWSDDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1B607F8C305C2DDE2170D517993A0542 /* AWSClientContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 2140A514BBE55620A5F7C45EC8BDC5AD /* AWSClientContext.m */; };
+		1BB794FB213EC4CA73B3C8BC4D05C3A5 /* CwlCatchException-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F9450A052E08F53A2E883BB2BB43E47A /* CwlCatchException-dummy.m */; };
+		1C3989F261B6DEB7427157E58FFAF18E /* AWSCognitoIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 28654CD2D624C23CC96C2288853B8A2A /* AWSCognitoIdentityProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1C458B6D3529A73474CA7ED48C718CEA /* AWSIdentityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 609FCBCB9B75FF5D167F70E56995C48E /* AWSIdentityManager.m */; };
+		1CEC54C8680C61BAE07A09608EE075A1 /* AWSDDOSLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 64B466ED2388DD02B72509DF230A91B8 /* AWSDDOSLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		20D58851C6F80D8EC03E236B6066D2E4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		20DE217DA9E41A2BFD1E4A71C564929B /* AWSSTSResources.m in Sources */ = {isa = PBXBuildFile; fileRef = 9804501BD5ABBA59BAE5D84867237A88 /* AWSSTSResources.m */; };
-		20F5B6668A2D5C62774918E1554E7B1D /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B941D41D42EEC8164DEA0106F284EA7 /* CwlBadInstructionException.swift */; };
-		2145910BF9E8293B01895487859507A7 /* tommath.c in Sources */ = {isa = PBXBuildFile; fileRef = 6589DE430E9F4408A4461C9D86E56C78 /* tommath.c */; };
-		221795EAC91598916CB8F66DAEEB2AE1 /* AWSCognitoIdentityModel.h in Headers */ = {isa = PBXBuildFile; fileRef = EEFE6143A25DA46E1E0FE5A33A1169A3 /* AWSCognitoIdentityModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		224E2C74968842E2CB20C0E708373B39 /* AWSCognitoIdentityProviderModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E67A1E5982F4EB37E89FB5A78A3C48E /* AWSCognitoIdentityProviderModel.m */; };
+		20DE217DA9E41A2BFD1E4A71C564929B /* AWSSTSResources.m in Sources */ = {isa = PBXBuildFile; fileRef = 37238A20DFA2590816F74C60C138AC3C /* AWSSTSResources.m */; };
+		20F5B6668A2D5C62774918E1554E7B1D /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EB656659FB0F58570111C58C204BDB /* CwlBadInstructionException.swift */; };
+		2145910BF9E8293B01895487859507A7 /* tommath.c in Sources */ = {isa = PBXBuildFile; fileRef = ED0CAF841324ADA03B78DC435F707B2F /* tommath.c */; };
+		221795EAC91598916CB8F66DAEEB2AE1 /* AWSCognitoIdentityModel.h in Headers */ = {isa = PBXBuildFile; fileRef = EEEE764AB257FC9226D559D8244CC9FA /* AWSCognitoIdentityModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		224E2C74968842E2CB20C0E708373B39 /* AWSCognitoIdentityProviderModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EDF7E5096048D8B966EF59D99125309 /* AWSCognitoIdentityProviderModel.m */; };
 		23B8ECAE96DAB3886CCE1CE90B8277F9 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 03D039338D77A6CA524CBC57DE6E2BCF /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-dummy.m */; };
-		248507F49B3F12E442FE6AC425DD398B /* AWSIdentityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = DED03D9B3329B6DBD77B3848BCE4F893 /* AWSIdentityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		264783C2F064A47445C5894BC568C1EB /* AWSNetworkingHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = DF9C38EA99E284232320822E6FF2779A /* AWSNetworkingHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2757F826A5D3164D7FF294C3C0D2DA44 /* AWSDDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A6C5897CC3CC996DB74F2BADF4C2AA9 /* AWSDDFileLogger.m */; };
-		2814D4D361A4E86079D72A04F0AB30D5 /* AWSCognitoIdentityModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 051437CDB0C1F99EB3D075000D7ED7C1 /* AWSCognitoIdentityModel.m */; };
-		292DFC7361D422AB72038DBEA947ECEC /* Fabric.h in Headers */ = {isa = PBXBuildFile; fileRef = C2775A802441C8060EB9BF86321820D9 /* Fabric.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		295FA629B96FCE0C14815243AF6F4DA6 /* AWSmetamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = D060CD7839514A5830127E29A440D945 /* AWSmetamacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		29A30DF1ED433FF2CF086D2CD5FDE391 /* aws_tommath_superclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D1AADC1D934456355F4DAC701612F79 /* aws_tommath_superclass.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		2A45D2B2E9015B55E07DD13D43E1A197 /* AWSModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 201B012B8DCABEAE0CD9EBE7D55791E5 /* AWSModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2A7389B92220C12253767AA85D2B23AB /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5963F8F37803D4F8DECB8F3B3C7AEF9A /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		248507F49B3F12E442FE6AC425DD398B /* AWSIdentityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F0C82C0DCCC4C930C8E1E67C26A75CA6 /* AWSIdentityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		264783C2F064A47445C5894BC568C1EB /* AWSNetworkingHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B57F812D68F53AAB507EBC060B0F553 /* AWSNetworkingHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2757F826A5D3164D7FF294C3C0D2DA44 /* AWSDDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = B5469A1E228546E79319E57BBFB5167C /* AWSDDFileLogger.m */; };
+		2814D4D361A4E86079D72A04F0AB30D5 /* AWSCognitoIdentityModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D6244F265CD8B9F8288AE5DC2C066A98 /* AWSCognitoIdentityModel.m */; };
+		2861A1716ABD10B59138E0608BE1C775 /* AWSCognitoAuthUICKeyChainStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 23FD0A4B909BC2DCBC1B238179001DA7 /* AWSCognitoAuthUICKeyChainStore.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		2914C15AB2C025430066747BE42F6A39 /* AWSUserPoolOperationsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB59F5236F0F40C4622B6A63740EEFC6 /* AWSUserPoolOperationsHandler.swift */; };
+		292DFC7361D422AB72038DBEA947ECEC /* Fabric.h in Headers */ = {isa = PBXBuildFile; fileRef = 671FA8A8981B6D9E4D607F197D583195 /* Fabric.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		295FA629B96FCE0C14815243AF6F4DA6 /* AWSmetamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 044E4A4B8546BF01B2105A7268CB7BB8 /* AWSmetamacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		29A30DF1ED433FF2CF086D2CD5FDE391 /* aws_tommath_superclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 1879352EF7D914793D16865F02E4BBAB /* aws_tommath_superclass.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		29F001B4F1F5D8369E7793F2E2C7518E /* AWSCognitoAuth+Extensions.h in Headers */ = {isa = PBXBuildFile; fileRef = AE0675F1138CD44A800B4EBD0B5E55DD /* AWSCognitoAuth+Extensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A45D2B2E9015B55E07DD13D43E1A197 /* AWSModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A96DCF8D41072E318B24C6CDFC727D7 /* AWSModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A7389B92220C12253767AA85D2B23AB /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D3FC3C5111DE0BB193D61CF5AC55161 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2BCA4C45CE7BE68A677F5B3042BC4BD7 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 70EF68EF61C4587DEC5119A866265B57 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-dummy.m */; };
-		2C4C1A6C7BED9A111DA724CAB2AB778C /* AWSCognitoIdentityProviderASF-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 6ABA495DEBA91095FE2A8E7D756E77FD /* AWSCognitoIdentityProviderASF-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2D0A57953832EF83AD2FA1511820B602 /* AWSMobileClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 638D8632CC8F27E6F1D10AE39197B5F6 /* AWSMobileClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2D7804C365C5B74B4CFCE9DCDB990FDA /* AWSXMLDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = AD7DA8547C6045EC6D31802C445EA2DE /* AWSXMLDictionary.m */; };
-		3037B29B6276CF8FE3546D3E977DD84A /* AWSFMDatabasePool.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B0510CBEEDE5FCA0299A0FD4D3F647A /* AWSFMDatabasePool.m */; };
-		3140BF9E55F36B4CE5E2FAC0317FBE58 /* NSDictionary+AWSMTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CF7E92216D1B04741144F93ACCF1F26 /* NSDictionary+AWSMTLManipulationAdditions.m */; };
-		327212D4B1210D85CEBFEE82E654D5A8 /* AWSFMDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 96B30AC1E2A2C23B6F1AB65BF4DBE3DC /* AWSFMDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		33438D6A7B769D16F1D528B0ADC783C6 /* AWSCognitoIdentityASF.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BF34501027170E35D5C40DE2AD55C64 /* AWSCognitoIdentityASF.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2C4C1A6C7BED9A111DA724CAB2AB778C /* AWSCognitoIdentityProviderASF-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = EE1A4D0C9A1309AD217883F861C5E6C7 /* AWSCognitoIdentityProviderASF-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D7804C365C5B74B4CFCE9DCDB990FDA /* AWSXMLDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = B62AB28531B4A1394BFBFC01AE0185B1 /* AWSXMLDictionary.m */; };
+		3037B29B6276CF8FE3546D3E977DD84A /* AWSFMDatabasePool.m in Sources */ = {isa = PBXBuildFile; fileRef = 0743FC34E4E6F0B38CDC9D632E2803A7 /* AWSFMDatabasePool.m */; };
+		3140BF9E55F36B4CE5E2FAC0317FBE58 /* NSDictionary+AWSMTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 119439775469EB44A41E15CABC1B7AEB /* NSDictionary+AWSMTLManipulationAdditions.m */; };
+		327212D4B1210D85CEBFEE82E654D5A8 /* AWSFMDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 0568F8FF5A2CBCE85271963650D4EB8A /* AWSFMDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		33438D6A7B769D16F1D528B0ADC783C6 /* AWSCognitoIdentityASF.h in Headers */ = {isa = PBXBuildFile; fileRef = 186B12D6F3453F5CBB8711FF4F62362C /* AWSCognitoIdentityASF.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		339FA6343AC88EB9B429322BAF8FF915 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1073C3EE5CBDD8387A3FB523E790C5CA /* SystemConfiguration.framework */; };
-		33AB80FF79E9E8922EB6414ECA6D13F4 /* AWSCognitoIdentityResources.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C5086639816CD0DADC764CEFF8DA89D /* AWSCognitoIdentityResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		34D02615F8968D64CC0F5B2F1CFB6CFD /* AWSSynchronizedMutableDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A98F3BC7E10504EB89277DBD08056E8 /* AWSSynchronizedMutableDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		34D0E0F7CFB4DFE1D93A31A57C6D97AD /* AWSMTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 661CD15775667147D9B7051F8B63D35A /* AWSMTLValueTransformer.m */; };
-		35439200B23D406C07D5161DAEB9F046 /* AWSCognitoIdentityUser_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B1A8CFD29736C239CEF3A5EB43AA3BFE /* AWSCognitoIdentityUser_Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		35A9EDB5F19A0AA37CFAC061744C58A4 /* DeviceOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CE1E26D07A0FED1773F6F755E99630 /* DeviceOperations.swift */; };
-		36793D105BE701C00338BDF313AB6C46 /* AWSDDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 43128D69FB45BBB7F4ADB2DFBCE21532 /* AWSDDContextFilterLogFormatter.m */; };
-		36F73E51FDF6AD36471B99E64C4A7730 /* NSObject+AWSMTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AD39ACA6DC4F3E8054B5364662EB998 /* NSObject+AWSMTLComparisonAdditions.m */; };
-		37899F8A7B0ED0B72C99334BAA54CEAB /* AWSMobileClient-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 791C72FC52723E22DC8CE87BDEEB54C7 /* AWSMobileClient-dummy.m */; };
-		37CF2468721210240B585FC038355BAD /* AWSJKBigDecimal.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C5FA08BD259CC53FCAB405F6BBF72FC /* AWSJKBigDecimal.m */; };
-		37E3C990B6B94ED3A68546B534D113F7 /* AWSDDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C8DDE8BDC075136E7854C7C130D4480 /* AWSDDMultiFormatter.m */; };
-		39182F41F7B148E56863FD6A48300A15 /* AWSAuthCore-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0476F9CA218102135BC385B5BB84C86C /* AWSAuthCore-dummy.m */; };
-		39678AF6674F85C354F294BE9F490B2F /* AWSExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8171E908773030DF8D186BD5A21D4608 /* AWSExecutor.m */; };
-		3979D282ECA583525A2099DDA11E1EBD /* AWSXMLWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0332051850FABA8FEB15A891758E27AB /* AWSXMLWriter.m */; };
-		3A211A601A173429FC164E21BFBD925C /* AWSCognitoIdentityResources.m in Sources */ = {isa = PBXBuildFile; fileRef = DCEBA99E8A7995FC38DC060850D040C9 /* AWSCognitoIdentityResources.m */; };
-		3A7F8C983F3205D2586B913580D7818D /* AWSSignInManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AEA8D2580C822EE561F1B85D15AB5B4 /* AWSSignInManager.m */; };
-		3B0F330CAAE0F4DF8D362E5C00EF3715 /* AWSKSReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 3585665D570BD8937FC9A32C98886EA6 /* AWSKSReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		33AB80FF79E9E8922EB6414ECA6D13F4 /* AWSCognitoIdentityResources.h in Headers */ = {isa = PBXBuildFile; fileRef = CC1CC4148160AE6E60028758296F76D5 /* AWSCognitoIdentityResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34D02615F8968D64CC0F5B2F1CFB6CFD /* AWSSynchronizedMutableDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = F45CC1625AD101EBB84773D83CF4EB6C /* AWSSynchronizedMutableDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34D0E0F7CFB4DFE1D93A31A57C6D97AD /* AWSMTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 88B3B1D5195F422193A42586F97E1395 /* AWSMTLValueTransformer.m */; };
+		35439200B23D406C07D5161DAEB9F046 /* AWSCognitoIdentityUser_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B3353B22C5BE756F269528D8722AC9C /* AWSCognitoIdentityUser_Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		36793D105BE701C00338BDF313AB6C46 /* AWSDDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 79839BA3B62F40A30032D76FC50C40B4 /* AWSDDContextFilterLogFormatter.m */; };
+		36F73E51FDF6AD36471B99E64C4A7730 /* NSObject+AWSMTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 426D0CDC2ACCEDDD1FDB54109388FAB9 /* NSObject+AWSMTLComparisonAdditions.m */; };
+		37CF2468721210240B585FC038355BAD /* AWSJKBigDecimal.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF895C1546E277DA655224065CADE4 /* AWSJKBigDecimal.m */; };
+		37E3C990B6B94ED3A68546B534D113F7 /* AWSDDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = BB7E0EA0CAD58734D312F08A9DA0E2E9 /* AWSDDMultiFormatter.m */; };
+		39182F41F7B148E56863FD6A48300A15 /* AWSAuthCore-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E6F951526A3C09FE18E6A3056495E051 /* AWSAuthCore-dummy.m */; };
+		39678AF6674F85C354F294BE9F490B2F /* AWSExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = B9666E7AC35B69974E1008C9C9240EE4 /* AWSExecutor.m */; };
+		3979D282ECA583525A2099DDA11E1EBD /* AWSXMLWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = B91D60620C0F71296D9A2756B377A350 /* AWSXMLWriter.m */; };
+		3A211A601A173429FC164E21BFBD925C /* AWSCognitoIdentityResources.m in Sources */ = {isa = PBXBuildFile; fileRef = 0779FEE0240035253F866AEEEBF8F7C0 /* AWSCognitoIdentityResources.m */; };
+		3A7F8C983F3205D2586B913580D7818D /* AWSSignInManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 05302BD579C89A3103BBAA83726E1834 /* AWSSignInManager.m */; };
+		3B0F330CAAE0F4DF8D362E5C00EF3715 /* AWSKSReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = EC98AEE548E0E61DE031738B090E0F56 /* AWSKSReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3B34E32ACD49583FA677CE0E51257228 /* JSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7EF26D3B368F8069DF3FF5B15DE00C6 /* JSONHelper.swift */; };
 		3B9FFB26452B15D69C725846E481624F /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8DB7849FE18394F4C1421ABE0CEA2E /* Security.framework */; };
-		3C295496C91AFABA2DA6D3202C7C482B /* AWSUICKeyChainStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 95B69FCC9C94459CC24FA0F476A45FEC /* AWSUICKeyChainStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3C295496C91AFABA2DA6D3202C7C482B /* AWSUICKeyChainStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 78A4809D27E589F4ECDA9C8EB822F642 /* AWSUICKeyChainStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C5CF7D00A143641F05F9B6BC1C1FEB1 /* Pods-Amplify-AWSPluginsCore-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B350FFEF637C6AF934EE101CD54DCE5 /* Pods-Amplify-AWSPluginsCore-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3CA3FA796B4F76092847C7CE45C7B2B0 /* AWSCognitoIdentityProviderASF-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C37E09DF58FA889A85DC5F6F4E692EAC /* AWSCognitoIdentityProviderASF-dummy.m */; };
-		3CA6B00BEC52629874A59C4425B040FF /* _AWSMobileClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A7F937A3048EEBAB2068BAE53499D9C /* _AWSMobileClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3D20174EDA7E54ACF0B3FA03BC9BAF4F /* AWSDDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 53D9BDE9B970F6CC3CF311DB67FF5054 /* AWSDDContextFilterLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3CA3FA796B4F76092847C7CE45C7B2B0 /* AWSCognitoIdentityProviderASF-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F019DA231CEA0C3F4310AEF8B1A5A93 /* AWSCognitoIdentityProviderASF-dummy.m */; };
+		3D20174EDA7E54ACF0B3FA03BC9BAF4F /* AWSDDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B855E530694F19AABF8B6EEA2537B4 /* AWSDDContextFilterLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3E7788CD8A9220F214923E66A480F5E7 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = EFD2AEC8F92F60614948319DA39DDA2C /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-dummy.m */; };
 		3EBD1DFC7072E4D27E1C6EE9BCF7A5EC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		3EE59D51700D3E008C115C34DDC73403 /* AWSDDASLLogCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = B0C83F24CB550E6006708C464C4978E1 /* AWSDDASLLogCapture.m */; };
-		41427B4C2C98D529E00FDDEEEAB32D0D /* AWSTMMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 54F2B9B424EA365272D4D45F6AA6B571 /* AWSTMMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4169B42294AE9AB96766A16B1293ED08 /* FABAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 522FF7223869E4B88DE29BC852A6EFA0 /* FABAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		416B3D71CD66C2F82429B252EDC0C4A7 /* AWSAuthUIHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2025F5D43350C89927348B43FE33E261 /* AWSAuthUIHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		440B8ECC492853A954F9EF74E134A1A9 /* AWSEXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = E5DE768FFA5EA9EA4368651C29CF4827 /* AWSEXTScope.m */; };
-		45036FC7C954DBE6E733CB429174B2EA /* AWSEXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 25F990CE79266048C3D300BF988751FC /* AWSEXTScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		452B95EB46C02DE66D5E2F415EAD1F85 /* AWSCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = 8314E4C7BEBD385F48DEA72FDD8FB69C /* AWSCategory.m */; };
-		45A742EBBE1D814917D2F4F44E48B9B7 /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = 09CDC287B301787A7A8B22CD3D76FFA5 /* mach_excServer.c */; };
-		45AFA12190BAF394C1B57536268CBD8D /* AWSSTSModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EC8B36FC6B914F164C0C2AF1AD96F83 /* AWSSTSModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		46239FCB5AA1A9C393996E3975E4AB72 /* AWSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D572A7B644427B4E310F33B8F49FA13 /* AWSModel.m */; };
-		466CB5C4FE8DD7AA3EE53FE3D1E728E1 /* AWSMTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 215DA62B09F66CEC9B18A68211635BAC /* AWSMTLModel+NSCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		46818E554C7902ABE93D24966BB50EE3 /* AWSAuthCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C49CC694143B932ACAEDAB2B998DE32A /* AWSAuthCore.framework */; };
-		4724A9B83CF9F3763A6C9B7AB185F780 /* AWSSignInProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = E83934A300E0256CF298A02BAC2E17F4 /* AWSSignInProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3EE59D51700D3E008C115C34DDC73403 /* AWSDDASLLogCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 0102E468AA0118F10BBC5E8A95511D8A /* AWSDDASLLogCapture.m */; };
+		408E26270F1ADEBB526CEDF85AD131DC /* AWSMobileClient.h in Headers */ = {isa = PBXBuildFile; fileRef = A5E2B2732E8C2E0DAB2B79B29CD13E84 /* AWSMobileClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		41427B4C2C98D529E00FDDEEEAB32D0D /* AWSTMMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 34858815A0F7379196A7B8853DB3DA33 /* AWSTMMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4169B42294AE9AB96766A16B1293ED08 /* FABAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 88ED5F9AFEA22F06CE869726B2F707E8 /* FABAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		416B3D71CD66C2F82429B252EDC0C4A7 /* AWSAuthUIHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 01982698B8DE672BA75249A3AB0109A0 /* AWSAuthUIHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		440B8ECC492853A954F9EF74E134A1A9 /* AWSEXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 270DA40631CAA420BD290BDC01F8ABD1 /* AWSEXTScope.m */; };
+		45036FC7C954DBE6E733CB429174B2EA /* AWSEXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CC578ED37E3D7D62477805312126FF0 /* AWSEXTScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		452B95EB46C02DE66D5E2F415EAD1F85 /* AWSCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = B70DE473AD6DAAFE965197BAC56C83AA /* AWSCategory.m */; };
+		4589F69C4934F11F1A17ACA1B08BC0E0 /* AWSMobileClient-Mixed-Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 01D6D4609A3577B4E149CB749B03486F /* AWSMobileClient-Mixed-Swift.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		45A742EBBE1D814917D2F4F44E48B9B7 /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = 61F232A732471703F7FDB543E40C17D3 /* mach_excServer.c */; };
+		45AFA12190BAF394C1B57536268CBD8D /* AWSSTSModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 33F0A8BDDF0DDB3CB666FBBA90C60448 /* AWSSTSModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		46239FCB5AA1A9C393996E3975E4AB72 /* AWSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D926F19E6FECEA9EFD801AF741B1453 /* AWSModel.m */; };
+		466CB5C4FE8DD7AA3EE53FE3D1E728E1 /* AWSMTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 586D67476E44A61969931883CA884BE2 /* AWSMTLModel+NSCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4724A9B83CF9F3763A6C9B7AB185F780 /* AWSSignInProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 2057888BC8E612EFC5320864A97728BA /* AWSSignInProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4746D2E0317722A3DED3470DB2DBFCD7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		4851DF7728E1A4D83BEBD0259F55894A /* AWSValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F30C86248908FA871CAAC451CD386A4 /* AWSValidation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		49BFAFCF8CD24786DBEE0DB525590378 /* AWSCognitoIdentityUserPool.m in Sources */ = {isa = PBXBuildFile; fileRef = E29D89F2F41A81528BFDBFBE32FACFA6 /* AWSCognitoIdentityUserPool.m */; };
-		49FB3545535B5BA67CAC16F4ADEC0D39 /* CwlPreconditionTesting-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E01301307CE42A2B4740B8BBDEF1A63 /* CwlPreconditionTesting-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4B0A6C1C5E40CA5991F72FE870380789 /* AWSCognitoIdentityUserPool+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 0163DD1DBE58F494454C5DFEEF1223C1 /* AWSCognitoIdentityUserPool+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4CAC8656530CBAB205D1B329885B2420 /* AWSFMDB+AWSHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = ED978F394A390FEF78F57B0E84DB463C /* AWSFMDB+AWSHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4D6195524E59D17144D2463C2245ACAC /* AWSGeneric.h in Headers */ = {isa = PBXBuildFile; fileRef = 215E6048187156C4EA2A028913C9CA04 /* AWSGeneric.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4851DF7728E1A4D83BEBD0259F55894A /* AWSValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F44B8C7B0BC344BFDE65FF3FB64D1E5 /* AWSValidation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		49BFAFCF8CD24786DBEE0DB525590378 /* AWSCognitoIdentityUserPool.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A9898F0E3C371B28BF2A2C1BD7D4358 /* AWSCognitoIdentityUserPool.m */; };
+		49FB3545535B5BA67CAC16F4ADEC0D39 /* CwlPreconditionTesting-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 37D0AF393DF178079A5AA4A88A223B5D /* CwlPreconditionTesting-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CAC8656530CBAB205D1B329885B2420 /* AWSFMDB+AWSHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = B9BE4F242531733D3769372176540E24 /* AWSFMDB+AWSHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4D6195524E59D17144D2463C2245ACAC /* AWSGeneric.h in Headers */ = {isa = PBXBuildFile; fileRef = 3502DCDB99858552F01128ED97F575A8 /* AWSGeneric.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4D68B5FF0FDD5D66EC75E01E4E55E881 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A7F5959C56A2F6E93DDA0D9EB3274DE /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-dummy.m */; };
-		4DF330318C6863C9A9457AB6A0D931AC /* AWSCognitoAuth.h in Headers */ = {isa = PBXBuildFile; fileRef = 48F780036E2D872F1A15B369BED38933 /* AWSCognitoAuth.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4E7A6FAE1EDFAEECBB22F317BB0A5619 /* NSArray+AWSMTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ED5694E8307F8C4EAB7DACE6C30C7FD /* NSArray+AWSMTLManipulationAdditions.m */; };
-		4EA7E8C75835B7707BCC449C87AE56B8 /* AWSMTLManagedObjectAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 82D5755093B849733862D6875C19C2EE /* AWSMTLManagedObjectAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4F775EE0184C10B66E9DCFC15493E1A3 /* AWSCognitoIdentityProviderSrpHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 61CDC6F402902D556759A67A3D6CCCF1 /* AWSCognitoIdentityProviderSrpHelper.m */; };
-		4FDF5A63D4580132177948D42603FB35 /* AWSCognitoIdentityProviderResources.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F13FE5A540C5996ECF56F372411917F /* AWSCognitoIdentityProviderResources.m */; };
-		4FF58842A18EEBA4291A5A9BC8DBA9D3 /* AWSTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C24137D9A15529190A1833D49230BD3 /* AWSTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		50C0FACEDA7EAF330865E3ABCF646734 /* CwlPreconditionTesting-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 68FF3770CBF110857CA77FFE046B0B4F /* CwlPreconditionTesting-dummy.m */; };
-		51250616CA565F13AACEBE3D53B538A9 /* AWSMobileClient-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B0FF6315F94A37AA4C22B5514E4291AA /* AWSMobileClient-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E7A6FAE1EDFAEECBB22F317BB0A5619 /* NSArray+AWSMTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2099B4FC1B4FFFEE5E121147A0956AA6 /* NSArray+AWSMTLManipulationAdditions.m */; };
+		4EA7E8C75835B7707BCC449C87AE56B8 /* AWSMTLManagedObjectAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DDCADACD641F1331A589286C9FB7E8C /* AWSMTLManagedObjectAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4F775EE0184C10B66E9DCFC15493E1A3 /* AWSCognitoIdentityProviderSrpHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 080855AA1347E7B97141BB92F01284A8 /* AWSCognitoIdentityProviderSrpHelper.m */; };
+		4FDF5A63D4580132177948D42603FB35 /* AWSCognitoIdentityProviderResources.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EE5EA345BF8114DD24BABAB8EB041A9 /* AWSCognitoIdentityProviderResources.m */; };
+		4FF58842A18EEBA4291A5A9BC8DBA9D3 /* AWSTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 5787035EDC3E98DB50D44230AF7C85C4 /* AWSTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		50C0FACEDA7EAF330865E3ABCF646734 /* CwlPreconditionTesting-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D613E3E5F0A4E19E4599EDBBE314D3D /* CwlPreconditionTesting-dummy.m */; };
 		51BB5558A79C35EFC02ED63C95726B97 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E7D5AC68E43CA3768505A58681304E1 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5296910C64F9CFF68149C484D4FCB927 /* AWSCognitoAuthUICKeyChainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = C5965311C253CC983E3C43861FE61DE4 /* AWSCognitoAuthUICKeyChainStore.m */; };
 		52CE898391D84D10885B9453ADF3335F /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47D46D2BEC1D90EDAE4F1B547348EEFB /* AWSCore.framework */; };
-		53BB8CAB8C037542DF1E4D61B141C140 /* AWSXMLWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 56F63DA64CFE5101D3680D82D88649ED /* AWSXMLWriter.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		551C054C3C2762ED76904044493A3649 /* AWSCognitoIdentityProviderService.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F41F0AFEC3B456F5D1D357773CABD22 /* AWSCognitoIdentityProviderService.m */; };
-		55B7F2064D84D89F672A51C07FAF3F25 /* AWSAuthCore-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 7028A59A9EF8E9D33381651C663C05D5 /* AWSAuthCore-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		565F48D47A3D4B7210AD3710A6D5DC31 /* AWSDDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = 358A5159A1A60BF02175C6A3D56B4E42 /* AWSDDLog+LOGV.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		585B8C3A6DD4AF9F63247DAEE3950B55 /* AWSGZIP.h in Headers */ = {isa = PBXBuildFile; fileRef = 593F6FE9E180C8D514A96C8AD34EB9CB /* AWSGZIP.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5881547D10D0115CB765498C4DD879C5 /* AWSMantle.h in Headers */ = {isa = PBXBuildFile; fileRef = EE1B00BD743F4B6F35AE7CE4D6C029E1 /* AWSMantle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		58BD66C69F22A39246C34EF273B1F368 /* aws_tommath.h in Headers */ = {isa = PBXBuildFile; fileRef = 2136ADF4DE424DF154BD2074865BE16B /* aws_tommath.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		58F04275CDDD17740755E139361A104A /* AWSCancellationTokenSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D0A429B94396EACDD9425A11E4C827C /* AWSCancellationTokenSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		53BB8CAB8C037542DF1E4D61B141C140 /* AWSXMLWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = B21B371F40AD3DB3AE0347F642CA716C /* AWSXMLWriter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		54D6C81AB4089CE00C5F58D243DCC8FA /* AWSCognitoAuth.h in Headers */ = {isa = PBXBuildFile; fileRef = 46A688748A61E83AE64381312E801169 /* AWSCognitoAuth.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		551C054C3C2762ED76904044493A3649 /* AWSCognitoIdentityProviderService.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DFC98441267A74AEB8AB146DE8D6D11 /* AWSCognitoIdentityProviderService.m */; };
+		55B7F2064D84D89F672A51C07FAF3F25 /* AWSAuthCore-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 530FB6F70F632A3D79D20015D4D33940 /* AWSAuthCore-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		565F48D47A3D4B7210AD3710A6D5DC31 /* AWSDDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = F3B914692155F84449ADB10B6A7C404B /* AWSDDLog+LOGV.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		585B8C3A6DD4AF9F63247DAEE3950B55 /* AWSGZIP.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FEB825F6CFEC0FF22828D99BACCE97F /* AWSGZIP.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5881547D10D0115CB765498C4DD879C5 /* AWSMantle.h in Headers */ = {isa = PBXBuildFile; fileRef = C14597FFE0390023D368F52DEF6321E9 /* AWSMantle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		589B4BDB54D0D172D532FC88D5D7C953 /* AWSAuthCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C49CC694143B932ACAEDAB2B998DE32A /* AWSAuthCore.framework */; };
+		58BD66C69F22A39246C34EF273B1F368 /* aws_tommath.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CBE1C7AC6B8A499F1F9F92F4B5878FD /* aws_tommath.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		58F04275CDDD17740755E139361A104A /* AWSCancellationTokenSource.h in Headers */ = {isa = PBXBuildFile; fileRef = A9201C2D174632B57C77653694F2FE9E /* AWSCancellationTokenSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		58F513DBEC30590405F5B3CDC4C472B2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
 		590D69E6710099A3290F2650B7FB5BB5 /* Pods-AmplifyTestApp-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D7E43FB42F81273FADA2B41F8A59397E /* Pods-AmplifyTestApp-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5997B9CD7C53755E5280D4C388059906 /* AWSJKBigDecimal.h in Headers */ = {isa = PBXBuildFile; fileRef = 70E3AAF4BC85478E182CB79281CA4A7A /* AWSJKBigDecimal.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		5A41DCFDD03C1FDF56839D98E31941EB /* AWSCognitoIdentityProviderSrpHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = E608D19A6E219A200C4EB304AA6158C6 /* AWSCognitoIdentityProviderSrpHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5C6F85ECFE37588A579291C57BA28E44 /* NSArray+AWSMTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = B18C183C23945DF961400C5B769B487F /* NSArray+AWSMTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5D1E1ED20C02309D4897C489A4FF1385 /* AWSCognitoAuth+Extensions.h in Headers */ = {isa = PBXBuildFile; fileRef = CEE13C907123CB23F408DAFC03368502 /* AWSCognitoAuth+Extensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5D97CDAB82AF5231ACF2D62F75FB4F55 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		5E0032B52DC5BB5FB3CA69F45D484781 /* AWSFMDatabaseQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CA709F5652B0398A9B29246F3F49EBB /* AWSFMDatabaseQueue.m */; };
-		5EB28630A9CC30863DE4382D0A18BB38 /* AWSSTSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 16A601DC16672A8A74349C446B163720 /* AWSSTSModel.m */; };
-		5FE479276304FDA83745E989DA2F79DF /* AWSDDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 646462FD5A2B43C2114AF829757A657B /* AWSDDASLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		600A24E9D61C48AE2664008652AF340C /* AWSURLRequestRetryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C4F2011018B14F3F4235228124861C3 /* AWSURLRequestRetryHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6026B603F1245AD52915F34CA6A83CC5 /* AWSCognitoAuth.m in Sources */ = {isa = PBXBuildFile; fileRef = EDF0A50253541A270DAE2ADAD984E0DA /* AWSCognitoAuth.m */; };
-		617A71B50115147C51AD0C6D00BFCCCF /* AWSMTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = E20AA1F28A014153CB5D903040321543 /* AWSMTLJSONAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		61B1A698911FFEDAC3E17424104462CF /* AWSKSReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 594C9789E8B6E3765CCB480D349AB2A0 /* AWSKSReachability.m */; };
-		623B9A6697A87E1F42B847CA8F2FE28B /* AWSURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 94EEEE23B143CAE7857143A60EDAEE91 /* AWSURLRequestSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		62D392DC89FC9697970873E8455C503E /* AWSTMCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C3C79C322308DCFF6CC07162D81B7B3 /* AWSTMCache.m */; };
-		657547730A8E5358B795A62B0A80137A /* AWSURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B2ED77C675E31F2C63768E7D59D25611 /* AWSURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		67D8229426E3B531C446102C3F290D63 /* AWSMobileClientUserDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E32B857CB41920FA239AE30655F37B7 /* AWSMobileClientUserDetails.swift */; };
-		69426D3130E20C2B3A6679390F539131 /* AWSCognitoIdentityProvider-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A9E09C54B5074D61B5E6B9031F15CA3 /* AWSCognitoIdentityProvider-dummy.m */; };
-		6A6F7F27DCCF6D5F73EA43FCCA1DAB92 /* _AWSMobileClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D8A99015D2EC60F2847A8211AEA6BBE /* _AWSMobileClient.m */; };
+		5997B9CD7C53755E5280D4C388059906 /* AWSJKBigDecimal.h in Headers */ = {isa = PBXBuildFile; fileRef = E166C1A7F424470ED9F0E35692D8A85A /* AWSJKBigDecimal.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		5A41DCFDD03C1FDF56839D98E31941EB /* AWSCognitoIdentityProviderSrpHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 79019805F668DD6072EACF09CA6F8051 /* AWSCognitoIdentityProviderSrpHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5B96288E92790AC284A258082D40A1C9 /* AWSMobileClientExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECB1A8A13CBB9044D931154C6DBDD99 /* AWSMobileClientExtensions.swift */; };
+		5C6F85ECFE37588A579291C57BA28E44 /* NSArray+AWSMTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 732715CF43E24A182818E45B9DD6CA42 /* NSArray+AWSMTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5E0032B52DC5BB5FB3CA69F45D484781 /* AWSFMDatabaseQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B8C6DFB6DFB81C8B155FFD0ACF428F1 /* AWSFMDatabaseQueue.m */; };
+		5E64CCB1D7FC10661B116F8ED8819648 /* AWSCognitoAuth_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AF4AC19FCD1C23576C5D9515AD63194 /* AWSCognitoAuth_Internal.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		5EB28630A9CC30863DE4382D0A18BB38 /* AWSSTSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 942FE31C14A3D5DE99F913F551DE6C54 /* AWSSTSModel.m */; };
+		5FE479276304FDA83745E989DA2F79DF /* AWSDDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = CB7F3F21B6D7750BD771620A20379BC2 /* AWSDDASLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		600A24E9D61C48AE2664008652AF340C /* AWSURLRequestRetryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B22392803C0BF56B11E6A8ACEC2D9388 /* AWSURLRequestRetryHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		601D294DEA3B5DA9613371722EAB154D /* DeviceOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6EA235B5B0C2DD44EDBFFC93212E251 /* DeviceOperations.swift */; };
+		617A71B50115147C51AD0C6D00BFCCCF /* AWSMTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = C199B5B2EFA7A4C45FDFDA4F1F7C34D6 /* AWSMTLJSONAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		61B1A698911FFEDAC3E17424104462CF /* AWSKSReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 14D74F6910BCF832CC69FD2773C06217 /* AWSKSReachability.m */; };
+		623B9A6697A87E1F42B847CA8F2FE28B /* AWSURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = D69BA5E648DC4036DBB189680E68AD9A /* AWSURLRequestSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		62D392DC89FC9697970873E8455C503E /* AWSTMCache.m in Sources */ = {isa = PBXBuildFile; fileRef = D5C2E1DD54B572091366135D61504120 /* AWSTMCache.m */; };
+		657547730A8E5358B795A62B0A80137A /* AWSURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 655090625CD0809A8FED4ED5C8B598C1 /* AWSURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66F79AA0A7BADE7040571FBA367C4239 /* AWSUserPoolCustomAuthHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40EF16538F48DD27D1C37BB7C77A24B2 /* AWSUserPoolCustomAuthHandler.swift */; };
+		69426D3130E20C2B3A6679390F539131 /* AWSCognitoIdentityProvider-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F054E267B7EE5CE815814DB443A8BC69 /* AWSCognitoIdentityProvider-dummy.m */; };
 		6CC5A1D52EF2B655C4F784DDF05E6570 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		6D4394F1745698365A9C40BB0A7A7AD2 /* AWSMTLModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 39C1FB84194B70A998EED9294936E302 /* AWSMTLModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6E4FD2AB420D24BA1FE7D53D4CABEAC8 /* AWSSignInButtonView.h in Headers */ = {isa = PBXBuildFile; fileRef = E86FBF7FE1863E0568B2936E6D617AB4 /* AWSSignInButtonView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6D4394F1745698365A9C40BB0A7A7AD2 /* AWSMTLModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 601FD7EC456EFFA2F76F7E3FAE1C9FA9 /* AWSMTLModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6E4FD2AB420D24BA1FE7D53D4CABEAC8 /* AWSSignInButtonView.h in Headers */ = {isa = PBXBuildFile; fileRef = 38D55155F2EC78678A65C37373A42D58 /* AWSSignInButtonView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6F173BDEC3D52002ECE0AFF78D666654 /* AWSMobileResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71D546C7AF70FD9677085DA4E2BA00D /* AWSMobileResults.swift */; };
 		719C0EFB3578E7E5303BDE1B25596ABD /* Pods-Amplify-AWSPluginsCore-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DEC3E3C3510C8A55F95F909E0207C7DD /* Pods-Amplify-AWSPluginsCore-dummy.m */; };
 		7220D03973258EA8DE357E18142CFBCE /* Pods-Amplify-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 64802F2E333FD29A93B939784FB965FE /* Pods-Amplify-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		781205D14C8BB2089F3A5EACB8D848CC /* AWSFMDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 435526BBCAF623B030E3026EC9DE1016 /* AWSFMDatabase.m */; };
-		7823E936D9B566B90F997812337AFF6D /* AWSTMDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D317A8D28190875854FE246A4450BDA /* AWSTMDiskCache.m */; };
-		786A00B206FE67A484E80BB4F52C65D5 /* AWSXMLDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = F3D29C275552286758AF490FD2311ABF /* AWSXMLDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		788692E6436FAA77FB4106A8A43A6D43 /* AWSFMDB+AWSHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = F05D5BDA387BCC2162C907D59247DE7A /* AWSFMDB+AWSHelpers.m */; };
-		7A91CEDA043B8B5257FD9D1EAA5614A7 /* AWSJKBigInteger.m in Sources */ = {isa = PBXBuildFile; fileRef = 42367677A832E1AADCF1E5DA24999515 /* AWSJKBigInteger.m */; };
-		7AD034A4C74DD3FAC09164FF4462B682 /* AWSFMDatabaseQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 8676BBF167AABCB755BBA9092D0BA3D9 /* AWSFMDatabaseQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7B81C22E00652B512C92118BE69467EE /* AWSCognitoIdentityProviderASF.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B1B00B9CC01A4FAC1E58AC7CA361218 /* AWSCognitoIdentityProviderASF.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7BA450B429AD6BFB0CD6903F48A3A73A /* AWSAuthCore.h in Headers */ = {isa = PBXBuildFile; fileRef = FE78EB8AF731A271AD6B3205D8955233 /* AWSAuthCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7C54E87DA0FEDA01C2E6466361F2E915 /* NSError+AWSMTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = 42D1297EBB5A1F9FB05A9C9DB30429CD /* NSError+AWSMTLModelException.m */; };
+		774615D361214800A581F3588FB96E5A /* AWSMobileClientUserDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8809858A5E01538E0D74FE13FD3903B3 /* AWSMobileClientUserDetails.swift */; };
+		781205D14C8BB2089F3A5EACB8D848CC /* AWSFMDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D1B2C9C16028528902AEA200EC6E83A /* AWSFMDatabase.m */; };
+		7823E936D9B566B90F997812337AFF6D /* AWSTMDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 20CDA4D4E70462A011D602573D39696E /* AWSTMDiskCache.m */; };
+		786A00B206FE67A484E80BB4F52C65D5 /* AWSXMLDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A185053CD443C6EBC867E791ED606C7 /* AWSXMLDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		788692E6436FAA77FB4106A8A43A6D43 /* AWSFMDB+AWSHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = E58B03068CE40D8ED77CDDDAEBA1F7CD /* AWSFMDB+AWSHelpers.m */; };
+		7A91CEDA043B8B5257FD9D1EAA5614A7 /* AWSJKBigInteger.m in Sources */ = {isa = PBXBuildFile; fileRef = D10626859DA048A75C2CCB320B621AED /* AWSJKBigInteger.m */; };
+		7AD034A4C74DD3FAC09164FF4462B682 /* AWSFMDatabaseQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 9070A8B295592AD54BB34A0D91C47A13 /* AWSFMDatabaseQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7B81C22E00652B512C92118BE69467EE /* AWSCognitoIdentityProviderASF.h in Headers */ = {isa = PBXBuildFile; fileRef = C7F6DB16EB1746250ACF870AAB650897 /* AWSCognitoIdentityProviderASF.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BA450B429AD6BFB0CD6903F48A3A73A /* AWSAuthCore.h in Headers */ = {isa = PBXBuildFile; fileRef = D2A728A07C5AB3BEBD73851BDE3014EC /* AWSAuthCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7C54E87DA0FEDA01C2E6466361F2E915 /* NSError+AWSMTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = 462CDC7FF48F22B4AAE6EEF830B635BC /* NSError+AWSMTLModelException.m */; };
 		7E563800D6BC72004F79096CF284A320 /* Pods-Amplify-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B8A667E74EC0A8A4EDFB8F2D2364FC92 /* Pods-Amplify-dummy.m */; };
-		7E72445D57E2B1377BB8C31D0D45F583 /* AWSDDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = C0EC70C2BA5512DF72AFA093567E3C77 /* AWSDDAbstractDatabaseLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7FAAD3074FCCD0FB5F7DC085A79F1352 /* AWSMTLManagedObjectAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 43D03953BFA2E6934D54CB37BD928875 /* AWSMTLManagedObjectAdapter.m */; };
-		82B604223403F2D8913736CDBCBD3421 /* AWSTMCacheBackgroundTaskManager.h in Headers */ = {isa = PBXBuildFile; fileRef = DE03FBF91D2AF7BAA3FB5C980A81A710 /* AWSTMCacheBackgroundTaskManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		84F1B973AFBCCC12088C40C41A9AAD0E /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = FDA5DAF5A2814098C88ED0FD0FC32609 /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		858196891699CB779D9415EE462CD40B /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = F8908348756A5F294A2146253E4E6036 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */; };
-		85DF3750F9FDC7219E7E1BF6F9194D4D /* AWSTMDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = CBFDB4B8172D6C61FE1187BBB4E56BC2 /* AWSTMDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		865DC647D80B2C560666A8BC90753092 /* AWSSTS.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DD558EF138166AFAEC0D40FDD36E577 /* AWSSTS.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		867F53F6C252DB86B6980B38127D670A /* AWSFMResultSet.h in Headers */ = {isa = PBXBuildFile; fileRef = A558F5B8A104C627E526058158AE0D6E /* AWSFMResultSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8B56F42D143D78C6F5BD42A941106BA9 /* AWSService.m in Sources */ = {isa = PBXBuildFile; fileRef = 4140977A6FA9DE8FA6A6D16739462D51 /* AWSService.m */; };
-		8B674E154C488891F92084314F681415 /* AWSCognitoIdentityProviderService.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DFFDD9A7C09947D8DF8677179D0A608 /* AWSCognitoIdentityProviderService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7E72445D57E2B1377BB8C31D0D45F583 /* AWSDDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = FA6A72CA7E9DB7934F504E63345D0635 /* AWSDDAbstractDatabaseLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7FAAD3074FCCD0FB5F7DC085A79F1352 /* AWSMTLManagedObjectAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = B11E3E578B6A82BCB60452DC1BD11497 /* AWSMTLManagedObjectAdapter.m */; };
+		82B604223403F2D8913736CDBCBD3421 /* AWSTMCacheBackgroundTaskManager.h in Headers */ = {isa = PBXBuildFile; fileRef = CFEFDEFC752A05AEBFAEE9287B8C6C95 /* AWSTMCacheBackgroundTaskManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		84F1B973AFBCCC12088C40C41A9AAD0E /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B36E571A29663AF25C341351BE0E535 /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		858196891699CB779D9415EE462CD40B /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = F2E12DA949B01FEE2CC603DA99CF8297 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */; };
+		85DF3750F9FDC7219E7E1BF6F9194D4D /* AWSTMDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 339E1CE102BC4BB102802E45F284D351 /* AWSTMDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		865DC647D80B2C560666A8BC90753092 /* AWSSTS.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D58BA2E475335E66080FC0D3FBFD71D /* AWSSTS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		867F53F6C252DB86B6980B38127D670A /* AWSFMResultSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 027C2C3E0A7A0F6A2B29BAD18C391FFF /* AWSFMResultSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		899F3EC9E3871788006C0546EBC03291 /* AWSMobileOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36153241DF271B6510265692E8601389 /* AWSMobileOptions.swift */; };
+		8B56F42D143D78C6F5BD42A941106BA9 /* AWSService.m in Sources */ = {isa = PBXBuildFile; fileRef = F5D5EF4FA3EE8E11F63F483551BBD131 /* AWSService.m */; };
+		8B674E154C488891F92084314F681415 /* AWSCognitoIdentityProviderService.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C19D4A110D91264453BBB9118B200A2 /* AWSCognitoIdentityProviderService.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8C3D6083788CFA96F014554916B47E96 /* Pods-AmplifyTestApp-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CC60529D233360B1F356DC750E15164 /* Pods-AmplifyTestApp-dummy.m */; };
-		8C4F65C6BCEB1D62FD195E15403F01F9 /* AWSGZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = E5650AB2D7426F36016C0C56FA58833F /* AWSGZIP.m */; };
-		8DE2768806CC526886BF6D06E8E83C1D /* AWSInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = D23EA41EC03920EDF5FE81A6E7774ECF /* AWSInfo.m */; };
-		8E17B1081D3CEBCA661AF6EF03AA9B91 /* AWSCognitoIdentityProviderASF.m in Sources */ = {isa = PBXBuildFile; fileRef = D5EEAEBFA0B348201AF50C3642961DEA /* AWSCognitoIdentityProviderASF.m */; };
-		92944936808E537A51D7FB76879573B0 /* AWSFMDatabasePool.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CC8A065D0769AB2ECDAC257704CD436 /* AWSFMDatabasePool.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9330A6BAFFA518B4BECBFAD3412BF162 /* AWSSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = B7A45684A9DDAC60CCD1D5EB54FF56C6 /* AWSSerialization.m */; };
-		9343EE314C0B2A5126CC43BA07AC6001 /* AWSUIConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AD291698E9564B20B51B0D4028722AA /* AWSUIConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		94E032B726F3F3D2425C5803AA3905E5 /* AWSCore-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = AF6921AC94F623D44C58944BE45619E2 /* AWSCore-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		95465C26DCAF34829BEDF0B2873E5D22 /* AWSSynchronizedMutableDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 97D015DB895D5976B9057D0058FA45B8 /* AWSSynchronizedMutableDictionary.m */; };
+		8C4F65C6BCEB1D62FD195E15403F01F9 /* AWSGZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = 6361BDBF377F2B9595FCD732C31B036C /* AWSGZIP.m */; };
+		8DE2768806CC526886BF6D06E8E83C1D /* AWSInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = D8EC027F8F5E0F4E44345B01B84922F9 /* AWSInfo.m */; };
+		8E17B1081D3CEBCA661AF6EF03AA9B91 /* AWSCognitoIdentityProviderASF.m in Sources */ = {isa = PBXBuildFile; fileRef = 908EC0C96498A900CFC04A0CDCC991CA /* AWSCognitoIdentityProviderASF.m */; };
+		8ED2F8EE57C9042901D80E722D41AC0D /* AWSCognitoIdentityUserPool+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 1511BFDFB232E150CCFE4273A8BEC15D /* AWSCognitoIdentityUserPool+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		900EB0A2321005B91FC71C7F8C7B92ED /* AWSCognitoIdentityProvider.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 897BE0E1152364146DF9E84966A20D23 /* AWSCognitoIdentityProvider.framework */; };
+		92944936808E537A51D7FB76879573B0 /* AWSFMDatabasePool.h in Headers */ = {isa = PBXBuildFile; fileRef = C07D57DF869D9069A075E30A89BCBDEA /* AWSFMDatabasePool.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9330A6BAFFA518B4BECBFAD3412BF162 /* AWSSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 684CECD6CF451445EB12F03012D0E497 /* AWSSerialization.m */; };
+		9343EE314C0B2A5126CC43BA07AC6001 /* AWSUIConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ECF880F10C3E80885D927556F50EBE0 /* AWSUIConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		941E42D1D509D1F582000664CD91E228 /* _AWSMobileClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 01FEE8B969AD0E52BDF198E5E5CF4E20 /* _AWSMobileClient.m */; };
+		94E032B726F3F3D2425C5803AA3905E5 /* AWSCore-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C8F7368725476CB7FE657AE00468D41 /* AWSCore-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		95465C26DCAF34829BEDF0B2873E5D22 /* AWSSynchronizedMutableDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = FF4D7246D889EDCC40A48C2DC76F486B /* AWSSynchronizedMutableDictionary.m */; };
 		960B8E71E94DFFC52104B7D2A005F701 /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47D46D2BEC1D90EDAE4F1B547348EEFB /* AWSCore.framework */; };
-		96D71A9A27A288204F9C2C6FB0938075 /* AWSCancellationTokenSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 70DC08BD2BFFE31FA6F545CDAE7F1521 /* AWSCancellationTokenSource.m */; };
-		96D859318FE7B536D841C4B7ED8915B9 /* AWSTMCache.h in Headers */ = {isa = PBXBuildFile; fileRef = F35780388FBA1CDB5C6EF5550FFA96A0 /* AWSTMCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		97C52BFCC42E09EEE37E0F079375C892 /* JSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9350B3FCF664ACBA1B6AAA745BBCA308 /* JSONHelper.swift */; };
-		98E684975408A0A06FE6BCE1431F686A /* AWSLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 036C1A0B72AAAD2A7B27A08BADDF1105 /* AWSLogging.m */; };
-		99D77CDBCF4C3CF91116F5E54921F181 /* NSError+AWSMTLModelException.h in Headers */ = {isa = PBXBuildFile; fileRef = F93CBFC571C283CD341B9B26BF47FC17 /* NSError+AWSMTLModelException.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9C348F0554641CE5E4D400226C483C84 /* AWSSignature.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E2C320736C8649DB501945D50D6C78A /* AWSSignature.m */; };
-		9C756224993E158189C803D1CF6DB659 /* AWSMobileClientExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4408ED574FF1E08009DA696D607E328E /* AWSMobileClientExtensions.swift */; };
+		96D71A9A27A288204F9C2C6FB0938075 /* AWSCancellationTokenSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DA3287D1051A982150A16354E05729C /* AWSCancellationTokenSource.m */; };
+		96D859318FE7B536D841C4B7ED8915B9 /* AWSTMCache.h in Headers */ = {isa = PBXBuildFile; fileRef = CE5510001721226909CB6D1FD2875C27 /* AWSTMCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		98E684975408A0A06FE6BCE1431F686A /* AWSLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 00CE72944F60DE5B6AFFE039FEE27628 /* AWSLogging.m */; };
+		99D77CDBCF4C3CF91116F5E54921F181 /* NSError+AWSMTLModelException.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A71BCB9D1D845C22B8809633F9620D0 /* NSError+AWSMTLModelException.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C348F0554641CE5E4D400226C483C84 /* AWSSignature.m in Sources */ = {isa = PBXBuildFile; fileRef = 4ED74CDFDF691D03F15EA506908E33BB /* AWSSignature.m */; };
 		9D914E2C5BB01F438CE2CEFAF3518D6F /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C6DDDDA1D966AED315AB70664004815 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9E6E606BC775C9D70B5F73B75F6466D7 /* AWSCognitoIdentityService.h in Headers */ = {isa = PBXBuildFile; fileRef = AD5FC9E5E349DFF661B54E9F8250C8DD /* AWSCognitoIdentityService.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9F178FED04D876360188F685980EC42B /* AWSSignInManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E8FD7E40163054B20474E96395CF492 /* AWSSignInManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A1B8BC6F446260D9062F08EE602A11BB /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = AE3F8F35FA2FD71D338FE3D37E52F586 /* CwlMachBadInstructionHandler.m */; };
-		A26278DDB3EBC5C5A65C4C86382B0AF8 /* NSObject+AWSMTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5647E2F9B6864AD929CCA40EA73DCE8B /* NSObject+AWSMTLComparisonAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A26C2FD9F3C6A6D8C8859C915163A0B6 /* AWSCognitoIdentity+Fabric.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F70FE0555C85607F11E8C4D0D47EB14 /* AWSCognitoIdentity+Fabric.m */; };
-		A325BDDE98FB22C8DCB42AFCA0A0A1A1 /* AWSFMResultSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D3606B6B7DB161FF6D16A4BE6B27CF3 /* AWSFMResultSet.m */; };
-		A3E2BFD1F35BCE94C2023D88AA5BC579 /* AWSDDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = D5A8E99D231E0EF059DDD30DC9EF7ACA /* AWSDDASLLogger.m */; };
+		9E6E606BC775C9D70B5F73B75F6466D7 /* AWSCognitoIdentityService.h in Headers */ = {isa = PBXBuildFile; fileRef = E6F202A2FD892627C0EF882824F27BCA /* AWSCognitoIdentityService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F178FED04D876360188F685980EC42B /* AWSSignInManager.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD5C07B7B0098C5EC1BEBF2AAD6C14A /* AWSSignInManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A16C4E9390E6BB2980D939DC8E65B67C /* AWSCognitoAuthUICKeyChainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = D7FB5EC310EC2FBA3E3D06C5E019776B /* AWSCognitoAuthUICKeyChainStore.m */; };
+		A1B8BC6F446260D9062F08EE602A11BB /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = FD79CF64ECEFC4149AE7F39B2B655E43 /* CwlMachBadInstructionHandler.m */; };
+		A26278DDB3EBC5C5A65C4C86382B0AF8 /* NSObject+AWSMTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = E659B3C97121218F1492034D211C16A4 /* NSObject+AWSMTLComparisonAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A26C2FD9F3C6A6D8C8859C915163A0B6 /* AWSCognitoIdentity+Fabric.m in Sources */ = {isa = PBXBuildFile; fileRef = B6D986AC4E2FA03EB562FBA9B4ECA3A7 /* AWSCognitoIdentity+Fabric.m */; };
+		A325BDDE98FB22C8DCB42AFCA0A0A1A1 /* AWSFMResultSet.m in Sources */ = {isa = PBXBuildFile; fileRef = E63D1E12BE6C215A049BDE4E29BE7A9F /* AWSFMResultSet.m */; };
+		A3E2BFD1F35BCE94C2023D88AA5BC579 /* AWSDDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 310DF5A3069A557E9AD8F57B23ADD30E /* AWSDDASLLogger.m */; };
 		A6598CE3C61D646FEB39A1CC9AC3BA6F /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9000133D745E33FE1ED02390F5F7E717 /* CoreGraphics.framework */; };
-		A81152A334E18EC67B13C8DE062572C9 /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = C631E2DE9FE7DA03B470387BA48FA71B /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9E6B3F4412CAA30168D675A302122E9 /* AWSNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = A8CE8311B2C6B175B02EC6B1F56687F0 /* AWSNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A81152A334E18EC67B13C8DE062572C9 /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A30705F0417FDF552E067AF6EF268D5 /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A9E6B3F4412CAA30168D675A302122E9 /* AWSNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 46B0C01A79129C2F6A54B238E8F9087D /* AWSNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA518F23ECB9642D933EEB2D112C00FB /* AWSCognitoIdentityProviderASF.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4144DE60EA249CC4A98549069F402FB /* AWSCognitoIdentityProviderASF.framework */; };
 		AA66B7FEEAF81CA08B1515A1BDFA8511 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		ABC164C2B5402553E19E1CE32AE65E14 /* AWSCredentialsProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 46294BA1DAA83E771D4E3CD12CF92E76 /* AWSCredentialsProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AC0913A1E4C9CDEC5699AD154BA254A1 /* AWSCognitoIdentityService.m in Sources */ = {isa = PBXBuildFile; fileRef = 6247E23DAB89A392D6700528BBD48435 /* AWSCognitoIdentityService.m */; };
-		AD223728D8DFA18B28E0340459453763 /* AWSCognitoIdentityProvider.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 897BE0E1152364146DF9E84966A20D23 /* AWSCognitoIdentityProvider.framework */; };
-		AE2C16CE9FB6CCEC0BAE444DEBD69234 /* AWSDDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 90D7A46D08EDB42C5A86B4AD9B660F37 /* AWSDDFileLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AF66AF015E286081DB48279E84D00286 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 941DB7BB735782EED88400ABA557EBEF /* CwlCatchException.m */; };
-		AF8EBCA0F90060448E15E47025733327 /* AWSCancellationToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 010AECEC67F6E8EEA0872F7CAC367AB9 /* AWSCancellationToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AFD9EAAB3DD21504017BEA68684667AD /* AWSFMDatabaseAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C8708ABDF32CDB4E9BFD531B2D8F853 /* AWSFMDatabaseAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B12C8A1CC225C17AFCA43D4BAF707E7B /* AWSCocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = 26E074B6C853307C638D3A214BCF13AD /* AWSCocoaLumberjack.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ABC164C2B5402553E19E1CE32AE65E14 /* AWSCredentialsProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = C2234B1A0DF8C9CE28E8C68E18C805D0 /* AWSCredentialsProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AC0913A1E4C9CDEC5699AD154BA254A1 /* AWSCognitoIdentityService.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F7CA3723D744757238C07123826DDC /* AWSCognitoIdentityService.m */; };
+		AE2C16CE9FB6CCEC0BAE444DEBD69234 /* AWSDDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 5585E543E7086486728B90AA10B862DA /* AWSDDFileLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AF66AF015E286081DB48279E84D00286 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = FBA16191241CDCD88AD45A8D7442A3F4 /* CwlCatchException.m */; };
+		AF8EBCA0F90060448E15E47025733327 /* AWSCancellationToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CEE5FE92E2539F612C836BB1A632631 /* AWSCancellationToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AFD9EAAB3DD21504017BEA68684667AD /* AWSFMDatabaseAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = AF18B5AF7B58C0B76C2A14EAEE5D5401 /* AWSFMDatabaseAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B12C8A1CC225C17AFCA43D4BAF707E7B /* AWSCocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EBB778180542D81D7FC5ED3366B2D14 /* AWSCocoaLumberjack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B496D83E23179346F1978A44D72C8CA5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		B5AFCE15B9D849BD84A6D6E46C144F16 /* AWSSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 767B4455799A98274C24D8D74C040E9B /* AWSSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B5AFCE15B9D849BD84A6D6E46C144F16 /* AWSSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DBE83C19DC30A060C2D831D7F984125 /* AWSSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5F01854ADFAC527435AAC6D505D9A46 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 11618E052B1995FC3B058B8E47104CFA /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-dummy.m */; };
-		B67CE9FC51F77CC591562D2BF2CA3EA2 /* AWSSTSResources.h in Headers */ = {isa = PBXBuildFile; fileRef = F8C4353DFDD27E3B9354357B7AA341EC /* AWSSTSResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B79F025D9EF7BB4E4860A39308B967B1 /* AWSCognitoIdentityUser.h in Headers */ = {isa = PBXBuildFile; fileRef = B99D4A986E8CBCFBC2680AF7EAC089A5 /* AWSCognitoIdentityUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BA498D6F2E108FF6A250EF156FB199CA /* AWSCognitoIdentity.h in Headers */ = {isa = PBXBuildFile; fileRef = 58FED07AFC163D4256064E2EF108B47A /* AWSCognitoIdentity.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BAC85A39D3808CE79873936E4231A6DA /* AWSURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = D06F68E04C132879F35438E6BE63CB8A /* AWSURLRequestSerialization.m */; };
-		BAF1E92557EF7F7F16BEBAB2E1A512A7 /* CwlPreconditionTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 95A58B6C533043AC03FC12B16145C38D /* CwlPreconditionTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BDAFBC302AFBD0169D63A493EF24F019 /* AWSEXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 4484ED4548415DDE3489B66C2F7ECC44 /* AWSEXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		BE6A0ECFE8619D15EF84F45C240644F5 /* AWSMTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D7F2FDC05F42701A1BDD38B8599A53E /* AWSMTLModel.m */; };
-		BE7ADABCCDB533FDC0433D0D631EF85E /* AWSMobileOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D90C37125647CF290576B422D6E22C /* AWSMobileOptions.swift */; };
-		BE8ABD8C2F11BF351AEC13B6FFFDF99A /* NSValueTransformer+AWSMTLInversionAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1ED7C4E40E0ADA485169F0899452DFDB /* NSValueTransformer+AWSMTLInversionAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B67CE9FC51F77CC591562D2BF2CA3EA2 /* AWSSTSResources.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B6BAF26D20D0180E4896EF36A5B0BF1 /* AWSSTSResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B79F025D9EF7BB4E4860A39308B967B1 /* AWSCognitoIdentityUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 5638C97B13152127D5E6E6557DC97A04 /* AWSCognitoIdentityUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BA498D6F2E108FF6A250EF156FB199CA /* AWSCognitoIdentity.h in Headers */ = {isa = PBXBuildFile; fileRef = 273AD73149D84DE6A9A770236B1AFE18 /* AWSCognitoIdentity.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BAC85A39D3808CE79873936E4231A6DA /* AWSURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A5B1767D9974D948007D9204B58EE4A /* AWSURLRequestSerialization.m */; };
+		BAF1E92557EF7F7F16BEBAB2E1A512A7 /* CwlPreconditionTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C9A91CD0EAEB627AE0578265E674CB7 /* CwlPreconditionTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BDAFBC302AFBD0169D63A493EF24F019 /* AWSEXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = CCFDCFECB7A9F22FBCE4A3FEE83F7A0F /* AWSEXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BE6A0ECFE8619D15EF84F45C240644F5 /* AWSMTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ED2F05C0CFB21845242D662C888AEAC /* AWSMTLModel.m */; };
+		BE8ABD8C2F11BF351AEC13B6FFFDF99A /* NSValueTransformer+AWSMTLInversionAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 41F1B2AFD50E7D6ACE8ECEB132F4ABD7 /* NSValueTransformer+AWSMTLInversionAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BEA4DBC17C6B9BCE2C41179ECC3DAA1D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
 		BEEC4A944FADA30EC4B4A113212AEEE5 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE49F6473631850D3EC76C328D5772CB /* UIKit.framework */; };
-		C2A8E95E1378D95C29118217596E5EEA /* AWSDDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 23B9D4394992AEF47ED06DEFAE0CCB3F /* AWSDDDispatchQueueLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C3525FB9301A85B4E55C6F01D3BBDD5A /* AWSMTLReflection.h in Headers */ = {isa = PBXBuildFile; fileRef = 77F306093B6CBBA95ABD2D5A3A3FB885 /* AWSMTLReflection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C35B120FF2B1D18672753CF6EC0985DD /* AWSCore-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 029EA3765EA878F565018D51C0483252 /* AWSCore-dummy.m */; };
-		C3E5346133EC63B83B5B163399B39A1B /* AWSURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1525D826E1F48AFA731D858D680381DE /* AWSURLSessionManager.m */; };
-		C46FEE5166870EAC61B19C9EDB7AADC3 /* AWSCognitoIdentityProviderHKDF.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AFD14509FFB3301CAB730E079CEEB0E /* AWSCognitoIdentityProviderHKDF.m */; };
+		C2A8E95E1378D95C29118217596E5EEA /* AWSDDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AC3528B305A2ADD668D6DB18F2A3B5B /* AWSDDDispatchQueueLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C3525FB9301A85B4E55C6F01D3BBDD5A /* AWSMTLReflection.h in Headers */ = {isa = PBXBuildFile; fileRef = ADA3BEA703C8045AA4F37E7A0DA538AA /* AWSMTLReflection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C35B120FF2B1D18672753CF6EC0985DD /* AWSCore-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F68A7DBCC0D3EAA59DF8D0B4D6246193 /* AWSCore-dummy.m */; };
+		C3E5346133EC63B83B5B163399B39A1B /* AWSURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5950D58519C02B45CFF4C1DDED370A48 /* AWSURLSessionManager.m */; };
+		C46FEE5166870EAC61B19C9EDB7AADC3 /* AWSCognitoIdentityProviderHKDF.m in Sources */ = {isa = PBXBuildFile; fileRef = C35534705967F0C84203915633DD3B00 /* AWSCognitoIdentityProviderHKDF.m */; };
 		C4F5A55C56D472D4F7D140D0950B6E97 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 189C8021820D164FA9236F1D27850C3F /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C61912BA5E6897BB6DF7A83C5114AC61 /* AWSAuthUIHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = AEFF9779FFD86E5968A8FE9D63B5D8C6 /* AWSAuthUIHelper.m */; };
-		C682CF45DC1BE3A1391C38D98B23178D /* AWSTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 971FD80F5A3D56DB110CD4F03667D4F7 /* AWSTask.m */; };
-		C6E6CC33D0DC9F7F706B5BEECD5C5A75 /* AWSDDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = BE8A00F21039086E055FBF70CCEC010F /* AWSDDTTYLogger.m */; };
-		C7BB5752DCF16A55A09916C85EB64EA1 /* AWSTMMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B7D7D279373248B855C695D8D59114CF /* AWSTMMemoryCache.m */; };
-		CA226D1FC3EC02847A70C9DC565362CC /* AWSTaskCompletionSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 155ECD0389C655CA5CAFCA1423B7F81E /* AWSTaskCompletionSource.m */; };
-		CA46FB0B92B5831CD73B49D188549037 /* aws_tommath_class.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B95B14A33E444B4CBF86C41B8B7D62E /* aws_tommath_class.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		CA8CAC4B7D5CEA18AEC162BE523E3368 /* AWSServiceEnum.h in Headers */ = {isa = PBXBuildFile; fileRef = 78880857643C7E7D963CA06F4F79046E /* AWSServiceEnum.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CAC63FC5740B67E322F64FA92C51BE29 /* AWSBolts.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A57694184C5305A7FCCB3AB57A02501 /* AWSBolts.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CAD5041B5768C4F6E0EE0C3D3EA1C439 /* AWSCognitoIdentityProviderHKDF.h in Headers */ = {isa = PBXBuildFile; fileRef = 1308C8001B6B55E7EC2C391A36C5A35F /* AWSCognitoIdentityProviderHKDF.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBFDA937C68D277582439A7F827791FA /* AWSBolts.m in Sources */ = {isa = PBXBuildFile; fileRef = C9855730379BD00EDA06B67D9E6ACE5A /* AWSBolts.m */; };
+		C61912BA5E6897BB6DF7A83C5114AC61 /* AWSAuthUIHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 872636C9955205D3C03F3292C874723D /* AWSAuthUIHelper.m */; };
+		C682CF45DC1BE3A1391C38D98B23178D /* AWSTask.m in Sources */ = {isa = PBXBuildFile; fileRef = A5ACFCA344CAB9104886458B50F41D9F /* AWSTask.m */; };
+		C6E6CC33D0DC9F7F706B5BEECD5C5A75 /* AWSDDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 03FF7AA2BD18C5D37CBB5E3373B83E71 /* AWSDDTTYLogger.m */; };
+		C7BB5752DCF16A55A09916C85EB64EA1 /* AWSTMMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = F5DE71904156D1E5147D1B17672FB2FE /* AWSTMMemoryCache.m */; };
+		CA226D1FC3EC02847A70C9DC565362CC /* AWSTaskCompletionSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 01D529BFBEBC106018D1829C409F5B6D /* AWSTaskCompletionSource.m */; };
+		CA46FB0B92B5831CD73B49D188549037 /* aws_tommath_class.h in Headers */ = {isa = PBXBuildFile; fileRef = B18D92A4C431C09D10D5D8CC118F2BA2 /* aws_tommath_class.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		CA8CAC4B7D5CEA18AEC162BE523E3368 /* AWSServiceEnum.h in Headers */ = {isa = PBXBuildFile; fileRef = 87194275CD609A95EE6BE32E11B439AF /* AWSServiceEnum.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CAC63FC5740B67E322F64FA92C51BE29 /* AWSBolts.h in Headers */ = {isa = PBXBuildFile; fileRef = A47DD5329604787552A80065E28C4562 /* AWSBolts.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CAD5041B5768C4F6E0EE0C3D3EA1C439 /* AWSCognitoIdentityProviderHKDF.h in Headers */ = {isa = PBXBuildFile; fileRef = 3502B24960607AF0083FB45A99DD9B78 /* AWSCognitoIdentityProviderHKDF.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CBFDA937C68D277582439A7F827791FA /* AWSBolts.m in Sources */ = {isa = PBXBuildFile; fileRef = BD964C13D7DC3E8EE957B28480B8577E /* AWSBolts.m */; };
 		CC3489D3AE121850205206C8DA3AC9BB /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 71803B908C82923324FBC55B50603420 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CCF3D812222A96CB42B542F4D68A6B3F /* AWSUserPoolOperationsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580FC54E047092D4BF64987DEBEB6CEC /* AWSUserPoolOperationsHandler.swift */; };
-		CD670349157D1CC299C595DBC118D553 /* AWSMobileResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714CBDF84C8FCD04FDAEA70868566A07 /* AWSMobileResults.swift */; };
-		CD9C8503D19F1E4D26A2D1705B7C922C /* AWSURLRequestRetryHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = A25BD6858ACA564889F5C1888E45B49F /* AWSURLRequestRetryHandler.m */; };
-		CEAD5A825A2B2228733F1F745D85024D /* AWSSignInProviderApplicationIntercept.h in Headers */ = {isa = PBXBuildFile; fileRef = E741028ED94706419B1152DBA9543194 /* AWSSignInProviderApplicationIntercept.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D0008DB1D694408559F50AD06E9DCF00 /* AWSUserPoolCustomAuthHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2C8BF9E57FA143E2FA9728ADECB584 /* AWSUserPoolCustomAuthHandler.swift */; };
-		D3C7CEE1ABDD4DB9F318808066874630 /* AWSInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = AEF01236FCF1B3D525155ED54ED94047 /* AWSInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D3F34BB211709B19D794F38CAE744DCF /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD31702686B78C00DC137B99F2D43FC1 /* CwlCatchException.swift */; };
-		D448DBF68ABFA8F084BE3AAE05171D4C /* AWSClientContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 7746660A2B9ABA1322C22635208C039D /* AWSClientContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D4F6F977E4D77F9982B1AF5B6ABBDC46 /* AWSFMDatabase+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = ADA0D94F6857763CE195680591541616 /* AWSFMDatabase+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D50A080B30C8131DB858F71727E0B271 /* AWSMTLValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DC551498486764772714478E98073EE /* AWSMTLValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CD9C8503D19F1E4D26A2D1705B7C922C /* AWSURLRequestRetryHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = F26E71EF1BDDEE78B79B7BB5D13867F2 /* AWSURLRequestRetryHandler.m */; };
+		CE96BB65FD82A94CC9C9BBE2FEDC0872 /* AWSCognitoAuth+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = A4D55EE93BAD6722690D0733CBA4DDAA /* AWSCognitoAuth+Extensions.m */; };
+		CEAD5A825A2B2228733F1F745D85024D /* AWSSignInProviderApplicationIntercept.h in Headers */ = {isa = PBXBuildFile; fileRef = AEEF8E360ECF4856E8D30DEA489B6375 /* AWSSignInProviderApplicationIntercept.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D3C7CEE1ABDD4DB9F318808066874630 /* AWSInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = A37E2B51E0D1700AA624270A7EDB8065 /* AWSInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D3F34BB211709B19D794F38CAE744DCF /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = A073D61814D5A8291BF1F81E0E356A86 /* CwlCatchException.swift */; };
+		D448DBF68ABFA8F084BE3AAE05171D4C /* AWSClientContext.h in Headers */ = {isa = PBXBuildFile; fileRef = E3DEB4BB14ADF2C4DA3E34690F303CCC /* AWSClientContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D4F6F977E4D77F9982B1AF5B6ABBDC46 /* AWSFMDatabase+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = FE7A4E003A10C45BE9B95A3DF34742ED /* AWSFMDatabase+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D50A080B30C8131DB858F71727E0B271 /* AWSMTLValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 242721755168E4E5F8D03D5703F95D45 /* AWSMTLValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D543D7550F4B79012301D277113C1132 /* AWSMobileClient-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D3C0F6EA1AA31E2C61D1EE399A42644 /* AWSMobileClient-dummy.m */; };
 		D5C3DC01A7E8D3CA0C9F9E2A09D56C86 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE49F6473631850D3EC76C328D5772CB /* UIKit.framework */; };
 		D6B6F05BD0397853158A47B854089582 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
 		D76CECDB2FAB94F3D8DD51B54EA7F510 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		D995F1889A0498202C5B04A04ED81688 /* NSDictionary+AWSMTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 87757B02A6B5FA4D18E0ED5C0605EEF3 /* NSDictionary+AWSMTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D9A075C15C47BC77535148A5A2D2C468 /* AWSDDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 622CFB3E9A43C8FE15F37616F03BDEF4 /* AWSDDAbstractDatabaseLogger.m */; };
-		DA8E7AD70C4E70661341B17628B98B9D /* CwlCatchException-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 30380984D336CF3DBF74479B66E317B8 /* CwlCatchException-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DABA700D6E837C34EA646731E2426132 /* AWSDDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E7216BDE7E63D1C09D9DD55B461C1F7 /* AWSDDMultiFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DBCA55BB7256CF0FCC1535AB9B0D3550 /* AWSURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ACD0297802CDDDFBC77BF5D6C40D7B6 /* AWSURLResponseSerialization.m */; };
-		DBF5AAEC5F1978380EC14D82EDF31054 /* AWSLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB7550EAF118FA23F6FBAE5B851974E /* AWSLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D995F1889A0498202C5B04A04ED81688 /* NSDictionary+AWSMTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 673E1078C0B75EFB8FE7F59BBE328D78 /* NSDictionary+AWSMTLManipulationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9A075C15C47BC77535148A5A2D2C468 /* AWSDDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DDAEC751D8F7248C8707C9C89D9C7BA1 /* AWSDDAbstractDatabaseLogger.m */; };
+		DA8E7AD70C4E70661341B17628B98B9D /* CwlCatchException-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A71B7F640BDB684BA90C692996235E16 /* CwlCatchException-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DABA700D6E837C34EA646731E2426132 /* AWSDDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7FF0F5FBA94A96228D3BFFD35DEB7110 /* AWSDDMultiFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBCA55BB7256CF0FCC1535AB9B0D3550 /* AWSURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = AF376D908F93D6D7CAD373AAE433A82C /* AWSURLResponseSerialization.m */; };
+		DBF5AAEC5F1978380EC14D82EDF31054 /* AWSLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = F755C43F37ED223430AC027C80588804 /* AWSLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD391DA8A4F2D8D3EFA2387964725A24 /* AWSCognitoAuth.m in Sources */ = {isa = PBXBuildFile; fileRef = 90DE9F1B9757E0239BEFD5FB9794389E /* AWSCognitoAuth.m */; };
 		DEFC6955484751C28D36B1126354830B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		E14859804FDF14B09F1DDF7C2E3404E4 /* AWSFMDatabaseAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 69F008F7FC765D8E3A19AAE2CB0540F1 /* AWSFMDatabaseAdditions.m */; };
-		E1702B4EF8EC1AB6F934AC3BC6600A6F /* AWSMTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CE9D44BE59C6645651F72F311DB6C0A /* AWSMTLReflection.m */; };
-		E2121B84A87B54637022A745BA905991 /* AWSCognitoIdentity+Fabric.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A364A9DC40F0E30BA70256B9A77A5BE /* AWSCognitoIdentity+Fabric.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		E67AC75CF625D30A349F06B872AD7DC7 /* FABKitProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C3978F270280E8D902436A08201BCD1 /* FABKitProtocol.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E14859804FDF14B09F1DDF7C2E3404E4 /* AWSFMDatabaseAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 49B67ABB110D56E576AC4D5F32B61152 /* AWSFMDatabaseAdditions.m */; };
+		E1702B4EF8EC1AB6F934AC3BC6600A6F /* AWSMTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = 30DDEEE98E0A7984402264B567FBD8B5 /* AWSMTLReflection.m */; };
+		E2121B84A87B54637022A745BA905991 /* AWSCognitoIdentity+Fabric.h in Headers */ = {isa = PBXBuildFile; fileRef = 10EF994DBB36E63B54867C1A41328E80 /* AWSCognitoIdentity+Fabric.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E2C09DB09ACE2CA2677337DB8BD28CF9 /* AWSCognitoCredentialsProvider+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EFCD22A63266EDD9823DF548654C7D0 /* AWSCognitoCredentialsProvider+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E67AC75CF625D30A349F06B872AD7DC7 /* FABKitProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CC923FF920DB28C101C420CE987CDE6 /* FABKitProtocol.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E70FC945E697C5DB7BEB83F5DDA67DA4 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 16B0120C1306E487433FCA2B1B0D2673 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E93E93B977E8B8E4C067729097481601 /* AWSEXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3228E5C6E903750905DC08BDF584C5DA /* AWSEXTRuntimeExtensions.m */; };
-		EBB5629A5A587AB94332D976DE76116B /* NSValueTransformer+AWSMTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A95F247C52F4E16F0A83457315C849CE /* NSValueTransformer+AWSMTLInversionAdditions.m */; };
-		EBDCAD5D12AE793D0A153530B8461492 /* AWSURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 149D72F554244193A0B7AF373ECCBD2F /* AWSURLResponseSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E93E93B977E8B8E4C067729097481601 /* AWSEXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F91B0BD12C66BBA65E5DAFD870CC13B /* AWSEXTRuntimeExtensions.m */; };
+		EBB5629A5A587AB94332D976DE76116B /* NSValueTransformer+AWSMTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B012CBF798D101D7AEA5DEBB931D457F /* NSValueTransformer+AWSMTLInversionAdditions.m */; };
+		EBDCAD5D12AE793D0A153530B8461492 /* AWSURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8331C110587ED90AD1EE22D37D3FB473 /* AWSURLResponseSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EC2BC6AB009C3407813297E7660041CD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		EC8750873DB5F6265E48BA9315A7B2F5 /* AWSMTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FB0B0BC703C60784559FD78705D2D3D /* AWSMTLJSONAdapter.m */; };
-		ED85DB4CE570B57E433BCFB56BBCBF04 /* AWSCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = 32DF266EBC63223640E52EF97B646531 /* AWSCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EE24CB2671D97C781BA65442CA43DB00 /* AWSCognitoIdentityUser.m in Sources */ = {isa = PBXBuildFile; fileRef = C84851ADEA14436507FF1E16E5963703 /* AWSCognitoIdentityUser.m */; };
-		F091C99F7BB142D1DB6152C7E144B9D2 /* AWSNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = E5B47752E9EE042403E350EA1AF40218 /* AWSNetworking.m */; };
-		F0C669060B8BFEF00131CC06B6995586 /* AWSExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = 25932903D3A78965B86E733E30B3A4F5 /* AWSExecutor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3909ADAF51026D1484701DFCB9F515D /* NSData+AWSCognitoIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 83A9210E4B66522692BA0A044AAEF7F9 /* NSData+AWSCognitoIdentityProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EC8750873DB5F6265E48BA9315A7B2F5 /* AWSMTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = BDDF6BB547C0073ED648AEE5125B4F0D /* AWSMTLJSONAdapter.m */; };
+		ED85DB4CE570B57E433BCFB56BBCBF04 /* AWSCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C9BDD821D2BDC642CAC2A7BF82A6913 /* AWSCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EE24CB2671D97C781BA65442CA43DB00 /* AWSCognitoIdentityUser.m in Sources */ = {isa = PBXBuildFile; fileRef = E59519C5B196AAADB322109C848F8D62 /* AWSCognitoIdentityUser.m */; };
+		F091C99F7BB142D1DB6152C7E144B9D2 /* AWSNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BDEA4EB168EBEBCC1D9348786941864 /* AWSNetworking.m */; };
+		F0C669060B8BFEF00131CC06B6995586 /* AWSExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = 39D68F4B4E147627F473B3F5A76EE989 /* AWSExecutor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F3909ADAF51026D1484701DFCB9F515D /* NSData+AWSCognitoIdentityProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D5EAB70088187E6D937450A0EE0371F /* NSData+AWSCognitoIdentityProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F57674F250149BF452F8E2CD1CFACB13 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */; };
-		F5EFC3BA946FAB0C653C0EFB9187348D /* AWSUICKeyChainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 975762B5F22BD7567982C2729A08EA29 /* AWSUICKeyChainStore.m */; };
-		F785DACA06792679253D0114D2B1B1C1 /* AWSCognitoIdentityProviderModel.h in Headers */ = {isa = PBXBuildFile; fileRef = E6817AA3657D8B7016DB050FE83CED49 /* AWSCognitoIdentityProviderModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F96D20AF94D29F7EF73DD8CD5F3197E0 /* AWSCognitoIdentityUserPool_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = BB95B4A12DFA6DF4B15369418C26B48C /* AWSCognitoIdentityUserPool_Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FA1F41CB174865C3ABAA696511940338 /* AWSSTSService.m in Sources */ = {isa = PBXBuildFile; fileRef = EF84299E434B6BC8812A597F60CF31F1 /* AWSSTSService.m */; };
-		FA57383E56731300CB3E661B5BEF21DE /* AWSIdentityProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 13A2D98960FD11A58FC06B45008B2AB5 /* AWSIdentityProvider.m */; };
-		FB8B41B95B8FCACA60CD482A37357212 /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 27606DBCBEE7FCFCBD83D2D588CEC248 /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FC0DF3B29BF928EB487F36248496068F /* AWSDDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 8159E8A1827AD9AF774C2E6B233D8476 /* AWSDDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FCB0E2F79322AAE4808375602EE9E27C /* AWSService.h in Headers */ = {isa = PBXBuildFile; fileRef = BF99389237A0C6D569874D05DDDF0737 /* AWSService.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FCCD667C2ECB8F6AB815CFBE869B7BAE /* AWSValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = 1303984DBCAB633CD483D7079ADC6C16 /* AWSValidation.m */; };
-		FCF5EF0D7D0E39CEF61A1F8E7029923A /* AWSCredentialsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = F7F0ED5603B9A33A5AB2840F17157E94 /* AWSCredentialsProvider.m */; };
-		FDBB04B8FC16CF6EAD1AAC14B5E7B978 /* AWSDDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = F7621F4DF375E8B06CC6CC04110251B3 /* AWSDDLegacyMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FDCCAC00A99C74E2BE6C3FD070D45C3D /* AWSCancellationTokenRegistration.h in Headers */ = {isa = PBXBuildFile; fileRef = 024F9CB6EB0FEAF8CAE4285F303CA53D /* AWSCancellationTokenRegistration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FEBDB02A795559B8678FF609BD63DC5D /* AWSMobileClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ECA73D18A22B3C441E418C9672F2275 /* AWSMobileClient.swift */; };
-		FF2758D837FB5A2D465659698E8D095F /* AWSMTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 77DBCE95EEDBE6CF449375F56ED6A8A3 /* AWSMTLModel+NSCoding.m */; };
-		FF35610D44E99E6782EF579730D183DF /* AWSNetworkingHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = AD631971BF2738DD07F986967E16668B /* AWSNetworkingHelpers.m */; };
-		FF5A3D0068C906E484D9FB5CC613556E /* AWSCognitoAuthUICKeyChainStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 26EA69A80E1EB46F76DAEBEC08852B5B /* AWSCognitoAuthUICKeyChainStore.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		F5EFC3BA946FAB0C653C0EFB9187348D /* AWSUICKeyChainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 269A40768550F653508FB48F30B84DE5 /* AWSUICKeyChainStore.m */; };
+		F785DACA06792679253D0114D2B1B1C1 /* AWSCognitoIdentityProviderModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 90D4490B3295BD88B2945BC735E90E20 /* AWSCognitoIdentityProviderModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F96D20AF94D29F7EF73DD8CD5F3197E0 /* AWSCognitoIdentityUserPool_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EF7B8FE649AA081D9B6EFEF5488405D /* AWSCognitoIdentityUserPool_Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FA1F41CB174865C3ABAA696511940338 /* AWSSTSService.m in Sources */ = {isa = PBXBuildFile; fileRef = 319A14F2ECA5CE66FBBF4947814FB55E /* AWSSTSService.m */; };
+		FA57383E56731300CB3E661B5BEF21DE /* AWSIdentityProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = EF55065E914F7AFFC57EABE4AA68EDA2 /* AWSIdentityProvider.m */; };
+		FB10B80CC418942706405C6FDA423234 /* AWSMobileClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10AAE910007F70838053CD8B2249DF61 /* AWSMobileClient.swift */; };
+		FB8B41B95B8FCACA60CD482A37357212 /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = E3637C8CE0432A849F4E8AD934B90A6D /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FC0DF3B29BF928EB487F36248496068F /* AWSDDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 9422D282E5A081892F5121EA194A3FBD /* AWSDDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FC33B5AE93CAD05125F41344A7DC295C /* _AWSMobileClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 7269EFAE1FC03A808400B92FBF21AEEB /* _AWSMobileClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FCB0E2F79322AAE4808375602EE9E27C /* AWSService.h in Headers */ = {isa = PBXBuildFile; fileRef = 29E4D3FCB3A323A33756F3C0A355CA7C /* AWSService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FCCD667C2ECB8F6AB815CFBE869B7BAE /* AWSValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = A6FAA9739F0775D555007B48C7C4C604 /* AWSValidation.m */; };
+		FCF5EF0D7D0E39CEF61A1F8E7029923A /* AWSCredentialsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 0114DB9D0B630AB1D443D313FDF77E2A /* AWSCredentialsProvider.m */; };
+		FD3A3329F3101AF1F8969EA38080957E /* AWSMobileClient-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A243228FEE8808D847077999FFCA7FF5 /* AWSMobileClient-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FDBB04B8FC16CF6EAD1AAC14B5E7B978 /* AWSDDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = EA576F7350A5543992033B84E94CB16D /* AWSDDLegacyMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FDCCAC00A99C74E2BE6C3FD070D45C3D /* AWSCancellationTokenRegistration.h in Headers */ = {isa = PBXBuildFile; fileRef = 16DB3680F94B801F66F71AD86D933CB1 /* AWSCancellationTokenRegistration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF2758D837FB5A2D465659698E8D095F /* AWSMTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 672FB5623F8C9DF7073AC2256E28883D /* AWSMTLModel+NSCoding.m */; };
+		FF35610D44E99E6782EF579730D183DF /* AWSNetworkingHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B517F2F767F72EE01C808AB9BABE8AE /* AWSNetworkingHelpers.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -489,6 +490,13 @@
 			remoteGlobalIDString = E4D853F6FBAB5A9BDBE843E4EFB22EB7;
 			remoteInfo = CwlPreconditionTesting;
 		};
+		5E6F9F34B5C8CFC5E5A1534148440CAD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8042F2B0721B13AEDEB81F058C2B2125;
+			remoteInfo = AWSAuthCore;
+		};
 		64D33CCA8C986FD4F0DE98C883594278 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
@@ -545,13 +553,6 @@
 			remoteGlobalIDString = 308B5C440C446909122081D367A27A8F;
 			remoteInfo = CwlCatchException;
 		};
-		808E02155DEA9FFFA7AB26A41DE112FA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 29212B2F049288E035AB98405A23E41E;
-			remoteInfo = AWSCognitoIdentityProvider;
-		};
 		823ACA39C425FB28F6D8371F2DAAC525 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
@@ -579,6 +580,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = BBF90BA4F6EC5653945C7B0FFD9128D2;
 			remoteInfo = AWSCognitoIdentityProviderASF;
+		};
+		93D132FE40403BE2D60EC7A29146AB21 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 29212B2F049288E035AB98405A23E41E;
+			remoteInfo = AWSCognitoIdentityProvider;
 		};
 		95AF594731E7B749152FEA1779660277 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -621,13 +629,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 29212B2F049288E035AB98405A23E41E;
 			remoteInfo = AWSCognitoIdentityProvider;
-		};
-		ABF241B4BEC3E8ADB5E0B8D8BB34B97C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8042F2B0721B13AEDEB81F058C2B2125;
-			remoteInfo = AWSAuthCore;
 		};
 		ACA985698F78CE51CD54B4CC2C26CF5A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -807,387 +808,388 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		010075438C45B44D020D0DEC44200331 /* AWSCognitoAuth_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuth_Internal.h; path = AWSCognitoAuth/Internal/AWSCognitoAuth_Internal.h; sourceTree = "<group>"; };
-		010AECEC67F6E8EEA0872F7CAC367AB9 /* AWSCancellationToken.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationToken.h; path = AWSCore/Bolts/AWSCancellationToken.h; sourceTree = "<group>"; };
-		0163DD1DBE58F494454C5DFEEF1223C1 /* AWSCognitoIdentityUserPool+Extension.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoIdentityUserPool+Extension.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoIdentityUserPool+Extension.h"; sourceTree = "<group>"; };
-		01BB6268E3D1EC6B1989DED349F56779 /* CwlCatchException.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CwlCatchException.release.xcconfig; sourceTree = "<group>"; };
+		00CE72944F60DE5B6AFFE039FEE27628 /* AWSLogging.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSLogging.m; path = AWSCore/Utility/AWSLogging.m; sourceTree = "<group>"; };
+		0102E468AA0118F10BBC5E8A95511D8A /* AWSDDASLLogCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDASLLogCapture.m; path = AWSCore/Logging/AWSDDASLLogCapture.m; sourceTree = "<group>"; };
+		0114DB9D0B630AB1D443D313FDF77E2A /* AWSCredentialsProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCredentialsProvider.m; path = AWSCore/Authentication/AWSCredentialsProvider.m; sourceTree = "<group>"; };
+		0187DBE67FCE1366346974DF80312B67 /* AWSTaskCompletionSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTaskCompletionSource.h; path = AWSCore/Bolts/AWSTaskCompletionSource.h; sourceTree = "<group>"; };
+		01982698B8DE672BA75249A3AB0109A0 /* AWSAuthUIHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSAuthUIHelper.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.h; sourceTree = "<group>"; };
 		01CEDC80C5B028F2AE09C4BECC2F076B /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsCoreTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsCoreTests.framework; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		024F9CB6EB0FEAF8CAE4285F303CA53D /* AWSCancellationTokenRegistration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationTokenRegistration.h; path = AWSCore/Bolts/AWSCancellationTokenRegistration.h; sourceTree = "<group>"; };
-		029EA3765EA878F565018D51C0483252 /* AWSCore-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCore-dummy.m"; sourceTree = "<group>"; };
-		0315D5F3EF56116A89062732A9987884 /* AWSCognitoIdentityProvider.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCognitoIdentityProvider.release.xcconfig; sourceTree = "<group>"; };
-		0332051850FABA8FEB15A891758E27AB /* AWSXMLWriter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSXMLWriter.m; path = AWSCore/XMLWriter/AWSXMLWriter.m; sourceTree = "<group>"; };
-		036C1A0B72AAAD2A7B27A08BADDF1105 /* AWSLogging.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSLogging.m; path = AWSCore/Utility/AWSLogging.m; sourceTree = "<group>"; };
+		01D529BFBEBC106018D1829C409F5B6D /* AWSTaskCompletionSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTaskCompletionSource.m; path = AWSCore/Bolts/AWSTaskCompletionSource.m; sourceTree = "<group>"; };
+		01D6D4609A3577B4E149CB749B03486F /* AWSMobileClient-Mixed-Swift.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSMobileClient-Mixed-Swift.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSMobileClient-Mixed-Swift.h"; sourceTree = "<group>"; };
+		01FEE8B969AD0E52BDF198E5E5CF4E20 /* _AWSMobileClient.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = _AWSMobileClient.m; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.m; sourceTree = "<group>"; };
+		027C2C3E0A7A0F6A2B29BAD18C391FFF /* AWSFMResultSet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMResultSet.h; path = AWSCore/FMDB/AWSFMResultSet.h; sourceTree = "<group>"; };
+		02AD342B30967821122292AE6868639E /* AWSCognitoIdentityProviderASF.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCognitoIdentityProviderASF.release.xcconfig; sourceTree = "<group>"; };
 		03D039338D77A6CA524CBC57DE6E2BCF /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-dummy.m"; sourceTree = "<group>"; };
-		044F723309888175C12015B0DF8AC9D5 /* AWSSTSService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSService.h; path = AWSCore/STS/AWSSTSService.h; sourceTree = "<group>"; };
-		0476F9CA218102135BC385B5BB84C86C /* AWSAuthCore-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSAuthCore-dummy.m"; sourceTree = "<group>"; };
-		05091549D84201D3FF1A8EEED67D8902 /* AWSAuthCore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSAuthCore.debug.xcconfig; sourceTree = "<group>"; };
-		051437CDB0C1F99EB3D075000D7ED7C1 /* AWSCognitoIdentityModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityModel.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityModel.m; sourceTree = "<group>"; };
+		03FF7AA2BD18C5D37CBB5E3373B83E71 /* AWSDDTTYLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDTTYLogger.m; path = AWSCore/Logging/AWSDDTTYLogger.m; sourceTree = "<group>"; };
+		044E4A4B8546BF01B2105A7268CB7BB8 /* AWSmetamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSmetamacros.h; path = AWSCore/Mantle/extobjc/AWSmetamacros.h; sourceTree = "<group>"; };
+		0488FA91ED857D8097EC068E16175D50 /* AWSCognitoIdentityProviderResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderResources.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderResources.h; sourceTree = "<group>"; };
+		05302BD579C89A3103BBAA83726E1834 /* AWSSignInManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSignInManager.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInManager.m; sourceTree = "<group>"; };
+		05475131E478AE171AD76E7C793CF0C1 /* AWSCore-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCore-prefix.pch"; sourceTree = "<group>"; };
 		055A209829E9548F5285CA89F94E6CC2 /* Pods-Amplify-AWSPluginsCore.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AWSPluginsCore.modulemap"; sourceTree = "<group>"; };
-		05B36D2D93B4A2C91F36C08694488424 /* AWSCore.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCore.modulemap; sourceTree = "<group>"; };
-		09CDC287B301787A7A8B22CD3D76FFA5 /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
+		0568F8FF5A2CBCE85271963650D4EB8A /* AWSFMDB.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDB.h; path = AWSCore/FMDB/AWSFMDB.h; sourceTree = "<group>"; };
+		061DB1E4B174776DD34B7A1D4026D64B /* AWSCognitoIdentityProvider-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProvider-umbrella.h"; sourceTree = "<group>"; };
+		0743FC34E4E6F0B38CDC9D632E2803A7 /* AWSFMDatabasePool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabasePool.m; path = AWSCore/FMDB/AWSFMDatabasePool.m; sourceTree = "<group>"; };
+		0779FEE0240035253F866AEEEBF8F7C0 /* AWSCognitoIdentityResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityResources.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityResources.m; sourceTree = "<group>"; };
+		080855AA1347E7B97141BB92F01284A8 /* AWSCognitoIdentityProviderSrpHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderSrpHelper.m; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderSrpHelper.m; sourceTree = "<group>"; };
+		0B063D30CC52E4E795C1A128701D20F2 /* AWSCore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCore.debug.xcconfig; sourceTree = "<group>"; };
 		0B350FFEF637C6AF934EE101CD54DCE5 /* Pods-Amplify-AWSPluginsCore-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AWSPluginsCore-umbrella.h"; sourceTree = "<group>"; };
+		0B8C6DFB6DFB81C8B155FFD0ACF428F1 /* AWSFMDatabaseQueue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabaseQueue.m; path = AWSCore/FMDB/AWSFMDatabaseQueue.m; sourceTree = "<group>"; };
 		0B8DB7849FE18394F4C1421ABE0CEA2E /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
-		0B95B14A33E444B4CBF86C41B8B7D62E /* aws_tommath_class.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath_class.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath_class.h; sourceTree = "<group>"; };
-		0CE9D44BE59C6645651F72F311DB6C0A /* AWSMTLReflection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLReflection.m; path = AWSCore/Mantle/AWSMTLReflection.m; sourceTree = "<group>"; };
-		0CFCA5D85B002DD014B94FF35A27A47E /* AWSDDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDDispatchQueueLogFormatter.m; path = AWSCore/Logging/Extensions/AWSDDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
-		0D572A7B644427B4E310F33B8F49FA13 /* AWSModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSModel.m; path = AWSCore/Utility/AWSModel.m; sourceTree = "<group>"; };
-		0EC8B36FC6B914F164C0C2AF1AD96F83 /* AWSSTSModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSModel.h; path = AWSCore/STS/AWSSTSModel.h; sourceTree = "<group>"; };
+		0F16051AA198DAE03CA0B00B25844939 /* CwlCatchException-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "CwlCatchException-Info.plist"; sourceTree = "<group>"; };
 		0F1DEDC150BBA9D337427317717EC680 /* Pods_AmplifyTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_AmplifyTestApp.framework; path = "Pods-AmplifyTestApp.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1073C3EE5CBDD8387A3FB523E790C5CA /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
+		10AAE910007F70838053CD8B2249DF61 /* AWSMobileClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClient.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift; sourceTree = "<group>"; };
+		10EF994DBB36E63B54867C1A41328E80 /* AWSCognitoIdentity+Fabric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoIdentity+Fabric.h"; path = "AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.h"; sourceTree = "<group>"; };
 		11618E052B1995FC3B058B8E47104CFA /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-dummy.m"; sourceTree = "<group>"; };
-		12BA902F81D3D089ACEDE790A2838040 /* AWSCognitoIdentityProviderResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderResources.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderResources.h; sourceTree = "<group>"; };
-		1303984DBCAB633CD483D7079ADC6C16 /* AWSValidation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSValidation.m; path = AWSCore/Serialization/AWSValidation.m; sourceTree = "<group>"; };
-		1308C8001B6B55E7EC2C391A36C5A35F /* AWSCognitoIdentityProviderHKDF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderHKDF.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderHKDF.h; sourceTree = "<group>"; };
-		13A2D98960FD11A58FC06B45008B2AB5 /* AWSIdentityProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSIdentityProvider.m; path = AWSCore/Authentication/AWSIdentityProvider.m; sourceTree = "<group>"; };
+		119439775469EB44A41E15CABC1B7AEB /* NSDictionary+AWSMTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+AWSMTLManipulationAdditions.m"; path = "AWSCore/Mantle/NSDictionary+AWSMTLManipulationAdditions.m"; sourceTree = "<group>"; };
+		13DDB3FE8723FB5DBF721EFC1C54E8B8 /* AWSDDLog.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLog.h; path = AWSCore/Logging/AWSDDLog.h; sourceTree = "<group>"; };
 		14469F121FFD84334E39499AEA8DBAE8 /* Pods-AmplifyTestApp-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-AmplifyTestApp-frameworks.sh"; sourceTree = "<group>"; };
-		149D72F554244193A0B7AF373ECCBD2F /* AWSURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLResponseSerialization.h; path = AWSCore/Serialization/AWSURLResponseSerialization.h; sourceTree = "<group>"; };
-		1525D826E1F48AFA731D858D680381DE /* AWSURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLSessionManager.m; path = AWSCore/Networking/AWSURLSessionManager.m; sourceTree = "<group>"; };
-		155ECD0389C655CA5CAFCA1423B7F81E /* AWSTaskCompletionSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTaskCompletionSource.m; path = AWSCore/Bolts/AWSTaskCompletionSource.m; sourceTree = "<group>"; };
+		14D74F6910BCF832CC69FD2773C06217 /* AWSKSReachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSKSReachability.m; path = AWSCore/KSReachability/AWSKSReachability.m; sourceTree = "<group>"; };
+		1511BFDFB232E150CCFE4273A8BEC15D /* AWSCognitoIdentityUserPool+Extension.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoIdentityUserPool+Extension.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoIdentityUserPool+Extension.h"; sourceTree = "<group>"; };
 		1668BE896BD53109C08AF7DC22CF4EB7 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		16A601DC16672A8A74349C446B163720 /* AWSSTSModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSModel.m; path = AWSCore/STS/AWSSTSModel.m; sourceTree = "<group>"; };
 		16B0120C1306E487433FCA2B1B0D2673 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-umbrella.h"; sourceTree = "<group>"; };
-		1728444760C2F9357E4C81D21598024A /* AWSMobileClient.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSMobileClient.modulemap; sourceTree = "<group>"; };
+		16DB3680F94B801F66F71AD86D933CB1 /* AWSCancellationTokenRegistration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationTokenRegistration.h; path = AWSCore/Bolts/AWSCancellationTokenRegistration.h; sourceTree = "<group>"; };
 		17C7782F05A2504AD7615DC3ECD11FE5 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.debug.xcconfig"; sourceTree = "<group>"; };
+		17F7CA3723D744757238C07123826DDC /* AWSCognitoIdentityService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityService.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityService.m; sourceTree = "<group>"; };
+		186B12D6F3453F5CBB8711FF4F62362C /* AWSCognitoIdentityASF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityASF.h; path = AWSCognitoIdentityProviderASF/Internal/AWSCognitoIdentityASF.h; sourceTree = "<group>"; };
+		1879352EF7D914793D16865F02E4BBAB /* aws_tommath_superclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath_superclass.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath_superclass.h; sourceTree = "<group>"; };
 		189C8021820D164FA9236F1D27850C3F /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-umbrella.h"; sourceTree = "<group>"; };
-		1A98F3BC7E10504EB89277DBD08056E8 /* AWSSynchronizedMutableDictionary.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSynchronizedMutableDictionary.h; path = AWSCore/Utility/AWSSynchronizedMutableDictionary.h; sourceTree = "<group>"; };
-		1AFD14509FFB3301CAB730E079CEEB0E /* AWSCognitoIdentityProviderHKDF.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderHKDF.m; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderHKDF.m; sourceTree = "<group>"; };
-		1B0510CBEEDE5FCA0299A0FD4D3F647A /* AWSFMDatabasePool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabasePool.m; path = AWSCore/FMDB/AWSFMDatabasePool.m; sourceTree = "<group>"; };
+		1A30705F0417FDF552E067AF6EF268D5 /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
+		1B36E571A29663AF25C341351BE0E535 /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
 		1BB9D281CBBD8B4517D1F76CCC30FC7B /* Pods-AmplifyTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-AmplifyTestApp.debug.xcconfig"; sourceTree = "<group>"; };
-		1C3978F270280E8D902436A08201BCD1 /* FABKitProtocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FABKitProtocol.h; path = AWSCore/Fabric/FABKitProtocol.h; sourceTree = "<group>"; };
-		1D7F2FDC05F42701A1BDD38B8599A53E /* AWSMTLModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLModel.m; path = AWSCore/Mantle/AWSMTLModel.m; sourceTree = "<group>"; };
 		1D87F3274BC9EDCF528FEDC7945B146C /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-Info.plist"; sourceTree = "<group>"; };
-		1E7216BDE7E63D1C09D9DD55B461C1F7 /* AWSDDMultiFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDMultiFormatter.h; path = AWSCore/Logging/Extensions/AWSDDMultiFormatter.h; sourceTree = "<group>"; };
-		1ED5694E8307F8C4EAB7DACE6C30C7FD /* NSArray+AWSMTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+AWSMTLManipulationAdditions.m"; path = "AWSCore/Mantle/NSArray+AWSMTLManipulationAdditions.m"; sourceTree = "<group>"; };
-		1ED7C4E40E0ADA485169F0899452DFDB /* NSValueTransformer+AWSMTLInversionAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+AWSMTLInversionAdditions.h"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLInversionAdditions.h"; sourceTree = "<group>"; };
-		1F13FE5A540C5996ECF56F372411917F /* AWSCognitoIdentityProviderResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderResources.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderResources.m; sourceTree = "<group>"; };
-		1F474296406106EFF39D2516DB0D7EDD /* AWSAuthCore.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSAuthCore.modulemap; sourceTree = "<group>"; };
-		1FB0B0BC703C60784559FD78705D2D3D /* AWSMTLJSONAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLJSONAdapter.m; path = AWSCore/Mantle/AWSMTLJSONAdapter.m; sourceTree = "<group>"; };
-		201B012B8DCABEAE0CD9EBE7D55791E5 /* AWSModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSModel.h; path = AWSCore/Utility/AWSModel.h; sourceTree = "<group>"; };
-		2025F5D43350C89927348B43FE33E261 /* AWSAuthUIHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSAuthUIHelper.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.h; sourceTree = "<group>"; };
-		2136ADF4DE424DF154BD2074865BE16B /* aws_tommath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath.h; sourceTree = "<group>"; };
-		215DA62B09F66CEC9B18A68211635BAC /* AWSMTLModel+NSCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSMTLModel+NSCoding.h"; path = "AWSCore/Mantle/AWSMTLModel+NSCoding.h"; sourceTree = "<group>"; };
-		215E6048187156C4EA2A028913C9CA04 /* AWSGeneric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSGeneric.h; path = AWSCore/Bolts/AWSGeneric.h; sourceTree = "<group>"; };
-		23B9D4394992AEF47ED06DEFAE0CCB3F /* AWSDDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDDispatchQueueLogFormatter.h; path = AWSCore/Logging/Extensions/AWSDDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
-		25932903D3A78965B86E733E30B3A4F5 /* AWSExecutor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSExecutor.h; path = AWSCore/Bolts/AWSExecutor.h; sourceTree = "<group>"; };
-		25E1407E1F3CA42AB2F68592A5CC6E48 /* AWSAuthCore-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSAuthCore-Info.plist"; sourceTree = "<group>"; };
-		25F990CE79266048C3D300BF988751FC /* AWSEXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTScope.h; path = AWSCore/Mantle/extobjc/AWSEXTScope.h; sourceTree = "<group>"; };
+		1DDCADACD641F1331A589286C9FB7E8C /* AWSMTLManagedObjectAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLManagedObjectAdapter.h; path = AWSCore/Mantle/AWSMTLManagedObjectAdapter.h; sourceTree = "<group>"; };
+		1F91B0BD12C66BBA65E5DAFD870CC13B /* AWSEXTRuntimeExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSEXTRuntimeExtensions.m; path = AWSCore/Mantle/extobjc/AWSEXTRuntimeExtensions.m; sourceTree = "<group>"; };
+		203C838CB1CE8D734686C30424D1DE5C /* CwlPreconditionTesting.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CwlPreconditionTesting.debug.xcconfig; sourceTree = "<group>"; };
+		2057888BC8E612EFC5320864A97728BA /* AWSSignInProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInProvider.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInProvider.h; sourceTree = "<group>"; };
+		2099B4FC1B4FFFEE5E121147A0956AA6 /* NSArray+AWSMTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+AWSMTLManipulationAdditions.m"; path = "AWSCore/Mantle/NSArray+AWSMTLManipulationAdditions.m"; sourceTree = "<group>"; };
+		20CDA4D4E70462A011D602573D39696E /* AWSTMDiskCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMDiskCache.m; path = AWSCore/TMCache/AWSTMDiskCache.m; sourceTree = "<group>"; };
+		2140A514BBE55620A5F7C45EC8BDC5AD /* AWSClientContext.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSClientContext.m; path = AWSCore/Service/AWSClientContext.m; sourceTree = "<group>"; };
+		23FD0A4B909BC2DCBC1B238179001DA7 /* AWSCognitoAuthUICKeyChainStore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuthUICKeyChainStore.h; path = AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.h; sourceTree = "<group>"; };
+		242721755168E4E5F8D03D5703F95D45 /* AWSMTLValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLValueTransformer.h; path = AWSCore/Mantle/AWSMTLValueTransformer.h; sourceTree = "<group>"; };
+		253206CA6FFCBA451A002CD959A8880D /* AWSDDLogMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLogMacros.h; path = AWSCore/Logging/AWSDDLogMacros.h; sourceTree = "<group>"; };
 		2610F9ADBE599E1ACDCAC688B21F3A61 /* Pods-Amplify-AWSPluginsCore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore.release.xcconfig"; sourceTree = "<group>"; };
-		26E074B6C853307C638D3A214BCF13AD /* AWSCocoaLumberjack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCocoaLumberjack.h; path = AWSCore/Logging/AWSCocoaLumberjack.h; sourceTree = "<group>"; };
-		26EA69A80E1EB46F76DAEBEC08852B5B /* AWSCognitoAuthUICKeyChainStore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuthUICKeyChainStore.h; path = AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.h; sourceTree = "<group>"; };
-		27606DBCBEE7FCFCBD83D2D588CEC248 /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
-		290CB885A0DA80E2C91393B784C70837 /* NSData+AWSCognitoIdentityProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+AWSCognitoIdentityProvider.m"; path = "AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.m"; sourceTree = "<group>"; };
-		2A606F0F6B2AA85DE163E941BF473344 /* AWSCore-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCore-prefix.pch"; sourceTree = "<group>"; };
-		2A7F937A3048EEBAB2068BAE53499D9C /* _AWSMobileClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = _AWSMobileClient.h; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.h; sourceTree = "<group>"; };
-		2AEA8D2580C822EE561F1B85D15AB5B4 /* AWSSignInManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSignInManager.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInManager.m; sourceTree = "<group>"; };
-		2C68FE2B5EB71F0D9C32F7A1353E1BF9 /* AWSTaskCompletionSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTaskCompletionSource.h; path = AWSCore/Bolts/AWSTaskCompletionSource.h; sourceTree = "<group>"; };
-		2CD8A6688890ED29073F77D8F3281C27 /* AWSMobileClient-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSMobileClient-prefix.pch"; sourceTree = "<group>"; };
+		269A40768550F653508FB48F30B84DE5 /* AWSUICKeyChainStore.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSUICKeyChainStore.m; path = AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m; sourceTree = "<group>"; };
+		26CAE8910E7FB2F9774A51188387B30A /* AWSCognitoIdentityProvider-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProvider-prefix.pch"; sourceTree = "<group>"; };
+		270DA40631CAA420BD290BDC01F8ABD1 /* AWSEXTScope.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSEXTScope.m; path = AWSCore/Mantle/extobjc/AWSEXTScope.m; sourceTree = "<group>"; };
+		273AD73149D84DE6A9A770236B1AFE18 /* AWSCognitoIdentity.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentity.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentity.h; sourceTree = "<group>"; };
+		28654CD2D624C23CC96C2288853B8A2A /* AWSCognitoIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProvider.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityProvider.h; sourceTree = "<group>"; };
+		29E4D3FCB3A323A33756F3C0A355CA7C /* AWSService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSService.h; path = AWSCore/Service/AWSService.h; sourceTree = "<group>"; };
+		2A96DCF8D41072E318B24C6CDFC727D7 /* AWSModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSModel.h; path = AWSCore/Utility/AWSModel.h; sourceTree = "<group>"; };
+		2AF4AC19FCD1C23576C5D9515AD63194 /* AWSCognitoAuth_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuth_Internal.h; path = AWSCognitoAuth/Internal/AWSCognitoAuth_Internal.h; sourceTree = "<group>"; };
+		2B6BAF26D20D0180E4896EF36A5B0BF1 /* AWSSTSResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSResources.h; path = AWSCore/STS/AWSSTSResources.h; sourceTree = "<group>"; };
+		2DA3287D1051A982150A16354E05729C /* AWSCancellationTokenSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationTokenSource.m; path = AWSCore/Bolts/AWSCancellationTokenSource.m; sourceTree = "<group>"; };
+		2EDF7E5096048D8B966EF59D99125309 /* AWSCognitoIdentityProviderModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderModel.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderModel.m; sourceTree = "<group>"; };
+		2EF7B8FE649AA081D9B6EFEF5488405D /* AWSCognitoIdentityUserPool_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUserPool_Internal.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityUserPool_Internal.h; sourceTree = "<group>"; };
 		2F99AE9B0E76188538C212C2BB77D456 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-Info.plist"; sourceTree = "<group>"; };
-		30380984D336CF3DBF74479B66E317B8 /* CwlCatchException-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlCatchException-umbrella.h"; sourceTree = "<group>"; };
+		2FEB825F6CFEC0FF22828D99BACCE97F /* AWSGZIP.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSGZIP.h; path = AWSCore/GZIP/AWSGZIP.h; sourceTree = "<group>"; };
+		30DDEEE98E0A7984402264B567FBD8B5 /* AWSMTLReflection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLReflection.m; path = AWSCore/Mantle/AWSMTLReflection.m; sourceTree = "<group>"; };
+		310DF5A3069A557E9AD8F57B23ADD30E /* AWSDDASLLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDASLLogger.m; path = AWSCore/Logging/AWSDDASLLogger.m; sourceTree = "<group>"; };
+		319A14F2ECA5CE66FBBF4947814FB55E /* AWSSTSService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSService.m; path = AWSCore/STS/AWSSTSService.m; sourceTree = "<group>"; };
 		31ACD2A46D4B2806FEF94323C827E97C /* Pods-AmplifyTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-AmplifyTestApp.release.xcconfig"; sourceTree = "<group>"; };
-		3228E5C6E903750905DC08BDF584C5DA /* AWSEXTRuntimeExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSEXTRuntimeExtensions.m; path = AWSCore/Mantle/extobjc/AWSEXTRuntimeExtensions.m; sourceTree = "<group>"; };
-		32DF266EBC63223640E52EF97B646531 /* AWSCategory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCategory.h; path = AWSCore/Utility/AWSCategory.h; sourceTree = "<group>"; };
-		3530F941D0991933A79B9D55F929710A /* AWSJKBigInteger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSJKBigInteger.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.h; sourceTree = "<group>"; };
+		339E1CE102BC4BB102802E45F284D351 /* AWSTMDiskCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMDiskCache.h; path = AWSCore/TMCache/AWSTMDiskCache.h; sourceTree = "<group>"; };
+		33F0A8BDDF0DDB3CB666FBBA90C60448 /* AWSSTSModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSModel.h; path = AWSCore/STS/AWSSTSModel.h; sourceTree = "<group>"; };
+		34858815A0F7379196A7B8853DB3DA33 /* AWSTMMemoryCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMMemoryCache.h; path = AWSCore/TMCache/AWSTMMemoryCache.h; sourceTree = "<group>"; };
+		3502B24960607AF0083FB45A99DD9B78 /* AWSCognitoIdentityProviderHKDF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderHKDF.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderHKDF.h; sourceTree = "<group>"; };
+		3502DCDB99858552F01128ED97F575A8 /* AWSGeneric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSGeneric.h; path = AWSCore/Bolts/AWSGeneric.h; sourceTree = "<group>"; };
 		356316C4DFEB6875A03C1B1AC2F84026 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-frameworks.sh"; sourceTree = "<group>"; };
-		3585665D570BD8937FC9A32C98886EA6 /* AWSKSReachability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSKSReachability.h; path = AWSCore/KSReachability/AWSKSReachability.h; sourceTree = "<group>"; };
-		358A5159A1A60BF02175C6A3D56B4E42 /* AWSDDLog+LOGV.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSDDLog+LOGV.h"; path = "AWSCore/Logging/AWSDDLog+LOGV.h"; sourceTree = "<group>"; };
+		36153241DF271B6510265692E8601389 /* AWSMobileOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileOptions.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileOptions.swift; sourceTree = "<group>"; };
 		36BDAD0F29489ADEBD0B1E3648F2A317 /* Pods-Amplify-AWSPluginsCore-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AWSPluginsCore-acknowledgements.markdown"; sourceTree = "<group>"; };
+		37238A20DFA2590816F74C60C138AC3C /* AWSSTSResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSResources.m; path = AWSCore/STS/AWSSTSResources.m; sourceTree = "<group>"; };
+		37D0AF393DF178079A5AA4A88A223B5D /* CwlPreconditionTesting-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlPreconditionTesting-umbrella.h"; sourceTree = "<group>"; };
 		38C6AD3DCE09BA628BA94A834905BFA2 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.release.xcconfig"; sourceTree = "<group>"; };
+		38D55155F2EC78678A65C37373A42D58 /* AWSSignInButtonView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInButtonView.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInButtonView.h; sourceTree = "<group>"; };
 		38FF9DA450E0F55F72749EB00C3E4C06 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.release.xcconfig"; sourceTree = "<group>"; };
-		39C1FB84194B70A998EED9294936E302 /* AWSMTLModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLModel.h; path = AWSCore/Mantle/AWSMTLModel.h; sourceTree = "<group>"; };
+		39D68F4B4E147627F473B3F5A76EE989 /* AWSExecutor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSExecutor.h; path = AWSCore/Bolts/AWSExecutor.h; sourceTree = "<group>"; };
 		3A7A8A66EAE3CF28E4545528AD125CFC /* Pods-Amplify.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify.release.xcconfig"; sourceTree = "<group>"; };
-		3A8D66842538327815F5470D8B00AB5E /* Fabric+FABKits.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Fabric+FABKits.h"; path = "AWSCore/Fabric/Fabric+FABKits.h"; sourceTree = "<group>"; };
-		3B23FCA3582BFF3C7711AF1C1630BCB4 /* AWSSignature.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignature.h; path = AWSCore/Authentication/AWSSignature.h; sourceTree = "<group>"; };
+		3B2EB0A457D0895CA40C8C9BA74A5D72 /* AWSAuthCore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSAuthCore.debug.xcconfig; sourceTree = "<group>"; };
+		3BDEA4EB168EBEBCC1D9348786941864 /* AWSNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSNetworking.m; path = AWSCore/Networking/AWSNetworking.m; sourceTree = "<group>"; };
 		3BF5B6D3E0339165EB3C15592888ACB3 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.debug.xcconfig"; sourceTree = "<group>"; };
-		3CA709F5652B0398A9B29246F3F49EBB /* AWSFMDatabaseQueue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabaseQueue.m; path = AWSCore/FMDB/AWSFMDatabaseQueue.m; sourceTree = "<group>"; };
-		3D0A429B94396EACDD9425A11E4C827C /* AWSCancellationTokenSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationTokenSource.h; path = AWSCore/Bolts/AWSCancellationTokenSource.h; sourceTree = "<group>"; };
-		3D3606B6B7DB161FF6D16A4BE6B27CF3 /* AWSFMResultSet.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMResultSet.m; path = AWSCore/FMDB/AWSFMResultSet.m; sourceTree = "<group>"; };
-		3DD558EF138166AFAEC0D40FDD36E577 /* AWSSTS.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTS.h; path = AWSCore/STS/AWSSTS.h; sourceTree = "<group>"; };
-		3E2C320736C8649DB501945D50D6C78A /* AWSSignature.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSignature.m; path = AWSCore/Authentication/AWSSignature.m; sourceTree = "<group>"; };
-		3E32B857CB41920FA239AE30655F37B7 /* AWSMobileClientUserDetails.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClientUserDetails.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSMobileClientUserDetails.swift; sourceTree = "<group>"; };
-		3E67A1E5982F4EB37E89FB5A78A3C48E /* AWSCognitoIdentityProviderModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderModel.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderModel.m; sourceTree = "<group>"; };
+		3C8F7368725476CB7FE657AE00468D41 /* AWSCore-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCore-umbrella.h"; sourceTree = "<group>"; };
+		3D613E3E5F0A4E19E4599EDBBE314D3D /* CwlPreconditionTesting-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CwlPreconditionTesting-dummy.m"; sourceTree = "<group>"; };
+		3DFC98441267A74AEB8AB146DE8D6D11 /* AWSCognitoIdentityProviderService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderService.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderService.m; sourceTree = "<group>"; };
 		3E93CB74B9F5DE129151102493A989CB /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsTestCommon.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsTestCommon.framework; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F8DD9A4C98BD4C5E30943C049E35926 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		40363564952E7B989CC8FD137DFC0347 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-Info.plist"; sourceTree = "<group>"; };
-		4140977A6FA9DE8FA6A6D16739462D51 /* AWSService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSService.m; path = AWSCore/Service/AWSService.m; sourceTree = "<group>"; };
-		42367677A832E1AADCF1E5DA24999515 /* AWSJKBigInteger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSJKBigInteger.m; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.m; sourceTree = "<group>"; };
-		42D1297EBB5A1F9FB05A9C9DB30429CD /* NSError+AWSMTLModelException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSError+AWSMTLModelException.m"; path = "AWSCore/Mantle/NSError+AWSMTLModelException.m"; sourceTree = "<group>"; };
+		40EF16538F48DD27D1C37BB7C77A24B2 /* AWSUserPoolCustomAuthHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSUserPoolCustomAuthHandler.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSUserPoolCustomAuthHandler.swift; sourceTree = "<group>"; };
+		41F1B2AFD50E7D6ACE8ECEB132F4ABD7 /* NSValueTransformer+AWSMTLInversionAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+AWSMTLInversionAdditions.h"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLInversionAdditions.h"; sourceTree = "<group>"; };
+		426D0CDC2ACCEDDD1FDB54109388FAB9 /* NSObject+AWSMTLComparisonAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+AWSMTLComparisonAdditions.m"; path = "AWSCore/Mantle/NSObject+AWSMTLComparisonAdditions.m"; sourceTree = "<group>"; };
+		428D3EA4240F70D5F918C0CB986F3528 /* AWSFMDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabase.h; path = AWSCore/FMDB/AWSFMDatabase.h; sourceTree = "<group>"; };
 		42F9974C1E644CB8D99A4CE7C7E2CA56 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-acknowledgements.markdown"; sourceTree = "<group>"; };
 		430811562C2E438327AA9EA8436484D5 /* Pods-AmplifyTestApp-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-AmplifyTestApp-Info.plist"; sourceTree = "<group>"; };
-		43128D69FB45BBB7F4ADB2DFBCE21532 /* AWSDDContextFilterLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDContextFilterLogFormatter.m; path = AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter.m; sourceTree = "<group>"; };
-		435526BBCAF623B030E3026EC9DE1016 /* AWSFMDatabase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabase.m; path = AWSCore/FMDB/AWSFMDatabase.m; sourceTree = "<group>"; };
-		43D03953BFA2E6934D54CB37BD928875 /* AWSMTLManagedObjectAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLManagedObjectAdapter.m; path = AWSCore/Mantle/AWSMTLManagedObjectAdapter.m; sourceTree = "<group>"; };
-		4408ED574FF1E08009DA696D607E328E /* AWSMobileClientExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClientExtensions.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift; sourceTree = "<group>"; };
-		4450DEEA3EB1397A391B814028F8A6F4 /* CwlPreconditionTesting.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CwlPreconditionTesting.debug.xcconfig; sourceTree = "<group>"; };
-		4484ED4548415DDE3489B66C2F7ECC44 /* AWSEXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTKeyPathCoding.h; path = AWSCore/Mantle/extobjc/AWSEXTKeyPathCoding.h; sourceTree = "<group>"; };
-		46294BA1DAA83E771D4E3CD12CF92E76 /* AWSCredentialsProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCredentialsProvider.h; path = AWSCore/Authentication/AWSCredentialsProvider.h; sourceTree = "<group>"; };
-		46988F326C331492F52C9FAC76BC0841 /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
+		451AC08FD4DD7DB6A50A5C7ECD6CB558 /* AWSCore.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCore.modulemap; sourceTree = "<group>"; };
+		462CDC7FF48F22B4AAE6EEF830B635BC /* NSError+AWSMTLModelException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSError+AWSMTLModelException.m"; path = "AWSCore/Mantle/NSError+AWSMTLModelException.m"; sourceTree = "<group>"; };
+		46A688748A61E83AE64381312E801169 /* AWSCognitoAuth.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuth.h; path = AWSCognitoAuth/AWSCognitoAuth.h; sourceTree = "<group>"; };
+		46B0C01A79129C2F6A54B238E8F9087D /* AWSNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSNetworking.h; path = AWSCore/Networking/AWSNetworking.h; sourceTree = "<group>"; };
 		47D46D2BEC1D90EDAE4F1B547348EEFB /* AWSCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		48A55168CF8C578FB9045F8BDD0D1677 /* AWSCognitoIdentityProviderASF-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProviderASF-prefix.pch"; sourceTree = "<group>"; };
 		48B10C571F93314CED282170847D63D8 /* Pods-AmplifyTestApp.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-AmplifyTestApp.modulemap"; sourceTree = "<group>"; };
-		48F780036E2D872F1A15B369BED38933 /* AWSCognitoAuth.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoAuth.h; path = AWSCognitoAuth/AWSCognitoAuth.h; sourceTree = "<group>"; };
-		4A4FA38EE0D5F12E02C928F9D0D90AF5 /* AWSClientContext.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSClientContext.m; path = AWSCore/Service/AWSClientContext.m; sourceTree = "<group>"; };
-		4A9E09C54B5074D61B5E6B9031F15CA3 /* AWSCognitoIdentityProvider-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCognitoIdentityProvider-dummy.m"; sourceTree = "<group>"; };
-		4C088E988DA4E79E7D02BF2FF788EDAE /* AWSDDTTYLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDTTYLogger.h; path = AWSCore/Logging/AWSDDTTYLogger.h; sourceTree = "<group>"; };
-		4C5FA08BD259CC53FCAB405F6BBF72FC /* AWSJKBigDecimal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSJKBigDecimal.m; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigDecimal.m; sourceTree = "<group>"; };
-		4C8708ABDF32CDB4E9BFD531B2D8F853 /* AWSFMDatabaseAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabaseAdditions.h; path = AWSCore/FMDB/AWSFMDatabaseAdditions.h; sourceTree = "<group>"; };
-		4DFFDD9A7C09947D8DF8677179D0A608 /* AWSCognitoIdentityProviderService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderService.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderService.h; sourceTree = "<group>"; };
-		522FF7223869E4B88DE29BC852A6EFA0 /* FABAttributes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FABAttributes.h; path = AWSCore/Fabric/FABAttributes.h; sourceTree = "<group>"; };
-		53D9BDE9B970F6CC3CF311DB67FF5054 /* AWSDDContextFilterLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDContextFilterLogFormatter.h; path = AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter.h; sourceTree = "<group>"; };
+		49B67ABB110D56E576AC4D5F32B61152 /* AWSFMDatabaseAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabaseAdditions.m; path = AWSCore/FMDB/AWSFMDatabaseAdditions.m; sourceTree = "<group>"; };
+		4B57F812D68F53AAB507EBC060B0F553 /* AWSNetworkingHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSNetworkingHelpers.h; path = AWSCore/Networking/AWSNetworkingHelpers.h; sourceTree = "<group>"; };
+		4BC4FCA3F9BDAE1F28A5E3EF4A14C418 /* AWSCancellationTokenRegistration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationTokenRegistration.m; path = AWSCore/Bolts/AWSCancellationTokenRegistration.m; sourceTree = "<group>"; };
+		4CAC325F4C19790A3C2A4947CFE9E363 /* AWSCore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCore.h; path = AWSCore/AWSCore.h; sourceTree = "<group>"; };
+		4D07B8F4B3BEAB4648898A034B91931D /* AWSAuthCore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSAuthCore.release.xcconfig; sourceTree = "<group>"; };
+		4D568287CCF8F49059025CA6EAC9A858 /* AWSIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSIdentityProvider.h; path = AWSCore/Authentication/AWSIdentityProvider.h; sourceTree = "<group>"; };
+		4ECB1A8A13CBB9044D931154C6DBDD99 /* AWSMobileClientExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClientExtensions.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift; sourceTree = "<group>"; };
+		4ED74CDFDF691D03F15EA506908E33BB /* AWSSignature.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSignature.m; path = AWSCore/Authentication/AWSSignature.m; sourceTree = "<group>"; };
+		4FDF895C1546E277DA655224065CADE4 /* AWSJKBigDecimal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSJKBigDecimal.m; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigDecimal.m; sourceTree = "<group>"; };
+		52760804261C891A3DD97614D8925107 /* AWSDDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDDispatchQueueLogFormatter.m; path = AWSCore/Logging/Extensions/AWSDDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
+		530FB6F70F632A3D79D20015D4D33940 /* AWSAuthCore-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSAuthCore-umbrella.h"; sourceTree = "<group>"; };
+		53EB656659FB0F58570111C58C204BDB /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
 		540B0D26F5B613408E8F5D94A66B5C28 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-acknowledgements.markdown"; sourceTree = "<group>"; };
-		54F2B9B424EA365272D4D45F6AA6B571 /* AWSTMMemoryCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMMemoryCache.h; path = AWSCore/TMCache/AWSTMMemoryCache.h; sourceTree = "<group>"; };
+		5585E543E7086486728B90AA10B862DA /* AWSDDFileLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDFileLogger.h; path = AWSCore/Logging/AWSDDFileLogger.h; sourceTree = "<group>"; };
+		55FFA9C0CA0B27CD56EFC5882E49685B /* AWSSTSService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSService.h; path = AWSCore/STS/AWSSTSService.h; sourceTree = "<group>"; };
 		5609021041C2F48853430E0091C5BB5A /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-Info.plist"; sourceTree = "<group>"; };
-		5647E2F9B6864AD929CCA40EA73DCE8B /* NSObject+AWSMTLComparisonAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+AWSMTLComparisonAdditions.h"; path = "AWSCore/Mantle/NSObject+AWSMTLComparisonAdditions.h"; sourceTree = "<group>"; };
-		56C453F9B3BA8F43250FC0DE9E37B3EE /* CwlPreconditionTesting.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CwlPreconditionTesting.modulemap; sourceTree = "<group>"; };
-		56F63DA64CFE5101D3680D82D88649ED /* AWSXMLWriter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSXMLWriter.h; path = AWSCore/XMLWriter/AWSXMLWriter.h; sourceTree = "<group>"; };
+		5638C97B13152127D5E6E6557DC97A04 /* AWSCognitoIdentityUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUser.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h; sourceTree = "<group>"; };
+		5787035EDC3E98DB50D44230AF7C85C4 /* AWSTask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTask.h; path = AWSCore/Bolts/AWSTask.h; sourceTree = "<group>"; };
 		5798D4EE25C6144BE3EE4EE7CD4AAE7B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		580FC54E047092D4BF64987DEBEB6CEC /* AWSUserPoolOperationsHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSUserPoolOperationsHandler.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift; sourceTree = "<group>"; };
-		58FED07AFC163D4256064E2EF108B47A /* AWSCognitoIdentity.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentity.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentity.h; sourceTree = "<group>"; };
+		586D67476E44A61969931883CA884BE2 /* AWSMTLModel+NSCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSMTLModel+NSCoding.h"; path = "AWSCore/Mantle/AWSMTLModel+NSCoding.h"; sourceTree = "<group>"; };
 		592313CB94B49286EEF277EA91D3D95A /* AWSCognitoIdentityProviderASF.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AWSCognitoIdentityProviderASF.framework; path = AWSCognitoIdentityProviderASF.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		593F6FE9E180C8D514A96C8AD34EB9CB /* AWSGZIP.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSGZIP.h; path = AWSCore/GZIP/AWSGZIP.h; sourceTree = "<group>"; };
-		594C9789E8B6E3765CCB480D349AB2A0 /* AWSKSReachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSKSReachability.m; path = AWSCore/KSReachability/AWSKSReachability.m; sourceTree = "<group>"; };
-		5963F8F37803D4F8DECB8F3B3C7AEF9A /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h"; sourceTree = "<group>"; };
+		5950D58519C02B45CFF4C1DDED370A48 /* AWSURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLSessionManager.m; path = AWSCore/Networking/AWSURLSessionManager.m; sourceTree = "<group>"; };
 		59AD6B8077039CA78508DA2892FE480F /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.modulemap"; sourceTree = "<group>"; };
-		5A364A9DC40F0E30BA70256B9A77A5BE /* AWSCognitoIdentity+Fabric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoIdentity+Fabric.h"; path = "AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.h"; sourceTree = "<group>"; };
-		5AB7550EAF118FA23F6FBAE5B851974E /* AWSLogging.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSLogging.h; path = AWSCore/Utility/AWSLogging.h; sourceTree = "<group>"; };
-		5AD39ACA6DC4F3E8054B5364662EB998 /* NSObject+AWSMTLComparisonAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+AWSMTLComparisonAdditions.m"; path = "AWSCore/Mantle/NSObject+AWSMTLComparisonAdditions.m"; sourceTree = "<group>"; };
-		5B3055A216626F89FF9251CDB64FB227 /* AWSCore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCore.release.xcconfig; sourceTree = "<group>"; };
-		5C3C79C322308DCFF6CC07162D81B7B3 /* AWSTMCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMCache.m; path = AWSCore/TMCache/AWSTMCache.m; sourceTree = "<group>"; };
+		5B3353B22C5BE756F269528D8722AC9C /* AWSCognitoIdentityUser_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUser_Internal.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityUser_Internal.h; sourceTree = "<group>"; };
 		5C6DDDDA1D966AED315AB70664004815 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-umbrella.h"; sourceTree = "<group>"; };
-		5C8DDE8BDC075136E7854C7C130D4480 /* AWSDDMultiFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDMultiFormatter.m; path = AWSCore/Logging/AWSDDMultiFormatter.m; sourceTree = "<group>"; };
 		5CC60529D233360B1F356DC750E15164 /* Pods-AmplifyTestApp-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-AmplifyTestApp-dummy.m"; sourceTree = "<group>"; };
-		5CF7E92216D1B04741144F93ACCF1F26 /* NSDictionary+AWSMTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+AWSMTLManipulationAdditions.m"; path = "AWSCore/Mantle/NSDictionary+AWSMTLManipulationAdditions.m"; sourceTree = "<group>"; };
-		5D1AADC1D934456355F4DAC701612F79 /* aws_tommath_superclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath_superclass.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath_superclass.h; sourceTree = "<group>"; };
+		5D1B2C9C16028528902AEA200EC6E83A /* AWSFMDatabase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabase.m; path = AWSCore/FMDB/AWSFMDatabase.m; sourceTree = "<group>"; };
+		5D3FC3C5111DE0BB193D61CF5AC55161 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h"; sourceTree = "<group>"; };
+		5D58BA2E475335E66080FC0D3FBFD71D /* AWSSTS.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTS.h; path = AWSCore/STS/AWSSTS.h; sourceTree = "<group>"; };
+		5DB02F82D35F0C4356FB9F0B429AB99B /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
+		5E41A84A8EBB7DB1B95A88FAE6C9E851 /* SwiftFormat.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftFormat.debug.xcconfig; sourceTree = "<group>"; };
 		5E7D5AC68E43CA3768505A58681304E1 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-umbrella.h"; sourceTree = "<group>"; };
-		5E8FD7E40163054B20474E96395CF492 /* AWSSignInManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInManager.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInManager.h; sourceTree = "<group>"; };
-		5ECA73D18A22B3C441E418C9672F2275 /* AWSMobileClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClient.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift; sourceTree = "<group>"; };
-		5F2C8BF9E57FA143E2FA9728ADECB584 /* AWSUserPoolCustomAuthHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSUserPoolCustomAuthHandler.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSUserPoolCustomAuthHandler.swift; sourceTree = "<group>"; };
-		5F30C86248908FA871CAAC451CD386A4 /* AWSValidation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSValidation.h; path = AWSCore/Serialization/AWSValidation.h; sourceTree = "<group>"; };
-		5F47A1D42B8B2FAD28D5AB97F44BB8F9 /* AWSCognitoIdentityProviderASF.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCognitoIdentityProviderASF.release.xcconfig; sourceTree = "<group>"; };
+		5ED2F05C0CFB21845242D662C888AEAC /* AWSMTLModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLModel.m; path = AWSCore/Mantle/AWSMTLModel.m; sourceTree = "<group>"; };
+		5F019DA231CEA0C3F4310AEF8B1A5A93 /* AWSCognitoIdentityProviderASF-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCognitoIdentityProviderASF-dummy.m"; sourceTree = "<group>"; };
 		5FA201FD7F04844F9B9C1F2974AD9B46 /* AWSCognitoIdentityProvider.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AWSCognitoIdentityProvider.framework; path = AWSCognitoIdentityProvider.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		60A7481863E0FBEC00846C480C56E6C3 /* AWSCore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCore.debug.xcconfig; sourceTree = "<group>"; };
-		61CDC6F402902D556759A67A3D6CCCF1 /* AWSCognitoIdentityProviderSrpHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderSrpHelper.m; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderSrpHelper.m; sourceTree = "<group>"; };
-		622CFB3E9A43C8FE15F37616F03BDEF4 /* AWSDDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDAbstractDatabaseLogger.m; path = AWSCore/Logging/AWSDDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
-		6247E23DAB89A392D6700528BBD48435 /* AWSCognitoIdentityService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityService.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityService.m; sourceTree = "<group>"; };
-		63129AB4EE71D01423866FD2AA8A71F4 /* AWSMobileClient.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSMobileClient.debug.xcconfig; sourceTree = "<group>"; };
+		601FD7EC456EFFA2F76F7E3FAE1C9FA9 /* AWSMTLModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLModel.h; path = AWSCore/Mantle/AWSMTLModel.h; sourceTree = "<group>"; };
+		609FCBCB9B75FF5D167F70E56995C48E /* AWSIdentityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSIdentityManager.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSIdentityManager.m; sourceTree = "<group>"; };
+		61F232A732471703F7FDB543E40C17D3 /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
+		62CC145608B6C86186B3A54AB9FA6498 /* Fabric+FABKits.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Fabric+FABKits.h"; path = "AWSCore/Fabric/Fabric+FABKits.h"; sourceTree = "<group>"; };
+		62E7C2AC7685CA25C83B4F04915C070D /* CwlCatchException-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlCatchException-prefix.pch"; sourceTree = "<group>"; };
+		6361BDBF377F2B9595FCD732C31B036C /* AWSGZIP.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSGZIP.m; path = AWSCore/GZIP/AWSGZIP.m; sourceTree = "<group>"; };
 		636498E92402BEB2BB38D02D7EC74238 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-acknowledgements.plist"; sourceTree = "<group>"; };
-		638D8632CC8F27E6F1D10AE39197B5F6 /* AWSMobileClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMobileClient.h; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.h; sourceTree = "<group>"; };
-		646462FD5A2B43C2114AF829757A657B /* AWSDDASLLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDASLLogger.h; path = AWSCore/Logging/AWSDDASLLogger.h; sourceTree = "<group>"; };
 		64802F2E333FD29A93B939784FB965FE /* Pods-Amplify-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-umbrella.h"; sourceTree = "<group>"; };
-		6589DE430E9F4408A4461C9D86E56C78 /* tommath.c */ = {isa = PBXFileReference; includeInIndex = 1; name = tommath.c; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/tommath.c; sourceTree = "<group>"; };
+		64B466ED2388DD02B72509DF230A91B8 /* AWSDDOSLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDOSLogger.h; path = AWSCore/Logging/AWSDDOSLogger.h; sourceTree = "<group>"; };
+		6523C226D22041D1BD540F0A8CC07355 /* CwlPreconditionTesting.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CwlPreconditionTesting.modulemap; sourceTree = "<group>"; };
+		655090625CD0809A8FED4ED5C8B598C1 /* AWSURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLSessionManager.h; path = AWSCore/Networking/AWSURLSessionManager.h; sourceTree = "<group>"; };
+		6578953AD64D0981CC6BD8A2682F5D6C /* AWSMobileClient.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSMobileClient.debug.xcconfig; sourceTree = "<group>"; };
 		66112A1C75E7120538B03A9B1914DB4A /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-Info.plist"; sourceTree = "<group>"; };
-		661CD15775667147D9B7051F8B63D35A /* AWSMTLValueTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLValueTransformer.m; path = AWSCore/Mantle/AWSMTLValueTransformer.m; sourceTree = "<group>"; };
-		68FF3770CBF110857CA77FFE046B0B4F /* CwlPreconditionTesting-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CwlPreconditionTesting-dummy.m"; sourceTree = "<group>"; };
-		69F008F7FC765D8E3A19AAE2CB0540F1 /* AWSFMDatabaseAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMDatabaseAdditions.m; path = AWSCore/FMDB/AWSFMDatabaseAdditions.m; sourceTree = "<group>"; };
-		6A57694184C5305A7FCCB3AB57A02501 /* AWSBolts.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSBolts.h; path = AWSCore/Bolts/AWSBolts.h; sourceTree = "<group>"; };
-		6A65C047280EA42ACAC564BAF26E7B45 /* AWSCognitoIdentityProviderASF-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProviderASF-prefix.pch"; sourceTree = "<group>"; };
-		6ABA495DEBA91095FE2A8E7D756E77FD /* AWSCognitoIdentityProviderASF-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProviderASF-umbrella.h"; sourceTree = "<group>"; };
-		6AD291698E9564B20B51B0D4028722AA /* AWSUIConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSUIConfiguration.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSUIConfiguration.h; sourceTree = "<group>"; };
+		671FA8A8981B6D9E4D607F197D583195 /* Fabric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Fabric.h; path = AWSCore/Fabric/Fabric.h; sourceTree = "<group>"; };
+		672FB5623F8C9DF7073AC2256E28883D /* AWSMTLModel+NSCoding.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSMTLModel+NSCoding.m"; path = "AWSCore/Mantle/AWSMTLModel+NSCoding.m"; sourceTree = "<group>"; };
+		673E1078C0B75EFB8FE7F59BBE328D78 /* NSDictionary+AWSMTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+AWSMTLManipulationAdditions.h"; path = "AWSCore/Mantle/NSDictionary+AWSMTLManipulationAdditions.h"; sourceTree = "<group>"; };
+		684CECD6CF451445EB12F03012D0E497 /* AWSSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSerialization.m; path = AWSCore/Serialization/AWSSerialization.m; sourceTree = "<group>"; };
+		697C4DC3BEEA6233CCA378E1675B85A3 /* AWSJKBigInteger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSJKBigInteger.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.h; sourceTree = "<group>"; };
+		6A5B1767D9974D948007D9204B58EE4A /* AWSURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLRequestSerialization.m; path = AWSCore/Serialization/AWSURLRequestSerialization.m; sourceTree = "<group>"; };
+		6A7B751B97A2DDD0C9910C8F55261DE9 /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
+		6B3B2876F8D87A891EF316D5C96BCFB3 /* AWSCore-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCore-Info.plist"; sourceTree = "<group>"; };
 		6C5ECBC402A49A42921C8BA77F0A19C5 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-acknowledgements.plist"; sourceTree = "<group>"; };
 		6C81CC0258D4E4C6230E583C79613573 /* AWSAuthCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AWSAuthCore.framework; path = AWSAuthCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C836C6AB96168F166B40979832ABA3F /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests-frameworks.sh"; sourceTree = "<group>"; };
-		6C8656F7AC30360AE4D12537118FBDC5 /* AWSCognitoIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProvider.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityProvider.h; sourceTree = "<group>"; };
-		6C89B5E8C8653EF6D614F1BE244FAE98 /* AWSFMDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabase.h; path = AWSCore/FMDB/AWSFMDatabase.h; sourceTree = "<group>"; };
-		6D317A8D28190875854FE246A4450BDA /* AWSTMDiskCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMDiskCache.m; path = AWSCore/TMCache/AWSTMDiskCache.m; sourceTree = "<group>"; };
-		6D8A99015D2EC60F2847A8211AEA6BBE /* _AWSMobileClient.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = _AWSMobileClient.m; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.m; sourceTree = "<group>"; };
-		6F70FE0555C85607F11E8C4D0D47EB14 /* AWSCognitoIdentity+Fabric.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSCognitoIdentity+Fabric.m"; path = "AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.m"; sourceTree = "<group>"; };
-		7028A59A9EF8E9D33381651C663C05D5 /* AWSAuthCore-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSAuthCore-umbrella.h"; sourceTree = "<group>"; };
-		70DC08BD2BFFE31FA6F545CDAE7F1521 /* AWSCancellationTokenSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationTokenSource.m; path = AWSCore/Bolts/AWSCancellationTokenSource.m; sourceTree = "<group>"; };
-		70E3AAF4BC85478E182CB79281CA4A7A /* AWSJKBigDecimal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSJKBigDecimal.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigDecimal.h; sourceTree = "<group>"; };
+		6C9A91CD0EAEB627AE0578265E674CB7 /* CwlPreconditionTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlPreconditionTesting.h; path = Sources/CwlPreconditionTesting/include/CwlPreconditionTesting.h; sourceTree = "<group>"; };
+		6C9BDD821D2BDC642CAC2A7BF82A6913 /* AWSCategory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCategory.h; path = AWSCore/Utility/AWSCategory.h; sourceTree = "<group>"; };
+		6D5EAB70088187E6D937450A0EE0371F /* NSData+AWSCognitoIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+AWSCognitoIdentityProvider.h"; path = "AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.h"; sourceTree = "<group>"; };
+		6DBE83C19DC30A060C2D831D7F984125 /* AWSSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSerialization.h; path = AWSCore/Serialization/AWSSerialization.h; sourceTree = "<group>"; };
+		6EFCD22A63266EDD9823DF548654C7D0 /* AWSCognitoCredentialsProvider+Extension.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoCredentialsProvider+Extension.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoCredentialsProvider+Extension.h"; sourceTree = "<group>"; };
 		70EF68EF61C4587DEC5119A866265B57 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-dummy.m"; sourceTree = "<group>"; };
-		714CBDF84C8FCD04FDAEA70868566A07 /* AWSMobileResults.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileResults.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileResults.swift; sourceTree = "<group>"; };
 		71803B908C82923324FBC55B50603420 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-umbrella.h"; sourceTree = "<group>"; };
-		72AAF4F216BB8E9BE91BFBFA3DCB2AA2 /* AWSAuthCore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSAuthCore.release.xcconfig; sourceTree = "<group>"; };
-		767B4455799A98274C24D8D74C040E9B /* AWSSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSerialization.h; path = AWSCore/Serialization/AWSSerialization.h; sourceTree = "<group>"; };
+		7269EFAE1FC03A808400B92FBF21AEEB /* _AWSMobileClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = _AWSMobileClient.h; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.h; sourceTree = "<group>"; };
+		732715CF43E24A182818E45B9DD6CA42 /* NSArray+AWSMTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+AWSMTLManipulationAdditions.h"; path = "AWSCore/Mantle/NSArray+AWSMTLManipulationAdditions.h"; sourceTree = "<group>"; };
+		74C17E59A382F19CD152527575F7BFA2 /* SwiftLint.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLint.debug.xcconfig; sourceTree = "<group>"; };
+		763805AAD99B21D77DA04985683F7904 /* AWSCognitoIdentityProviderASF.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCognitoIdentityProviderASF.modulemap; sourceTree = "<group>"; };
 		77145BB1E378943FCB981368F4B9E771 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests.release.xcconfig"; sourceTree = "<group>"; };
-		77151F54F4FB266CE6A2D7162F277D21 /* AWSDDOSLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDOSLogger.m; path = AWSCore/Logging/AWSDDOSLogger.m; sourceTree = "<group>"; };
-		7746660A2B9ABA1322C22635208C039D /* AWSClientContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSClientContext.h; path = AWSCore/Service/AWSClientContext.h; sourceTree = "<group>"; };
-		7799BCB5D7602926CD8534E8D595CD25 /* CwlCatchException-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CwlCatchException-dummy.m"; sourceTree = "<group>"; };
-		77DBCE95EEDBE6CF449375F56ED6A8A3 /* AWSMTLModel+NSCoding.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSMTLModel+NSCoding.m"; path = "AWSCore/Mantle/AWSMTLModel+NSCoding.m"; sourceTree = "<group>"; };
-		77F306093B6CBBA95ABD2D5A3A3FB885 /* AWSMTLReflection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLReflection.h; path = AWSCore/Mantle/AWSMTLReflection.h; sourceTree = "<group>"; };
-		78880857643C7E7D963CA06F4F79046E /* AWSServiceEnum.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSServiceEnum.h; path = AWSCore/Service/AWSServiceEnum.h; sourceTree = "<group>"; };
-		791C72FC52723E22DC8CE87BDEEB54C7 /* AWSMobileClient-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSMobileClient-dummy.m"; sourceTree = "<group>"; };
-		7ACD0297802CDDDFBC77BF5D6C40D7B6 /* AWSURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLResponseSerialization.m; path = AWSCore/Serialization/AWSURLResponseSerialization.m; sourceTree = "<group>"; };
-		7B1B00B9CC01A4FAC1E58AC7CA361218 /* AWSCognitoIdentityProviderASF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderASF.h; path = AWSCognitoIdentityProviderASF/AWSCognitoIdentityProviderASF.h; sourceTree = "<group>"; };
-		7C24137D9A15529190A1833D49230BD3 /* AWSTask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTask.h; path = AWSCore/Bolts/AWSTask.h; sourceTree = "<group>"; };
-		7C5086639816CD0DADC764CEFF8DA89D /* AWSCognitoIdentityResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityResources.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityResources.h; sourceTree = "<group>"; };
-		7DC551498486764772714478E98073EE /* AWSMTLValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLValueTransformer.h; path = AWSCore/Mantle/AWSMTLValueTransformer.h; sourceTree = "<group>"; };
-		7E497CA1D2B416C4AF9A01F578B63DD3 /* AWSEXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTRuntimeExtensions.h; path = AWSCore/Mantle/extobjc/AWSEXTRuntimeExtensions.h; sourceTree = "<group>"; };
+		78A4809D27E589F4ECDA9C8EB822F642 /* AWSUICKeyChainStore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSUICKeyChainStore.h; path = AWSCore/UICKeyChainStore/AWSUICKeyChainStore.h; sourceTree = "<group>"; };
+		79019805F668DD6072EACF09CA6F8051 /* AWSCognitoIdentityProviderSrpHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderSrpHelper.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderSrpHelper.h; sourceTree = "<group>"; };
+		79839BA3B62F40A30032D76FC50C40B4 /* AWSDDContextFilterLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDContextFilterLogFormatter.m; path = AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter.m; sourceTree = "<group>"; };
+		7A185053CD443C6EBC867E791ED606C7 /* AWSXMLDictionary.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSXMLDictionary.h; path = AWSCore/XMLDictionary/AWSXMLDictionary.h; sourceTree = "<group>"; };
+		7A3745FA07AB86D670E8F463497DA121 /* AWSCognitoIdentityProviderASF.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCognitoIdentityProviderASF.debug.xcconfig; sourceTree = "<group>"; };
+		7A9898F0E3C371B28BF2A2C1BD7D4358 /* AWSCognitoIdentityUserPool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityUserPool.m; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m; sourceTree = "<group>"; };
+		7AC3528B305A2ADD668D6DB18F2A3B5B /* AWSDDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDDispatchQueueLogFormatter.h; path = AWSCore/Logging/Extensions/AWSDDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
+		7BA8C89DAC641587B83E6F3BFE1924C6 /* AWSCognitoIdentityProvider.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCognitoIdentityProvider.debug.xcconfig; sourceTree = "<group>"; };
+		7CEE5FE92E2539F612C836BB1A632631 /* AWSCancellationToken.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationToken.h; path = AWSCore/Bolts/AWSCancellationToken.h; sourceTree = "<group>"; };
+		7E62AEFB6CD3A801302D181EBC31257A /* AWSMobileClient-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSMobileClient-prefix.pch"; sourceTree = "<group>"; };
 		7E95AAB996428D7874DB2E4B93260F35 /* CwlCatchException.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CwlCatchException.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7ECF880F10C3E80885D927556F50EBE0 /* AWSUIConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSUIConfiguration.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSUIConfiguration.h; sourceTree = "<group>"; };
+		7FF0F5FBA94A96228D3BFFD35DEB7110 /* AWSDDMultiFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDMultiFormatter.h; path = AWSCore/Logging/Extensions/AWSDDMultiFormatter.h; sourceTree = "<group>"; };
 		80DF1944FBE1C02C0D19FA556279CF7A /* Pods_Amplify.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify.framework; path = "Pods-Amplify.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8159E8A1827AD9AF774C2E6B233D8476 /* AWSDDAssertMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDAssertMacros.h; path = AWSCore/Logging/AWSDDAssertMacros.h; sourceTree = "<group>"; };
-		8171E908773030DF8D186BD5A21D4608 /* AWSExecutor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSExecutor.m; path = AWSCore/Bolts/AWSExecutor.m; sourceTree = "<group>"; };
-		819579E5CAEE9144BC828E9B6D7B2F04 /* AWSCognitoIdentityProviderASF-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCognitoIdentityProviderASF-Info.plist"; sourceTree = "<group>"; };
-		822AFB1D38A97E144B98521D98A44F0C /* AWSIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSIdentityProvider.h; path = AWSCore/Authentication/AWSIdentityProvider.h; sourceTree = "<group>"; };
-		82D5755093B849733862D6875C19C2EE /* AWSMTLManagedObjectAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLManagedObjectAdapter.h; path = AWSCore/Mantle/AWSMTLManagedObjectAdapter.h; sourceTree = "<group>"; };
-		8314E4C7BEBD385F48DEA72FDD8FB69C /* AWSCategory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCategory.m; path = AWSCore/Utility/AWSCategory.m; sourceTree = "<group>"; };
-		83A9210E4B66522692BA0A044AAEF7F9 /* NSData+AWSCognitoIdentityProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+AWSCognitoIdentityProvider.h"; path = "AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.h"; sourceTree = "<group>"; };
-		8676BBF167AABCB755BBA9092D0BA3D9 /* AWSFMDatabaseQueue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabaseQueue.h; path = AWSCore/FMDB/AWSFMDatabaseQueue.h; sourceTree = "<group>"; };
-		87757B02A6B5FA4D18E0ED5C0605EEF3 /* NSDictionary+AWSMTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+AWSMTLManipulationAdditions.h"; path = "AWSCore/Mantle/NSDictionary+AWSMTLManipulationAdditions.h"; sourceTree = "<group>"; };
-		87CE1E26D07A0FED1773F6F755E99630 /* DeviceOperations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeviceOperations.swift; path = AWSAuthSDK/Sources/AWSMobileClient/DeviceOperations.swift; sourceTree = "<group>"; };
+		8331C110587ED90AD1EE22D37D3FB473 /* AWSURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLResponseSerialization.h; path = AWSCore/Serialization/AWSURLResponseSerialization.h; sourceTree = "<group>"; };
+		847FDD4A5924154C67F278F229C8B9CE /* CwlCatchException.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CwlCatchException.modulemap; sourceTree = "<group>"; };
+		87194275CD609A95EE6BE32E11B439AF /* AWSServiceEnum.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSServiceEnum.h; path = AWSCore/Service/AWSServiceEnum.h; sourceTree = "<group>"; };
+		872636C9955205D3C03F3292C874723D /* AWSAuthUIHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSAuthUIHelper.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.m; sourceTree = "<group>"; };
+		87621921A248C6EF6BF53C7D51B346DA /* AWSDDOSLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDOSLogger.m; path = AWSCore/Logging/AWSDDOSLogger.m; sourceTree = "<group>"; };
+		8809858A5E01538E0D74FE13FD3903B3 /* AWSMobileClientUserDetails.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileClientUserDetails.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSMobileClientUserDetails.swift; sourceTree = "<group>"; };
 		8866A6188CF9937D30E31F9C3AF4744D /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests.modulemap"; sourceTree = "<group>"; };
+		88B3B1D5195F422193A42586F97E1395 /* AWSMTLValueTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLValueTransformer.m; path = AWSCore/Mantle/AWSMTLValueTransformer.m; sourceTree = "<group>"; };
 		88B5B053284A3CD214CB2345BB04C33F /* AWSMobileClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AWSMobileClient.framework; path = AWSMobileClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		88E787B8E15B912AC396282DC00F1F4E /* AWSDDASLLogCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDASLLogCapture.h; path = AWSCore/Logging/AWSDDASLLogCapture.h; sourceTree = "<group>"; };
+		88ED5F9AFEA22F06CE869726B2F707E8 /* FABAttributes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FABAttributes.h; path = AWSCore/Fabric/FABAttributes.h; sourceTree = "<group>"; };
 		897BE0E1152364146DF9E84966A20D23 /* AWSCognitoIdentityProvider.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSCognitoIdentityProvider.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		899616849AD1E99FABEF8D9C7BF5ADA4 /* AWSCore-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCore-Info.plist"; sourceTree = "<group>"; };
-		89D80A302B3AB53984C2EBFC63E75D9E /* CwlCatchException.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CwlCatchException.modulemap; sourceTree = "<group>"; };
-		89E885F128A28CAF00D3C9EA70F5A2DE /* CwlPreconditionTesting-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlPreconditionTesting-prefix.pch"; sourceTree = "<group>"; };
 		8A7F5959C56A2F6E93DDA0D9EB3274DE /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-dummy.m"; sourceTree = "<group>"; };
 		8B37EE7562B33B09D027EE4A0B32AA75 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.release.xcconfig"; sourceTree = "<group>"; };
-		8BC46419BA3507B1B650E2E09B3787EA /* AWSCognitoIdentityProvider-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProvider-umbrella.h"; sourceTree = "<group>"; };
-		8CC8A065D0769AB2ECDAC257704CD436 /* AWSFMDatabasePool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabasePool.h; path = AWSCore/FMDB/AWSFMDatabasePool.h; sourceTree = "<group>"; };
-		8E01301307CE42A2B4740B8BBDEF1A63 /* CwlPreconditionTesting-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlPreconditionTesting-umbrella.h"; sourceTree = "<group>"; };
+		8CC923FF920DB28C101C420CE987CDE6 /* FABKitProtocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FABKitProtocol.h; path = AWSCore/Fabric/FABKitProtocol.h; sourceTree = "<group>"; };
+		8D3C0F6EA1AA31E2C61D1EE399A42644 /* AWSMobileClient-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSMobileClient-dummy.m"; sourceTree = "<group>"; };
+		8D44E4083D05EB6AB9B74809F65F6FC2 /* AWSCognitoIdentityProvider.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCognitoIdentityProvider.release.xcconfig; sourceTree = "<group>"; };
+		8EBB778180542D81D7FC5ED3366B2D14 /* AWSCocoaLumberjack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCocoaLumberjack.h; path = AWSCore/Logging/AWSCocoaLumberjack.h; sourceTree = "<group>"; };
+		8F8DC78698DCFAB9BA43F5468B4A840D /* AWSDDTTYLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDTTYLogger.h; path = AWSCore/Logging/AWSDDTTYLogger.h; sourceTree = "<group>"; };
 		9000133D745E33FE1ED02390F5F7E717 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
 		9022B9B1EE62A9406A47544AF1A9A60A /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		90D7A46D08EDB42C5A86B4AD9B660F37 /* AWSDDFileLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDFileLogger.h; path = AWSCore/Logging/AWSDDFileLogger.h; sourceTree = "<group>"; };
-		9350B3FCF664ACBA1B6AAA745BBCA308 /* JSONHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JSONHelper.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/JSONHelper.swift; sourceTree = "<group>"; };
-		941DB7BB735782EED88400ABA557EBEF /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
-		94EEEE23B143CAE7857143A60EDAEE91 /* AWSURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLRequestSerialization.h; path = AWSCore/Serialization/AWSURLRequestSerialization.h; sourceTree = "<group>"; };
-		95A58B6C533043AC03FC12B16145C38D /* CwlPreconditionTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlPreconditionTesting.h; path = Sources/CwlPreconditionTesting/include/CwlPreconditionTesting.h; sourceTree = "<group>"; };
-		95B69FCC9C94459CC24FA0F476A45FEC /* AWSUICKeyChainStore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSUICKeyChainStore.h; path = AWSCore/UICKeyChainStore/AWSUICKeyChainStore.h; sourceTree = "<group>"; };
-		96B30AC1E2A2C23B6F1AB65BF4DBE3DC /* AWSFMDB.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDB.h; path = AWSCore/FMDB/AWSFMDB.h; sourceTree = "<group>"; };
-		971FD80F5A3D56DB110CD4F03667D4F7 /* AWSTask.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTask.m; path = AWSCore/Bolts/AWSTask.m; sourceTree = "<group>"; };
-		975762B5F22BD7567982C2729A08EA29 /* AWSUICKeyChainStore.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSUICKeyChainStore.m; path = AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m; sourceTree = "<group>"; };
-		97D015DB895D5976B9057D0058FA45B8 /* AWSSynchronizedMutableDictionary.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSynchronizedMutableDictionary.m; path = AWSCore/Utility/AWSSynchronizedMutableDictionary.m; sourceTree = "<group>"; };
-		9804501BD5ABBA59BAE5D84867237A88 /* AWSSTSResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSResources.m; path = AWSCore/STS/AWSSTSResources.m; sourceTree = "<group>"; };
-		9A6C5897CC3CC996DB74F2BADF4C2AA9 /* AWSDDFileLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDFileLogger.m; path = AWSCore/Logging/AWSDDFileLogger.m; sourceTree = "<group>"; };
-		9B941D41D42EEC8164DEA0106F284EA7 /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
-		9BF34501027170E35D5C40DE2AD55C64 /* AWSCognitoIdentityASF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityASF.h; path = AWSCognitoIdentityProviderASF/Internal/AWSCognitoIdentityASF.h; sourceTree = "<group>"; };
-		9C1A67C9050CCB40F2F72D8A032AF67D /* AWSCognitoIdentityUserPool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUserPool.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h; sourceTree = "<group>"; };
-		9C4F2011018B14F3F4235228124861C3 /* AWSURLRequestRetryHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLRequestRetryHandler.h; path = AWSCore/Serialization/AWSURLRequestRetryHandler.h; sourceTree = "<group>"; };
+		9070A8B295592AD54BB34A0D91C47A13 /* AWSFMDatabaseQueue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabaseQueue.h; path = AWSCore/FMDB/AWSFMDatabaseQueue.h; sourceTree = "<group>"; };
+		908EC0C96498A900CFC04A0CDCC991CA /* AWSCognitoIdentityProviderASF.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderASF.m; path = AWSCognitoIdentityProviderASF/AWSCognitoIdentityProviderASF.m; sourceTree = "<group>"; };
+		90D4490B3295BD88B2945BC735E90E20 /* AWSCognitoIdentityProviderModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderModel.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderModel.h; sourceTree = "<group>"; };
+		90DE9F1B9757E0239BEFD5FB9794389E /* AWSCognitoAuth.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoAuth.m; path = AWSCognitoAuth/AWSCognitoAuth.m; sourceTree = "<group>"; };
+		9253B55179A547D34BC77CA641557737 /* AWSCore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCore.release.xcconfig; sourceTree = "<group>"; };
+		9422D282E5A081892F5121EA194A3FBD /* AWSDDAssertMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDAssertMacros.h; path = AWSCore/Logging/AWSDDAssertMacros.h; sourceTree = "<group>"; };
+		942FE31C14A3D5DE99F913F551DE6C54 /* AWSSTSModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSModel.m; path = AWSCore/STS/AWSSTSModel.m; sourceTree = "<group>"; };
+		9439C729F9BFD63741282A364FC5A32E /* AWSMobileClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSMobileClient.release.xcconfig; sourceTree = "<group>"; };
+		944F5689ABB43BAA26EF5E6C8EF89444 /* AWSCognitoIdentityUserPool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUserPool.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h; sourceTree = "<group>"; };
+		9509DC857FE4ABF77D04D86E3CA870FC /* AWSCognitoIdentityProviderASF-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCognitoIdentityProviderASF-Info.plist"; sourceTree = "<group>"; };
+		96D8AF31153FEB41A531D8036E0330E2 /* AWSCognitoIdentityProvider.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCognitoIdentityProvider.modulemap; sourceTree = "<group>"; };
+		9A71BCB9D1D845C22B8809633F9620D0 /* NSError+AWSMTLModelException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSError+AWSMTLModelException.h"; path = "AWSCore/Mantle/NSError+AWSMTLModelException.h"; sourceTree = "<group>"; };
+		9B517F2F767F72EE01C808AB9BABE8AE /* AWSNetworkingHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSNetworkingHelpers.m; path = AWSCore/Networking/AWSNetworkingHelpers.m; sourceTree = "<group>"; };
+		9C19D4A110D91264453BBB9118B200A2 /* AWSCognitoIdentityProviderService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderService.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderService.h; sourceTree = "<group>"; };
+		9CBE1C7AC6B8A499F1F9F92F4B5878FD /* aws_tommath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath.h; sourceTree = "<group>"; };
+		9CC578ED37E3D7D62477805312126FF0 /* AWSEXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTScope.h; path = AWSCore/Mantle/extobjc/AWSEXTScope.h; sourceTree = "<group>"; };
+		9D926F19E6FECEA9EFD801AF741B1453 /* AWSModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSModel.m; path = AWSCore/Utility/AWSModel.m; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		9F41F0AFEC3B456F5D1D357773CABD22 /* AWSCognitoIdentityProviderService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderService.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderService.m; sourceTree = "<group>"; };
-		A25BD6858ACA564889F5C1888E45B49F /* AWSURLRequestRetryHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLRequestRetryHandler.m; path = AWSCore/Serialization/AWSURLRequestRetryHandler.m; sourceTree = "<group>"; };
-		A369FE77E8A7E105DD515C5A0238222F /* AWSCognitoIdentityProvider-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCognitoIdentityProvider-Info.plist"; sourceTree = "<group>"; };
+		9EE5EA345BF8114DD24BABAB8EB041A9 /* AWSCognitoIdentityProviderResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderResources.m; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderResources.m; sourceTree = "<group>"; };
+		9F44B8C7B0BC344BFDE65FF3FB64D1E5 /* AWSValidation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSValidation.h; path = AWSCore/Serialization/AWSValidation.h; sourceTree = "<group>"; };
+		A073D61814D5A8291BF1F81E0E356A86 /* CwlCatchException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchException.swift; path = Sources/CwlCatchException/CwlCatchException.swift; sourceTree = "<group>"; };
+		A243228FEE8808D847077999FFCA7FF5 /* AWSMobileClient-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSMobileClient-umbrella.h"; sourceTree = "<group>"; };
+		A37E2B51E0D1700AA624270A7EDB8065 /* AWSInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSInfo.h; path = AWSCore/Service/AWSInfo.h; sourceTree = "<group>"; };
+		A47DD5329604787552A80065E28C4562 /* AWSBolts.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSBolts.h; path = AWSCore/Bolts/AWSBolts.h; sourceTree = "<group>"; };
 		A483C9091059B80817F2F1D6E7F4ADC0 /* Pods-Amplify-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Amplify-acknowledgements.markdown"; sourceTree = "<group>"; };
 		A4B8551213E176E1C8DC109BF5957DD3 /* Pods_Amplify_AmplifyTestConfigs_AmplifyTestCommon.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AmplifyTestConfigs_AmplifyTestCommon.framework; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		A558F5B8A104C627E526058158AE0D6E /* AWSFMResultSet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMResultSet.h; path = AWSCore/FMDB/AWSFMResultSet.h; sourceTree = "<group>"; };
+		A4D55EE93BAD6722690D0733CBA4DDAA /* AWSCognitoAuth+Extensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSCognitoAuth+Extensions.m"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.m"; sourceTree = "<group>"; };
+		A5ACFCA344CAB9104886458B50F41D9F /* AWSTask.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTask.m; path = AWSCore/Bolts/AWSTask.m; sourceTree = "<group>"; };
+		A5E2B2732E8C2E0DAB2B79B29CD13E84 /* AWSMobileClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMobileClient.h; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.h; sourceTree = "<group>"; };
+		A6FAA9739F0775D555007B48C7C4C604 /* AWSValidation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSValidation.m; path = AWSCore/Serialization/AWSValidation.m; sourceTree = "<group>"; };
 		A70C7A2407B818ECD1C5D3D6EF9E6781 /* Pods-Amplify-AWSPluginsCore-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-Info.plist"; sourceTree = "<group>"; };
-		A78730E05ABF4E299EDFBE9D6E383E47 /* AWSIdentityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSIdentityManager.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSIdentityManager.m; sourceTree = "<group>"; };
-		A8CE8311B2C6B175B02EC6B1F56687F0 /* AWSNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSNetworking.h; path = AWSCore/Networking/AWSNetworking.h; sourceTree = "<group>"; };
-		A95F247C52F4E16F0A83457315C849CE /* NSValueTransformer+AWSMTLInversionAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+AWSMTLInversionAdditions.m"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLInversionAdditions.m"; sourceTree = "<group>"; };
-		AD31702686B78C00DC137B99F2D43FC1 /* CwlCatchException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchException.swift; path = Sources/CwlCatchException/CwlCatchException.swift; sourceTree = "<group>"; };
-		AD5FC9E5E349DFF661B54E9F8250C8DD /* AWSCognitoIdentityService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityService.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityService.h; sourceTree = "<group>"; };
-		AD631971BF2738DD07F986967E16668B /* AWSNetworkingHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSNetworkingHelpers.m; path = AWSCore/Networking/AWSNetworkingHelpers.m; sourceTree = "<group>"; };
-		AD7DA8547C6045EC6D31802C445EA2DE /* AWSXMLDictionary.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSXMLDictionary.m; path = AWSCore/XMLDictionary/AWSXMLDictionary.m; sourceTree = "<group>"; };
-		ADA0D94F6857763CE195680591541616 /* AWSFMDatabase+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSFMDatabase+Private.h"; path = "AWSCore/FMDB/AWSFMDatabase+Private.h"; sourceTree = "<group>"; };
-		AE3F8F35FA2FD71D338FE3D37E52F586 /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
-		AE6B81E83AB18322B2DD058E842D2F4E /* AWSAuthCore-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSAuthCore-prefix.pch"; sourceTree = "<group>"; };
-		AE8CC2E06DEBCE5EF191799D1127C5F1 /* AWSDDLog.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLog.h; path = AWSCore/Logging/AWSDDLog.h; sourceTree = "<group>"; };
-		AEF01236FCF1B3D525155ED54ED94047 /* AWSInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSInfo.h; path = AWSCore/Service/AWSInfo.h; sourceTree = "<group>"; };
-		AEFF9779FFD86E5968A8FE9D63B5D8C6 /* AWSAuthUIHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSAuthUIHelper.m; path = AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.m; sourceTree = "<group>"; };
-		AF6921AC94F623D44C58944BE45619E2 /* AWSCore-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCore-umbrella.h"; sourceTree = "<group>"; };
+		A71B7F640BDB684BA90C692996235E16 /* CwlCatchException-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlCatchException-umbrella.h"; sourceTree = "<group>"; };
+		A85D785EC4F26572EC8F5A5F629F6FFC /* AWSMobileClient-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSMobileClient-Info.plist"; sourceTree = "<group>"; };
+		A9201C2D174632B57C77653694F2FE9E /* AWSCancellationTokenSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCancellationTokenSource.h; path = AWSCore/Bolts/AWSCancellationTokenSource.h; sourceTree = "<group>"; };
+		AA221FF719FFFD173DFF9FC756863A67 /* CwlPreconditionTesting.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CwlPreconditionTesting.release.xcconfig; sourceTree = "<group>"; };
+		ADA3BEA703C8045AA4F37E7A0DA538AA /* AWSMTLReflection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLReflection.h; path = AWSCore/Mantle/AWSMTLReflection.h; sourceTree = "<group>"; };
+		AE0675F1138CD44A800B4EBD0B5E55DD /* AWSCognitoAuth+Extensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoAuth+Extensions.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h"; sourceTree = "<group>"; };
+		AEEF8E360ECF4856E8D30DEA489B6375 /* AWSSignInProviderApplicationIntercept.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInProviderApplicationIntercept.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInProviderApplicationIntercept.h; sourceTree = "<group>"; };
+		AF18B5AF7B58C0B76C2A14EAEE5D5401 /* AWSFMDatabaseAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabaseAdditions.h; path = AWSCore/FMDB/AWSFMDatabaseAdditions.h; sourceTree = "<group>"; };
+		AF376D908F93D6D7CAD373AAE433A82C /* AWSURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLResponseSerialization.m; path = AWSCore/Serialization/AWSURLResponseSerialization.m; sourceTree = "<group>"; };
 		AF9100203F45E4A2CE2EE987A561A14F /* Pods-AmplifyTestApp-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-AmplifyTestApp-acknowledgements.plist"; sourceTree = "<group>"; };
-		AFB5BF50AD93515A92630A2145F8DDE2 /* AWSCognitoAuth+Extensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSCognitoAuth+Extensions.m"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.m"; sourceTree = "<group>"; };
-		B0C83F24CB550E6006708C464C4978E1 /* AWSDDASLLogCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDASLLogCapture.m; path = AWSCore/Logging/AWSDDASLLogCapture.m; sourceTree = "<group>"; };
-		B0FF6315F94A37AA4C22B5514E4291AA /* AWSMobileClient-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSMobileClient-umbrella.h"; sourceTree = "<group>"; };
-		B18C183C23945DF961400C5B769B487F /* NSArray+AWSMTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+AWSMTLManipulationAdditions.h"; path = "AWSCore/Mantle/NSArray+AWSMTLManipulationAdditions.h"; sourceTree = "<group>"; };
-		B1A8CFD29736C239CEF3A5EB43AA3BFE /* AWSCognitoIdentityUser_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUser_Internal.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityUser_Internal.h; sourceTree = "<group>"; };
+		B012CBF798D101D7AEA5DEBB931D457F /* NSValueTransformer+AWSMTLInversionAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+AWSMTLInversionAdditions.m"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLInversionAdditions.m"; sourceTree = "<group>"; };
+		B11E3E578B6A82BCB60452DC1BD11497 /* AWSMTLManagedObjectAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLManagedObjectAdapter.m; path = AWSCore/Mantle/AWSMTLManagedObjectAdapter.m; sourceTree = "<group>"; };
+		B13BE58F43DF7C58E227E8E88A40B4E0 /* CwlCatchException.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CwlCatchException.debug.xcconfig; sourceTree = "<group>"; };
+		B18D92A4C431C09D10D5D8CC118F2BA2 /* aws_tommath_class.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aws_tommath_class.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/aws_tommath_class.h; sourceTree = "<group>"; };
+		B1D278448B10A80E29C4434D94F1C76C /* AWSDDLog.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDLog.m; path = AWSCore/Logging/AWSDDLog.m; sourceTree = "<group>"; };
+		B21B371F40AD3DB3AE0347F642CA716C /* AWSXMLWriter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSXMLWriter.h; path = AWSCore/XMLWriter/AWSXMLWriter.h; sourceTree = "<group>"; };
+		B22392803C0BF56B11E6A8ACEC2D9388 /* AWSURLRequestRetryHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLRequestRetryHandler.h; path = AWSCore/Serialization/AWSURLRequestRetryHandler.h; sourceTree = "<group>"; };
 		B270484543DC97A2E5759EB4E30E0E90 /* Pods_Amplify_AmplifyTestConfigs_AmplifyTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AmplifyTestConfigs_AmplifyTests.framework; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		B2ED77C675E31F2C63768E7D59D25611 /* AWSURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLSessionManager.h; path = AWSCore/Networking/AWSURLSessionManager.h; sourceTree = "<group>"; };
 		B4144DE60EA249CC4A98549069F402FB /* AWSCognitoIdentityProviderASF.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSCognitoIdentityProviderASF.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B4D90C37125647CF290576B422D6E22C /* AWSMobileOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileOptions.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileOptions.swift; sourceTree = "<group>"; };
-		B7A45684A9DDAC60CCD1D5EB54FF56C6 /* AWSSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSerialization.m; path = AWSCore/Serialization/AWSSerialization.m; sourceTree = "<group>"; };
-		B7ADE5543A95AE17B1E9115EC5CDF0CC /* AWSCancellationTokenRegistration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationTokenRegistration.m; path = AWSCore/Bolts/AWSCancellationTokenRegistration.m; sourceTree = "<group>"; };
-		B7D7D279373248B855C695D8D59114CF /* AWSTMMemoryCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMMemoryCache.m; path = AWSCore/TMCache/AWSTMMemoryCache.m; sourceTree = "<group>"; };
+		B5469A1E228546E79319E57BBFB5167C /* AWSDDFileLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDFileLogger.m; path = AWSCore/Logging/AWSDDFileLogger.m; sourceTree = "<group>"; };
+		B62AB28531B4A1394BFBFC01AE0185B1 /* AWSXMLDictionary.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSXMLDictionary.m; path = AWSCore/XMLDictionary/AWSXMLDictionary.m; sourceTree = "<group>"; };
+		B6D986AC4E2FA03EB562FBA9B4ECA3A7 /* AWSCognitoIdentity+Fabric.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSCognitoIdentity+Fabric.m"; path = "AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.m"; sourceTree = "<group>"; };
+		B70DE473AD6DAAFE965197BAC56C83AA /* AWSCategory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCategory.m; path = AWSCore/Utility/AWSCategory.m; sourceTree = "<group>"; };
+		B7EF26D3B368F8069DF3FF5B15DE00C6 /* JSONHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JSONHelper.swift; path = AWSAuthSDK/Sources/AWSMobileClient/Internal/JSONHelper.swift; sourceTree = "<group>"; };
 		B8A667E74EC0A8A4EDFB8F2D2364FC92 /* Pods-Amplify-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-dummy.m"; sourceTree = "<group>"; };
-		B99D4A986E8CBCFBC2680AF7EAC089A5 /* AWSCognitoIdentityUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUser.h; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h; sourceTree = "<group>"; };
-		BB95B4A12DFA6DF4B15369418C26B48C /* AWSCognitoIdentityUserPool_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityUserPool_Internal.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityUserPool_Internal.h; sourceTree = "<group>"; };
+		B909FE2414420753D99E82A24999CE77 /* AWSMobileClient.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSMobileClient.modulemap; sourceTree = "<group>"; };
+		B91D60620C0F71296D9A2756B377A350 /* AWSXMLWriter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSXMLWriter.m; path = AWSCore/XMLWriter/AWSXMLWriter.m; sourceTree = "<group>"; };
+		B9666E7AC35B69974E1008C9C9240EE4 /* AWSExecutor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSExecutor.m; path = AWSCore/Bolts/AWSExecutor.m; sourceTree = "<group>"; };
+		B9BE4F242531733D3769372176540E24 /* AWSFMDB+AWSHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSFMDB+AWSHelpers.h"; path = "AWSCore/FMDB/AWSFMDB+AWSHelpers.h"; sourceTree = "<group>"; };
+		BA40F9C8C5AB8AEED653C42B5748A2AB /* CwlPreconditionTesting-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "CwlPreconditionTesting-Info.plist"; sourceTree = "<group>"; };
+		BB7E0EA0CAD58734D312F08A9DA0E2E9 /* AWSDDMultiFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDMultiFormatter.m; path = AWSCore/Logging/AWSDDMultiFormatter.m; sourceTree = "<group>"; };
 		BBCCE722E2FD574C72320E1D0DFA805A /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-acknowledgements.plist"; sourceTree = "<group>"; };
 		BC0AAAB222E3424AB42C3968AE2DD9F7 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests.debug.xcconfig"; sourceTree = "<group>"; };
+		BD964C13D7DC3E8EE957B28480B8577E /* AWSBolts.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSBolts.m; path = AWSCore/Bolts/AWSBolts.m; sourceTree = "<group>"; };
+		BDDF6BB547C0073ED648AEE5125B4F0D /* AWSMTLJSONAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSMTLJSONAdapter.m; path = AWSCore/Mantle/AWSMTLJSONAdapter.m; sourceTree = "<group>"; };
 		BDE3D242E320015920FF9968B3B82469 /* Pods-Amplify-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-Info.plist"; sourceTree = "<group>"; };
 		BE3DBB67EEF91BEAEEF0780F753CCB8E /* Pods-Amplify-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-acknowledgements.plist"; sourceTree = "<group>"; };
-		BE8A00F21039086E055FBF70CCEC010F /* AWSDDTTYLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDTTYLogger.m; path = AWSCore/Logging/AWSDDTTYLogger.m; sourceTree = "<group>"; };
+		BEA270D6FB0B1C10DFBFF1B0F85B5E72 /* AWSAuthCore-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSAuthCore-prefix.pch"; sourceTree = "<group>"; };
 		BF3EC1DB119CD6294BF8B76C95215B6E /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.modulemap"; sourceTree = "<group>"; };
-		BF99389237A0C6D569874D05DDDF0737 /* AWSService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSService.h; path = AWSCore/Service/AWSService.h; sourceTree = "<group>"; };
-		C06B1ECB53889BBE9E30295A379B1435 /* AWSCognitoIdentityProvider-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProvider-prefix.pch"; sourceTree = "<group>"; };
+		BFC19B69A58D11D24120B5E24CCE1BCC /* CwlCatchException.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CwlCatchException.release.xcconfig; sourceTree = "<group>"; };
 		C0764D426402BEC77DB42BBD5102F91F /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-acknowledgements.plist"; sourceTree = "<group>"; };
-		C07DC5E1C216277E1A0C189EF804BC04 /* CwlPreconditionTesting-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "CwlPreconditionTesting-Info.plist"; sourceTree = "<group>"; };
-		C0A8E0C4A94821AB03AC041AD9615DB7 /* AWSCognitoIdentityProviderASF.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCognitoIdentityProviderASF.modulemap; sourceTree = "<group>"; };
-		C0EC70C2BA5512DF72AFA093567E3C77 /* AWSDDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDAbstractDatabaseLogger.h; path = AWSCore/Logging/AWSDDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
-		C1E20A028FAC0FAFB1FADAEB12A370FF /* AWSMobileClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSMobileClient.release.xcconfig; sourceTree = "<group>"; };
-		C2775A802441C8060EB9BF86321820D9 /* Fabric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Fabric.h; path = AWSCore/Fabric/Fabric.h; sourceTree = "<group>"; };
-		C27ECFAC14BAD96D20837754F1CD3DEE /* AWSCognitoIdentityProvider.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSCognitoIdentityProvider.modulemap; sourceTree = "<group>"; };
-		C37E09DF58FA889A85DC5F6F4E692EAC /* AWSCognitoIdentityProviderASF-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCognitoIdentityProviderASF-dummy.m"; sourceTree = "<group>"; };
+		C07D57DF869D9069A075E30A89BCBDEA /* AWSFMDatabasePool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSFMDatabasePool.h; path = AWSCore/FMDB/AWSFMDatabasePool.h; sourceTree = "<group>"; };
+		C14597FFE0390023D368F52DEF6321E9 /* AWSMantle.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMantle.h; path = AWSCore/Mantle/AWSMantle.h; sourceTree = "<group>"; };
+		C199B5B2EFA7A4C45FDFDA4F1F7C34D6 /* AWSMTLJSONAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLJSONAdapter.h; path = AWSCore/Mantle/AWSMTLJSONAdapter.h; sourceTree = "<group>"; };
+		C2234B1A0DF8C9CE28E8C68E18C805D0 /* AWSCredentialsProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCredentialsProvider.h; path = AWSCore/Authentication/AWSCredentialsProvider.h; sourceTree = "<group>"; };
+		C333C778BBD5047F5871443C25865128 /* libAWSCognitoIdentityProviderASFBinary.a */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = archive.ar; name = libAWSCognitoIdentityProviderASFBinary.a; path = AWSCognitoIdentityProviderASF/Internal/libAWSCognitoIdentityProviderASFBinary.a; sourceTree = "<group>"; };
+		C35534705967F0C84203915633DD3B00 /* AWSCognitoIdentityProviderHKDF.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderHKDF.m; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderHKDF.m; sourceTree = "<group>"; };
 		C49CC694143B932ACAEDAB2B998DE32A /* AWSAuthCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSAuthCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C527417CF3621C2D730B8DDB950B8F5C /* CwlPreconditionTesting.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CwlPreconditionTesting.release.xcconfig; sourceTree = "<group>"; };
-		C5965311C253CC983E3C43861FE61DE4 /* AWSCognitoAuthUICKeyChainStore.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoAuthUICKeyChainStore.m; path = AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.m; sourceTree = "<group>"; };
-		C631E2DE9FE7DA03B470387BA48FA71B /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
-		C84851ADEA14436507FF1E16E5963703 /* AWSCognitoIdentityUser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityUser.m; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m; sourceTree = "<group>"; };
-		C889B4FD8E0B46B1330DDC69207E75C8 /* CwlCatchException.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CwlCatchException.debug.xcconfig; sourceTree = "<group>"; };
+		C71D546C7AF70FD9677085DA4E2BA00D /* AWSMobileResults.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSMobileResults.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSMobileResults.swift; sourceTree = "<group>"; };
+		C72F32AF9B06780B96C0306FC3489DAD /* AWSCognitoIdentityProvider-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSCognitoIdentityProvider-Info.plist"; sourceTree = "<group>"; };
+		C7F6DB16EB1746250ACF870AAB650897 /* AWSCognitoIdentityProviderASF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderASF.h; path = AWSCognitoIdentityProviderASF/AWSCognitoIdentityProviderASF.h; sourceTree = "<group>"; };
 		C8D22E6E639FD8B2AA18F007DEDB51F7 /* Pods-Amplify.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify.debug.xcconfig"; sourceTree = "<group>"; };
-		C9855730379BD00EDA06B67D9E6ACE5A /* AWSBolts.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSBolts.m; path = AWSCore/Bolts/AWSBolts.m; sourceTree = "<group>"; };
-		CA4FA7BEDE7F4F5A4F52727D799961AC /* AWSCore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCore.h; path = AWSCore/AWSCore.h; sourceTree = "<group>"; };
+		C9C84929EC5363F579A75A9F5043F686 /* NSData+AWSCognitoIdentityProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+AWSCognitoIdentityProvider.m"; path = "AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.m"; sourceTree = "<group>"; };
 		CAB297499AF600870ECB83BC5970DED8 /* Pods-AmplifyTestApp-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-AmplifyTestApp-acknowledgements.markdown"; sourceTree = "<group>"; };
+		CB59F5236F0F40C4622B6A63740EEFC6 /* AWSUserPoolOperationsHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AWSUserPoolOperationsHandler.swift; path = AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift; sourceTree = "<group>"; };
+		CB7F3F21B6D7750BD771620A20379BC2 /* AWSDDASLLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDASLLogger.h; path = AWSCore/Logging/AWSDDASLLogger.h; sourceTree = "<group>"; };
 		CBED44CF131280494DBEBD7CF2B56150 /* Pods_Amplify_AWSPluginsCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AWSPluginsCore.framework; path = "Pods-Amplify-AWSPluginsCore.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		CBFDB4B8172D6C61FE1187BBB4E56BC2 /* AWSTMDiskCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMDiskCache.h; path = AWSCore/TMCache/AWSTMDiskCache.h; sourceTree = "<group>"; };
+		CC1CC4148160AE6E60028758296F76D5 /* AWSCognitoIdentityResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityResources.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityResources.h; sourceTree = "<group>"; };
 		CC46A423E858362387E2F494BE58A39B /* Pods-Amplify.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify.modulemap"; sourceTree = "<group>"; };
 		CC56497384E780278F916D6C57EA4951 /* CwlPreconditionTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = CwlPreconditionTesting.framework; path = CwlPreconditionTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCFB8F03867DB892EFC47B53186590C4 /* AWSCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AWSCore.framework; path = AWSCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CEE13C907123CB23F408DAFC03368502 /* AWSCognitoAuth+Extensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoAuth+Extensions.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h"; sourceTree = "<group>"; };
-		D060CD7839514A5830127E29A440D945 /* AWSmetamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSmetamacros.h; path = AWSCore/Mantle/extobjc/AWSmetamacros.h; sourceTree = "<group>"; };
-		D06F68E04C132879F35438E6BE63CB8A /* AWSURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLRequestSerialization.m; path = AWSCore/Serialization/AWSURLRequestSerialization.m; sourceTree = "<group>"; };
-		D23EA41EC03920EDF5FE81A6E7774ECF /* AWSInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSInfo.m; path = AWSCore/Service/AWSInfo.m; sourceTree = "<group>"; };
+		CCFDCFECB7A9F22FBCE4A3FEE83F7A0F /* AWSEXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTKeyPathCoding.h; path = AWSCore/Mantle/extobjc/AWSEXTKeyPathCoding.h; sourceTree = "<group>"; };
+		CDD5C07B7B0098C5EC1BEBF2AAD6C14A /* AWSSignInManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInManager.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInManager.h; sourceTree = "<group>"; };
+		CE5510001721226909CB6D1FD2875C27 /* AWSTMCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMCache.h; path = AWSCore/TMCache/AWSTMCache.h; sourceTree = "<group>"; };
+		CFEFDEFC752A05AEBFAEE9287B8C6C95 /* AWSTMCacheBackgroundTaskManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMCacheBackgroundTaskManager.h; path = AWSCore/TMCache/AWSTMCacheBackgroundTaskManager.h; sourceTree = "<group>"; };
+		D0B855E530694F19AABF8B6EEA2537B4 /* AWSDDContextFilterLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDContextFilterLogFormatter.h; path = AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter.h; sourceTree = "<group>"; };
+		D10626859DA048A75C2CCB320B621AED /* AWSJKBigInteger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSJKBigInteger.m; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.m; sourceTree = "<group>"; };
 		D278F5748D57849269D3BC19FE845B99 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.release.xcconfig"; sourceTree = "<group>"; };
+		D2A728A07C5AB3BEBD73851BDE3014EC /* AWSAuthCore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSAuthCore.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSAuthCore.h; sourceTree = "<group>"; };
 		D2FC9F4ECE3B1251F36F9AC548B8969B /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.modulemap"; sourceTree = "<group>"; };
-		D3CA713D7BC33CCB06A920F7DFE545B1 /* SwiftLint.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLint.release.xcconfig; sourceTree = "<group>"; };
-		D5A8E99D231E0EF059DDD30DC9EF7ACA /* AWSDDASLLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDASLLogger.m; path = AWSCore/Logging/AWSDDASLLogger.m; sourceTree = "<group>"; };
-		D5EEAEBFA0B348201AF50C3642961DEA /* AWSCognitoIdentityProviderASF.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityProviderASF.m; path = AWSCognitoIdentityProviderASF/AWSCognitoIdentityProviderASF.m; sourceTree = "<group>"; };
-		D730CA76B9F5586885C45C8BD0271261 /* AWSDDOSLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDOSLogger.h; path = AWSCore/Logging/AWSDDOSLogger.h; sourceTree = "<group>"; };
+		D3E2BB91CFE8DFE5E2662AEB332405F2 /* CwlPreconditionTesting-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlPreconditionTesting-prefix.pch"; sourceTree = "<group>"; };
+		D5C2E1DD54B572091366135D61504120 /* AWSTMCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMCache.m; path = AWSCore/TMCache/AWSTMCache.m; sourceTree = "<group>"; };
+		D6244F265CD8B9F8288AE5DC2C066A98 /* AWSCognitoIdentityModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityModel.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityModel.m; sourceTree = "<group>"; };
+		D672B362556B89C8F2118A98DA7D9F00 /* AWSAuthCore-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSAuthCore-Info.plist"; sourceTree = "<group>"; };
+		D69BA5E648DC4036DBB189680E68AD9A /* AWSURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSURLRequestSerialization.h; path = AWSCore/Serialization/AWSURLRequestSerialization.h; sourceTree = "<group>"; };
 		D745E2A5C3D7BB82BB00BA0C3CD9A56C /* Pods_Amplify_AmplifyTestConfigs_AmplifyFunctionalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Amplify_AmplifyTestConfigs_AmplifyFunctionalTests.framework; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D7E43FB42F81273FADA2B41F8A59397E /* Pods-AmplifyTestApp-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-AmplifyTestApp-umbrella.h"; sourceTree = "<group>"; };
+		D7FB5EC310EC2FBA3E3D06C5E019776B /* AWSCognitoAuthUICKeyChainStore.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoAuthUICKeyChainStore.m; path = AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.m; sourceTree = "<group>"; };
+		D8EC027F8F5E0F4E44345B01B84922F9 /* AWSInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSInfo.m; path = AWSCore/Service/AWSInfo.m; sourceTree = "<group>"; };
 		D9D21961D651909C5E5D1161C7FF4859 /* Pods-Amplify-AWSPluginsCore-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AWSPluginsCore-acknowledgements.plist"; sourceTree = "<group>"; };
-		DB341684F2F48AE24DCA151ECC2C86D4 /* SwiftFormat.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftFormat.release.xcconfig; sourceTree = "<group>"; };
-		DC848AA86A44B12AA9160C97145E729E /* AWSDDLogMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLogMacros.h; path = AWSCore/Logging/AWSDDLogMacros.h; sourceTree = "<group>"; };
-		DCEBA99E8A7995FC38DC060850D040C9 /* AWSCognitoIdentityResources.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityResources.m; path = AWSCore/CognitoIdentity/AWSCognitoIdentityResources.m; sourceTree = "<group>"; };
-		DE03FBF91D2AF7BAA3FB5C980A81A710 /* AWSTMCacheBackgroundTaskManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMCacheBackgroundTaskManager.h; path = AWSCore/TMCache/AWSTMCacheBackgroundTaskManager.h; sourceTree = "<group>"; };
+		DA440F401A2693910F06D03474E38B28 /* AWSAuthCore.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AWSAuthCore.modulemap; sourceTree = "<group>"; };
+		DDAEC751D8F7248C8707C9C89D9C7BA1 /* AWSDDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDAbstractDatabaseLogger.m; path = AWSCore/Logging/AWSDDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
 		DEC3E3C3510C8A55F95F909E0207C7DD /* Pods-Amplify-AWSPluginsCore-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AWSPluginsCore-dummy.m"; sourceTree = "<group>"; };
-		DED03D9B3329B6DBD77B3848BCE4F893 /* AWSIdentityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSIdentityManager.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSIdentityManager.h; sourceTree = "<group>"; };
-		DF9C38EA99E284232320822E6FF2779A /* AWSNetworkingHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSNetworkingHelpers.h; path = AWSCore/Networking/AWSNetworkingHelpers.h; sourceTree = "<group>"; };
-		DFB368D4F469CFFEDE97D532E253A068 /* AWSCognitoIdentityProviderASF.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCognitoIdentityProviderASF.debug.xcconfig; sourceTree = "<group>"; };
 		E0BC8BB0FE4725CF87EB0A9F5D400FD6 /* CwlCatchException.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = CwlCatchException.framework; path = CwlCatchException.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E20AA1F28A014153CB5D903040321543 /* AWSMTLJSONAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMTLJSONAdapter.h; path = AWSCore/Mantle/AWSMTLJSONAdapter.h; sourceTree = "<group>"; };
-		E29D89F2F41A81528BFDBFBE32FACFA6 /* AWSCognitoIdentityUserPool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityUserPool.m; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m; sourceTree = "<group>"; };
-		E3896A3F2C482FFBC76D016CCEE102D7 /* AWSDDLog.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSDDLog.m; path = AWSCore/Logging/AWSDDLog.m; sourceTree = "<group>"; };
-		E391A6CDBB25CD9CD616C8379AC49870 /* AWSCancellationToken.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationToken.m; path = AWSCore/Bolts/AWSCancellationToken.m; sourceTree = "<group>"; };
-		E4070F244C7DE55BD8060BAA1E763CC3 /* libAWSCognitoIdentityProviderASFBinary.a */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = archive.ar; name = libAWSCognitoIdentityProviderASFBinary.a; path = AWSCognitoIdentityProviderASF/Internal/libAWSCognitoIdentityProviderASFBinary.a; sourceTree = "<group>"; };
-		E5650AB2D7426F36016C0C56FA58833F /* AWSGZIP.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSGZIP.m; path = AWSCore/GZIP/AWSGZIP.m; sourceTree = "<group>"; };
-		E5B47752E9EE042403E350EA1AF40218 /* AWSNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSNetworking.m; path = AWSCore/Networking/AWSNetworking.m; sourceTree = "<group>"; };
-		E5DE768FFA5EA9EA4368651C29CF4827 /* AWSEXTScope.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSEXTScope.m; path = AWSCore/Mantle/extobjc/AWSEXTScope.m; sourceTree = "<group>"; };
-		E608D19A6E219A200C4EB304AA6158C6 /* AWSCognitoIdentityProviderSrpHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderSrpHelper.h; path = AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderSrpHelper.h; sourceTree = "<group>"; };
-		E6817AA3657D8B7016DB050FE83CED49 /* AWSCognitoIdentityProviderModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityProviderModel.h; path = AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderModel.h; sourceTree = "<group>"; };
-		E6C4866E9EA5FF270F3D2269789BF571 /* SwiftFormat.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftFormat.debug.xcconfig; sourceTree = "<group>"; };
-		E741028ED94706419B1152DBA9543194 /* AWSSignInProviderApplicationIntercept.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInProviderApplicationIntercept.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInProviderApplicationIntercept.h; sourceTree = "<group>"; };
-		E83934A300E0256CF298A02BAC2E17F4 /* AWSSignInProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInProvider.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInProvider.h; sourceTree = "<group>"; };
-		E86FBF7FE1863E0568B2936E6D617AB4 /* AWSSignInButtonView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignInButtonView.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSSignInButtonView.h; sourceTree = "<group>"; };
-		ED978F394A390FEF78F57B0E84DB463C /* AWSFMDB+AWSHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSFMDB+AWSHelpers.h"; path = "AWSCore/FMDB/AWSFMDB+AWSHelpers.h"; sourceTree = "<group>"; };
-		EDF0A50253541A270DAE2ADAD984E0DA /* AWSCognitoAuth.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoAuth.m; path = AWSCognitoAuth/AWSCognitoAuth.m; sourceTree = "<group>"; };
-		EE1B00BD743F4B6F35AE7CE4D6C029E1 /* AWSMantle.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSMantle.h; path = AWSCore/Mantle/AWSMantle.h; sourceTree = "<group>"; };
+		E166C1A7F424470ED9F0E35692D8A85A /* AWSJKBigDecimal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSJKBigDecimal.h; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigDecimal.h; sourceTree = "<group>"; };
+		E3637C8CE0432A849F4E8AD934B90A6D /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
+		E3DEB4BB14ADF2C4DA3E34690F303CCC /* AWSClientContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSClientContext.h; path = AWSCore/Service/AWSClientContext.h; sourceTree = "<group>"; };
+		E4003F52E2BBF00826A847B636581208 /* AWSSignature.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSignature.h; path = AWSCore/Authentication/AWSSignature.h; sourceTree = "<group>"; };
+		E58B03068CE40D8ED77CDDDAEBA1F7CD /* AWSFMDB+AWSHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSFMDB+AWSHelpers.m"; path = "AWSCore/FMDB/AWSFMDB+AWSHelpers.m"; sourceTree = "<group>"; };
+		E59519C5B196AAADB322109C848F8D62 /* AWSCognitoIdentityUser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCognitoIdentityUser.m; path = AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m; sourceTree = "<group>"; };
+		E5B9725E282813EE09B00F8FFC242521 /* AWSCancellationToken.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCancellationToken.m; path = AWSCore/Bolts/AWSCancellationToken.m; sourceTree = "<group>"; };
+		E63D1E12BE6C215A049BDE4E29BE7A9F /* AWSFMResultSet.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSFMResultSet.m; path = AWSCore/FMDB/AWSFMResultSet.m; sourceTree = "<group>"; };
+		E659B3C97121218F1492034D211C16A4 /* NSObject+AWSMTLComparisonAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+AWSMTLComparisonAdditions.h"; path = "AWSCore/Mantle/NSObject+AWSMTLComparisonAdditions.h"; sourceTree = "<group>"; };
+		E6F202A2FD892627C0EF882824F27BCA /* AWSCognitoIdentityService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityService.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityService.h; sourceTree = "<group>"; };
+		E6F951526A3C09FE18E6A3056495E051 /* AWSAuthCore-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSAuthCore-dummy.m"; sourceTree = "<group>"; };
+		E7EFD0A7EF3677CE21C15C2F9A4E64E3 /* AWSEXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSEXTRuntimeExtensions.h; path = AWSCore/Mantle/extobjc/AWSEXTRuntimeExtensions.h; sourceTree = "<group>"; };
+		EA576F7350A5543992033B84E94CB16D /* AWSDDLegacyMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLegacyMacros.h; path = AWSCore/Logging/AWSDDLegacyMacros.h; sourceTree = "<group>"; };
+		EBB04B121569067A57985E4FE295205B /* SwiftFormat.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftFormat.release.xcconfig; sourceTree = "<group>"; };
+		EC98AEE548E0E61DE031738B090E0F56 /* AWSKSReachability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSKSReachability.h; path = AWSCore/KSReachability/AWSKSReachability.h; sourceTree = "<group>"; };
+		ED0CAF841324ADA03B78DC435F707B2F /* tommath.c */ = {isa = PBXFileReference; includeInIndex = 1; name = tommath.c; path = AWSCognitoIdentityProvider/Internal/JKBigInteger/LibTomMath/tommath.c; sourceTree = "<group>"; };
+		EE1A4D0C9A1309AD217883F861C5E6C7 /* AWSCognitoIdentityProviderASF-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProviderASF-umbrella.h"; sourceTree = "<group>"; };
 		EE377F76EBC89AD773429D3EBE8EF8D5 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.modulemap"; sourceTree = "<group>"; };
 		EE49F6473631850D3EC76C328D5772CB /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		EEFE6143A25DA46E1E0FE5A33A1169A3 /* AWSCognitoIdentityModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityModel.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityModel.h; sourceTree = "<group>"; };
-		EF84299E434B6BC8812A597F60CF31F1 /* AWSSTSService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSTSService.m; path = AWSCore/STS/AWSSTSService.m; sourceTree = "<group>"; };
+		EEEE764AB257FC9226D559D8244CC9FA /* AWSCognitoIdentityModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSCognitoIdentityModel.h; path = AWSCore/CognitoIdentity/AWSCognitoIdentityModel.h; sourceTree = "<group>"; };
+		EF55065E914F7AFFC57EABE4AA68EDA2 /* AWSIdentityProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSIdentityProvider.m; path = AWSCore/Authentication/AWSIdentityProvider.m; sourceTree = "<group>"; };
+		EFCBD8953313EA0478E2ABBBEAAE5DE8 /* AWSDDASLLogCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDASLLogCapture.h; path = AWSCore/Logging/AWSDDASLLogCapture.h; sourceTree = "<group>"; };
 		EFD2AEC8F92F60614948319DA39DDA2C /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon-dummy.m"; sourceTree = "<group>"; };
 		F046E64EB8EA7F1638E89AFEA89BD856 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon-acknowledgements.plist"; sourceTree = "<group>"; };
-		F05D5BDA387BCC2162C907D59247DE7A /* AWSFMDB+AWSHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AWSFMDB+AWSHelpers.m"; path = "AWSCore/FMDB/AWSFMDB+AWSHelpers.m"; sourceTree = "<group>"; };
-		F0AA2D1E137F1AC15AA0F283B3F3243E /* CwlCatchException-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CwlCatchException-prefix.pch"; sourceTree = "<group>"; };
-		F145F245F41E0504E4EBAB93E0EBCE78 /* SwiftLint.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLint.debug.xcconfig; sourceTree = "<group>"; };
+		F054E267B7EE5CE815814DB443A8BC69 /* AWSCognitoIdentityProvider-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCognitoIdentityProvider-dummy.m"; sourceTree = "<group>"; };
+		F0C82C0DCCC4C930C8E1E67C26A75CA6 /* AWSIdentityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSIdentityManager.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSIdentityManager.h; sourceTree = "<group>"; };
 		F15EBDBF674EB1666EE4635030DAB0DE /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F1B77771753AD2D834119C6AF9F65C72 /* Pods-Amplify-AWSPluginsCore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore.debug.xcconfig"; sourceTree = "<group>"; };
-		F2106BBD2524DBF1B3BEC5103CF2259F /* AWSCognitoCredentialsProvider+Extension.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSCognitoCredentialsProvider+Extension.h"; path = "AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoCredentialsProvider+Extension.h"; sourceTree = "<group>"; };
-		F35780388FBA1CDB5C6EF5550FFA96A0 /* AWSTMCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSTMCache.h; path = AWSCore/TMCache/AWSTMCache.h; sourceTree = "<group>"; };
-		F3D29C275552286758AF490FD2311ABF /* AWSXMLDictionary.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSXMLDictionary.h; path = AWSCore/XMLDictionary/AWSXMLDictionary.h; sourceTree = "<group>"; };
-		F7621F4DF375E8B06CC6CC04110251B3 /* AWSDDLegacyMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDLegacyMacros.h; path = AWSCore/Logging/AWSDDLegacyMacros.h; sourceTree = "<group>"; };
-		F7F0ED5603B9A33A5AB2840F17157E94 /* AWSCredentialsProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSCredentialsProvider.m; path = AWSCore/Authentication/AWSCredentialsProvider.m; sourceTree = "<group>"; };
-		F8908348756A5F294A2146253E4E6036 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m"; sourceTree = "<group>"; };
-		F8C4353DFDD27E3B9354357B7AA341EC /* AWSSTSResources.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSTSResources.h; path = AWSCore/STS/AWSSTSResources.h; sourceTree = "<group>"; };
-		F91D6E9D904D2BC3C7A70748D50F9FB8 /* AWSCognitoIdentityProvider.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AWSCognitoIdentityProvider.debug.xcconfig; sourceTree = "<group>"; };
-		F93CBFC571C283CD341B9B26BF47FC17 /* NSError+AWSMTLModelException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSError+AWSMTLModelException.h"; path = "AWSCore/Mantle/NSError+AWSMTLModelException.h"; sourceTree = "<group>"; };
-		F95C3B6C2DD534171FAD7B7FDE1C70A5 /* AWSMobileClient-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AWSMobileClient-Info.plist"; sourceTree = "<group>"; };
+		F26E71EF1BDDEE78B79B7BB5D13867F2 /* AWSURLRequestRetryHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSURLRequestRetryHandler.m; path = AWSCore/Serialization/AWSURLRequestRetryHandler.m; sourceTree = "<group>"; };
+		F2E12DA949B01FEE2CC603DA99CF8297 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m"; path = "AWSCore/Mantle/NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m"; sourceTree = "<group>"; };
+		F3B914692155F84449ADB10B6A7C404B /* AWSDDLog+LOGV.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSDDLog+LOGV.h"; path = "AWSCore/Logging/AWSDDLog+LOGV.h"; sourceTree = "<group>"; };
+		F45CC1625AD101EBB84773D83CF4EB6C /* AWSSynchronizedMutableDictionary.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSSynchronizedMutableDictionary.h; path = AWSCore/Utility/AWSSynchronizedMutableDictionary.h; sourceTree = "<group>"; };
+		F5D5EF4FA3EE8E11F63F483551BBD131 /* AWSService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSService.m; path = AWSCore/Service/AWSService.m; sourceTree = "<group>"; };
+		F5DE71904156D1E5147D1B17672FB2FE /* AWSTMMemoryCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSTMMemoryCache.m; path = AWSCore/TMCache/AWSTMMemoryCache.m; sourceTree = "<group>"; };
+		F68A7DBCC0D3EAA59DF8D0B4D6246193 /* AWSCore-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AWSCore-dummy.m"; sourceTree = "<group>"; };
+		F6EA235B5B0C2DD44EDBFFC93212E251 /* DeviceOperations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeviceOperations.swift; path = AWSAuthSDK/Sources/AWSMobileClient/DeviceOperations.swift; sourceTree = "<group>"; };
+		F755C43F37ED223430AC027C80588804 /* AWSLogging.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSLogging.h; path = AWSCore/Utility/AWSLogging.h; sourceTree = "<group>"; };
+		F9450A052E08F53A2E883BB2BB43E47A /* CwlCatchException-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CwlCatchException-dummy.m"; sourceTree = "<group>"; };
 		F9918FB3EA173FD1AC5374D0FE2A4C3D /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.debug.xcconfig"; sourceTree = "<group>"; };
 		F9B0E837F8889C0E70E3B3CAD7D9D949 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsCoreTests-frameworks.sh"; sourceTree = "<group>"; };
-		FDA5DAF5A2814098C88ED0FD0FC32609 /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
-		FE78EB8AF731A271AD6B3205D8955233 /* AWSAuthCore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSAuthCore.h; path = AWSAuthSDK/Sources/AWSAuthCore/AWSAuthCore.h; sourceTree = "<group>"; };
-		FEE333F7C6ACC595DEBC08E6B8A5E5C9 /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
-		FF66F779E8C7279368883B75C15B5038 /* CwlCatchException-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "CwlCatchException-Info.plist"; sourceTree = "<group>"; };
+		FA6A72CA7E9DB7934F504E63345D0635 /* AWSDDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AWSDDAbstractDatabaseLogger.h; path = AWSCore/Logging/AWSDDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
+		FBA16191241CDCD88AD45A8D7442A3F4 /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
+		FD79CF64ECEFC4149AE7F39B2B655E43 /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
+		FE5C6AC41A29A3BE24ED1A630EFFBA7A /* SwiftLint.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLint.release.xcconfig; sourceTree = "<group>"; };
+		FE7A4E003A10C45BE9B95A3DF34742ED /* AWSFMDatabase+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AWSFMDatabase+Private.h"; path = "AWSCore/FMDB/AWSFMDatabase+Private.h"; sourceTree = "<group>"; };
+		FF4D7246D889EDCC40A48C2DC76F486B /* AWSSynchronizedMutableDictionary.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AWSSynchronizedMutableDictionary.m; path = AWSCore/Utility/AWSSynchronizedMutableDictionary.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1219,21 +1221,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3E145C62E18EB143A9D5C8EB279CC99A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				589B4BDB54D0D172D532FC88D5D7C953 /* AWSAuthCore.framework in Frameworks */,
+				900EB0A2321005B91FC71C7F8C7B92ED /* AWSCognitoIdentityProvider.framework in Frameworks */,
+				58F513DBEC30590405F5B3CDC4C472B2 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4A76839E88FACA782C1C6CF90585C55D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				D76CECDB2FAB94F3D8DD51B54EA7F510 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8DD65B45F2688280FD422D5D7364A10A /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				46818E554C7902ABE93D24966BB50EE3 /* AWSAuthCore.framework in Frameworks */,
-				AD223728D8DFA18B28E0340459453763 /* AWSCognitoIdentityProvider.framework in Frameworks */,
-				5D97CDAB82AF5231ACF2D62F75FB4F55 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1326,35 +1328,27 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		02D3095C4836936A4D26CFDAAA5A29E8 /* Pods */ = {
+		03E8B440274984CA059509651D79E02C /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				844CBD88D3BF9A8D3A2061345815AE26 /* AWSAuthCore */,
-				29F5AB84844BC00D49670648722C2A6F /* AWSCognitoIdentityProvider */,
-				D4CCCE2844E53A82198D2BEDC7B79D34 /* AWSCognitoIdentityProviderASF */,
-				D06091CEDE01976F8A28884A34C69A8A /* AWSCore */,
-				91E80509604DB3D554DC764A4121456D /* AWSMobileClient */,
-				78EB225089D47E576B65F0E8C88D88B9 /* CwlCatchException */,
-				B19D7511EE44ABD3BDE6AE5A6D3DFF59 /* CwlPreconditionTesting */,
-				1C3ADA90D484B2154CAE1E60EBEFC57B /* SwiftFormat */,
-				4964B76DF731982661ED3EDD3CCA0747 /* SwiftLint */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		071917F2B84CC5375287068CC98F7366 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				05B36D2D93B4A2C91F36C08694488424 /* AWSCore.modulemap */,
-				029EA3765EA878F565018D51C0483252 /* AWSCore-dummy.m */,
-				899616849AD1E99FABEF8D9C7BF5ADA4 /* AWSCore-Info.plist */,
-				2A606F0F6B2AA85DE163E941BF473344 /* AWSCore-prefix.pch */,
-				AF6921AC94F623D44C58944BE45619E2 /* AWSCore-umbrella.h */,
-				60A7481863E0FBEC00846C480C56E6C3 /* AWSCore.debug.xcconfig */,
-				5B3055A216626F89FF9251CDB64FB227 /* AWSCore.release.xcconfig */,
+				763805AAD99B21D77DA04985683F7904 /* AWSCognitoIdentityProviderASF.modulemap */,
+				5F019DA231CEA0C3F4310AEF8B1A5A93 /* AWSCognitoIdentityProviderASF-dummy.m */,
+				9509DC857FE4ABF77D04D86E3CA870FC /* AWSCognitoIdentityProviderASF-Info.plist */,
+				48A55168CF8C578FB9045F8BDD0D1677 /* AWSCognitoIdentityProviderASF-prefix.pch */,
+				EE1A4D0C9A1309AD217883F861C5E6C7 /* AWSCognitoIdentityProviderASF-umbrella.h */,
+				7A3745FA07AB86D670E8F463497DA121 /* AWSCognitoIdentityProviderASF.debug.xcconfig */,
+				02AD342B30967821122292AE6868639E /* AWSCognitoIdentityProviderASF.release.xcconfig */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/AWSCore";
+			path = "../Target Support Files/AWSCognitoIdentityProviderASF";
+			sourceTree = "<group>";
+		};
+		04BAEEF8018AD2B42BDE44706685CDC6 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				C333C778BBD5047F5871443C25865128 /* libAWSCognitoIdentityProviderASFBinary.a */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		07B15F0B0839BB873BF49FF0A5A12925 /* Pods-Amplify-AWSPluginsCore */ = {
@@ -1373,14 +1367,16 @@
 			path = "Target Support Files/Pods-Amplify-AWSPluginsCore";
 			sourceTree = "<group>";
 		};
-		082FE7EEF86646134FF6F32A198AE30E /* Support Files */ = {
+		085EE9F09B29867F7A213B0EBB935F69 /* CwlCatchException */ = {
 			isa = PBXGroup;
 			children = (
-				E6C4866E9EA5FF270F3D2269789BF571 /* SwiftFormat.debug.xcconfig */,
-				DB341684F2F48AE24DCA151ECC2C86D4 /* SwiftFormat.release.xcconfig */,
+				1A30705F0417FDF552E067AF6EF268D5 /* CwlCatchException.h */,
+				FBA16191241CDCD88AD45A8D7442A3F4 /* CwlCatchException.m */,
+				A073D61814D5A8291BF1F81E0E356A86 /* CwlCatchException.swift */,
+				E4ED606FAD0D3F25076F29DA97FB4B80 /* Support Files */,
 			);
-			name = "Support Files";
-			path = "../Target Support Files/SwiftFormat";
+			name = CwlCatchException;
+			path = CwlCatchException;
 			sourceTree = "<group>";
 		};
 		09AD8BEF7343A541603839F476C7F70E /* Targets Support Files */ = {
@@ -1428,6 +1424,34 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		10B5CA95922A00E8D6CB31A2D6FF09DA /* AWSCognitoIdentityProviderASF */ = {
+			isa = PBXGroup;
+			children = (
+				186B12D6F3453F5CBB8711FF4F62362C /* AWSCognitoIdentityASF.h */,
+				C7F6DB16EB1746250ACF870AAB650897 /* AWSCognitoIdentityProviderASF.h */,
+				908EC0C96498A900CFC04A0CDCC991CA /* AWSCognitoIdentityProviderASF.m */,
+				04BAEEF8018AD2B42BDE44706685CDC6 /* Frameworks */,
+				03E8B440274984CA059509651D79E02C /* Support Files */,
+			);
+			name = AWSCognitoIdentityProviderASF;
+			path = AWSCognitoIdentityProviderASF;
+			sourceTree = "<group>";
+		};
+		11388F95EAFA454E030562EAF79B2770 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				DA440F401A2693910F06D03474E38B28 /* AWSAuthCore.modulemap */,
+				E6F951526A3C09FE18E6A3056495E051 /* AWSAuthCore-dummy.m */,
+				D672B362556B89C8F2118A98DA7D9F00 /* AWSAuthCore-Info.plist */,
+				BEA270D6FB0B1C10DFBFF1B0F85B5E72 /* AWSAuthCore-prefix.pch */,
+				530FB6F70F632A3D79D20015D4D33940 /* AWSAuthCore-umbrella.h */,
+				3B2EB0A457D0895CA40C8C9BA74A5D72 /* AWSAuthCore.debug.xcconfig */,
+				4D07B8F4B3BEAB4648898A034B91931D /* AWSAuthCore.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/AWSAuthCore";
+			sourceTree = "<group>";
+		};
 		1AEAD31DC1C1DD9F4F43BEB61EDEB4C2 /* Pods-AmplifyTestApp */ = {
 			isa = PBXGroup;
 			children = (
@@ -1445,96 +1469,91 @@
 			path = "Target Support Files/Pods-AmplifyTestApp";
 			sourceTree = "<group>";
 		};
-		1C3ADA90D484B2154CAE1E60EBEFC57B /* SwiftFormat */ = {
+		24077C0DEBDAC1C508738332CBE213CE /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				082FE7EEF86646134FF6F32A198AE30E /* Support Files */,
+				342D3FC605D738D19797907E7765E0E8 /* AWSAuthCore */,
+				8929E9EE97E1D19E77CAC1DCF477AC5D /* AWSCognitoIdentityProvider */,
+				10B5CA95922A00E8D6CB31A2D6FF09DA /* AWSCognitoIdentityProviderASF */,
+				791578118EE790D1D3137C072B2E3CD0 /* AWSCore */,
+				55D24C9278830CF031A54559EA9DE1B0 /* AWSMobileClient */,
+				085EE9F09B29867F7A213B0EBB935F69 /* CwlCatchException */,
+				2B23AD21F0304F8CF0BC1B16CB33BA0A /* CwlPreconditionTesting */,
+				3C7E8A13FD36E79C7AD9251A23C9F5C9 /* SwiftFormat */,
+				AD117C9E74E8BF038BCEA6CCB45B359B /* SwiftLint */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		2B23AD21F0304F8CF0BC1B16CB33BA0A /* CwlPreconditionTesting */ = {
+			isa = PBXGroup;
+			children = (
+				53EB656659FB0F58570111C58C204BDB /* CwlBadInstructionException.swift */,
+				5DB02F82D35F0C4356FB9F0B429AB99B /* CwlCatchBadInstruction.swift */,
+				6A7B751B97A2DDD0C9910C8F55261DE9 /* CwlDarwinDefinitions.swift */,
+				1B36E571A29663AF25C341351BE0E535 /* CwlMachBadInstructionHandler.h */,
+				FD79CF64ECEFC4149AE7F39B2B655E43 /* CwlMachBadInstructionHandler.m */,
+				6C9A91CD0EAEB627AE0578265E674CB7 /* CwlPreconditionTesting.h */,
+				61F232A732471703F7FDB543E40C17D3 /* mach_excServer.c */,
+				E3637C8CE0432A849F4E8AD934B90A6D /* mach_excServer.h */,
+				4F15857DD8BE2D27701868CC107CB09E /* Support Files */,
+			);
+			name = CwlPreconditionTesting;
+			path = CwlPreconditionTesting;
+			sourceTree = "<group>";
+		};
+		342D3FC605D738D19797907E7765E0E8 /* AWSAuthCore */ = {
+			isa = PBXGroup;
+			children = (
+				D2A728A07C5AB3BEBD73851BDE3014EC /* AWSAuthCore.h */,
+				01982698B8DE672BA75249A3AB0109A0 /* AWSAuthUIHelper.h */,
+				872636C9955205D3C03F3292C874723D /* AWSAuthUIHelper.m */,
+				F0C82C0DCCC4C930C8E1E67C26A75CA6 /* AWSIdentityManager.h */,
+				609FCBCB9B75FF5D167F70E56995C48E /* AWSIdentityManager.m */,
+				38D55155F2EC78678A65C37373A42D58 /* AWSSignInButtonView.h */,
+				CDD5C07B7B0098C5EC1BEBF2AAD6C14A /* AWSSignInManager.h */,
+				05302BD579C89A3103BBAA83726E1834 /* AWSSignInManager.m */,
+				2057888BC8E612EFC5320864A97728BA /* AWSSignInProvider.h */,
+				AEEF8E360ECF4856E8D30DEA489B6375 /* AWSSignInProviderApplicationIntercept.h */,
+				7ECF880F10C3E80885D927556F50EBE0 /* AWSUIConfiguration.h */,
+				11388F95EAFA454E030562EAF79B2770 /* Support Files */,
+			);
+			name = AWSAuthCore;
+			path = AWSAuthCore;
+			sourceTree = "<group>";
+		};
+		3C7E8A13FD36E79C7AD9251A23C9F5C9 /* SwiftFormat */ = {
+			isa = PBXGroup;
+			children = (
+				B15421FECECAA640DF153E0E7FC575E6 /* Support Files */,
 			);
 			name = SwiftFormat;
 			path = SwiftFormat;
 			sourceTree = "<group>";
 		};
-		23EF989061AAADFA48C46C412220F8AC /* Support Files */ = {
+		4029B6E841AC0138A52ED43B2BD9BB9B /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				1F474296406106EFF39D2516DB0D7EDD /* AWSAuthCore.modulemap */,
-				0476F9CA218102135BC385B5BB84C86C /* AWSAuthCore-dummy.m */,
-				25E1407E1F3CA42AB2F68592A5CC6E48 /* AWSAuthCore-Info.plist */,
-				AE6B81E83AB18322B2DD058E842D2F4E /* AWSAuthCore-prefix.pch */,
-				7028A59A9EF8E9D33381651C663C05D5 /* AWSAuthCore-umbrella.h */,
-				05091549D84201D3FF1A8EEED67D8902 /* AWSAuthCore.debug.xcconfig */,
-				72AAF4F216BB8E9BE91BFBFA3DCB2AA2 /* AWSAuthCore.release.xcconfig */,
+				451AC08FD4DD7DB6A50A5C7ECD6CB558 /* AWSCore.modulemap */,
+				F68A7DBCC0D3EAA59DF8D0B4D6246193 /* AWSCore-dummy.m */,
+				6B3B2876F8D87A891EF316D5C96BCFB3 /* AWSCore-Info.plist */,
+				05475131E478AE171AD76E7C793CF0C1 /* AWSCore-prefix.pch */,
+				3C8F7368725476CB7FE657AE00468D41 /* AWSCore-umbrella.h */,
+				0B063D30CC52E4E795C1A128701D20F2 /* AWSCore.debug.xcconfig */,
+				9253B55179A547D34BC77CA641557737 /* AWSCore.release.xcconfig */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/AWSAuthCore";
+			path = "../Target Support Files/AWSCore";
 			sourceTree = "<group>";
 		};
-		29F5AB84844BC00D49670648722C2A6F /* AWSCognitoIdentityProvider */ = {
+		4A074B69570F156F007B62BF8F33CAEA /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				2136ADF4DE424DF154BD2074865BE16B /* aws_tommath.h */,
-				0B95B14A33E444B4CBF86C41B8B7D62E /* aws_tommath_class.h */,
-				5D1AADC1D934456355F4DAC701612F79 /* aws_tommath_superclass.h */,
-				6C8656F7AC30360AE4D12537118FBDC5 /* AWSCognitoIdentityProvider.h */,
-				1308C8001B6B55E7EC2C391A36C5A35F /* AWSCognitoIdentityProviderHKDF.h */,
-				1AFD14509FFB3301CAB730E079CEEB0E /* AWSCognitoIdentityProviderHKDF.m */,
-				E6817AA3657D8B7016DB050FE83CED49 /* AWSCognitoIdentityProviderModel.h */,
-				3E67A1E5982F4EB37E89FB5A78A3C48E /* AWSCognitoIdentityProviderModel.m */,
-				12BA902F81D3D089ACEDE790A2838040 /* AWSCognitoIdentityProviderResources.h */,
-				1F13FE5A540C5996ECF56F372411917F /* AWSCognitoIdentityProviderResources.m */,
-				4DFFDD9A7C09947D8DF8677179D0A608 /* AWSCognitoIdentityProviderService.h */,
-				9F41F0AFEC3B456F5D1D357773CABD22 /* AWSCognitoIdentityProviderService.m */,
-				E608D19A6E219A200C4EB304AA6158C6 /* AWSCognitoIdentityProviderSrpHelper.h */,
-				61CDC6F402902D556759A67A3D6CCCF1 /* AWSCognitoIdentityProviderSrpHelper.m */,
-				B99D4A986E8CBCFBC2680AF7EAC089A5 /* AWSCognitoIdentityUser.h */,
-				C84851ADEA14436507FF1E16E5963703 /* AWSCognitoIdentityUser.m */,
-				B1A8CFD29736C239CEF3A5EB43AA3BFE /* AWSCognitoIdentityUser_Internal.h */,
-				9C1A67C9050CCB40F2F72D8A032AF67D /* AWSCognitoIdentityUserPool.h */,
-				E29D89F2F41A81528BFDBFBE32FACFA6 /* AWSCognitoIdentityUserPool.m */,
-				BB95B4A12DFA6DF4B15369418C26B48C /* AWSCognitoIdentityUserPool_Internal.h */,
-				70E3AAF4BC85478E182CB79281CA4A7A /* AWSJKBigDecimal.h */,
-				4C5FA08BD259CC53FCAB405F6BBF72FC /* AWSJKBigDecimal.m */,
-				3530F941D0991933A79B9D55F929710A /* AWSJKBigInteger.h */,
-				42367677A832E1AADCF1E5DA24999515 /* AWSJKBigInteger.m */,
-				83A9210E4B66522692BA0A044AAEF7F9 /* NSData+AWSCognitoIdentityProvider.h */,
-				290CB885A0DA80E2C91393B784C70837 /* NSData+AWSCognitoIdentityProvider.m */,
-				6589DE430E9F4408A4461C9D86E56C78 /* tommath.c */,
-				BD07F0BB432C7A91203167E6003FD7FA /* Support Files */,
-			);
-			name = AWSCognitoIdentityProvider;
-			path = AWSCognitoIdentityProvider;
-			sourceTree = "<group>";
-		};
-		452B4448A1B88D5F3F5C06CA6868BF13 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				89D80A302B3AB53984C2EBFC63E75D9E /* CwlCatchException.modulemap */,
-				7799BCB5D7602926CD8534E8D595CD25 /* CwlCatchException-dummy.m */,
-				FF66F779E8C7279368883B75C15B5038 /* CwlCatchException-Info.plist */,
-				F0AA2D1E137F1AC15AA0F283B3F3243E /* CwlCatchException-prefix.pch */,
-				30380984D336CF3DBF74479B66E317B8 /* CwlCatchException-umbrella.h */,
-				C889B4FD8E0B46B1330DDC69207E75C8 /* CwlCatchException.debug.xcconfig */,
-				01BB6268E3D1EC6B1989DED349F56779 /* CwlCatchException.release.xcconfig */,
+				74C17E59A382F19CD152527575F7BFA2 /* SwiftLint.debug.xcconfig */,
+				FE5C6AC41A29A3BE24ED1A630EFFBA7A /* SwiftLint.release.xcconfig */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/CwlCatchException";
-			sourceTree = "<group>";
-		};
-		4964B76DF731982661ED3EDD3CCA0747 /* SwiftLint */ = {
-			isa = PBXGroup;
-			children = (
-				BF9B541D30E4F248D6D51D60F0A76895 /* Support Files */,
-			);
-			name = SwiftLint;
-			path = SwiftLint;
-			sourceTree = "<group>";
-		};
-		4D253C87471DA1F9F7D7712037E5E683 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				E4070F244C7DE55BD8060BAA1E763CC3 /* libAWSCognitoIdentityProviderASFBinary.a */,
-			);
-			name = Frameworks;
+			path = "../Target Support Files/SwiftLint";
 			sourceTree = "<group>";
 		};
 		4E14FB6CA44176BC9D0444841C733692 /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests */ = {
@@ -1554,19 +1573,50 @@
 			path = "Target Support Files/Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests";
 			sourceTree = "<group>";
 		};
-		51D6956E4F16F8A798AA40B626044C52 /* Support Files */ = {
+		4F15857DD8BE2D27701868CC107CB09E /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				1728444760C2F9357E4C81D21598024A /* AWSMobileClient.modulemap */,
-				791C72FC52723E22DC8CE87BDEEB54C7 /* AWSMobileClient-dummy.m */,
-				F95C3B6C2DD534171FAD7B7FDE1C70A5 /* AWSMobileClient-Info.plist */,
-				2CD8A6688890ED29073F77D8F3281C27 /* AWSMobileClient-prefix.pch */,
-				B0FF6315F94A37AA4C22B5514E4291AA /* AWSMobileClient-umbrella.h */,
-				63129AB4EE71D01423866FD2AA8A71F4 /* AWSMobileClient.debug.xcconfig */,
-				C1E20A028FAC0FAFB1FADAEB12A370FF /* AWSMobileClient.release.xcconfig */,
+				6523C226D22041D1BD540F0A8CC07355 /* CwlPreconditionTesting.modulemap */,
+				3D613E3E5F0A4E19E4599EDBBE314D3D /* CwlPreconditionTesting-dummy.m */,
+				BA40F9C8C5AB8AEED653C42B5748A2AB /* CwlPreconditionTesting-Info.plist */,
+				D3E2BB91CFE8DFE5E2662AEB332405F2 /* CwlPreconditionTesting-prefix.pch */,
+				37D0AF393DF178079A5AA4A88A223B5D /* CwlPreconditionTesting-umbrella.h */,
+				203C838CB1CE8D734686C30424D1DE5C /* CwlPreconditionTesting.debug.xcconfig */,
+				AA221FF719FFFD173DFF9FC756863A67 /* CwlPreconditionTesting.release.xcconfig */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/AWSMobileClient";
+			path = "../Target Support Files/CwlPreconditionTesting";
+			sourceTree = "<group>";
+		};
+		55D24C9278830CF031A54559EA9DE1B0 /* AWSMobileClient */ = {
+			isa = PBXGroup;
+			children = (
+				7269EFAE1FC03A808400B92FBF21AEEB /* _AWSMobileClient.h */,
+				01FEE8B969AD0E52BDF198E5E5CF4E20 /* _AWSMobileClient.m */,
+				46A688748A61E83AE64381312E801169 /* AWSCognitoAuth.h */,
+				90DE9F1B9757E0239BEFD5FB9794389E /* AWSCognitoAuth.m */,
+				AE0675F1138CD44A800B4EBD0B5E55DD /* AWSCognitoAuth+Extensions.h */,
+				A4D55EE93BAD6722690D0733CBA4DDAA /* AWSCognitoAuth+Extensions.m */,
+				2AF4AC19FCD1C23576C5D9515AD63194 /* AWSCognitoAuth_Internal.h */,
+				23FD0A4B909BC2DCBC1B238179001DA7 /* AWSCognitoAuthUICKeyChainStore.h */,
+				D7FB5EC310EC2FBA3E3D06C5E019776B /* AWSCognitoAuthUICKeyChainStore.m */,
+				6EFCD22A63266EDD9823DF548654C7D0 /* AWSCognitoCredentialsProvider+Extension.h */,
+				1511BFDFB232E150CCFE4273A8BEC15D /* AWSCognitoIdentityUserPool+Extension.h */,
+				A5E2B2732E8C2E0DAB2B79B29CD13E84 /* AWSMobileClient.h */,
+				10AAE910007F70838053CD8B2249DF61 /* AWSMobileClient.swift */,
+				01D6D4609A3577B4E149CB749B03486F /* AWSMobileClient-Mixed-Swift.h */,
+				4ECB1A8A13CBB9044D931154C6DBDD99 /* AWSMobileClientExtensions.swift */,
+				8809858A5E01538E0D74FE13FD3903B3 /* AWSMobileClientUserDetails.swift */,
+				36153241DF271B6510265692E8601389 /* AWSMobileOptions.swift */,
+				C71D546C7AF70FD9677085DA4E2BA00D /* AWSMobileResults.swift */,
+				40EF16538F48DD27D1C37BB7C77A24B2 /* AWSUserPoolCustomAuthHandler.swift */,
+				CB59F5236F0F40C4622B6A63740EEFC6 /* AWSUserPoolOperationsHandler.swift */,
+				F6EA235B5B0C2DD44EDBFFC93212E251 /* DeviceOperations.swift */,
+				B7EF26D3B368F8069DF3FF5B15DE00C6 /* JSONHelper.swift */,
+				F3CE6B27D086CBC0DA4CBA5E9C8DF8D5 /* Support Files */,
+			);
+			name = AWSMobileClient;
+			path = AWSMobileClient;
 			sourceTree = "<group>";
 		};
 		7849ED9E3F18FE1FE213C9FB97D7F75F /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests */ = {
@@ -1586,36 +1636,209 @@
 			path = "Target Support Files/Pods-Amplify-AmplifyTestConfigs-AmplifyTests";
 			sourceTree = "<group>";
 		};
-		78EB225089D47E576B65F0E8C88D88B9 /* CwlCatchException */ = {
+		791578118EE790D1D3137C072B2E3CD0 /* AWSCore */ = {
 			isa = PBXGroup;
 			children = (
-				C631E2DE9FE7DA03B470387BA48FA71B /* CwlCatchException.h */,
-				941DB7BB735782EED88400ABA557EBEF /* CwlCatchException.m */,
-				AD31702686B78C00DC137B99F2D43FC1 /* CwlCatchException.swift */,
-				452B4448A1B88D5F3F5C06CA6868BF13 /* Support Files */,
+				A47DD5329604787552A80065E28C4562 /* AWSBolts.h */,
+				BD964C13D7DC3E8EE957B28480B8577E /* AWSBolts.m */,
+				7CEE5FE92E2539F612C836BB1A632631 /* AWSCancellationToken.h */,
+				E5B9725E282813EE09B00F8FFC242521 /* AWSCancellationToken.m */,
+				16DB3680F94B801F66F71AD86D933CB1 /* AWSCancellationTokenRegistration.h */,
+				4BC4FCA3F9BDAE1F28A5E3EF4A14C418 /* AWSCancellationTokenRegistration.m */,
+				A9201C2D174632B57C77653694F2FE9E /* AWSCancellationTokenSource.h */,
+				2DA3287D1051A982150A16354E05729C /* AWSCancellationTokenSource.m */,
+				6C9BDD821D2BDC642CAC2A7BF82A6913 /* AWSCategory.h */,
+				B70DE473AD6DAAFE965197BAC56C83AA /* AWSCategory.m */,
+				E3DEB4BB14ADF2C4DA3E34690F303CCC /* AWSClientContext.h */,
+				2140A514BBE55620A5F7C45EC8BDC5AD /* AWSClientContext.m */,
+				8EBB778180542D81D7FC5ED3366B2D14 /* AWSCocoaLumberjack.h */,
+				273AD73149D84DE6A9A770236B1AFE18 /* AWSCognitoIdentity.h */,
+				10EF994DBB36E63B54867C1A41328E80 /* AWSCognitoIdentity+Fabric.h */,
+				B6D986AC4E2FA03EB562FBA9B4ECA3A7 /* AWSCognitoIdentity+Fabric.m */,
+				EEEE764AB257FC9226D559D8244CC9FA /* AWSCognitoIdentityModel.h */,
+				D6244F265CD8B9F8288AE5DC2C066A98 /* AWSCognitoIdentityModel.m */,
+				CC1CC4148160AE6E60028758296F76D5 /* AWSCognitoIdentityResources.h */,
+				0779FEE0240035253F866AEEEBF8F7C0 /* AWSCognitoIdentityResources.m */,
+				E6F202A2FD892627C0EF882824F27BCA /* AWSCognitoIdentityService.h */,
+				17F7CA3723D744757238C07123826DDC /* AWSCognitoIdentityService.m */,
+				4CAC325F4C19790A3C2A4947CFE9E363 /* AWSCore.h */,
+				C2234B1A0DF8C9CE28E8C68E18C805D0 /* AWSCredentialsProvider.h */,
+				0114DB9D0B630AB1D443D313FDF77E2A /* AWSCredentialsProvider.m */,
+				FA6A72CA7E9DB7934F504E63345D0635 /* AWSDDAbstractDatabaseLogger.h */,
+				DDAEC751D8F7248C8707C9C89D9C7BA1 /* AWSDDAbstractDatabaseLogger.m */,
+				EFCBD8953313EA0478E2ABBBEAAE5DE8 /* AWSDDASLLogCapture.h */,
+				0102E468AA0118F10BBC5E8A95511D8A /* AWSDDASLLogCapture.m */,
+				CB7F3F21B6D7750BD771620A20379BC2 /* AWSDDASLLogger.h */,
+				310DF5A3069A557E9AD8F57B23ADD30E /* AWSDDASLLogger.m */,
+				9422D282E5A081892F5121EA194A3FBD /* AWSDDAssertMacros.h */,
+				D0B855E530694F19AABF8B6EEA2537B4 /* AWSDDContextFilterLogFormatter.h */,
+				79839BA3B62F40A30032D76FC50C40B4 /* AWSDDContextFilterLogFormatter.m */,
+				7AC3528B305A2ADD668D6DB18F2A3B5B /* AWSDDDispatchQueueLogFormatter.h */,
+				52760804261C891A3DD97614D8925107 /* AWSDDDispatchQueueLogFormatter.m */,
+				5585E543E7086486728B90AA10B862DA /* AWSDDFileLogger.h */,
+				B5469A1E228546E79319E57BBFB5167C /* AWSDDFileLogger.m */,
+				EA576F7350A5543992033B84E94CB16D /* AWSDDLegacyMacros.h */,
+				13DDB3FE8723FB5DBF721EFC1C54E8B8 /* AWSDDLog.h */,
+				B1D278448B10A80E29C4434D94F1C76C /* AWSDDLog.m */,
+				F3B914692155F84449ADB10B6A7C404B /* AWSDDLog+LOGV.h */,
+				253206CA6FFCBA451A002CD959A8880D /* AWSDDLogMacros.h */,
+				7FF0F5FBA94A96228D3BFFD35DEB7110 /* AWSDDMultiFormatter.h */,
+				BB7E0EA0CAD58734D312F08A9DA0E2E9 /* AWSDDMultiFormatter.m */,
+				64B466ED2388DD02B72509DF230A91B8 /* AWSDDOSLogger.h */,
+				87621921A248C6EF6BF53C7D51B346DA /* AWSDDOSLogger.m */,
+				8F8DC78698DCFAB9BA43F5468B4A840D /* AWSDDTTYLogger.h */,
+				03FF7AA2BD18C5D37CBB5E3373B83E71 /* AWSDDTTYLogger.m */,
+				39D68F4B4E147627F473B3F5A76EE989 /* AWSExecutor.h */,
+				B9666E7AC35B69974E1008C9C9240EE4 /* AWSExecutor.m */,
+				CCFDCFECB7A9F22FBCE4A3FEE83F7A0F /* AWSEXTKeyPathCoding.h */,
+				E7EFD0A7EF3677CE21C15C2F9A4E64E3 /* AWSEXTRuntimeExtensions.h */,
+				1F91B0BD12C66BBA65E5DAFD870CC13B /* AWSEXTRuntimeExtensions.m */,
+				9CC578ED37E3D7D62477805312126FF0 /* AWSEXTScope.h */,
+				270DA40631CAA420BD290BDC01F8ABD1 /* AWSEXTScope.m */,
+				428D3EA4240F70D5F918C0CB986F3528 /* AWSFMDatabase.h */,
+				5D1B2C9C16028528902AEA200EC6E83A /* AWSFMDatabase.m */,
+				FE7A4E003A10C45BE9B95A3DF34742ED /* AWSFMDatabase+Private.h */,
+				AF18B5AF7B58C0B76C2A14EAEE5D5401 /* AWSFMDatabaseAdditions.h */,
+				49B67ABB110D56E576AC4D5F32B61152 /* AWSFMDatabaseAdditions.m */,
+				C07D57DF869D9069A075E30A89BCBDEA /* AWSFMDatabasePool.h */,
+				0743FC34E4E6F0B38CDC9D632E2803A7 /* AWSFMDatabasePool.m */,
+				9070A8B295592AD54BB34A0D91C47A13 /* AWSFMDatabaseQueue.h */,
+				0B8C6DFB6DFB81C8B155FFD0ACF428F1 /* AWSFMDatabaseQueue.m */,
+				0568F8FF5A2CBCE85271963650D4EB8A /* AWSFMDB.h */,
+				B9BE4F242531733D3769372176540E24 /* AWSFMDB+AWSHelpers.h */,
+				E58B03068CE40D8ED77CDDDAEBA1F7CD /* AWSFMDB+AWSHelpers.m */,
+				027C2C3E0A7A0F6A2B29BAD18C391FFF /* AWSFMResultSet.h */,
+				E63D1E12BE6C215A049BDE4E29BE7A9F /* AWSFMResultSet.m */,
+				3502DCDB99858552F01128ED97F575A8 /* AWSGeneric.h */,
+				2FEB825F6CFEC0FF22828D99BACCE97F /* AWSGZIP.h */,
+				6361BDBF377F2B9595FCD732C31B036C /* AWSGZIP.m */,
+				4D568287CCF8F49059025CA6EAC9A858 /* AWSIdentityProvider.h */,
+				EF55065E914F7AFFC57EABE4AA68EDA2 /* AWSIdentityProvider.m */,
+				A37E2B51E0D1700AA624270A7EDB8065 /* AWSInfo.h */,
+				D8EC027F8F5E0F4E44345B01B84922F9 /* AWSInfo.m */,
+				EC98AEE548E0E61DE031738B090E0F56 /* AWSKSReachability.h */,
+				14D74F6910BCF832CC69FD2773C06217 /* AWSKSReachability.m */,
+				F755C43F37ED223430AC027C80588804 /* AWSLogging.h */,
+				00CE72944F60DE5B6AFFE039FEE27628 /* AWSLogging.m */,
+				C14597FFE0390023D368F52DEF6321E9 /* AWSMantle.h */,
+				044E4A4B8546BF01B2105A7268CB7BB8 /* AWSmetamacros.h */,
+				2A96DCF8D41072E318B24C6CDFC727D7 /* AWSModel.h */,
+				9D926F19E6FECEA9EFD801AF741B1453 /* AWSModel.m */,
+				C199B5B2EFA7A4C45FDFDA4F1F7C34D6 /* AWSMTLJSONAdapter.h */,
+				BDDF6BB547C0073ED648AEE5125B4F0D /* AWSMTLJSONAdapter.m */,
+				1DDCADACD641F1331A589286C9FB7E8C /* AWSMTLManagedObjectAdapter.h */,
+				B11E3E578B6A82BCB60452DC1BD11497 /* AWSMTLManagedObjectAdapter.m */,
+				601FD7EC456EFFA2F76F7E3FAE1C9FA9 /* AWSMTLModel.h */,
+				5ED2F05C0CFB21845242D662C888AEAC /* AWSMTLModel.m */,
+				586D67476E44A61969931883CA884BE2 /* AWSMTLModel+NSCoding.h */,
+				672FB5623F8C9DF7073AC2256E28883D /* AWSMTLModel+NSCoding.m */,
+				ADA3BEA703C8045AA4F37E7A0DA538AA /* AWSMTLReflection.h */,
+				30DDEEE98E0A7984402264B567FBD8B5 /* AWSMTLReflection.m */,
+				242721755168E4E5F8D03D5703F95D45 /* AWSMTLValueTransformer.h */,
+				88B3B1D5195F422193A42586F97E1395 /* AWSMTLValueTransformer.m */,
+				46B0C01A79129C2F6A54B238E8F9087D /* AWSNetworking.h */,
+				3BDEA4EB168EBEBCC1D9348786941864 /* AWSNetworking.m */,
+				4B57F812D68F53AAB507EBC060B0F553 /* AWSNetworkingHelpers.h */,
+				9B517F2F767F72EE01C808AB9BABE8AE /* AWSNetworkingHelpers.m */,
+				6DBE83C19DC30A060C2D831D7F984125 /* AWSSerialization.h */,
+				684CECD6CF451445EB12F03012D0E497 /* AWSSerialization.m */,
+				29E4D3FCB3A323A33756F3C0A355CA7C /* AWSService.h */,
+				F5D5EF4FA3EE8E11F63F483551BBD131 /* AWSService.m */,
+				87194275CD609A95EE6BE32E11B439AF /* AWSServiceEnum.h */,
+				E4003F52E2BBF00826A847B636581208 /* AWSSignature.h */,
+				4ED74CDFDF691D03F15EA506908E33BB /* AWSSignature.m */,
+				5D58BA2E475335E66080FC0D3FBFD71D /* AWSSTS.h */,
+				33F0A8BDDF0DDB3CB666FBBA90C60448 /* AWSSTSModel.h */,
+				942FE31C14A3D5DE99F913F551DE6C54 /* AWSSTSModel.m */,
+				2B6BAF26D20D0180E4896EF36A5B0BF1 /* AWSSTSResources.h */,
+				37238A20DFA2590816F74C60C138AC3C /* AWSSTSResources.m */,
+				55FFA9C0CA0B27CD56EFC5882E49685B /* AWSSTSService.h */,
+				319A14F2ECA5CE66FBBF4947814FB55E /* AWSSTSService.m */,
+				F45CC1625AD101EBB84773D83CF4EB6C /* AWSSynchronizedMutableDictionary.h */,
+				FF4D7246D889EDCC40A48C2DC76F486B /* AWSSynchronizedMutableDictionary.m */,
+				5787035EDC3E98DB50D44230AF7C85C4 /* AWSTask.h */,
+				A5ACFCA344CAB9104886458B50F41D9F /* AWSTask.m */,
+				0187DBE67FCE1366346974DF80312B67 /* AWSTaskCompletionSource.h */,
+				01D529BFBEBC106018D1829C409F5B6D /* AWSTaskCompletionSource.m */,
+				CE5510001721226909CB6D1FD2875C27 /* AWSTMCache.h */,
+				D5C2E1DD54B572091366135D61504120 /* AWSTMCache.m */,
+				CFEFDEFC752A05AEBFAEE9287B8C6C95 /* AWSTMCacheBackgroundTaskManager.h */,
+				339E1CE102BC4BB102802E45F284D351 /* AWSTMDiskCache.h */,
+				20CDA4D4E70462A011D602573D39696E /* AWSTMDiskCache.m */,
+				34858815A0F7379196A7B8853DB3DA33 /* AWSTMMemoryCache.h */,
+				F5DE71904156D1E5147D1B17672FB2FE /* AWSTMMemoryCache.m */,
+				78A4809D27E589F4ECDA9C8EB822F642 /* AWSUICKeyChainStore.h */,
+				269A40768550F653508FB48F30B84DE5 /* AWSUICKeyChainStore.m */,
+				B22392803C0BF56B11E6A8ACEC2D9388 /* AWSURLRequestRetryHandler.h */,
+				F26E71EF1BDDEE78B79B7BB5D13867F2 /* AWSURLRequestRetryHandler.m */,
+				D69BA5E648DC4036DBB189680E68AD9A /* AWSURLRequestSerialization.h */,
+				6A5B1767D9974D948007D9204B58EE4A /* AWSURLRequestSerialization.m */,
+				8331C110587ED90AD1EE22D37D3FB473 /* AWSURLResponseSerialization.h */,
+				AF376D908F93D6D7CAD373AAE433A82C /* AWSURLResponseSerialization.m */,
+				655090625CD0809A8FED4ED5C8B598C1 /* AWSURLSessionManager.h */,
+				5950D58519C02B45CFF4C1DDED370A48 /* AWSURLSessionManager.m */,
+				9F44B8C7B0BC344BFDE65FF3FB64D1E5 /* AWSValidation.h */,
+				A6FAA9739F0775D555007B48C7C4C604 /* AWSValidation.m */,
+				7A185053CD443C6EBC867E791ED606C7 /* AWSXMLDictionary.h */,
+				B62AB28531B4A1394BFBFC01AE0185B1 /* AWSXMLDictionary.m */,
+				B21B371F40AD3DB3AE0347F642CA716C /* AWSXMLWriter.h */,
+				B91D60620C0F71296D9A2756B377A350 /* AWSXMLWriter.m */,
+				88ED5F9AFEA22F06CE869726B2F707E8 /* FABAttributes.h */,
+				8CC923FF920DB28C101C420CE987CDE6 /* FABKitProtocol.h */,
+				671FA8A8981B6D9E4D607F197D583195 /* Fabric.h */,
+				62CC145608B6C86186B3A54AB9FA6498 /* Fabric+FABKits.h */,
+				732715CF43E24A182818E45B9DD6CA42 /* NSArray+AWSMTLManipulationAdditions.h */,
+				2099B4FC1B4FFFEE5E121147A0956AA6 /* NSArray+AWSMTLManipulationAdditions.m */,
+				673E1078C0B75EFB8FE7F59BBE328D78 /* NSDictionary+AWSMTLManipulationAdditions.h */,
+				119439775469EB44A41E15CABC1B7AEB /* NSDictionary+AWSMTLManipulationAdditions.m */,
+				9A71BCB9D1D845C22B8809633F9620D0 /* NSError+AWSMTLModelException.h */,
+				462CDC7FF48F22B4AAE6EEF830B635BC /* NSError+AWSMTLModelException.m */,
+				E659B3C97121218F1492034D211C16A4 /* NSObject+AWSMTLComparisonAdditions.h */,
+				426D0CDC2ACCEDDD1FDB54109388FAB9 /* NSObject+AWSMTLComparisonAdditions.m */,
+				41F1B2AFD50E7D6ACE8ECEB132F4ABD7 /* NSValueTransformer+AWSMTLInversionAdditions.h */,
+				B012CBF798D101D7AEA5DEBB931D457F /* NSValueTransformer+AWSMTLInversionAdditions.m */,
+				5D3FC3C5111DE0BB193D61CF5AC55161 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */,
+				F2E12DA949B01FEE2CC603DA99CF8297 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */,
+				4029B6E841AC0138A52ED43B2BD9BB9B /* Support Files */,
 			);
-			name = CwlCatchException;
-			path = CwlCatchException;
+			name = AWSCore;
+			path = AWSCore;
 			sourceTree = "<group>";
 		};
-		844CBD88D3BF9A8D3A2061345815AE26 /* AWSAuthCore */ = {
+		8929E9EE97E1D19E77CAC1DCF477AC5D /* AWSCognitoIdentityProvider */ = {
 			isa = PBXGroup;
 			children = (
-				FE78EB8AF731A271AD6B3205D8955233 /* AWSAuthCore.h */,
-				2025F5D43350C89927348B43FE33E261 /* AWSAuthUIHelper.h */,
-				AEFF9779FFD86E5968A8FE9D63B5D8C6 /* AWSAuthUIHelper.m */,
-				DED03D9B3329B6DBD77B3848BCE4F893 /* AWSIdentityManager.h */,
-				A78730E05ABF4E299EDFBE9D6E383E47 /* AWSIdentityManager.m */,
-				E86FBF7FE1863E0568B2936E6D617AB4 /* AWSSignInButtonView.h */,
-				5E8FD7E40163054B20474E96395CF492 /* AWSSignInManager.h */,
-				2AEA8D2580C822EE561F1B85D15AB5B4 /* AWSSignInManager.m */,
-				E83934A300E0256CF298A02BAC2E17F4 /* AWSSignInProvider.h */,
-				E741028ED94706419B1152DBA9543194 /* AWSSignInProviderApplicationIntercept.h */,
-				6AD291698E9564B20B51B0D4028722AA /* AWSUIConfiguration.h */,
-				23EF989061AAADFA48C46C412220F8AC /* Support Files */,
+				9CBE1C7AC6B8A499F1F9F92F4B5878FD /* aws_tommath.h */,
+				B18D92A4C431C09D10D5D8CC118F2BA2 /* aws_tommath_class.h */,
+				1879352EF7D914793D16865F02E4BBAB /* aws_tommath_superclass.h */,
+				28654CD2D624C23CC96C2288853B8A2A /* AWSCognitoIdentityProvider.h */,
+				3502B24960607AF0083FB45A99DD9B78 /* AWSCognitoIdentityProviderHKDF.h */,
+				C35534705967F0C84203915633DD3B00 /* AWSCognitoIdentityProviderHKDF.m */,
+				90D4490B3295BD88B2945BC735E90E20 /* AWSCognitoIdentityProviderModel.h */,
+				2EDF7E5096048D8B966EF59D99125309 /* AWSCognitoIdentityProviderModel.m */,
+				0488FA91ED857D8097EC068E16175D50 /* AWSCognitoIdentityProviderResources.h */,
+				9EE5EA345BF8114DD24BABAB8EB041A9 /* AWSCognitoIdentityProviderResources.m */,
+				9C19D4A110D91264453BBB9118B200A2 /* AWSCognitoIdentityProviderService.h */,
+				3DFC98441267A74AEB8AB146DE8D6D11 /* AWSCognitoIdentityProviderService.m */,
+				79019805F668DD6072EACF09CA6F8051 /* AWSCognitoIdentityProviderSrpHelper.h */,
+				080855AA1347E7B97141BB92F01284A8 /* AWSCognitoIdentityProviderSrpHelper.m */,
+				5638C97B13152127D5E6E6557DC97A04 /* AWSCognitoIdentityUser.h */,
+				E59519C5B196AAADB322109C848F8D62 /* AWSCognitoIdentityUser.m */,
+				5B3353B22C5BE756F269528D8722AC9C /* AWSCognitoIdentityUser_Internal.h */,
+				944F5689ABB43BAA26EF5E6C8EF89444 /* AWSCognitoIdentityUserPool.h */,
+				7A9898F0E3C371B28BF2A2C1BD7D4358 /* AWSCognitoIdentityUserPool.m */,
+				2EF7B8FE649AA081D9B6EFEF5488405D /* AWSCognitoIdentityUserPool_Internal.h */,
+				E166C1A7F424470ED9F0E35692D8A85A /* AWSJKBigDecimal.h */,
+				4FDF895C1546E277DA655224065CADE4 /* AWSJKBigDecimal.m */,
+				697C4DC3BEEA6233CCA378E1675B85A3 /* AWSJKBigInteger.h */,
+				D10626859DA048A75C2CCB320B621AED /* AWSJKBigInteger.m */,
+				6D5EAB70088187E6D937450A0EE0371F /* NSData+AWSCognitoIdentityProvider.h */,
+				C9C84929EC5363F579A75A9F5043F686 /* NSData+AWSCognitoIdentityProvider.m */,
+				ED0CAF841324ADA03B78DC435F707B2F /* tommath.c */,
+				B74618A87CA7A2DC4B26C2E82146AACA /* Support Files */,
 			);
-			name = AWSAuthCore;
-			path = AWSAuthCore;
+			name = AWSCognitoIdentityProvider;
+			path = AWSCognitoIdentityProvider;
 			sourceTree = "<group>";
 		};
 		8B4308E9F48A6891A7915CA1BC478FDA /* Products */ = {
@@ -1640,51 +1863,23 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		91E80509604DB3D554DC764A4121456D /* AWSMobileClient */ = {
+		AD117C9E74E8BF038BCEA6CCB45B359B /* SwiftLint */ = {
 			isa = PBXGroup;
 			children = (
-				2A7F937A3048EEBAB2068BAE53499D9C /* _AWSMobileClient.h */,
-				6D8A99015D2EC60F2847A8211AEA6BBE /* _AWSMobileClient.m */,
-				48F780036E2D872F1A15B369BED38933 /* AWSCognitoAuth.h */,
-				EDF0A50253541A270DAE2ADAD984E0DA /* AWSCognitoAuth.m */,
-				CEE13C907123CB23F408DAFC03368502 /* AWSCognitoAuth+Extensions.h */,
-				AFB5BF50AD93515A92630A2145F8DDE2 /* AWSCognitoAuth+Extensions.m */,
-				010075438C45B44D020D0DEC44200331 /* AWSCognitoAuth_Internal.h */,
-				26EA69A80E1EB46F76DAEBEC08852B5B /* AWSCognitoAuthUICKeyChainStore.h */,
-				C5965311C253CC983E3C43861FE61DE4 /* AWSCognitoAuthUICKeyChainStore.m */,
-				F2106BBD2524DBF1B3BEC5103CF2259F /* AWSCognitoCredentialsProvider+Extension.h */,
-				0163DD1DBE58F494454C5DFEEF1223C1 /* AWSCognitoIdentityUserPool+Extension.h */,
-				638D8632CC8F27E6F1D10AE39197B5F6 /* AWSMobileClient.h */,
-				5ECA73D18A22B3C441E418C9672F2275 /* AWSMobileClient.swift */,
-				4408ED574FF1E08009DA696D607E328E /* AWSMobileClientExtensions.swift */,
-				3E32B857CB41920FA239AE30655F37B7 /* AWSMobileClientUserDetails.swift */,
-				B4D90C37125647CF290576B422D6E22C /* AWSMobileOptions.swift */,
-				714CBDF84C8FCD04FDAEA70868566A07 /* AWSMobileResults.swift */,
-				5F2C8BF9E57FA143E2FA9728ADECB584 /* AWSUserPoolCustomAuthHandler.swift */,
-				580FC54E047092D4BF64987DEBEB6CEC /* AWSUserPoolOperationsHandler.swift */,
-				87CE1E26D07A0FED1773F6F755E99630 /* DeviceOperations.swift */,
-				9350B3FCF664ACBA1B6AAA745BBCA308 /* JSONHelper.swift */,
-				51D6956E4F16F8A798AA40B626044C52 /* Support Files */,
+				4A074B69570F156F007B62BF8F33CAEA /* Support Files */,
 			);
-			name = AWSMobileClient;
-			path = AWSMobileClient;
+			name = SwiftLint;
+			path = SwiftLint;
 			sourceTree = "<group>";
 		};
-		B19D7511EE44ABD3BDE6AE5A6D3DFF59 /* CwlPreconditionTesting */ = {
+		B15421FECECAA640DF153E0E7FC575E6 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				9B941D41D42EEC8164DEA0106F284EA7 /* CwlBadInstructionException.swift */,
-				FEE333F7C6ACC595DEBC08E6B8A5E5C9 /* CwlCatchBadInstruction.swift */,
-				46988F326C331492F52C9FAC76BC0841 /* CwlDarwinDefinitions.swift */,
-				FDA5DAF5A2814098C88ED0FD0FC32609 /* CwlMachBadInstructionHandler.h */,
-				AE3F8F35FA2FD71D338FE3D37E52F586 /* CwlMachBadInstructionHandler.m */,
-				95A58B6C533043AC03FC12B16145C38D /* CwlPreconditionTesting.h */,
-				09CDC287B301787A7A8B22CD3D76FFA5 /* mach_excServer.c */,
-				27606DBCBEE7FCFCBD83D2D588CEC248 /* mach_excServer.h */,
-				D52BD4C6B40EACDD1DD84FCBCDE6F2CF /* Support Files */,
+				5E41A84A8EBB7DB1B95A88FAE6C9E851 /* SwiftFormat.debug.xcconfig */,
+				EBB04B121569067A57985E4FE295205B /* SwiftFormat.release.xcconfig */,
 			);
-			name = CwlPreconditionTesting;
-			path = CwlPreconditionTesting;
+			name = "Support Files";
+			path = "../Target Support Files/SwiftFormat";
 			sourceTree = "<group>";
 		};
 		B4EABFCFD498135F4126D3A716F7B109 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon */ = {
@@ -1703,29 +1898,19 @@
 			path = "Target Support Files/Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon";
 			sourceTree = "<group>";
 		};
-		BD07F0BB432C7A91203167E6003FD7FA /* Support Files */ = {
+		B74618A87CA7A2DC4B26C2E82146AACA /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				C27ECFAC14BAD96D20837754F1CD3DEE /* AWSCognitoIdentityProvider.modulemap */,
-				4A9E09C54B5074D61B5E6B9031F15CA3 /* AWSCognitoIdentityProvider-dummy.m */,
-				A369FE77E8A7E105DD515C5A0238222F /* AWSCognitoIdentityProvider-Info.plist */,
-				C06B1ECB53889BBE9E30295A379B1435 /* AWSCognitoIdentityProvider-prefix.pch */,
-				8BC46419BA3507B1B650E2E09B3787EA /* AWSCognitoIdentityProvider-umbrella.h */,
-				F91D6E9D904D2BC3C7A70748D50F9FB8 /* AWSCognitoIdentityProvider.debug.xcconfig */,
-				0315D5F3EF56116A89062732A9987884 /* AWSCognitoIdentityProvider.release.xcconfig */,
+				96D8AF31153FEB41A531D8036E0330E2 /* AWSCognitoIdentityProvider.modulemap */,
+				F054E267B7EE5CE815814DB443A8BC69 /* AWSCognitoIdentityProvider-dummy.m */,
+				C72F32AF9B06780B96C0306FC3489DAD /* AWSCognitoIdentityProvider-Info.plist */,
+				26CAE8910E7FB2F9774A51188387B30A /* AWSCognitoIdentityProvider-prefix.pch */,
+				061DB1E4B174776DD34B7A1D4026D64B /* AWSCognitoIdentityProvider-umbrella.h */,
+				7BA8C89DAC641587B83E6F3BFE1924C6 /* AWSCognitoIdentityProvider.debug.xcconfig */,
+				8D44E4083D05EB6AB9B74809F65F6FC2 /* AWSCognitoIdentityProvider.release.xcconfig */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/AWSCognitoIdentityProvider";
-			sourceTree = "<group>";
-		};
-		BF9B541D30E4F248D6D51D60F0A76895 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				F145F245F41E0504E4EBAB93E0EBCE78 /* SwiftLint.debug.xcconfig */,
-				D3CA713D7BC33CCB06A920F7DFE545B1 /* SwiftLint.release.xcconfig */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/SwiftLint";
 			sourceTree = "<group>";
 		};
 		CF1408CF629C7361332E53B88F7BD30C = {
@@ -1733,222 +1918,10 @@
 			children = (
 				9D940727FF8FB9C785EB98E56350EF41 /* Podfile */,
 				0CEE57DA1055C19A1014C9B885209183 /* Frameworks */,
-				02D3095C4836936A4D26CFDAAA5A29E8 /* Pods */,
+				24077C0DEBDAC1C508738332CBE213CE /* Pods */,
 				8B4308E9F48A6891A7915CA1BC478FDA /* Products */,
 				09AD8BEF7343A541603839F476C7F70E /* Targets Support Files */,
 			);
-			sourceTree = "<group>";
-		};
-		D06091CEDE01976F8A28884A34C69A8A /* AWSCore */ = {
-			isa = PBXGroup;
-			children = (
-				6A57694184C5305A7FCCB3AB57A02501 /* AWSBolts.h */,
-				C9855730379BD00EDA06B67D9E6ACE5A /* AWSBolts.m */,
-				010AECEC67F6E8EEA0872F7CAC367AB9 /* AWSCancellationToken.h */,
-				E391A6CDBB25CD9CD616C8379AC49870 /* AWSCancellationToken.m */,
-				024F9CB6EB0FEAF8CAE4285F303CA53D /* AWSCancellationTokenRegistration.h */,
-				B7ADE5543A95AE17B1E9115EC5CDF0CC /* AWSCancellationTokenRegistration.m */,
-				3D0A429B94396EACDD9425A11E4C827C /* AWSCancellationTokenSource.h */,
-				70DC08BD2BFFE31FA6F545CDAE7F1521 /* AWSCancellationTokenSource.m */,
-				32DF266EBC63223640E52EF97B646531 /* AWSCategory.h */,
-				8314E4C7BEBD385F48DEA72FDD8FB69C /* AWSCategory.m */,
-				7746660A2B9ABA1322C22635208C039D /* AWSClientContext.h */,
-				4A4FA38EE0D5F12E02C928F9D0D90AF5 /* AWSClientContext.m */,
-				26E074B6C853307C638D3A214BCF13AD /* AWSCocoaLumberjack.h */,
-				58FED07AFC163D4256064E2EF108B47A /* AWSCognitoIdentity.h */,
-				5A364A9DC40F0E30BA70256B9A77A5BE /* AWSCognitoIdentity+Fabric.h */,
-				6F70FE0555C85607F11E8C4D0D47EB14 /* AWSCognitoIdentity+Fabric.m */,
-				EEFE6143A25DA46E1E0FE5A33A1169A3 /* AWSCognitoIdentityModel.h */,
-				051437CDB0C1F99EB3D075000D7ED7C1 /* AWSCognitoIdentityModel.m */,
-				7C5086639816CD0DADC764CEFF8DA89D /* AWSCognitoIdentityResources.h */,
-				DCEBA99E8A7995FC38DC060850D040C9 /* AWSCognitoIdentityResources.m */,
-				AD5FC9E5E349DFF661B54E9F8250C8DD /* AWSCognitoIdentityService.h */,
-				6247E23DAB89A392D6700528BBD48435 /* AWSCognitoIdentityService.m */,
-				CA4FA7BEDE7F4F5A4F52727D799961AC /* AWSCore.h */,
-				46294BA1DAA83E771D4E3CD12CF92E76 /* AWSCredentialsProvider.h */,
-				F7F0ED5603B9A33A5AB2840F17157E94 /* AWSCredentialsProvider.m */,
-				C0EC70C2BA5512DF72AFA093567E3C77 /* AWSDDAbstractDatabaseLogger.h */,
-				622CFB3E9A43C8FE15F37616F03BDEF4 /* AWSDDAbstractDatabaseLogger.m */,
-				88E787B8E15B912AC396282DC00F1F4E /* AWSDDASLLogCapture.h */,
-				B0C83F24CB550E6006708C464C4978E1 /* AWSDDASLLogCapture.m */,
-				646462FD5A2B43C2114AF829757A657B /* AWSDDASLLogger.h */,
-				D5A8E99D231E0EF059DDD30DC9EF7ACA /* AWSDDASLLogger.m */,
-				8159E8A1827AD9AF774C2E6B233D8476 /* AWSDDAssertMacros.h */,
-				53D9BDE9B970F6CC3CF311DB67FF5054 /* AWSDDContextFilterLogFormatter.h */,
-				43128D69FB45BBB7F4ADB2DFBCE21532 /* AWSDDContextFilterLogFormatter.m */,
-				23B9D4394992AEF47ED06DEFAE0CCB3F /* AWSDDDispatchQueueLogFormatter.h */,
-				0CFCA5D85B002DD014B94FF35A27A47E /* AWSDDDispatchQueueLogFormatter.m */,
-				90D7A46D08EDB42C5A86B4AD9B660F37 /* AWSDDFileLogger.h */,
-				9A6C5897CC3CC996DB74F2BADF4C2AA9 /* AWSDDFileLogger.m */,
-				F7621F4DF375E8B06CC6CC04110251B3 /* AWSDDLegacyMacros.h */,
-				AE8CC2E06DEBCE5EF191799D1127C5F1 /* AWSDDLog.h */,
-				E3896A3F2C482FFBC76D016CCEE102D7 /* AWSDDLog.m */,
-				358A5159A1A60BF02175C6A3D56B4E42 /* AWSDDLog+LOGV.h */,
-				DC848AA86A44B12AA9160C97145E729E /* AWSDDLogMacros.h */,
-				1E7216BDE7E63D1C09D9DD55B461C1F7 /* AWSDDMultiFormatter.h */,
-				5C8DDE8BDC075136E7854C7C130D4480 /* AWSDDMultiFormatter.m */,
-				D730CA76B9F5586885C45C8BD0271261 /* AWSDDOSLogger.h */,
-				77151F54F4FB266CE6A2D7162F277D21 /* AWSDDOSLogger.m */,
-				4C088E988DA4E79E7D02BF2FF788EDAE /* AWSDDTTYLogger.h */,
-				BE8A00F21039086E055FBF70CCEC010F /* AWSDDTTYLogger.m */,
-				25932903D3A78965B86E733E30B3A4F5 /* AWSExecutor.h */,
-				8171E908773030DF8D186BD5A21D4608 /* AWSExecutor.m */,
-				4484ED4548415DDE3489B66C2F7ECC44 /* AWSEXTKeyPathCoding.h */,
-				7E497CA1D2B416C4AF9A01F578B63DD3 /* AWSEXTRuntimeExtensions.h */,
-				3228E5C6E903750905DC08BDF584C5DA /* AWSEXTRuntimeExtensions.m */,
-				25F990CE79266048C3D300BF988751FC /* AWSEXTScope.h */,
-				E5DE768FFA5EA9EA4368651C29CF4827 /* AWSEXTScope.m */,
-				6C89B5E8C8653EF6D614F1BE244FAE98 /* AWSFMDatabase.h */,
-				435526BBCAF623B030E3026EC9DE1016 /* AWSFMDatabase.m */,
-				ADA0D94F6857763CE195680591541616 /* AWSFMDatabase+Private.h */,
-				4C8708ABDF32CDB4E9BFD531B2D8F853 /* AWSFMDatabaseAdditions.h */,
-				69F008F7FC765D8E3A19AAE2CB0540F1 /* AWSFMDatabaseAdditions.m */,
-				8CC8A065D0769AB2ECDAC257704CD436 /* AWSFMDatabasePool.h */,
-				1B0510CBEEDE5FCA0299A0FD4D3F647A /* AWSFMDatabasePool.m */,
-				8676BBF167AABCB755BBA9092D0BA3D9 /* AWSFMDatabaseQueue.h */,
-				3CA709F5652B0398A9B29246F3F49EBB /* AWSFMDatabaseQueue.m */,
-				96B30AC1E2A2C23B6F1AB65BF4DBE3DC /* AWSFMDB.h */,
-				ED978F394A390FEF78F57B0E84DB463C /* AWSFMDB+AWSHelpers.h */,
-				F05D5BDA387BCC2162C907D59247DE7A /* AWSFMDB+AWSHelpers.m */,
-				A558F5B8A104C627E526058158AE0D6E /* AWSFMResultSet.h */,
-				3D3606B6B7DB161FF6D16A4BE6B27CF3 /* AWSFMResultSet.m */,
-				215E6048187156C4EA2A028913C9CA04 /* AWSGeneric.h */,
-				593F6FE9E180C8D514A96C8AD34EB9CB /* AWSGZIP.h */,
-				E5650AB2D7426F36016C0C56FA58833F /* AWSGZIP.m */,
-				822AFB1D38A97E144B98521D98A44F0C /* AWSIdentityProvider.h */,
-				13A2D98960FD11A58FC06B45008B2AB5 /* AWSIdentityProvider.m */,
-				AEF01236FCF1B3D525155ED54ED94047 /* AWSInfo.h */,
-				D23EA41EC03920EDF5FE81A6E7774ECF /* AWSInfo.m */,
-				3585665D570BD8937FC9A32C98886EA6 /* AWSKSReachability.h */,
-				594C9789E8B6E3765CCB480D349AB2A0 /* AWSKSReachability.m */,
-				5AB7550EAF118FA23F6FBAE5B851974E /* AWSLogging.h */,
-				036C1A0B72AAAD2A7B27A08BADDF1105 /* AWSLogging.m */,
-				EE1B00BD743F4B6F35AE7CE4D6C029E1 /* AWSMantle.h */,
-				D060CD7839514A5830127E29A440D945 /* AWSmetamacros.h */,
-				201B012B8DCABEAE0CD9EBE7D55791E5 /* AWSModel.h */,
-				0D572A7B644427B4E310F33B8F49FA13 /* AWSModel.m */,
-				E20AA1F28A014153CB5D903040321543 /* AWSMTLJSONAdapter.h */,
-				1FB0B0BC703C60784559FD78705D2D3D /* AWSMTLJSONAdapter.m */,
-				82D5755093B849733862D6875C19C2EE /* AWSMTLManagedObjectAdapter.h */,
-				43D03953BFA2E6934D54CB37BD928875 /* AWSMTLManagedObjectAdapter.m */,
-				39C1FB84194B70A998EED9294936E302 /* AWSMTLModel.h */,
-				1D7F2FDC05F42701A1BDD38B8599A53E /* AWSMTLModel.m */,
-				215DA62B09F66CEC9B18A68211635BAC /* AWSMTLModel+NSCoding.h */,
-				77DBCE95EEDBE6CF449375F56ED6A8A3 /* AWSMTLModel+NSCoding.m */,
-				77F306093B6CBBA95ABD2D5A3A3FB885 /* AWSMTLReflection.h */,
-				0CE9D44BE59C6645651F72F311DB6C0A /* AWSMTLReflection.m */,
-				7DC551498486764772714478E98073EE /* AWSMTLValueTransformer.h */,
-				661CD15775667147D9B7051F8B63D35A /* AWSMTLValueTransformer.m */,
-				A8CE8311B2C6B175B02EC6B1F56687F0 /* AWSNetworking.h */,
-				E5B47752E9EE042403E350EA1AF40218 /* AWSNetworking.m */,
-				DF9C38EA99E284232320822E6FF2779A /* AWSNetworkingHelpers.h */,
-				AD631971BF2738DD07F986967E16668B /* AWSNetworkingHelpers.m */,
-				767B4455799A98274C24D8D74C040E9B /* AWSSerialization.h */,
-				B7A45684A9DDAC60CCD1D5EB54FF56C6 /* AWSSerialization.m */,
-				BF99389237A0C6D569874D05DDDF0737 /* AWSService.h */,
-				4140977A6FA9DE8FA6A6D16739462D51 /* AWSService.m */,
-				78880857643C7E7D963CA06F4F79046E /* AWSServiceEnum.h */,
-				3B23FCA3582BFF3C7711AF1C1630BCB4 /* AWSSignature.h */,
-				3E2C320736C8649DB501945D50D6C78A /* AWSSignature.m */,
-				3DD558EF138166AFAEC0D40FDD36E577 /* AWSSTS.h */,
-				0EC8B36FC6B914F164C0C2AF1AD96F83 /* AWSSTSModel.h */,
-				16A601DC16672A8A74349C446B163720 /* AWSSTSModel.m */,
-				F8C4353DFDD27E3B9354357B7AA341EC /* AWSSTSResources.h */,
-				9804501BD5ABBA59BAE5D84867237A88 /* AWSSTSResources.m */,
-				044F723309888175C12015B0DF8AC9D5 /* AWSSTSService.h */,
-				EF84299E434B6BC8812A597F60CF31F1 /* AWSSTSService.m */,
-				1A98F3BC7E10504EB89277DBD08056E8 /* AWSSynchronizedMutableDictionary.h */,
-				97D015DB895D5976B9057D0058FA45B8 /* AWSSynchronizedMutableDictionary.m */,
-				7C24137D9A15529190A1833D49230BD3 /* AWSTask.h */,
-				971FD80F5A3D56DB110CD4F03667D4F7 /* AWSTask.m */,
-				2C68FE2B5EB71F0D9C32F7A1353E1BF9 /* AWSTaskCompletionSource.h */,
-				155ECD0389C655CA5CAFCA1423B7F81E /* AWSTaskCompletionSource.m */,
-				F35780388FBA1CDB5C6EF5550FFA96A0 /* AWSTMCache.h */,
-				5C3C79C322308DCFF6CC07162D81B7B3 /* AWSTMCache.m */,
-				DE03FBF91D2AF7BAA3FB5C980A81A710 /* AWSTMCacheBackgroundTaskManager.h */,
-				CBFDB4B8172D6C61FE1187BBB4E56BC2 /* AWSTMDiskCache.h */,
-				6D317A8D28190875854FE246A4450BDA /* AWSTMDiskCache.m */,
-				54F2B9B424EA365272D4D45F6AA6B571 /* AWSTMMemoryCache.h */,
-				B7D7D279373248B855C695D8D59114CF /* AWSTMMemoryCache.m */,
-				95B69FCC9C94459CC24FA0F476A45FEC /* AWSUICKeyChainStore.h */,
-				975762B5F22BD7567982C2729A08EA29 /* AWSUICKeyChainStore.m */,
-				9C4F2011018B14F3F4235228124861C3 /* AWSURLRequestRetryHandler.h */,
-				A25BD6858ACA564889F5C1888E45B49F /* AWSURLRequestRetryHandler.m */,
-				94EEEE23B143CAE7857143A60EDAEE91 /* AWSURLRequestSerialization.h */,
-				D06F68E04C132879F35438E6BE63CB8A /* AWSURLRequestSerialization.m */,
-				149D72F554244193A0B7AF373ECCBD2F /* AWSURLResponseSerialization.h */,
-				7ACD0297802CDDDFBC77BF5D6C40D7B6 /* AWSURLResponseSerialization.m */,
-				B2ED77C675E31F2C63768E7D59D25611 /* AWSURLSessionManager.h */,
-				1525D826E1F48AFA731D858D680381DE /* AWSURLSessionManager.m */,
-				5F30C86248908FA871CAAC451CD386A4 /* AWSValidation.h */,
-				1303984DBCAB633CD483D7079ADC6C16 /* AWSValidation.m */,
-				F3D29C275552286758AF490FD2311ABF /* AWSXMLDictionary.h */,
-				AD7DA8547C6045EC6D31802C445EA2DE /* AWSXMLDictionary.m */,
-				56F63DA64CFE5101D3680D82D88649ED /* AWSXMLWriter.h */,
-				0332051850FABA8FEB15A891758E27AB /* AWSXMLWriter.m */,
-				522FF7223869E4B88DE29BC852A6EFA0 /* FABAttributes.h */,
-				1C3978F270280E8D902436A08201BCD1 /* FABKitProtocol.h */,
-				C2775A802441C8060EB9BF86321820D9 /* Fabric.h */,
-				3A8D66842538327815F5470D8B00AB5E /* Fabric+FABKits.h */,
-				B18C183C23945DF961400C5B769B487F /* NSArray+AWSMTLManipulationAdditions.h */,
-				1ED5694E8307F8C4EAB7DACE6C30C7FD /* NSArray+AWSMTLManipulationAdditions.m */,
-				87757B02A6B5FA4D18E0ED5C0605EEF3 /* NSDictionary+AWSMTLManipulationAdditions.h */,
-				5CF7E92216D1B04741144F93ACCF1F26 /* NSDictionary+AWSMTLManipulationAdditions.m */,
-				F93CBFC571C283CD341B9B26BF47FC17 /* NSError+AWSMTLModelException.h */,
-				42D1297EBB5A1F9FB05A9C9DB30429CD /* NSError+AWSMTLModelException.m */,
-				5647E2F9B6864AD929CCA40EA73DCE8B /* NSObject+AWSMTLComparisonAdditions.h */,
-				5AD39ACA6DC4F3E8054B5364662EB998 /* NSObject+AWSMTLComparisonAdditions.m */,
-				1ED7C4E40E0ADA485169F0899452DFDB /* NSValueTransformer+AWSMTLInversionAdditions.h */,
-				A95F247C52F4E16F0A83457315C849CE /* NSValueTransformer+AWSMTLInversionAdditions.m */,
-				5963F8F37803D4F8DECB8F3B3C7AEF9A /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h */,
-				F8908348756A5F294A2146253E4E6036 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m */,
-				071917F2B84CC5375287068CC98F7366 /* Support Files */,
-			);
-			name = AWSCore;
-			path = AWSCore;
-			sourceTree = "<group>";
-		};
-		D1803BFFD9F2DD7DF000B9BD4341F894 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				C0A8E0C4A94821AB03AC041AD9615DB7 /* AWSCognitoIdentityProviderASF.modulemap */,
-				C37E09DF58FA889A85DC5F6F4E692EAC /* AWSCognitoIdentityProviderASF-dummy.m */,
-				819579E5CAEE9144BC828E9B6D7B2F04 /* AWSCognitoIdentityProviderASF-Info.plist */,
-				6A65C047280EA42ACAC564BAF26E7B45 /* AWSCognitoIdentityProviderASF-prefix.pch */,
-				6ABA495DEBA91095FE2A8E7D756E77FD /* AWSCognitoIdentityProviderASF-umbrella.h */,
-				DFB368D4F469CFFEDE97D532E253A068 /* AWSCognitoIdentityProviderASF.debug.xcconfig */,
-				5F47A1D42B8B2FAD28D5AB97F44BB8F9 /* AWSCognitoIdentityProviderASF.release.xcconfig */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/AWSCognitoIdentityProviderASF";
-			sourceTree = "<group>";
-		};
-		D4CCCE2844E53A82198D2BEDC7B79D34 /* AWSCognitoIdentityProviderASF */ = {
-			isa = PBXGroup;
-			children = (
-				9BF34501027170E35D5C40DE2AD55C64 /* AWSCognitoIdentityASF.h */,
-				7B1B00B9CC01A4FAC1E58AC7CA361218 /* AWSCognitoIdentityProviderASF.h */,
-				D5EEAEBFA0B348201AF50C3642961DEA /* AWSCognitoIdentityProviderASF.m */,
-				4D253C87471DA1F9F7D7712037E5E683 /* Frameworks */,
-				D1803BFFD9F2DD7DF000B9BD4341F894 /* Support Files */,
-			);
-			name = AWSCognitoIdentityProviderASF;
-			path = AWSCognitoIdentityProviderASF;
-			sourceTree = "<group>";
-		};
-		D52BD4C6B40EACDD1DD84FCBCDE6F2CF /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				56C453F9B3BA8F43250FC0DE9E37B3EE /* CwlPreconditionTesting.modulemap */,
-				68FF3770CBF110857CA77FFE046B0B4F /* CwlPreconditionTesting-dummy.m */,
-				C07DC5E1C216277E1A0C189EF804BC04 /* CwlPreconditionTesting-Info.plist */,
-				89E885F128A28CAF00D3C9EA70F5A2DE /* CwlPreconditionTesting-prefix.pch */,
-				8E01301307CE42A2B4740B8BBDEF1A63 /* CwlPreconditionTesting-umbrella.h */,
-				4450DEEA3EB1397A391B814028F8A6F4 /* CwlPreconditionTesting.debug.xcconfig */,
-				C527417CF3621C2D730B8DDB950B8F5C /* CwlPreconditionTesting.release.xcconfig */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/CwlPreconditionTesting";
 			sourceTree = "<group>";
 		};
 		D5CE6FD3F74C74F66A240B353AF7E722 /* iOS */ = {
@@ -1979,6 +1952,21 @@
 			path = "Target Support Files/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon";
 			sourceTree = "<group>";
 		};
+		E4ED606FAD0D3F25076F29DA97FB4B80 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				847FDD4A5924154C67F278F229C8B9CE /* CwlCatchException.modulemap */,
+				F9450A052E08F53A2E883BB2BB43E47A /* CwlCatchException-dummy.m */,
+				0F16051AA198DAE03CA0B00B25844939 /* CwlCatchException-Info.plist */,
+				62E7C2AC7685CA25C83B4F04915C070D /* CwlCatchException-prefix.pch */,
+				A71B7F640BDB684BA90C692996235E16 /* CwlCatchException-umbrella.h */,
+				B13BE58F43DF7C58E227E8E88A40B4E0 /* CwlCatchException.debug.xcconfig */,
+				BFC19B69A58D11D24120B5E24CCE1BCC /* CwlCatchException.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/CwlCatchException";
+			sourceTree = "<group>";
+		};
 		F317EA87105ABDAE64570CCCC20B5912 /* Pods-Amplify */ = {
 			isa = PBXGroup;
 			children = (
@@ -1995,6 +1983,21 @@
 			path = "Target Support Files/Pods-Amplify";
 			sourceTree = "<group>";
 		};
+		F3CE6B27D086CBC0DA4CBA5E9C8DF8D5 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				B909FE2414420753D99E82A24999CE77 /* AWSMobileClient.modulemap */,
+				8D3C0F6EA1AA31E2C61D1EE399A42644 /* AWSMobileClient-dummy.m */,
+				A85D785EC4F26572EC8F5A5F629F6FFC /* AWSMobileClient-Info.plist */,
+				7E62AEFB6CD3A801302D181EBC31257A /* AWSMobileClient-prefix.pch */,
+				A243228FEE8808D847077999FFCA7FF5 /* AWSMobileClient-umbrella.h */,
+				6578953AD64D0981CC6BD8A2682F5D6C /* AWSMobileClient.debug.xcconfig */,
+				9439C729F9BFD63741282A364FC5A32E /* AWSMobileClient.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/AWSMobileClient";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -2009,27 +2012,28 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		1C6362B963B51C00EB918F5486B46BEA /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC33B5AE93CAD05125F41344A7DC295C /* _AWSMobileClient.h in Headers */,
+				29F001B4F1F5D8369E7793F2E2C7518E /* AWSCognitoAuth+Extensions.h in Headers */,
+				54D6C81AB4089CE00C5F58D243DCC8FA /* AWSCognitoAuth.h in Headers */,
+				5E64CCB1D7FC10661B116F8ED8819648 /* AWSCognitoAuth_Internal.h in Headers */,
+				2861A1716ABD10B59138E0608BE1C775 /* AWSCognitoAuthUICKeyChainStore.h in Headers */,
+				E2C09DB09ACE2CA2677337DB8BD28CF9 /* AWSCognitoCredentialsProvider+Extension.h in Headers */,
+				8ED2F8EE57C9042901D80E722D41AC0D /* AWSCognitoIdentityUserPool+Extension.h in Headers */,
+				4589F69C4934F11F1A17ACA1B08BC0E0 /* AWSMobileClient-Mixed-Swift.h in Headers */,
+				FD3A3329F3101AF1F8969EA38080957E /* AWSMobileClient-umbrella.h in Headers */,
+				408E26270F1ADEBB526CEDF85AD131DC /* AWSMobileClient.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		490B1475EE35A1DFF2E34F4E0B863549 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				9D914E2C5BB01F438CE2CEFAF3518D6F /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4FA2461680E769976C4D06608A2A9004 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				3CA6B00BEC52629874A59C4425B040FF /* _AWSMobileClient.h in Headers */,
-				5D1E1ED20C02309D4897C489A4FF1385 /* AWSCognitoAuth+Extensions.h in Headers */,
-				4DF330318C6863C9A9457AB6A0D931AC /* AWSCognitoAuth.h in Headers */,
-				080A963CA88B480650FFE9DA4C1FB652 /* AWSCognitoAuth_Internal.h in Headers */,
-				FF5A3D0068C906E484D9FB5CC613556E /* AWSCognitoAuthUICKeyChainStore.h in Headers */,
-				06286FFF5F9A837D882033756A51BA6F /* AWSCognitoCredentialsProvider+Extension.h in Headers */,
-				4B0A6C1C5E40CA5991F72FE870380789 /* AWSCognitoIdentityUserPool+Extension.h in Headers */,
-				51250616CA565F13AACEBE3D53B538A9 /* AWSMobileClient-umbrella.h in Headers */,
-				2D0A57953832EF83AD2FA1511820B602 /* AWSMobileClient.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2370,18 +2374,18 @@
 		};
 		6428ED7DAC8003D918A4F549769F079D /* AWSMobileClient */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 6C1B0082F55622F61D55E4DF5F89B58D /* Build configuration list for PBXNativeTarget "AWSMobileClient" */;
+			buildConfigurationList = 8303AF580CB32D93D56CB25771284834 /* Build configuration list for PBXNativeTarget "AWSMobileClient" */;
 			buildPhases = (
-				4FA2461680E769976C4D06608A2A9004 /* Headers */,
-				49C4F997373C728DF83F55FD7FCCB1A8 /* Sources */,
-				8DD65B45F2688280FD422D5D7364A10A /* Frameworks */,
-				B219A243F752A8EC273DCB0D9186D7C0 /* Resources */,
+				1C6362B963B51C00EB918F5486B46BEA /* Headers */,
+				6207831AD768716452B1848E61EEAF65 /* Sources */,
+				3E145C62E18EB143A9D5C8EB279CC99A /* Frameworks */,
+				BF5B87B637529AE68F42AD7B3D225C41 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				06729402D244E9B3898403BE3BECA781 /* PBXTargetDependency */,
-				3956B7AEEEE178E01F0DEA935F7D7E02 /* PBXTargetDependency */,
+				5667EF0F959239F15E58BB582963AE92 /* PBXTargetDependency */,
+				F5B0421585F0FF6459D4B846436CD62B /* PBXTargetDependency */,
 			);
 			name = AWSMobileClient;
 			productName = AWSMobileClient;
@@ -2695,13 +2699,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B219A243F752A8EC273DCB0D9186D7C0 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		B417A984DF6BABD8867BB25AD9BC1503 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2717,6 +2714,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		B9311AFD8AC2DD0D5BABA9D418762F1D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BF5B87B637529AE68F42AD7B3D225C41 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2826,24 +2830,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		49C4F997373C728DF83F55FD7FCCB1A8 /* Sources */ = {
+		6207831AD768716452B1848E61EEAF65 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6A6F7F27DCCF6D5F73EA43FCCA1DAB92 /* _AWSMobileClient.m in Sources */,
-				0DC60DC3F6A7EDA73648721C422359A7 /* AWSCognitoAuth+Extensions.m in Sources */,
-				6026B603F1245AD52915F34CA6A83CC5 /* AWSCognitoAuth.m in Sources */,
-				5296910C64F9CFF68149C484D4FCB927 /* AWSCognitoAuthUICKeyChainStore.m in Sources */,
-				37899F8A7B0ED0B72C99334BAA54CEAB /* AWSMobileClient-dummy.m in Sources */,
-				FEBDB02A795559B8678FF609BD63DC5D /* AWSMobileClient.swift in Sources */,
-				9C756224993E158189C803D1CF6DB659 /* AWSMobileClientExtensions.swift in Sources */,
-				67D8229426E3B531C446102C3F290D63 /* AWSMobileClientUserDetails.swift in Sources */,
-				BE7ADABCCDB533FDC0433D0D631EF85E /* AWSMobileOptions.swift in Sources */,
-				CD670349157D1CC299C595DBC118D553 /* AWSMobileResults.swift in Sources */,
-				D0008DB1D694408559F50AD06E9DCF00 /* AWSUserPoolCustomAuthHandler.swift in Sources */,
-				CCF3D812222A96CB42B542F4D68A6B3F /* AWSUserPoolOperationsHandler.swift in Sources */,
-				35A9EDB5F19A0AA37CFAC061744C58A4 /* DeviceOperations.swift in Sources */,
-				97C52BFCC42E09EEE37E0F079375C892 /* JSONHelper.swift in Sources */,
+				941E42D1D509D1F582000664CD91E228 /* _AWSMobileClient.m in Sources */,
+				CE96BB65FD82A94CC9C9BBE2FEDC0872 /* AWSCognitoAuth+Extensions.m in Sources */,
+				DD391DA8A4F2D8D3EFA2387964725A24 /* AWSCognitoAuth.m in Sources */,
+				A16C4E9390E6BB2980D939DC8E65B67C /* AWSCognitoAuthUICKeyChainStore.m in Sources */,
+				D543D7550F4B79012301D277113C1132 /* AWSMobileClient-dummy.m in Sources */,
+				FB10B80CC418942706405C6FDA423234 /* AWSMobileClient.swift in Sources */,
+				5B96288E92790AC284A258082D40A1C9 /* AWSMobileClientExtensions.swift in Sources */,
+				774615D361214800A581F3588FB96E5A /* AWSMobileClientUserDetails.swift in Sources */,
+				899F3EC9E3871788006C0546EBC03291 /* AWSMobileOptions.swift in Sources */,
+				6F173BDEC3D52002ECE0AFF78D666654 /* AWSMobileResults.swift in Sources */,
+				66F79AA0A7BADE7040571FBA367C4239 /* AWSUserPoolCustomAuthHandler.swift in Sources */,
+				2914C15AB2C025430066747BE42F6A39 /* AWSUserPoolOperationsHandler.swift in Sources */,
+				601D294DEA3B5DA9613371722EAB154D /* DeviceOperations.swift in Sources */,
+				3B34E32ACD49583FA677CE0E51257228 /* JSONHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2980,12 +2984,6 @@
 			target = 52B60EC2A583F24ACBB69C113F5488B9 /* SwiftLint */;
 			targetProxy = D39665078EF67EB882056A22CF65FE80 /* PBXContainerItemProxy */;
 		};
-		06729402D244E9B3898403BE3BECA781 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = AWSAuthCore;
-			target = 8042F2B0721B13AEDEB81F058C2B2125 /* AWSAuthCore */;
-			targetProxy = ABF241B4BEC3E8ADB5E0B8D8BB34B97C /* PBXContainerItemProxy */;
-		};
 		0677872B62BA77DECE8C9125D7C238B1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = SwiftLint;
@@ -3058,12 +3056,6 @@
 			target = 1CD0618C486973D5588EF20D2E8C0AEA /* SwiftFormat */;
 			targetProxy = B74E5D04FC60F052519803DF490FA801 /* PBXContainerItemProxy */;
 		};
-		3956B7AEEEE178E01F0DEA935F7D7E02 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = AWSCognitoIdentityProvider;
-			target = 29212B2F049288E035AB98405A23E41E /* AWSCognitoIdentityProvider */;
-			targetProxy = 808E02155DEA9FFFA7AB26A41DE112FA /* PBXContainerItemProxy */;
-		};
 		3D8B7F3F5BB71669A7C025928D1072D2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = AWSAuthCore;
@@ -3099,6 +3091,12 @@
 			name = SwiftFormat;
 			target = 1CD0618C486973D5588EF20D2E8C0AEA /* SwiftFormat */;
 			targetProxy = 0B15C6B49EE32852CECA199085B40CF5 /* PBXContainerItemProxy */;
+		};
+		5667EF0F959239F15E58BB582963AE92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AWSAuthCore;
+			target = 8042F2B0721B13AEDEB81F058C2B2125 /* AWSAuthCore */;
+			targetProxy = 5E6F9F34B5C8CFC5E5A1534148440CAD /* PBXContainerItemProxy */;
 		};
 		56727A38DC5793FCE8DCF48D44EFC2AA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3370,6 +3368,12 @@
 			target = 52B60EC2A583F24ACBB69C113F5488B9 /* SwiftLint */;
 			targetProxy = 00EEF00846B79EED10A448BF95960D73 /* PBXContainerItemProxy */;
 		};
+		F5B0421585F0FF6459D4B846436CD62B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AWSCognitoIdentityProvider;
+			target = 29212B2F049288E035AB98405A23E41E /* AWSCognitoIdentityProvider */;
+			targetProxy = 93D132FE40403BE2D60EC7A29146AB21 /* PBXContainerItemProxy */;
+		};
 		FB1CAB383ACC481695189C429B46C7F4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = AWSCore;
@@ -3502,7 +3506,7 @@
 		};
 		0A044C808D5147A7A6984B4D5F693235 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5B3055A216626F89FF9251CDB64FB227 /* AWSCore.release.xcconfig */;
+			baseConfigurationReference = 9253B55179A547D34BC77CA641557737 /* AWSCore.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3538,7 +3542,7 @@
 		};
 		0C8AE3232300B897A8290D079D5D08A9 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 60A7481863E0FBEC00846C480C56E6C3 /* AWSCore.debug.xcconfig */;
+			baseConfigurationReference = 0B063D30CC52E4E795C1A128701D20F2 /* AWSCore.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3612,7 +3616,7 @@
 		};
 		1DB798CA4A76BE0F7561B1F197481D42 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E6C4866E9EA5FF270F3D2269789BF571 /* SwiftFormat.debug.xcconfig */;
+			baseConfigurationReference = 5E41A84A8EBB7DB1B95A88FAE6C9E851 /* SwiftFormat.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -3764,41 +3768,6 @@
 			};
 			name = Release;
 		};
-		2C0A01629DCB8659CB2816A186C07E80 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 63129AB4EE71D01423866FD2AA8A71F4 /* AWSMobileClient.debug.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/AWSMobileClient/AWSMobileClient-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient.modulemap";
-				PRODUCT_MODULE_NAME = AWSMobileClient;
-				PRODUCT_NAME = AWSMobileClient;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		2F89E5170F326F14D95FB1EDDEEBEA54 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC0AAAB222E3424AB42C3968AE2DD9F7 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests.debug.xcconfig */;
@@ -3916,7 +3885,7 @@
 		};
 		45F0FC44DCE793C265DE51E3A62F7D41 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0315D5F3EF56116A89062732A9987884 /* AWSCognitoIdentityProvider.release.xcconfig */;
+			baseConfigurationReference = 8D44E4083D05EB6AB9B74809F65F6FC2 /* AWSCognitoIdentityProvider.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3952,7 +3921,7 @@
 		};
 		46EECD2DED30D7C5FE141C0B267C2D3F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F145F245F41E0504E4EBAB93E0EBCE78 /* SwiftLint.debug.xcconfig */;
+			baseConfigurationReference = 74C17E59A382F19CD152527575F7BFA2 /* SwiftLint.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -3968,7 +3937,7 @@
 		};
 		476EDB783CC0A9F1D6D8F36011E4DE40 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 05091549D84201D3FF1A8EEED67D8902 /* AWSAuthCore.debug.xcconfig */;
+			baseConfigurationReference = 3B2EB0A457D0895CA40C8C9BA74A5D72 /* AWSAuthCore.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4003,7 +3972,7 @@
 		};
 		4818F91204228E9806FAC1D95CEEBF4C /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4450DEEA3EB1397A391B814028F8A6F4 /* CwlPreconditionTesting.debug.xcconfig */;
+			baseConfigurationReference = 203C838CB1CE8D734686C30424D1DE5C /* CwlPreconditionTesting.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4076,7 +4045,7 @@
 		};
 		48FC17FCF5FACC6080887BFAC744F672 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C889B4FD8E0B46B1330DDC69207E75C8 /* CwlCatchException.debug.xcconfig */;
+			baseConfigurationReference = B13BE58F43DF7C58E227E8E88A40B4E0 /* CwlCatchException.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4109,9 +4078,44 @@
 			};
 			name = Debug;
 		};
+		4D2BD58136D99FDB2BF04058372CFDA8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6578953AD64D0981CC6BD8A2682F5D6C /* AWSMobileClient.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/AWSMobileClient/AWSMobileClient-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient.modulemap";
+				PRODUCT_MODULE_NAME = AWSMobileClient;
+				PRODUCT_NAME = AWSMobileClient;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		50060BD3822F9D62C4EF6DAD90E4B073 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F91D6E9D904D2BC3C7A70748D50F9FB8 /* AWSCognitoIdentityProvider.debug.xcconfig */;
+			baseConfigurationReference = 7BA8C89DAC641587B83E6F3BFE1924C6 /* AWSCognitoIdentityProvider.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4185,7 +4189,7 @@
 		};
 		54FF3E21EFAC29F34AFB3D67F89E0AFE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C527417CF3621C2D730B8DDB950B8F5C /* CwlPreconditionTesting.release.xcconfig */;
+			baseConfigurationReference = AA221FF719FFFD173DFF9FC756863A67 /* CwlPreconditionTesting.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4221,7 +4225,7 @@
 		};
 		55DD740115BE746C8DBB7753806D85D5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D3CA713D7BC33CCB06A920F7DFE545B1 /* SwiftLint.release.xcconfig */;
+			baseConfigurationReference = FE5C6AC41A29A3BE24ED1A630EFFBA7A /* SwiftLint.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -4276,7 +4280,7 @@
 		};
 		684562FE9230A5925BCF5ACAF0342496 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DB341684F2F48AE24DCA151ECC2C86D4 /* SwiftFormat.release.xcconfig */;
+			baseConfigurationReference = EBB04B121569067A57985E4FE295205B /* SwiftFormat.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -4293,7 +4297,7 @@
 		};
 		778E30284900C4FA2ED0C8A214CF2562 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DFB368D4F469CFFEDE97D532E253A068 /* AWSCognitoIdentityProviderASF.debug.xcconfig */;
+			baseConfigurationReference = 7A3745FA07AB86D670E8F463497DA121 /* AWSCognitoIdentityProviderASF.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4367,7 +4371,7 @@
 		};
 		BC7E0F1BEF5A94F0267AE13004488A0A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5F47A1D42B8B2FAD28D5AB97F44BB8F9 /* AWSCognitoIdentityProviderASF.release.xcconfig */;
+			baseConfigurationReference = 02AD342B30967821122292AE6868639E /* AWSCognitoIdentityProviderASF.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4390,6 +4394,42 @@
 				MODULEMAP_FILE = "Target Support Files/AWSCognitoIdentityProviderASF/AWSCognitoIdentityProviderASF.modulemap";
 				PRODUCT_MODULE_NAME = AWSCognitoIdentityProviderASF;
 				PRODUCT_NAME = AWSCognitoIdentityProviderASF;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		BF848F0D707191349682D4F048DCDE4C /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9439C729F9BFD63741282A364FC5A32E /* AWSMobileClient.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/AWSMobileClient/AWSMobileClient-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient.modulemap";
+				PRODUCT_MODULE_NAME = AWSMobileClient;
+				PRODUCT_NAME = AWSMobileClient;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
@@ -4440,42 +4480,6 @@
 			};
 			name = Release;
 		};
-		CF9B9DB58B7AC20019C25B753C394183 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C1E20A028FAC0FAFB1FADAEB12A370FF /* AWSMobileClient.release.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/AWSMobileClient/AWSMobileClient-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/AWSMobileClient/AWSMobileClient.modulemap";
-				PRODUCT_MODULE_NAME = AWSMobileClient;
-				PRODUCT_NAME = AWSMobileClient;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 		D250DB70F94A3DC2ABAE8CA80D0CEDCC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C8D22E6E639FD8B2AA18F007DEDB51F7 /* Pods-Amplify.debug.xcconfig */;
@@ -4516,7 +4520,7 @@
 		};
 		D9DD7470867AE463E701061C1DEA76AD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 72AAF4F216BB8E9BE91BFBFA3DCB2AA2 /* AWSAuthCore.release.xcconfig */;
+			baseConfigurationReference = 4D07B8F4B3BEAB4648898A034B91931D /* AWSAuthCore.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4616,7 +4620,7 @@
 		};
 		F24C3092108AA43B846E0CABE7E27376 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 01BB6268E3D1EC6B1989DED349F56779 /* CwlCatchException.release.xcconfig */;
+			baseConfigurationReference = BFC19B69A58D11D24120B5E24CCE1BCC /* CwlCatchException.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4745,20 +4749,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		6C1B0082F55622F61D55E4DF5F89B58D /* Build configuration list for PBXNativeTarget "AWSMobileClient" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				2C0A01629DCB8659CB2816A186C07E80 /* Debug */,
-				CF9B9DB58B7AC20019C25B753C394183 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		7C3B83A384027AAE79E0A6C8D268CC69 /* Build configuration list for PBXNativeTarget "Pods-AmplifyTestApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				018A6D71EC5BCAC6F0A37D87974E596D /* Debug */,
 				9DEEE6868679007B228157ABEE9989F3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8303AF580CB32D93D56CB25771284834 /* Build configuration list for PBXNativeTarget "AWSMobileClient" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4D2BD58136D99FDB2BF04058372CFDA8 /* Debug */,
+				BF848F0D707191349682D4F048DCDE4C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/356

*Description of changes:*
Ran `pod cache clean --all && pod install --repo-update` across all plugins after dependency update

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
