### PR TITLE
Pass instance of DataStoreConfiguration through Datastore

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -70,7 +70,7 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
     public func configure(using configuration: Any) throws {
         modelRegistration.registerModels(registry: ModelRegistry.self)
         resolveSyncEnabled()
-        try resolveStorageEngine()
+        try resolveStorageEngine(dataStoreConfiguration: self.configuration)
 
         try storageEngine.setUp(models: ModelRegistry.models)
 
@@ -92,7 +92,7 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
             if #available(iOS 13.0, *) {
                 self.dataStorePublisher = DataStorePublisher()
             }
-            try resolveStorageEngine()
+            try resolveStorageEngine(dataStoreConfiguration: configuration)
             try storageEngine.setUp(models: ModelRegistry.models)
             storageEngine.startSync()
         } catch {
@@ -100,12 +100,12 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
         }
     }
 
-    func resolveStorageEngine() throws {
+    func resolveStorageEngine(dataStoreConfiguration: DataStoreConfiguration) throws {
         guard storageEngine == nil else {
             return
         }
 
-        storageEngine = try StorageEngine(isSyncEnabled: isSyncEnabled)
+        storageEngine = try StorageEngine(isSyncEnabled: isSyncEnabled, dataStoreConfiguration: dataStoreConfiguration)
         if #available(iOS 13.0, *) {
             setupStorageSink()
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -13,9 +13,8 @@ import AWSPluginsCore
 final class StorageEngine: StorageEngineBehavior {
     // TODO: Make this private once we get a mutation flow that passes the type of mutation as needed
     let storageAdapter: StorageEngineAdapter
-
+    private let dataStoreConfiguration: DataStoreConfiguration
     private var syncEngine: RemoteSyncEngineBehavior?
-
     private weak var api: APICategoryGraphQLBehavior?
 
     var iSyncEngineSink: Any?
@@ -62,25 +61,32 @@ final class StorageEngine: StorageEngineBehavior {
     // Internal initializer used for testing, to allow lazy initialization of the SyncEngine. Note that the provided
     // storageAdapter must have already been set up with system models
     init(storageAdapter: StorageEngineAdapter,
+         dataStoreConfiguration: DataStoreConfiguration,
          syncEngine: RemoteSyncEngineBehavior?) {
         self.storageAdapter = storageAdapter
+        self.dataStoreConfiguration = dataStoreConfiguration
         self.syncEngine = syncEngine
     }
 
-    convenience init(isSyncEnabled: Bool) throws {
+    convenience init(isSyncEnabled: Bool, dataStoreConfiguration: DataStoreConfiguration) throws {
         let key = kCFBundleNameKey as String
         let databaseName = Bundle.main.object(forInfoDictionaryKey: key) as? String
         let storageAdapter = try SQLiteStorageEngineAdapter(databaseName: databaseName ?? "app")
 
         try storageAdapter.setUp(models: StorageEngine.systemModels)
         if #available(iOS 13.0, *) {
-            let syncEngine = isSyncEnabled ? try? RemoteSyncEngine(storageAdapter: storageAdapter) : nil
-            self.init(storageAdapter: storageAdapter, syncEngine: syncEngine)
+            let syncEngine = isSyncEnabled ? try? RemoteSyncEngine(storageAdapter: storageAdapter,
+                                                                   dataStoreConfiguration: dataStoreConfiguration) : nil
+            self.init(storageAdapter: storageAdapter,
+                      dataStoreConfiguration: dataStoreConfiguration,
+                      syncEngine: syncEngine)
             self.storageEnginePublisher = PassthroughSubject<StorageEngineEvent, DataStoreError>()
             sinkEngineSink = syncEngine?.publisher.sink(receiveCompletion: onReceiveCompletion(receiveCompletion:),
                                                         receiveValue: onReceive(receiveValue:))
         } else {
-            self.init(storageAdapter: storageAdapter, syncEngine: nil)
+            self.init(storageAdapter: storageAdapter,
+                      dataStoreConfiguration: dataStoreConfiguration,
+                      syncEngine: nil)
         }
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -15,6 +15,7 @@ final class InitialSyncOperation: AsynchronousOperation {
     private weak var api: APICategoryGraphQLBehavior?
     private weak var reconciliationQueue: IncomingEventReconciliationQueue?
     private weak var storageAdapter: StorageEngineAdapter?
+    private let dataStoreConfiguration: DataStoreConfiguration
 
     private let modelType: Model.Type
     private let completion: AWSInitialSyncOrchestrator.SyncOperationResultHandler
@@ -25,11 +26,13 @@ final class InitialSyncOperation: AsynchronousOperation {
          api: APICategoryGraphQLBehavior?,
          reconciliationQueue: IncomingEventReconciliationQueue?,
          storageAdapter: StorageEngineAdapter?,
+         dataStoreConfiguration: DataStoreConfiguration,
          completion: @escaping AWSInitialSyncOrchestrator.SyncOperationResultHandler) {
         self.modelType = modelType
         self.api = api
         self.reconciliationQueue = reconciliationQueue
         self.storageAdapter = storageAdapter
+        self.dataStoreConfiguration = dataStoreConfiguration
         self.completion = completion
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
@@ -15,13 +15,17 @@ protocol InitialSyncOrchestrator {
 // For testing
 @available(iOS 13.0, *)
 typealias InitialSyncOrchestratorFactory =
-    (APICategoryGraphQLBehavior?, IncomingEventReconciliationQueue?, StorageEngineAdapter?) -> InitialSyncOrchestrator
+    (DataStoreConfiguration,
+    APICategoryGraphQLBehavior?,
+    IncomingEventReconciliationQueue?,
+    StorageEngineAdapter?) -> InitialSyncOrchestrator
 
 @available(iOS 13.0, *)
 final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
     typealias SyncOperationResult = Result<Void, DataStoreError>
     typealias SyncOperationResultHandler = (SyncOperationResult) -> Void
 
+    private let dataStoreConfiguration: DataStoreConfiguration
     private weak var api: APICategoryGraphQLBehavior?
     private weak var reconciliationQueue: IncomingEventReconciliationQueue?
     private weak var storageAdapter: StorageEngineAdapter?
@@ -34,9 +38,11 @@ final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
     // interdependencies
     private let syncOperationQueue: OperationQueue
 
-    init(api: APICategoryGraphQLBehavior?,
+    init(dataStoreConfiguration: DataStoreConfiguration,
+         api: APICategoryGraphQLBehavior?,
          reconciliationQueue: IncomingEventReconciliationQueue?,
          storageAdapter: StorageEngineAdapter?) {
+        self.dataStoreConfiguration = dataStoreConfiguration
         self.api = api
         self.reconciliationQueue = reconciliationQueue
         self.storageAdapter = storageAdapter
@@ -91,6 +97,7 @@ final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
                                                        api: api,
                                                        reconciliationQueue: reconciliationQueue,
                                                        storageAdapter: storageAdapter,
+                                                       dataStoreConfiguration: dataStoreConfiguration,
                                                        completion: syncOperationCompletion)
 
         syncOperationQueue.addOperation(initialSyncForModel)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
@@ -67,8 +67,10 @@ extension APICategoryDependencyTests {
         storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
         try storageAdapter.setUp(models: StorageEngine.systemModels)
 
-        let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter)
+        let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
+                                              dataStoreConfiguration: .default)
         let storageEngine = StorageEngine(storageAdapter: storageAdapter,
+                                          dataStoreConfiguration: .default,
                                           syncEngine: syncEngine)
 
         let dataStorePublisher = DataStorePublisher()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -47,7 +47,8 @@ class InitialSyncOperationTests: XCTestCase {
             modelType: MockSynced.self,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
-            storageAdapter: storageAdapter) { _ in }
+            storageAdapter: storageAdapter,
+            dataStoreConfiguration: .default) { _ in }
 
         operation.main()
 
@@ -81,7 +82,8 @@ class InitialSyncOperationTests: XCTestCase {
             modelType: MockSynced.self,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
-            storageAdapter: storageAdapter) { _ in }
+            storageAdapter: storageAdapter,
+            dataStoreConfiguration: .default) { _ in }
 
         operation.main()
 
@@ -114,7 +116,8 @@ class InitialSyncOperationTests: XCTestCase {
             modelType: MockSynced.self,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
-            storageAdapter: storageAdapter) { _ in
+            storageAdapter: storageAdapter,
+            dataStoreConfiguration: .default) { _ in
                 syncCallbackReceived.fulfill()
         }
 
@@ -155,7 +158,8 @@ class InitialSyncOperationTests: XCTestCase {
             modelType: MockSynced.self,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
-            storageAdapter: storageAdapter) { _ in }
+            storageAdapter: storageAdapter,
+            dataStoreConfiguration: .default) { _ in }
 
         operation.main()
 
@@ -203,7 +207,8 @@ class InitialSyncOperationTests: XCTestCase {
             modelType: MockSynced.self,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
-            storageAdapter: storageAdapter) { _ in }
+            storageAdapter: storageAdapter,
+            dataStoreConfiguration: .default) { _ in }
 
         operation.main()
 
@@ -237,7 +242,8 @@ class InitialSyncOperationTests: XCTestCase {
             modelType: MockSynced.self,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
-            storageAdapter: storageAdapter) { _ in
+            storageAdapter: storageAdapter,
+            dataStoreConfiguration: .default) { _ in
                 syncCallbackReceived.fulfill()
         }
 
@@ -297,7 +303,8 @@ class InitialSyncOperationTests: XCTestCase {
             modelType: MockSynced.self,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
-            storageAdapter: storageAdapter) {_ in }
+            storageAdapter: storageAdapter,
+            dataStoreConfiguration: .default) {_ in }
 
         operation.main()
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
@@ -43,7 +43,8 @@ class InitialSyncOrchestratorTests: XCTestCase {
         let reconciliationQueue = MockReconciliationQueue()
 
         let orchestrator: InitialSyncOrchestrator =
-            AWSInitialSyncOrchestrator(api: apiPlugin,
+            AWSInitialSyncOrchestrator(dataStoreConfiguration: .default,
+                                       api: apiPlugin,
                                        reconciliationQueue: reconciliationQueue,
                                        storageAdapter: storageAdapter)
 
@@ -88,7 +89,8 @@ class InitialSyncOrchestratorTests: XCTestCase {
         let reconciliationQueue = MockReconciliationQueue()
 
         let orchestrator: InitialSyncOrchestrator =
-            AWSInitialSyncOrchestrator(api: apiPlugin,
+            AWSInitialSyncOrchestrator(dataStoreConfiguration: .default,
+                                       api: apiPlugin,
                                        reconciliationQueue: reconciliationQueue,
                                        storageAdapter: storageAdapter)
 
@@ -139,7 +141,8 @@ class InitialSyncOrchestratorTests: XCTestCase {
         let reconciliationQueue = MockReconciliationQueue()
 
         let orchestrator: InitialSyncOrchestrator =
-            AWSInitialSyncOrchestrator(api: apiPlugin,
+            AWSInitialSyncOrchestrator(dataStoreConfiguration: .default,
+                                       api: apiPlugin,
                                        reconciliationQueue: reconciliationQueue,
                                        storageAdapter: storageAdapter)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
@@ -36,16 +36,18 @@ class LocalSubscriptionTests: XCTestCase {
             stateMachine = MockStateMachine(initialState: .notStarted, resolver: RemoteSyncEngine.Resolver.resolve(currentState:action:))
 
             let syncEngine = RemoteSyncEngine(storageAdapter: storageAdapter,
-                                             outgoingMutationQueue: outgoingMutationQueue,
-                                             mutationEventIngester: mutationDatabaseAdapter,
-                                             mutationEventPublisher: awsMutationEventPublisher,
-                                             initialSyncOrchestratorFactory: NoOpInitialSyncOrchestrator.factory,
-                                             reconciliationQueueFactory: MockAWSIncomingEventReconciliationQueue.factory,
-                                             stateMachine: stateMachine,
-                                             networkReachabilityPublisher: nil,
-                                             requestRetryablePolicy: MockRequestRetryablePolicy())
+                                              dataStoreConfiguration: .default,
+                                              outgoingMutationQueue: outgoingMutationQueue,
+                                              mutationEventIngester: mutationDatabaseAdapter,
+                                              mutationEventPublisher: awsMutationEventPublisher,
+                                              initialSyncOrchestratorFactory: NoOpInitialSyncOrchestrator.factory,
+                                              reconciliationQueueFactory: MockAWSIncomingEventReconciliationQueue.factory,
+                                              stateMachine: stateMachine,
+                                              networkReachabilityPublisher: nil,
+                                              requestRetryablePolicy: MockRequestRetryablePolicy())
 
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
+                                          dataStoreConfiguration: .default,
                                           syncEngine: syncEngine)
         } catch {
             XCTFail(String(describing: error))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
@@ -37,9 +37,11 @@ class AWSMutationEventIngesterTests: XCTestCase {
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
             try storageAdapter.setUp(models: StorageEngine.systemModels)
 
-            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter)
+            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
+                                                  dataStoreConfiguration: .default)
 
             let storageEngine = StorageEngine(storageAdapter: storageAdapter,
+                                              dataStoreConfiguration: .default,
                                               syncEngine: syncEngine)
 
             let publisher = DataStorePublisher()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
@@ -40,8 +40,10 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
             try storageAdapter.setUp(models: StorageEngine.systemModels)
 
-            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter)
+            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
+                                                  dataStoreConfiguration: .default)
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
+                                          dataStoreConfiguration: .default,
                                           syncEngine: syncEngine)
         } catch {
             XCTFail(String(describing: error))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSyncEngineTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSyncEngineTests.swift
@@ -31,6 +31,7 @@ class RemoteSyncEngineTests: XCTestCase {
         mockRequestRetryablePolicy = MockRequestRetryablePolicy()
         do {
             remoteSyncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
+                                                    dataStoreConfiguration: .default,
                                                     outgoingMutationQueue: mockOutgoingMutationQueue,
                                                     initialSyncOrchestratorFactory: MockAWSInitialSyncOrchestrator.factory,
                                                     reconciliationQueueFactory: MockAWSIncomingEventReconciliationQueue.factory,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
@@ -33,8 +33,10 @@ class BaseDataStoreTests: XCTestCase {
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
             try storageAdapter.setUp(models: StorageEngine.systemModels)
 
-            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter)
+            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
+                                                  dataStoreConfiguration: .default)
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
+                                          dataStoreConfiguration: .default,
                                           syncEngine: syncEngine)
         } catch {
             XCTFail(String(describing: error))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSInitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSInitialSyncOrchestrator.swift
@@ -14,8 +14,11 @@ import Combine
 @testable import AWSDataStoreCategoryPlugin
 
 class MockAWSInitialSyncOrchestrator: InitialSyncOrchestrator {
-    static let factory: InitialSyncOrchestratorFactory = { api, reconciliationQueue, storageAdapter in
-        MockAWSInitialSyncOrchestrator(api: api, reconciliationQueue: reconciliationQueue, storageAdapter: storageAdapter)
+    static let factory: InitialSyncOrchestratorFactory = { dataStoreConfiguration, api, reconciliationQueue, storageAdapter in
+        MockAWSInitialSyncOrchestrator(dataStoreConfiguration: dataStoreConfiguration,
+                                       api: api,
+                                       reconciliationQueue: reconciliationQueue,
+                                       storageAdapter: storageAdapter)
     }
 
     typealias SyncOperationResult = Result<Void, DataStoreError>
@@ -24,7 +27,8 @@ class MockAWSInitialSyncOrchestrator: InitialSyncOrchestrator {
     private static var instance: MockAWSInitialSyncOrchestrator?
     private static var mockedResponse: SyncOperationResult?
 
-    init(api: APICategoryGraphQLBehavior?,
+    init(dataStoreConfiguration: DataStoreConfiguration,
+         api: APICategoryGraphQLBehavior?,
          reconciliationQueue: IncomingEventReconciliationQueue?,
          storageAdapter: StorageEngineAdapter?) {
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/NoOpInitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/NoOpInitialSyncOrchestrator.swift
@@ -9,7 +9,7 @@
 @testable import AWSDataStoreCategoryPlugin
 
 struct NoOpInitialSyncOrchestrator: InitialSyncOrchestrator {
-    static let factory: InitialSyncOrchestratorFactory = { _, _, _ in
+    static let factory: InitialSyncOrchestratorFactory = { _, _, _, _ in
         NoOpInitialSyncOrchestrator()
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -80,6 +80,7 @@ class SyncEngineTestBase: XCTestCase {
                                     resolver: RemoteSyncEngine.Resolver.resolve(currentState:action:))
 
         syncEngine = RemoteSyncEngine(storageAdapter: storageAdapter,
+                                      dataStoreConfiguration: .default,
                                       outgoingMutationQueue: mutationQueue,
                                       mutationEventIngester: mutationDatabaseAdapter,
                                       mutationEventPublisher: awsMutationEventPublisher,
@@ -104,6 +105,7 @@ class SyncEngineTestBase: XCTestCase {
         })
 
         let storageEngine = StorageEngine(storageAdapter: storageAdapter,
+                                          dataStoreConfiguration: .default,
                                           syncEngine: syncEngine)
 
         let publisher = DataStorePublisher()


### PR DESCRIPTION
Sending out draft PR since branch feature/datastore-config has not been pushed yet.

- Basic infrastructure changes to pass datastoreconfiguration through datastore 
- added default conflict handler to datastore configuration 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
