### PR TITLE
0.11.0 Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 
 defaults: &defaults
   macos:
-    xcode: "11.2.1"
+    xcode: "11.4.0"
   working_directory: ~/amplify-ios
   environment:
       BUNDLE_PATH: vendor/bundle
@@ -157,13 +157,10 @@ jobs:
       - *restore_repo
       - restore_gems
       - check_bundle
-      # - run:
-      #     name: Bump pod versions
-      #     command: bundle exec fastlane bump_podspecs_patch
       - run:
           name: Release pods
           command: bundle exec fastlane release_pods
-
+          no_output_timeout: 20m
 
 workflows:
   build_test_deploy:

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,5 +1,5 @@
 module: Amplify
-module_version: 0.9.0
+module_version: 0.11.0
 author: Amazon Web Services
 github_url: https://github.com/aws-amplify/amplify-ios
 

--- a/AWSPluginsCore.podspec
+++ b/AWSPluginsCore.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
 
   s.name         = 'AWSPluginsCore'
-  s.version      = '0.10.0'
+  s.version      = '0.11.0'
   s.summary      = 'Amazon Web Services Amplify for iOS.'
 
   s.description  = 'AWS Amplify for iOS provides a declarative library for application development using cloud services'
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   AWS_SDK_VERSION = "~> 2.13.0"
 
   s.source_files = 'AmplifyPlugins/Core/AWSPluginsCore/**/*.swift'
-  s.dependency 'Amplify', '0.10.0'
+  s.dependency 'Amplify', '0.11.0'
   s.dependency 'AWSMobileClient', AWS_SDK_VERSION
 
 end

--- a/AWSPredictionsPlugin.podspec
+++ b/AWSPredictionsPlugin.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name         = 'AWSPredictionsPlugin'
-    s.version      = '0.10.0'
+    s.version      = '0.11.0'
     s.summary      = 'Amazon Web Services Amplify for iOS.'
   
     s.description  = 'AWS Amplify for iOS provides a declarative library for application development using cloud services'
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     s.requires_arc = true
 
     AWS_SDK_VERSION = '~> 2.13.0'
-    AMPLIFY_VERSION = '0.10.0'
+    AMPLIFY_VERSION = '0.11.0'
     
     s.source_files = 'AmplifyPlugins/Predictions/AWSPredictionsPlugin/**/*.swift'
     s.dependency 'AWSComprehend', AWS_SDK_VERSION

--- a/Amplify.podspec
+++ b/Amplify.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
 
   s.name         = 'Amplify'
-  s.version      = '0.10.0'
+  s.version      = '0.11.0'
   s.summary      = 'Amazon Web Services Amplify for iOS.'
 
   s.description  = 'AWS Amplify for iOS provides a declarative library for application development using cloud services'

--- a/Amplify/Info.plist
+++ b/Amplify/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyFunctionalTests/Info.plist
+++ b/AmplifyFunctionalTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/AmplifyPlugins.podspec
+++ b/AmplifyPlugins.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
 
   s.name         = 'AmplifyPlugins'
-  s.version      = '0.10.0'
+  s.version      = '0.11.0'
   s.summary      = 'Amazon Web Services Amplify for iOS.'
 
   s.description  = 'AWS Amplify for iOS provides a declarative library for application development using cloud services'
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true 
 
   AWS_SDK_VERSION = '~> 2.13.0'
