### PR TITLE
fix: Bug where subscription connections happen at the same time

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -67,7 +67,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         let awsMutationEventPublisher = AWSMutationEventPublisher(eventSource: mutationDatabaseAdapter)
         let outgoingMutationQueue = outgoingMutationQueue ?? OutgoingMutationQueue()
         let reconciliationQueueFactory = reconciliationQueueFactory ??
-            AWSIncomingEventReconciliationQueue.init(modelTypes:api:storageAdapter:)
+            AWSIncomingEventReconciliationQueue.init(modelTypes:api:storageAdapter:modelReconciliationQueueFactory:)
         let initialSyncOrchestratorFactory = initialSyncOrchestratorFactory ??
             AWSInitialSyncOrchestrator.init(dataStoreConfiguration:api:reconciliationQueue:storageAdapter:)
         let stateMachine = stateMachine ?? StateMachine(initialState: .notStarted,
@@ -231,7 +231,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
                                          storageAdapter: StorageEngineAdapter) {
         log.debug(#function)
         let syncableModelTypes = ModelRegistry.models.filter { $0.schema.isSyncable }
-        reconciliationQueue = reconciliationQueueFactory(syncableModelTypes, api, storageAdapter)
+        reconciliationQueue = reconciliationQueueFactory(syncableModelTypes, api, storageAdapter, nil)
         reconciliationQueueSink = reconciliationQueue?.publisher.sink(
             receiveCompletion: onReceiveCompletion(receiveCompletion:),
             receiveValue: onReceive(receiveValue:))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -13,13 +13,13 @@ import Foundation
 //Used for testing:
 @available(iOS 13.0, *)
 typealias IncomingEventReconciliationQueueFactory =
-    ([Model.Type], APICategoryGraphQLBehavior, StorageEngineAdapter) -> IncomingEventReconciliationQueue
+    ([Model.Type], APICategoryGraphQLBehavior, StorageEngineAdapter, ModelReconciliationQueueFactory?) -> IncomingEventReconciliationQueue
 
 @available(iOS 13.0, *)
 final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue {
 
-    static let factory: IncomingEventReconciliationQueueFactory = { modelTypes, api, storageAdapter in
-        AWSIncomingEventReconciliationQueue(modelTypes: modelTypes, api: api, storageAdapter: storageAdapter)
+    static let factory: IncomingEventReconciliationQueueFactory = { modelTypes, api, storageAdapter, _ in
+        AWSIncomingEventReconciliationQueue(modelTypes: modelTypes, api: api, storageAdapter: storageAdapter, modelReconciliationQueueFactory: nil)
     }
     private var modelReconciliationQueueSinks: [String: AnyCancellable]
 
@@ -28,21 +28,27 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
         return eventReconciliationQueueTopic.eraseToAnyPublisher()
     }
 
+    private let connectionStatusSerialQueue: DispatchQueue
     private var reconciliationQueues: [String: ModelReconciliationQueue]
     private var reconciliationQueueConnectionStatus: [String: Bool]
+    private var modelReconciliationQueueFactory: ModelReconciliationQueueFactory
 
     init(modelTypes: [Model.Type],
          api: APICategoryGraphQLBehavior,
-         storageAdapter: StorageEngineAdapter) {
+         storageAdapter: StorageEngineAdapter,
+         modelReconciliationQueueFactory: ModelReconciliationQueueFactory? = nil) {
         self.modelReconciliationQueueSinks = [:]
         self.eventReconciliationQueueTopic = PassthroughSubject<IncomingEventReconciliationQueueEvent, DataStoreError>()
         self.reconciliationQueues = [:]
         self.reconciliationQueueConnectionStatus = [:]
+        self.modelReconciliationQueueFactory = modelReconciliationQueueFactory ??
+            AWSModelReconciliationQueue.init(modelType:storageAdapter:api:incomingSubscriptionEvents:)
+        //TODO: Add target for SyncEngine system to help prevent thread explosion and increase performance
+        // https://github.com/aws-amplify/amplify-ios/issues/399
+        self.connectionStatusSerialQueue = DispatchQueue(label: "com.amazonaws.DataStore.AWSIncomingEventReconciliationQueue")
         for modelType in modelTypes {
             let modelName = modelType.modelName
-            let queue = AWSModelReconciliationQueue(modelType: modelType,
-                                                    storageAdapter: storageAdapter,
-                                                    api: api)
+            let queue = self.modelReconciliationQueueFactory(modelType, storageAdapter, api, nil)
             guard reconciliationQueues[modelName] == nil else {
                 Amplify.DataStore.log
                     .warn("Duplicate model name found: \(modelName), not subscribing")
@@ -75,7 +81,9 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
     }
 
     private func onReceiveCompletion(completed: Subscribers.Completion<DataStoreError>) {
-        reconciliationQueueConnectionStatus = [:]
+        connectionStatusSerialQueue.async {
+            self.reconciliationQueueConnectionStatus = [:]
+        }
         switch completed {
         case .failure(let error):
             eventReconciliationQueueTopic.send(completion: .failure(error))
@@ -89,9 +97,11 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
         case .mutationEvent(let event):
             eventReconciliationQueueTopic.send(.mutationEvent(event))
         case .connected(let modelName):
-            reconciliationQueueConnectionStatus[modelName] = true
-            if reconciliationQueueConnectionStatus.count == reconciliationQueues.count {
-                eventReconciliationQueueTopic.send(.initialized)
+            connectionStatusSerialQueue.async {
+                self.reconciliationQueueConnectionStatus[modelName] = true
+                if self.reconciliationQueueConnectionStatus.count == self.reconciliationQueues.count {
+                    self.eventReconciliationQueueTopic.send(.initialized)
+                }
             }
         default:
             break
@@ -101,8 +111,10 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
     func cancel() {
         modelReconciliationQueueSinks.values.forEach { $0.cancel() }
         reconciliationQueues.values.forEach { $0.cancel()}
-        reconciliationQueues = [:]
-        modelReconciliationQueueSinks = [:]
+        connectionStatusSerialQueue.async {
+            self.reconciliationQueues = [:]
+            self.modelReconciliationQueueSinks = [:]
+        }
     }
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -10,6 +10,11 @@ import AWSPluginsCore
 import Combine
 import Foundation
 
+//Used for testing:
+@available(iOS 13.0, *)
+typealias ModelReconciliationQueueFactory =
+    (Model.Type, StorageEngineAdapter, APICategoryGraphQLBehavior, IncomingSubscriptionEventPublisher?) -> ModelReconciliationQueue
+
 /// A queue of reconciliation operations, merged from incoming subscription events and responses to locally-sourced
 /// mutations for a single model type.
 ///

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -1,0 +1,75 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSPluginsCore
+@testable import AWSDataStoreCategoryPlugin
+
+
+class AWSIncomingEventReconciliationQueueTests: XCTestCase {
+    var storageAdapter: MockSQLiteStorageEngineAdapter!
+    var apiPlugin: MockAPICategoryPlugin!
+
+    override func setUp() {
+        MockModelReconciliationQueue.reset()
+        storageAdapter = MockSQLiteStorageEngineAdapter()
+        storageAdapter.returnOnQuery(dataStoreResult: .none)
+        storageAdapter.returnOnSave(dataStoreResult: .none)
+
+        apiPlugin = MockAPICategoryPlugin()
+
+    }
+    var operationQueue: OperationQueue!
+
+    //This test case attempts to hit a race condition, and may be required to execute multiple times
+    // in order to demonstrate the bug
+    func testTwoConnectionStatusUpdatesAtSameTime() {
+        let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
+
+        let modelReconciliationQueueFactory
+            = MockModelReconciliationQueue.init(modelType:storageAdapter:api:incomingSubscriptionEvents:)
+        let eventQueue = AWSIncomingEventReconciliationQueue(
+            modelTypes: [Post.self, Comment.self],
+            api: apiPlugin,
+            storageAdapter: storageAdapter,
+            modelReconciliationQueueFactory: modelReconciliationQueueFactory)
+        eventQueue.start()
+
+        let eventSync = eventQueue.publisher.sink(receiveCompletion: { _ in
+            XCTFail("Not expecting this to call")
+        }, receiveValue: { event  in
+            switch event {
+            case .initialized:
+                expectInitialized.fulfill()
+            default:
+                XCTFail("Should not expect any other state")
+            }
+        })
+
+        operationQueue = OperationQueue()
+        operationQueue.name = "com.amazonaws.DataStore.UnitTestQueue"
+        operationQueue.maxConcurrentOperationCount = 2
+        operationQueue.underlyingQueue = DispatchQueue.global()
+        operationQueue.isSuspended = true
+
+        let reconciliationQueues = MockModelReconciliationQueue.mockModelReconciliationQueues
+        for (queueName, queue) in reconciliationQueues {
+            let cancellableOperation = CancelAwareBlockOperation {
+                queue.modelReconciliationQueueSubject.send(.connected(queueName))
+            }
+            operationQueue.addOperation(cancellableOperation)
+        }
+        operationQueue.isSuspended = false
+        waitForExpectations(timeout: 2)
+
+    }
+}
+

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockModelReconciliatinQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockModelReconciliatinQueue.swift
@@ -1,0 +1,52 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Combine
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSPluginsCore
+@testable import AWSDataStoreCategoryPlugin
+class MockModelReconciliationQueue: ModelReconciliationQueue {
+
+    public static var mockModelReconciliationQueues: [String: MockModelReconciliationQueue] = [:]
+
+    private let modelType: Model.Type
+    let modelReconciliationQueueSubject: PassthroughSubject<ModelReconciliationQueueEvent, DataStoreError>
+    var publisher: AnyPublisher<ModelReconciliationQueueEvent, DataStoreError> {
+        return modelReconciliationQueueSubject.eraseToAnyPublisher()
+    }
+
+    init(modelType: Model.Type,
+         storageAdapter: StorageEngineAdapter?,
+         api: APICategoryGraphQLBehavior,
+         incomingSubscriptionEvents: IncomingSubscriptionEventPublisher? = nil) {
+        self.modelReconciliationQueueSubject = PassthroughSubject<ModelReconciliationQueueEvent, DataStoreError>()
+        self.modelType = modelType
+        MockModelReconciliationQueue.mockModelReconciliationQueues[modelType.modelName] = self
+    }
+
+    func start() {
+        //no-op
+    }
+    func pause() {
+        //no-op
+    }
+
+    func cancel() {
+        //no-op
+    }
+
+    func enqueue(_ remoteModel: MutationSync<AnyModel>) {
+        //no-op
+    }
+
+    static func reset() {
+        MockModelReconciliationQueue.mockModelReconciliationQueues = [:]
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
@@ -13,7 +13,7 @@ import Combine
 @testable import AWSDataStoreCategoryPlugin
 
 class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue {
-    static let factory: IncomingEventReconciliationQueueFactory = { modelTypes, api, storageAdapter in
+    static let factory: IncomingEventReconciliationQueueFactory = { modelTypes, api, storageAdapter, _ in
         MockAWSIncomingEventReconciliationQueue(modelTypes: modelTypes, api: api, storageAdapter: storageAdapter)
     }
     let incomingEventSubject: PassthroughSubject<IncomingEventReconciliationQueueEvent, DataStoreError>

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		6B4693E923A5645F006BE2C5 /* MutationRetryNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4693E823A5645F006BE2C5 /* MutationRetryNotifier.swift */; };
 		6B4E3DF42397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E3DF32397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift */; };
 		6B4E3DF62397327E00AD962B /* MockStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E3DF52397327E00AD962B /* MockStateMachine.swift */; };
+		6B52DC94244784FC007F5AD3 /* AWSIncomingEventReconciliationQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B52DC93244784FC007F5AD3 /* AWSIncomingEventReconciliationQueueTests.swift */; };
+		6B52DC9624478E75007F5AD3 /* MockModelReconciliatinQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B52DC9524478E75007F5AD3 /* MockModelReconciliatinQueue.swift */; };
 		6B64027923E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B64027823E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift */; };
 		6B64027B23E38B9900001FD7 /* MockOutgoingMutationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */; };
 		6B91DEBF238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */; };
@@ -241,6 +243,8 @@
 		6B4693E823A5645F006BE2C5 /* MutationRetryNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationRetryNotifier.swift; sourceTree = "<group>"; };
 		6B4E3DF32397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingMutationQueueTestsWithMockStateMachine.swift; sourceTree = "<group>"; };
 		6B4E3DF52397327E00AD962B /* MockStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStateMachine.swift; sourceTree = "<group>"; };
+		6B52DC93244784FC007F5AD3 /* AWSIncomingEventReconciliationQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSIncomingEventReconciliationQueueTests.swift; sourceTree = "<group>"; };
+		6B52DC9524478E75007F5AD3 /* MockModelReconciliatinQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockModelReconciliatinQueue.swift; sourceTree = "<group>"; };
 		6B64027823E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSIncomingEventReconciliationQueue.swift; sourceTree = "<group>"; };
 		6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOutgoingMutationQueue.swift; sourceTree = "<group>"; };
 		6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcileAndLocalSaveOperationTests.swift; sourceTree = "<group>"; };
@@ -732,6 +736,7 @@
 		FAE01F9B23997C3700B468DA /* SubscriptionSync */ = {
 			isa = PBXGroup;
 			children = (
+				6B52DC93244784FC007F5AD3 /* AWSIncomingEventReconciliationQueueTests.swift */,
 				FA4A9556239ACAD7008E876E /* ModelReconciliationQueueBehaviorTests.swift */,
 				FAABC224239B1B3500740F9F /* ModelReconciliationDeleteTests.swift */,
 				6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */,
@@ -756,6 +761,7 @@
 				FAE4146B239AA40600CE94C2 /* MockSQLiteStorageEngineAdapter.swift */,
 				FA4A955C239AD810008E876E /* MockSQLiteStorageEngineAdapterResponders.swift */,
 				FAABC226239B1B9100740F9F /* ReconciliationQueueTestBase.swift */,
+				6B52DC9524478E75007F5AD3 /* MockModelReconciliatinQueue.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -1359,10 +1365,12 @@
 				FAE4146A239AA2B700CE94C2 /* RemoteSyncReconcilerTests.swift in Sources */,
 				2149E5FE238869CF00873955 /* RemoteSyncAPIInvocationTests.swift in Sources */,
 				B9FAA142238C6082009414B4 /* BaseDataStoreTests.swift in Sources */,
+				6B52DC9624478E75007F5AD3 /* MockModelReconciliatinQueue.swift in Sources */,
 				FA4A955B239AD3F4008E876E /* Foundation+TestExtensions.swift in Sources */,
 				6B64027B23E38B9900001FD7 /* MockOutgoingMutationQueue.swift in Sources */,
 				2149E600238869CF00873955 /* SQLiteStorageEngineAdapterTests.swift in Sources */,
 				21B3AD27242BB58000C7E1DA /* ProcessMutationErrorFromCloudOperationTests.swift in Sources */,
+				6B52DC94244784FC007F5AD3 /* AWSIncomingEventReconciliationQueueTests.swift in Sources */,
 				6B4E3DF62397327E00AD962B /* MockStateMachine.swift in Sources */,
 				FAF5287B2399814F0053A717 /* MockReconciliationQueue.swift in Sources */,
 			);


### PR DESCRIPTION
Prior to this fix, the crash looked something like this:

Seems like a race condition, where both subscription connections are coming in very quick succession, and somehow we are getting into a read/write race condition with `reconciliationQueueConnectionStatus` inside of `AWSIncomingEventReconciliationQueue`.

To reproduce this issue, you can remove the `connectionStatusOperationQueue.async` and run the unit test in `AWSIncomingEventReconciliationQueueTests` to see a very similar segfault:
```
2020-04-09 17:42:10.082784-0700 SampleDataStore[92033:19843535] [IncomingAsyncSubscriptionEventToAnyModelMapper] connectionState now connected
2020-04-09 17:42:10.082807-0700 SampleDataStore[92033:19843493] [IncomingAsyncSubscriptionEventToAnyModelMapper] connectionState now connected
2020-04-09 17:42:10.083090-0700 SampleDataStore[92033:19843535] -[__NSCFNumber count]: unrecognized selector sent to instance 0x8000000000000000
2020-04-09 17:42:10.103774-0700 SampleDataStore[92033:19843535] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[__NSCFNumber count]: unrecognized selector sent to instance 0x8000000000000000'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff23c7127e __exceptionPreprocess + 350
	1   libobjc.A.dylib                     0x00007fff513fbb20 objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff23c91fd4 -[NSObject(NSObject) doesNotRecognizeSelector:] + 132
	3   CoreFoundation                      0x00007fff23c75c4c ___forwarding___ + 1436
	4   CoreFoundation                      0x00007fff23c77f78 _CF_forwarding_prep_0 + 120
	5   libswiftCore.dylib                  0x00007fff5191b813 $sSD8_VariantV8setValue_6forKeyyq_n_xtF + 147
	6   libswiftCore.dylib                  0x00007fff51b10c6d $sSDyq_SgxcisTf4ngn_n + 301
	7   libswiftCore.dylib                  0x00007fff518eb7a2 $sSDyq_Sgxcis + 18
	8   AmplifyPlugins                      0x000000010e0732b5 $s14AmplifyPlugins35AWSIncomingEventReconciliationQueueC14onReceiveValue33_6BCE524E5F5E68D42C91D7334411AD0BLL07receiveI0yAA05ModelefD0O_tF + 757
	9   Combine                             0x00007fff23337433 $s7Combine11SubscribersO4SinkC7receiveyAC6DemandVxF + 35
	10  Combine                             0x00007fff23337670 $s7Combine11SubscribersO4SinkCy_xq_GAA10SubscriberA2aGP7receiveyAC6DemandV5InputQzFTW + 16
	11  Combine                             0x00007fff23337bb3 $s7Combine16AnySubscriberBoxC7receiveyAA11SubscribersO6DemandV5InputQzF + 35
	12  Combine                             0x00007fff23342f10 $s7Combine18PassthroughSubjectC7Conduit33_A517F1CF3C35FD924691D71B0A4E0FAFLLC5offeryyxF + 160
	13  Combine                             0x00007fff23342e08 $s7Combine18PassthroughSubjectC4sendyyxF + 168
	14  AmplifyPlugins                      0x000000010e079083 $s14AmplifyPlugins27AWSModelReconciliationQueueC7receive33_3FE212790B4B53CA8F25F1F4642C80CFLLyyAA034IncomingSubscriptionEventPublisherR0OF + 659
	15  AmplifyPlugins                      0x000000010e078c92 $s14AmplifyPlugins27AWSModelReconciliationQueueC9modelType14storageAdapter3api26incomingSubscriptionEventsAC0A05Model_pXp_AA013StorageEngineI0_pSgAH26APICategoryGraphQLBehavior_pAA08IncomingL14EventPublisher_pSgtcfcyAA0tluvU0OcfU0_ + 242
	16  Combine                             0x00007fff23337433 $s7Combine11SubscribersO4SinkC7receiveyAC6DemandVxF + 35
	17  Combine                             0x00007fff23337670 $s7Combine11SubscribersO4SinkCy_xq_GAA10SubscriberA2aGP7receiveyAC6DemandV5InputQzFTW + 16
	18  Combine                             0x00007fff23337bb3 $s7Combine16AnySubscriberBoxC7receiveyAA11SubscribersO6DemandV5InputQzF + 35
	19  Combine                             0x00007fff23342f10 $s7Combine18PassthroughSubjectC7Conduit33_A517F1CF3C35FD924691D71B0A4E0FAFLLC5offeryyxF + 160
	20  Combine                             0x00007fff23342e08 $s7Combine18PassthroughSubjectC4sendyyxF + 168
	21  AmplifyPlugins                      0x000000010e076093 $s14AmplifyPlugins37AWSIncomingSubscriptionEventPublisherC9onReceive33_050B108B990E83D57A3F0C1939BA23AALL12receiveValueyAA013IncomingAsyncdE0O_tF + 371
	22  Combine                             0x00007fff23337433 $s7Combine11SubscribersO4SinkC7receiveyAC6DemandVxF + 35
	23  Combine                             0x00007fff23337670 $s7Combine11SubscribersO4SinkCy_xq_GAA10SubscriberA2aGP7receiveyAC6DemandV5InputQzFTW + 16
	24  Combine                             0x00007fff23337bb3 $s7Combine16AnySubscriberBoxC7receiveyAA11SubscribersO6DemandV5InputQzF + 35
	25  Combine                             0x00007fff23342f10 $s7Combine18PassthroughSubjectC7Conduit33_A517F1CF3C35FD924691D71B0A4E0FAFLLC5offeryyxF + 160
	26  Combine                             0x00007fff23342e08 $s7Combine18PassthroughSubjectC4sendyyxF + 168
	27  AmplifyPlugins                      0x000000010e0a320e $s14AmplifyPlugins46IncomingAsyncSubscriptionEventToAnyModelMapperC7dispose33_0E4FA60B4937AFAF7EB35F5A08F28826LL2ofy0A00eF0Oys6ResultOy14AWSPluginsCore12MutationSyncVyAG0hI0VGAG20GraphQLResponseErrorOyAQGGG_tF + 798
	28  AmplifyPlugins                      0x000000010e0a2b8f $s14AmplifyPlugins46IncomingAsyncSubscriptionEventToAnyModelMapperC7receivey7Combine11SubscribersO6DemandV0A00dF0OyAJ0eF0Oys6ResultOy14AWSPluginsCore12MutationSyncVyAJ0hI0VGAJ20GraphQLResponseErrorOyAVGGGytAJ8APIErrorOGF + 1327
	29  AmplifyPlugins                      0x000000010e0a4340 $s14AmplifyPlugins46IncomingAsyncSubscriptionEventToAnyModelMapperC7Combine10SubscriberAadEP7receiveyAD11SubscribersO6DemandV5InputQzFTW + 16
	30  Combine                             0x00007fff23337bb3 $s7Combine16AnySubscriberBoxC7receiveyAA11SubscribersO6DemandV5InputQzF + 35
	31  Combine                             0x00007fff23342f10 $s7Combine18PassthroughSubjectC7Conduit33_A517F1CF3C35FD924691D71B0A4E0FAFLLC5offeryyxF + 160
	32  Combine                             0x00007fff23342e08 $s7Combine18PassthroughSubjectC4sendyyxF + 168
	33  AmplifyPlugins                      0x000000010e0a0259 $s14AmplifyPlugins39IncomingAsyncSubscriptionEventPublisherC014sendConnectionF11IfConnected5eventy0A00dF0OyAF0eF0Oys6ResultOy14AWSPluginsCore12MutationSyncVyAF8AnyModelVGAF20GraphQLResponseErrorOyARGGGytAF8APIErrorOG_tF + 121
	34  AmplifyPlugins                      0x000000010e0a05e2 $s14AmplifyPlugins39IncomingAsyncSubscriptionEventPublisherC23onUpdateListenerHandler5eventy0A00dF0OyAF0eF0Oys6ResultOy14AWSPluginsCore12MutationSyncVyAF8AnyModelVGAF20GraphQLResponseErrorOyARGGGytAF8APIErrorOG_tFyycfU_ + 130
	35  AmplifyPlugins                      0x000000010e08bfba $s14AmplifyPlugins25CancelAwareBlockOperationC4mainyyF + 154
	36  AmplifyPlugins                      0x000000010e08bffb $s14AmplifyPlugins25CancelAwareBlockOperationC4mainyyFTo + 43
	37  Foundation                          0x00007fff25755bd6 __NSOPERATION_IS_INVOKING_MAIN__ + 17
	38  Foundation                          0x00007fff25751e49 -[NSOperation start] + 731
	39  Foundation                          0x00007fff25756530 __NSOPERATIONQUEUE_IS_STARTING_AN_OPERATION__ + 17
	40  Foundation                          0x00007fff2575603a __NSOQSchedule_f + 182
	41  libdispatch.dylib                   0x000000010e5f43c9 _dispatch_block_async_invoke2 + 83
	42  libdispatch.dylib                   0x000000010e5e5d48 _dispatch_client_callout + 8
	43  libdispatch.dylib                   0x000000010e5e86ba _dispatch_continuation_pop + 552
	44  libdispatch.dylib                   0x000000010e5e7ac5 _dispatch_async_redirect_invoke + 849
	45  libdispatch.dylib                   0x000000010e5f728c _dispatch_root_queue_drain + 351
	46  libdispatch.dylib                   0x000000010e5f7b96 _dispatch_worker_thread2 + 132
	47  libsystem_pthread.dylib             0x00007fff5245f6b3 _pthread_wqthread + 583
	48  libsystem_pthread.dylib             0x00007fff5245f3fd start_wqthread + 13
)
libc++abi.dylib: terminating with uncaught exception of type NSException
(lldb)
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
