### PR TITLE
Fix DataStore E2E test - testCreateMutateDelete

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
@@ -68,25 +68,24 @@ extension SelectionSet {
         var result = [String]()
         let indent = indentSize == 0 ? "" : String(repeating: "  ", count: indentSize)
 
-        // Account for the root node,
-        if let name = value.name {
-            result.append(indent + name)
-        }
-
-        children.forEach { selectionSetField in
-            guard let name = selectionSetField.value.name else {
-                return
-            }
-
-            if !selectionSetField.children.isEmpty {
+        switch value.fieldType {
+        case .model, .pagination:
+            if let name = value.name {
                 result.append(indent + name + " {")
-                selectionSetField.children.forEach { innerSelectionSetField in
+                children.forEach { innerSelectionSetField in
                     result.append(innerSelectionSetField.stringValue(indentSize: indentSize + 1))
                 }
                 result.append(indent + "}")
             } else {
-                result.append(indent + name)
+                children.forEach { innerSelectionSetField in
+                    result.append(innerSelectionSetField.stringValue(indentSize: indentSize))
+                }
             }
+        case .value:
+            guard let name = value.name else {
+                return ""
+            }
+            result.append(indent + name)
         }
 
         return result.joined(separator: "\n    ")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
@@ -92,15 +92,16 @@ class SyncMutationToCloudOperation: Operation {
     func createAPIRequest(mutationType: GraphQLMutationType) -> GraphQLRequest<MutationSync<AnyModel>>? {
         let request: GraphQLRequest<MutationSync<AnyModel>>
         do {
-            let model = try mutationEvent.decodeModel()
             switch mutationType {
             case .delete:
                 request = GraphQLRequest<MutationSyncResult>.deleteMutation(modelName: mutationEvent.modelName,
-                                                                            id: model.id,
+                                                                            id: mutationEvent.modelId,
                                                                             version: mutationEvent.version)
             case .update:
+                let model = try mutationEvent.decodeModel()
                 request = GraphQLRequest<MutationSyncResult>.updateMutation(of: model, version: mutationEvent.version)
             case .create:
+                let model = try mutationEvent.decodeModel()
                 request = GraphQLRequest<MutationSyncResult>.createMutation(of: model, version: mutationEvent.version)
             }
         } catch {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/README.md
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/README.md
@@ -1,0 +1,32 @@
+## DataStore Integration Tests
+
+The following steps demonstrate how to set up DataStore with a conflict resolution enabled API through amplify CLI, with API key authentication mode. 
+
+
+### Set-up
+
+1. `amplify init` and choose `iOS` for type of app you are building
+
+2. Create the `schema.graphql` file in the same directory and use the schema from [AmplifyTestCommon](https://github.com/aws-amplify/amplify-ios/blob/master/AmplifyTestCommon/Models/schema.graphql)
+
+3. `amplify add api`
+
+```perl
+? Please select from one of the below mentioned services: `GraphQL`
+? Provide API name: `apiName`
+? Choose the default authorization type for the API `API key`
+? Enter a description for the API key:
+? After how many days from now the API key should expire (1-365): `365`
+? Do you want to configure advanced settings for the GraphQL API `Yes, I want to make some additional changes.`
+? Configure additional auth types? `No`
+? Configure conflict detection? `Yes`
+? Select the default resolution strategy `Auto Merge`
+? Do you have an annotated GraphQL schema? `Yes`
+? Provide your schema file path: `schema.graphql`
+```
+
+4. `amplify push`
+
+5. Copy `awsconfiguration.json` over to the Config folder
+
+You should now be able to run all of the tests 

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		0DA38963A6DD53AF9BCDFC68 /* Pods_AWSDataStoreCategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6CF3060AE9E227813325029F /* Pods_AWSDataStoreCategoryPlugin.framework */; };
 		1CB256DB1E49BBEF19B0DE8C /* Pods_AWSDataStoreCategoryPlugin_AWSDataStoreCategoryPluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 901B53EACEE953021704BB41 /* Pods_AWSDataStoreCategoryPlugin_AWSDataStoreCategoryPluginTests.framework */; };
 		2129BE4A23948A97006363A1 /* StorageAdapterMutationSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2129BE4923948A97006363A1 /* StorageAdapterMutationSyncTests.swift */; };
+		213481BF24213E14001966DE /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 213481BE24213E13001966DE /* README.md */; };
+		213481C5242140BE001966DE /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 213481C4242140BE001966DE /* amplifyconfiguration.json */; };
 		2149E5C52388684F00873955 /* StorageEngineBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5A82388684F00873955 /* StorageEngineBehavior.swift */; };
 		2149E5C62388684F00873955 /* StorageEngineAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5A92388684F00873955 /* StorageEngineAdapter.swift */; };
 		2149E5C72388684F00873955 /* StorageEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5AA2388684F00873955 /* StorageEngine.swift */; };
