### PR TITLE
Rest of changes to make amplify-tools work

### DIFF
--- a/Amplify.podspec
+++ b/Amplify.podspec
@@ -22,12 +22,22 @@ Pod::Spec.new do |s|
   
   s.requires_arc = true
   s.source_files = 'Amplify/**/*.swift'
+  s.default_subspec = 'Default'
+  
+  s.subspec 'Default' do |default|
+    default.preserve_path = 'AmplifyTools'
+    default.script_phase = {
+      :name => 'Default',
+      :script => 'echo "no-op"',
+      :execution_position => :before_compile
+    }
+  end
 
   s.subspec 'Tools' do |ss|
-    ss.source_files = 'AmplifyTools/amplify-tools.sh'
+    ss.preserve_path = 'AmplifyTools'
     ss.script_phase = {
-      :name => 'Amplify',
-      :script => '"${PODS_ROOT}/Amplify/AmplifyTools/amplify-tools.sh"',
+      :name => 'AmplifyTools',
+      :script => 'mkdir -p ${PODS_ROOT}/AmplifyTools; cp -vf "${PODS_TARGET_SRCROOT}/AmplifyTools/amplify-tools.sh" ${PODS_ROOT}/AmplifyTools/.',
       :execution_position => :before_compile
     }
   end

--- a/AmplifyTools/amplify-tools.sh
+++ b/AmplifyTools/amplify-tools.sh
@@ -7,7 +7,6 @@
 
 set -e
 export PATH=$PATH:$(npm bin -g)
-cd ..
 
 if ! which node >/dev/null; then
   echo "warning: Node is not installed. Vist https://nodejs.org/en/download/ to install it"


### PR DESCRIPTION
Updates based on @drochetti 's PR with regards to making amplify tools work in the amplify-ios package.

If end-user apps want to use amplify tools they need to.
1.  pod init
2.  add the following to their pod file:
```
  pod 'Amplify'
  pod 'Amplify/Tools'
```
3.  run
```
pod install --repo-update
```
4. open the project
```
xed .
```
5.  Add the following as a build step to their project.  For example
![addRunScript](https://user-images.githubusercontent.com/1911939/78309871-0f47c400-7501-11ea-902f-d0d1f4fa8163.png)

6. Build the project via xcode (cmd +b)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
