### PR TITLE
Fix resuming outgoing mutation queue

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Action.swift
@@ -21,6 +21,7 @@ extension OutgoingMutationQueue {
         // Event loop
         case enqueuedEvent
         case processedEvent
+        case resumedSyncingToCloud
 
         // Terminal actions
         case receivedCancel
@@ -36,6 +37,8 @@ extension OutgoingMutationQueue {
                 return "initialized"
             case .processedEvent:
                 return "processedEvent"
+            case .resumedSyncingToCloud:
+                return "resumedSyncingToCloud"
             case .receivedCancel:
                 return "receivedCancel"
             case .receivedStart:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Resolver.swift
@@ -12,6 +12,7 @@ import Combine
 extension OutgoingMutationQueue {
 
     struct Resolver {
+        // swiftlint:disable cyclomatic_complexity
         static func resolve(currentState: State, action: Action) -> State {
             switch (currentState, action) {
 
@@ -22,6 +23,13 @@ extension OutgoingMutationQueue {
 
             case (.notStarted, .receivedStart(let api, let mutationEventPublisher)):
                 return .starting(api, mutationEventPublisher)
+            case (_, .receivedStart):
+                return .resumingMutationQueue
+
+            case (.resumingMutationQueue, .resumedSyncingToCloud):
+                return .resumed
+            case (.resumed, .processedEvent):
+                return .requestingEvent
 
             case (.starting, .receivedSubscription):
                 return .requestingEvent

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+State.swift
@@ -21,6 +21,8 @@ extension OutgoingMutationQueue {
         // Event loop
         case requestingEvent
         case waitingForEventToProcess
+        case resumingMutationQueue
+        case resumed
 
         // Terminal states
         case finished
@@ -42,6 +44,10 @@ extension OutgoingMutationQueue {
                 return "starting"
             case .waitingForEventToProcess:
                 return "waitingForEventToProcess"
+            case .resumingMutationQueue:
+                return "resumingMutationQueue"
+            case .resumed:
+                return "resumed"
             }
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -92,6 +92,9 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
         case .requestingEvent:
             requestEvent()
 
+        case .resumingMutationQueue:
+            resumeSyncingToCloud()
+
         case .inError(let error):
             // Maybe we have to notify the Hub?
             log.error(error: error)
@@ -99,10 +102,17 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
         case .notInitialized,
              .notStarted,
              .finished,
-             .waitingForEventToProcess:
+             .waitingForEventToProcess,
+             .resumed:
             break
         }
 
+    }
+
+    func resumeSyncingToCloud() {
+        log.verbose(#function)
+        operationQueue.isSuspended = false
+        stateMachine.notify(action: .resumedSyncingToCloud)
     }
 
     /// Responder method for `starting`. Starts the operation queue and subscribes to the publisher. Return actions:


### PR DESCRIPTION
I was thinking to destroying the operation that is responsible for sending the mutation event to the backend, and on resume re-reading it out of the local data store, but... I decided against that in the short term, as the changes seem to balloon pretty quickly.

I decided that it would be better just to fix the immediate bug first (e.g. ensure that the outgoing mutation queue gets resumed), and then take a step back to figure out if there's a better way to accomplish this (if needed)

Tested making a bunch of create mutations,
then going offline,
then made create mutations while offline
then go online (and check to make sure that the mutations are automatically sync'ed to the backend)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
