### PR TITLE
APIPlugin error deserialization with ConflictUnhandled errorType and model data

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		210DBC142332B3C6009B9E51 /* StorageGetURLOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210DBC132332B3C6009B9E51 /* StorageGetURLOperation.swift */; };
 		210DBC162332B3CB009B9E51 /* StorageDownloadDataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210DBC152332B3CB009B9E51 /* StorageDownloadDataOperation.swift */; };
 		210DBC472332F0C5009B9E51 /* StorageError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210DBC462332F0C5009B9E51 /* StorageError.swift */; };
+		210E789E2433A23600907486 /* AppSyncGraphQLError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210E789D2433A23600907486 /* AppSyncGraphQLError.swift */; };
 		2125E2542319EC3100B3DEB5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2125E2532319EC3100B3DEB5 /* AppDelegate.swift */; };
 		2125E2562319EC3100B3DEB5 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2125E2552319EC3100B3DEB5 /* ViewController.swift */; };
 		2125E2592319EC3100B3DEB5 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2125E2572319EC3100B3DEB5 /* Main.storyboard */; };
@@ -537,6 +538,7 @@
 		210DBC132332B3C6009B9E51 /* StorageGetURLOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageGetURLOperation.swift; sourceTree = "<group>"; };
 		210DBC152332B3CB009B9E51 /* StorageDownloadDataOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageDownloadDataOperation.swift; sourceTree = "<group>"; };
 		210DBC462332F0C5009B9E51 /* StorageError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageError.swift; sourceTree = "<group>"; };
+		210E789D2433A23600907486 /* AppSyncGraphQLError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSyncGraphQLError.swift; sourceTree = "<group>"; };
 		2125E20D2318CD3900B3DEB5 /* MockAWSMobileClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSMobileClient.swift; sourceTree = "<group>"; };
 		2125E2102318D73B00B3DEB5 /* awsconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = awsconfiguration.json; sourceTree = "<group>"; };
 		2125E2512319EC3000B3DEB5 /* AmplifyTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AmplifyTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1191,6 +1193,14 @@
 				210922562359693800CEC295 /* BasicAnalyticsEvent.swift */,
 			);
 			path = Event;