-  AMPLIFY_VERSION = '0.10.0'
+  AMPLIFY_VERSION = '0.11.0'
   
   s.subspec 'AWSAPIPlugin' do |ss|
     ss.source_files = 'AmplifyPlugins/API/AWSAPICategoryPlugin/**/*.swift'

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Info.plist
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Resources/Info.plist
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Resources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyPlugins/Core/AWSPluginsCore/Info.plist
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -12,7 +12,7 @@ public class AmplifyAWSServiceConfiguration: AWSServiceConfiguration {
     override public class func baseUserAgent() -> String! {
         //TODO: Retrieve this version from a centralized location:
         //https://github.com/aws-amplify/amplify-ios/issues/276
-        let version = "0.10.0"
+        let version = "0.11.0"
         let sdkName = "amplify-iOS"
         let systemName = UIDevice.current.systemName.replacingOccurrences(of: " ", with: "-")
         let systemVersion = UIDevice.current.systemVersion

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Info.plist
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/Info.plist
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Resources/Info.plist
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Resources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Resources/Info.plist
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Resources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Resources/Info.plist
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Resources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyTestApp/Info.plist
+++ b/AmplifyTestApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/AmplifyTestCommon.podspec
+++ b/AmplifyTestCommon.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "AmplifyTestCommon"
-  spec.version      = "0.10.0"
+  spec.version      = "0.11.0"
   spec.summary      = "Test resources used by different targets"
   spec.description  = "Provides different test resources and mock methods"
 
@@ -22,10 +22,10 @@ Pod::Spec.new do |spec|
   spec.requires_arc = true
 
   spec.source_files = 'AmplifyTestCommon/**/*.swift'
-  spec.dependency 'Amplify', '0.10.0'
+  spec.dependency 'Amplify', '0.11.0'
 
   spec.subspec 'AWSPluginsTestCommon' do |subspec|
     subspec.source_files = 'AmplifyPlugins/Core/AWSPluginsTestCommon/**/*.swift'
-    spec.dependency 'AWSPluginsCore', '0.10.0'
+    spec.dependency 'AWSPluginsCore', '0.11.0'
   end
 end

--- a/AmplifyTestCommon/Info.plist
+++ b/AmplifyTestCommon/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyTests/Info.plist
+++ b/AmplifyTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/CoreMLPredictionsPlugin.podspec
+++ b/CoreMLPredictionsPlugin.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = 'CoreMLPredictionsPlugin'
-  s.version      = '0.10.0'
+  s.version      = '0.11.0'
   s.summary      = 'Amazon Web Services Amplify for iOS.'
 
   s.description  = 'AWS Amplify for iOS provides a declarative library for application development using cloud services'
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   
   s.requires_arc = true
   s.source_files = 'AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/**/*.swift'
-  s.dependency 'Amplify', '0.10.0'
+  s.dependency 'Amplify', '0.11.0'
 
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,6 +21,8 @@ COCOAPODS_PUSH_WAIT_TIME = 600
 
 pods = [
   {spec: "Amplify.podspec", sleep: true},
+  # AmplifyPlugins depends on AWSPluginsCore, but skipping the sleep here
+  # since there's one after CoreMLPredictionsPlugin
   {spec: "AWSPluginsCore.podspec", sleep: false},
   {spec: "CoreMLPredictionsPlugin.podspec", sleep: true},
   {spec: "AWSPredictionsPlugin.podspec", sleep: false},

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,27 +17,28 @@ opt_out_usage
 
 default_platform(:ios)
 
+COCOAPODS_PUSH_WAIT_TIME = 6
+
 pods = [
-  "Amplify.podspec",
-  "AWSPluginsCore.podspec",
-  "CoreMLPredictionsPlugin.podspec",
-  "AWSPredictionsPlugin.podspec",
-  "AmplifyPlugins.podspec"
+  {spec: "Amplify.podspec", sleep: true},
+  {spec: "AWSPluginsCore.podspec", sleep: false},
+  {spec: "CoreMLPredictionsPlugin.podspec", sleep: true},
+  {spec: "AWSPredictionsPlugin.podspec", sleep: false},
+  {spec: "AmplifyPlugins.podspec", sleep: false}
 ]
 
 platform :ios do
-  desc "Bump pod versions"
-  lane :bump_podspecs_patch do
-
-    pods.each { |pod| version_bump_podspec(path: pod, bump_type: "patch") }
-
-  end
-
   desc "Release pods"
   lane :release_pods do
 
     pods.each { |pod|
-      pod_push(path: pod, allow_warnings: true, swift_version: "5.1")
+      UI.message("Pushing pod #{pod[:spec]}")
+      pod_push(path: pod[:spec], allow_warnings: true, swift_version: "5.1")
+      if pod[:sleep]
+        UI.message("Sleeping for #{COCOAPODS_PUSH_WAIT_TIME}s")
+        sleep COCOAPODS_PUSH_WAIT_TIME
+      end
+      
       Actions.sh('pod repo update')
     }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,7 @@ opt_out_usage
 
 default_platform(:ios)
 
-COCOAPODS_PUSH_WAIT_TIME = 6
+COCOAPODS_PUSH_WAIT_TIME = 600
 
 pods = [
   {spec: "Amplify.podspec", sleep: true},


### PR DESCRIPTION
* Adding `sleep` for 10 mins in between dependent pods. This is a temporary measure, as the CocoaPods team now have a [PR](https://github.com/CocoaPods/cocoapods-trunk/pull/147) for allowing pushing pods straight to the git repo (circumventing the CDN, which will obviate the need for the delay between pushes)

* Bump versions to 0.11.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
