### PR TITLE
Mark outgoing mutation as inProcess if nextEventPromise exists

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
@@ -202,7 +202,11 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
               completionPromise: @escaping Future<MutationEvent, DataStoreError>.Promise) {
 
         log.verbose("\(#function) mutationEvent: \(mutationEvent)")
-        storageAdapter.save(mutationEvent, condition: nil) { result in
+        var eventToPersist = mutationEvent
+        if nextEventPromise != nil {
+            eventToPersist.inProcess = true
+        }
+        storageAdapter.save(eventToPersist, condition: nil) { result in
             switch result {
             case .failure(let dataStoreError):
                 self.log.verbose("\(#function): Error saving mutation event: \(dataStoreError)")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