+			sourceTree = "<group>";
+		};
+		210E78A02436C68D00907486 /* API */ = {
+			isa = PBXGroup;
+			children = (
+				210E789D2433A23600907486 /* AppSyncGraphQLError.swift */,
+			);
+			path = API;
 			sourceTree = "<group>";
 		};
 		2125E2522319EC3100B3DEB5 /* AmplifyTestApp */ = {
@@ -1964,9 +1974,10 @@
 		FA131AAB2360FE070008381C /* AWSPluginsCore */ = {
 			isa = PBXGroup;
 			children = (
+				210E78A02436C68D00907486 /* API */,
+				FA131ACB2360FE470008381C /* Auth */,
 				FA131AAC2360FE070008381C /* AWSPluginsCore.h */,
 				FA131AAD2360FE070008381C /* Info.plist */,
-				FA131ACB2360FE470008381C /* Auth */,
 				2129BE0223947FA3006363A1 /* Model */,
 				6BBECD6F23ADA7C100C8DFBE /* ServiceConfiguration */,
 				2129BE3F23948909006363A1 /* Sync */,
@@ -3502,6 +3513,7 @@
 				21420A90237222A900FA140C /* APIKeyConfiguration.swift in Sources */,
 				219A887F23EB627100BBC5F2 /* ModelBasedGraphQLDocumentBuilder.swift in Sources */,
 				2129BE552395CAEF006363A1 /* PaginatedList.swift in Sources */,
+				210E789E2433A23600907486 /* AppSyncGraphQLError.swift in Sources */,
 				2129BE212394806B006363A1 /* ModelSchema+GraphQL.swift in Sources */,
 				212CE70B23E9E991007D8E71 /* ModelIdDecorator.swift in Sources */,
 				2129BE4223948924006363A1 /* MutationSync.swift in Sources */,

--- a/Amplify/Categories/API/Response/GraphQLError.swift
+++ b/Amplify/Categories/API/Response/GraphQLError.swift
@@ -6,23 +6,23 @@
 //
 
 /// The error format according to https://graphql.github.io/graphql-spec/June2018/#sec-Errors
-public struct GraphQLError: Decodable {
+public protocol GraphQLError: Decodable {
 
     /// Description of the error
-    public let message: String
+    var message: String { get }
 
     /// list of locations describing the syntax element
-    public let locations: [Location]?
+    var locations: [Location]? { get }
 
     /// Details the path of the response field with error. The values are either strings or 0-index integers
-    public let path: [JSONValue]?
+    var path: [JSONValue]? { get }
 
     /// Additional map of of errors
-    public let extensions: [String: JSONValue]?
+    var extensions: [String: JSONValue]? { get }
+}
 
-    /// Both `line` and `column` are positive numbers describing the beginning of an associated syntax element
-    public struct Location: Decodable {
-        public let line: Int
-        public let column: Int
-    }
+/// Both `line` and `column` are positive numbers describing the beginning of an associated syntax element
+public struct Location: Decodable {
+    public let line: Int
+    public let column: Int
 }

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
@@ -699,7 +699,6 @@
 		21D7A08B237B54D90057D00D /* AWSAPICategoryPlugin */ = {
 			isa = PBXGroup;
 			children = (
-				21D7A0DE237B54D90057D00D /* Info.plist */,
 				21D7A09A237B54D90057D00D /* AWSAPIPlugin.swift */,
 				21D7A098237B54D90057D00D /* AWSAPIPlugin+Configure.swift */,
 				21D7A0B1237B54D90057D00D /* AWSAPIPlugin+GraphQLBehavior.swift */,
@@ -712,6 +711,7 @@
 				21D7A0D1237B54D90057D00D /* AWSAPIPlugin+URLSessionBehaviorDelegate.swift */,
 				21D7A09B237B54D90057D00D /* AWSAPIPlugin+URLSessionDelegate.swift */,
 				21D7A093237B54D90057D00D /* Configuration */,
+				21D7A0DE237B54D90057D00D /* Info.plist */,
 				21D7A0D2237B54D90057D00D /* Interceptor */,
 				21D7A08C237B54D90057D00D /* Operation */,
 				6B2E465323AAA5000066EDCE /* Reachability */,

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncBasedTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncBasedTests.swift
@@ -12,6 +12,7 @@ import XCTest
 @testable import AWSAPICategoryPluginTestCommon
 import AWSPluginsCore
 
+// swiftlint:disable type_body_length
 class GraphQLSyncBasedTests: XCTestCase {
 
     static let amplifyConfiguration = "GraphQLSyncBasedTests-amplifyconfiguration"
@@ -280,11 +281,18 @@ class GraphQLSyncBasedTests: XCTestCase {
         case .failure(let error):
             switch error {
             case .error(let errors):
-                errors.forEach { error in
-                    if error.message.contains("conditional request failed") {
-                        conditionalFailedError.fulfill()
-                    }
+                XCTAssertEqual(errors.count, 1)
+                guard let error = errors.first,
+                    let appSyncGraphQLError = error as? AppSyncGraphQLError<MutationSync<AnyModel>>,
+                    let errorType = appSyncGraphQLError.appSyncErrorType else {
+                        XCTFail("Failed to get AppSyncGraphQLError and AppSyncErrorType")
+                        return
                 }
+                XCTAssertNotNil(errorType)
+                XCTAssertEqual(errorType, AppSyncErrorType.conditionalCheck)
+                XCTAssertNil(appSyncGraphQLError.data)
+                conditionalFailedError.fulfill()
+
             case .partial(let model, let errors):
                 XCTFail("partial: \(model), \(errors)")
             case .transformationError(let rawResponse, let apiError):
@@ -293,6 +301,96 @@ class GraphQLSyncBasedTests: XCTestCase {
         }
 
         wait(for: [conditionalFailedError], timeout: TestCommonConstants.networkTimeout)
+    }
+
+    // Given: A newly created post
+    // When: Call update mutation, with updated title and version 1, twice
+    // Then: The first mutation is successful, and second returns conflict unhandled exception due to older version.
+    func testCreatePostThenUpdateTwiceWithConflictUnhandledException() {
+        let uuid = UUID().uuidString
+        let testMethodName = String("\(#function)".dropLast(2))
+        let title = testMethodName + "Title"
+        let post = Post.keys
+        guard let createdPost = createPost(id: uuid, title: title) else {
+            XCTFail("Failed to create post with version 1")
+            return
+        }
+        let updatedTitle = title + "Updated"
+        let modifiedPost = Post(id: createdPost.model["id"] as? String ?? "",
+                                title: updatedTitle,
+                                content: createdPost.model["content"] as? String ?? "",
+                                createdAt: Date())
+        let firstUpdateSuccess = expectation(description: "first update mutation should be successful")
+
+        let request = GraphQLRequest<MutationSyncResult>.updateMutation(of: modifiedPost,
+                                                                        version: 1)
+        _ = Amplify.API.mutate(request: request) { event in
+            switch event {
+            case .completed(let graphQLResponse):
+                firstUpdateSuccess.fulfill()
+            case .failed(let apiError):
+                XCTFail("\(apiError)")
+            default:
+                XCTFail("Could not get data back")
+            }
+        }
+        wait(for: [firstUpdateSuccess], timeout: TestCommonConstants.networkTimeout)
+
+        var responseFromOperation: GraphQLResponse<MutationSync<AnyModel>>?
+        let secondUpdateFailed = expectation(
+            description: "second update mutatiion request should failed with ConflictUnhandled errorType")
+
+        _ = Amplify.API.mutate(request: request) { event in
+            defer {
+                secondUpdateFailed.fulfill()
+            }
+            switch event {
+            case .completed(let graphQLResponse):
+                responseFromOperation = graphQLResponse
+            case .failed(let apiError):
+                XCTFail("\(apiError)")
+            default:
+                XCTFail("Could not get data back")
+            }
+        }
+        wait(for: [secondUpdateFailed], timeout: TestCommonConstants.networkTimeout)
+
+        guard let response = responseFromOperation else {
+            XCTAssertNotNil(responseFromOperation)
+            return
+        }
+
+        let conflictUnhandledError = expectation(description: "error should be conditional request failed")
+        switch response {
+        case .success(let mutationSync):
+            XCTFail("success: \(mutationSync)")
+        case .failure(let error):
+            switch error {
+            case .error(let errors):
+                XCTAssertEqual(errors.count, 1)
+                guard let error = errors.first,
+                    let appSyncGraphQLError = error as? AppSyncGraphQLError<MutationSync<AnyModel>>,
+                    let errorType = appSyncGraphQLError.appSyncErrorType else {
+                        XCTFail("Failed to get AppSyncGraphQLError's AppSyncErrorType and response object")
+                        return
+                }
+                XCTAssertEqual(errorType, AppSyncErrorType.conflictUnhandled)
+                guard let mutationSync = appSyncGraphQLError.data else {
+                    XCTFail("Failed to get data object for conflict unhandled error")
+                    return
+                }
+                XCTAssertEqual(mutationSync.model["title"] as? String, updatedTitle)
+                XCTAssertEqual(mutationSync.model["content"] as? String, createdPost.model["content"] as? String)
+                XCTAssertEqual(mutationSync.syncMetadata.version, 2)
+                conflictUnhandledError.fulfill()
+            case .partial(let model, let errors):
+                XCTFail("partial: \(model), \(errors)")
+            case .transformationError(let rawResponse, let apiError):
+                XCTFail("transformationError: \(rawResponse), \(apiError)")
+            }
+        }
+
+        wait(for: [conflictUnhandledError], timeout: TestCommonConstants.networkTimeout)
     }
 
     // Given: Two newly created posts

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLSyncBased/README.md
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLSyncBased/README.md
@@ -19,7 +19,7 @@ The following steps demonstrate how to set up an GraphQL endpoint with AppSync t
 ? Do you want to configure advanced settings for the GraphQL API `Yes, I want to make some additional changes.`
 ? Configure additional auth types? `No`
 ? Configure conflict detection? `Yes`
-? Select the default resolution strategy `Auto Merge`
+? Select the default resolution strategy `Optimistic Concurrency`
 ? Do you want to override default per model settings? `No`
 ? Do you have an annotated GraphQL schema? `Yes`
 ? Provide your schema file path: `schema.graphql`

--- a/AmplifyPlugins/Core/AWSPluginsCore/API/AppSyncGraphQLError.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/API/AppSyncGraphQLError.swift
@@ -1,0 +1,83 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+
+/// Error object returned from AppSync services
+public class AppSyncGraphQLError<ResponseType: Decodable>: GraphQLError {
+    public var message: String
+
+    public var locations: [Location]?
+
+    public var path: [JSONValue]?
+
+    public var extensions: [String: JSONValue]?
+
+    public var errorType: String?
+
+    public var data: ResponseType?
+
+    public init(message: String,
+                locations: [Location]? = nil,
+                path: [JSONValue]? = nil,
+                extensions: [String: JSONValue]? = nil,
+                errorType: String? = nil,
+                data: ResponseType? = nil) {
+        self.message = message
+        self.locations = locations
+        self.path = path
+        self.extensions = extensions
+        self.errorType = errorType
+        self.data = data
+    }
+}
+
+extension AppSyncGraphQLError {
+    /// Convenient method for parsing `errorType` into one of AppSync's error types
+    public var appSyncErrorType: AppSyncErrorType? {
+        guard let errorType = self.errorType else { return nil }
+
+        return AppSyncErrorType(value: errorType)
+    }
+}
+
+/// Efficient way to check common AppSync error types
+public enum AppSyncErrorType: Equatable {
+
+    private static let conditionalCheckFailedErrorString = "ConditionalCheckFailedException"
+    private static let conflictUnhandledErrorString = "ConflictUnhandled"
+
+    /// Conflict detection finds a version mismatch and the conflict handler rejects the mutation.
+    /// See https://docs.aws.amazon.com/appsync/latest/devguide/conflict-detection-and-sync.html for more information
+    case conflictUnhandled
+
+    case conditionalCheck
+
+    case unknown(String)
+
+    init(value: String) {
+        switch value {
+        case AppSyncErrorType.conditionalCheckFailedErrorString:
+            self = .conditionalCheck
+        case AppSyncErrorType.conflictUnhandledErrorString:
+            self = .conflictUnhandled
+        default:
+            self = .unknown(value)
+        }
+    }
+
+    var rawValue: String {
+        switch self {
+        case .conditionalCheck:
+            return AppSyncErrorType.conditionalCheckFailedErrorString
+        case .conflictUnhandled:
+            return AppSyncErrorType.conflictUnhandledErrorString
+        case .unknown(let value):
+            return value
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
@@ -47,7 +47,12 @@ class ProcessMutationErrorFromCloudOperation: Operation {
             // TODO: Check for 'ConflictUnhandled', execute conflict handler configurated
 
             let hasConditionalRequestFailed = graphQLErrors.contains { (error) -> Bool in
-                error.message.contains("conditional request failed")
+                if let appSyncError = error as? AppSyncGraphQLError<MutationSync<AnyModel>>,
+                    let errorType = appSyncError.appSyncErrorType {
+                    return errorType == .conditionalCheck
+                }
+
+                return false
             }
 
             if hasConditionalRequestFailed {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -40,10 +40,9 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
         }
         let post1 = Post(title: "post1", content: "content1", createdAt: Date())
         let mutationEvent = try MutationEvent(model: post1, mutationType: .create)
-        let graphQLError = GraphQLError(message: "conditional request failed",
-                                  locations: nil,
-                                  path: nil,
-                                  extensions: nil)
+        let graphQLError = AppSyncGraphQLError<MutationSync<AnyModel>>(
+            message: "conditional request failed",
+            errorType: AppSyncErrorType.conditionalCheck.rawValue)
         let graphQLResponseError = GraphQLResponseError<MutationSync<AnyModel>>.error([graphQLError])
 
         let operation = ProcessMutationErrorFromCloudOperation(mutationEvent: mutationEvent,

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -494,9 +494,9 @@
 			children = (
 				B9FAA141238C6082009414B4 /* BaseDataStoreTests.swift */,
 				FA4A955A239AD3F4008E876E /* Foundation+TestExtensions.swift */,
+				FAF101A62398807100D5ECC9 /* Mocks */,
 				FAC010F1239570D300FCE7BB /* SyncEngineTestBase.swift */,
 				FA4B8E952391C609009FC10F /* XCTest+AmplifyExtensions.swift */,
-				FAF101A62398807100D5ECC9 /* Mocks */,
 			);
 			path = TestSupport;
 			sourceTree = "<group>";


### PR DESCRIPTION
*Description of changes:*
- This keeps the Amplify's GraphQLError generic by making it a protocol, such that any GraphQL Plugin continues to implement their own conformance to GraphQLError.
- The AmplifyPluginsCore contains a new AppSync specific class for deserializing the AppSync's graphQL errors into `AppSyncGraphQLError`.
- Provide some conveient methods for getting the errorType: `AppSyncErrorType`
- This work is mostly for propagating AppSync's conflict unhandled errors back to DataStore for conflict resolution handling. common use case for developers using API Plugin may cast to AppSyncGraphQLError if needed for additional fields like errorType string and data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