@@ -131,7 +133,6 @@
 		FAD2BDF6239583B2006EB065 /* TestModelRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD2BDF5239583B2006EB065 /* TestModelRegistration.swift */; };
 		FADD728F238B0F10005AA69A /* IncomingAsyncSubscriptionEventPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADD728E238B0F10005AA69A /* IncomingAsyncSubscriptionEventPublisher.swift */; };
 		FADD7291238B19CB005AA69A /* IncomingAsyncSubscriptionEventToAnyModelMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADD7290238B19CB005AA69A /* IncomingAsyncSubscriptionEventToAnyModelMapper.swift */; };
-		FAE414682399CD6300CE94C2 /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = FAE414672399CD6300CE94C2 /* amplifyconfiguration.json */; };
 		FAE4146A239AA2B700CE94C2 /* RemoteSyncReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE41469239AA2B700CE94C2 /* RemoteSyncReconcilerTests.swift */; };
 		FAE4146C239AA40600CE94C2 /* MockSQLiteStorageEngineAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE4146B239AA40600CE94C2 /* MockSQLiteStorageEngineAdapter.swift */; };
 		FAE4146F239AA71300CE94C2 /* EquatableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE4146E239AA71300CE94C2 /* EquatableExtensions.swift */; };
@@ -172,6 +173,8 @@
 /* Begin PBXFileReference section */
 		18669A1BE454F2AE676FBEA4 /* Pods-HostApp-AWSDataStoreCategoryPluginIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSDataStoreCategoryPluginIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSDataStoreCategoryPluginIntegrationTests/Pods-HostApp-AWSDataStoreCategoryPluginIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		2129BE4923948A97006363A1 /* StorageAdapterMutationSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAdapterMutationSyncTests.swift; sourceTree = "<group>"; };
+		213481BE24213E13001966DE /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		213481C4242140BE001966DE /* amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = amplifyconfiguration.json; sourceTree = "<group>"; };
 		2149E59B238867E100873955 /* AWSDataStoreCategoryPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSDataStoreCategoryPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2149E5A82388684F00873955 /* StorageEngineBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageEngineBehavior.swift; sourceTree = "<group>"; };
 		2149E5A92388684F00873955 /* StorageEngineAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageEngineAdapter.swift; sourceTree = "<group>"; };
@@ -308,7 +311,6 @@
 		FAD2BDF5239583B2006EB065 /* TestModelRegistration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModelRegistration.swift; sourceTree = "<group>"; };
 		FADD728E238B0F10005AA69A /* IncomingAsyncSubscriptionEventPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncomingAsyncSubscriptionEventPublisher.swift; sourceTree = "<group>"; };
 		FADD7290238B19CB005AA69A /* IncomingAsyncSubscriptionEventToAnyModelMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncomingAsyncSubscriptionEventToAnyModelMapper.swift; sourceTree = "<group>"; };
-		FAE414672399CD6300CE94C2 /* amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = amplifyconfiguration.json; sourceTree = "<group>"; };
 		FAE41469239AA2B700CE94C2 /* RemoteSyncReconcilerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSyncReconcilerTests.swift; sourceTree = "<group>"; };
 		FAE4146B239AA40600CE94C2 /* MockSQLiteStorageEngineAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSQLiteStorageEngineAdapter.swift; sourceTree = "<group>"; };
 		FAE4146E239AA71300CE94C2 /* EquatableExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableExtensions.swift; sourceTree = "<group>"; };
@@ -507,11 +509,12 @@
 		2149E61E23886CEE00873955 /* AWSDataStoreCategoryPluginIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
-				2149E62123886CEE00873955 /* Info.plist */,
+				FAE414662399CD0C00CE94C2 /* Config */,
 				FAB571412395A3E80006A5F8 /* DataStoreEndToEndTests.swift */,
+				2149E62123886CEE00873955 /* Info.plist */,
+				213481BE24213E13001966DE /* README.md */,
 				FA3841EA23889D6C0070AD5B /* SubscriptionEndToEndTests.swift */,
 				2149E62B23886D3900873955 /* SyncMetadataTests.swift */,
-				FAE414662399CD0C00CE94C2 /* Config */,
 				FAD2BDF7239583B5006EB065 /* TestSupport */,
 			);
 			path = AWSDataStoreCategoryPluginIntegrationTests;
@@ -720,7 +723,7 @@
 		FAE414662399CD0C00CE94C2 /* Config */ = {
 			isa = PBXGroup;
 			children = (
-				FAE414672399CD6300CE94C2 /* amplifyconfiguration.json */,
+				213481C4242140BE001966DE /* amplifyconfiguration.json */,
 			);
 			path = Config;
 			sourceTree = "<group>";
@@ -951,7 +954,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FAE414682399CD6300CE94C2 /* amplifyconfiguration.json in Resources */,
+				213481BF24213E14001966DE /* README.md in Resources */,
+				213481C5242140BE001966DE /* amplifyconfiguration.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
*Description of changes:*
`DataStoreEndToEndTests.testCreateMutateDelete` was broken for two reasons:
- SelectionSet string generation logic was incorrect, fixed with added unit test
- MutationEvent does not contain model for delete mutationTypes, and the id of the model should be retrieved from mutationEvent.modelId

This also adds a README for setting up the DataStore tests and made sure the tests are passing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
