### PR TITLE
feat: analytics updates API improvements (unregisterGlobalProperties)

### DIFF
--- a/Amplify/Categories/Analytics/AnalyticsCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Analytics/AnalyticsCategory+ClientBehavior.swift
@@ -18,7 +18,7 @@ extension AnalyticsCategory: AnalyticsCategoryBehavior {
         plugin.record(eventWithName: eventName)
     }
 
-    public func registerGlobalProperties(_ properties: [String: AnalyticsPropertyValue]) {
+    public func registerGlobalProperties(_ properties: AnalyticsProperties) {
         plugin.registerGlobalProperties(properties)
     }
 
@@ -36,5 +36,18 @@ extension AnalyticsCategory: AnalyticsCategoryBehavior {
 
     public func disable() {
         plugin.disable()
+    }
+}
+
+/// Methods that wrap `AnalyticsCategoryBehavior` to provides additional useful calling patterns
+extension AnalyticsCategory {
+
+    /// Registered global properties can be unregistered though this method. In case no keys are provided, *all*
+    /// registered global properties will be unregistered. Duplicate keys will be ignored. This method can be called
+    /// from `Amplify.Analytics` and is a wrapper for `unregisterGlobalProperties(_ keys: Set<String>? = nil)`
+    ///
+    /// - Parameter keys: one or more of property names to unregister
+    public func unregisterGlobalProperties(_ keys: String...) {
+        plugin.unregisterGlobalProperties(keys.isEmpty ? nil : Set<String>(keys))
     }
 }

--- a/Amplify/Categories/Analytics/AnalyticsCategoryBehavior.swift
+++ b/Amplify/Categories/Analytics/AnalyticsCategoryBehavior.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+public typealias AnalyticsProperties = [String: AnalyticsPropertyValue]
+
 /// Behavior of the Analytics category that clients will use
 public protocol AnalyticsCategoryBehavior {
 
@@ -33,7 +35,7 @@ public protocol AnalyticsCategoryBehavior {
     /// name when calling `record`. Examples of global properties would be `selectedPlan`, `campaignSource`
     ///
     /// - Parameter properties: The dictionary of property name to property values
-    func registerGlobalProperties(_ properties: [String: AnalyticsPropertyValue])
+    func registerGlobalProperties(_ properties: AnalyticsProperties)
 
     /// Registered global properties can be unregistered though this method. In case no keys are provided, *all*
     /// registered global properties will be unregistered.

--- a/Amplify/Categories/Analytics/AnalyticsProfile.swift
+++ b/Amplify/Categories/Analytics/AnalyticsProfile.swift
@@ -23,13 +23,13 @@ public struct AnalyticsUserProfile {
     public var location: Location?
 
     /// Properties of the user profile
-    public var properties: [String: AnalyticsPropertyValue]?
+    public var properties: AnalyticsProperties?
 
     public init(name: String? = nil,
                 email: String? = nil,
                 plan: String? = nil,
                 location: Location?,
-                properties: [String: AnalyticsPropertyValue]? = nil) {
+                properties: AnalyticsProperties? = nil) {
         self.name = name
         self.email = email
         self.plan = plan

--- a/Amplify/Categories/Analytics/Event/AnalyticsEvent.swift
+++ b/Amplify/Categories/Analytics/Event/AnalyticsEvent.swift
@@ -13,5 +13,5 @@ public protocol AnalyticsEvent {
     var name: String { get }
 
     // Properties of the event
-    var properties: [String: AnalyticsPropertyValue]? { get }
+    var properties: AnalyticsProperties? { get }
 }

--- a/Amplify/Categories/Analytics/Event/BasicAnalyticsEvent.swift
+++ b/Amplify/Categories/Analytics/Event/BasicAnalyticsEvent.swift
@@ -13,10 +13,10 @@ public struct BasicAnalyticsEvent: AnalyticsEvent {
     public var name: String
 
     /// Properties of the event
-    public var properties: [String: AnalyticsPropertyValue]?
+    public var properties: AnalyticsProperties?
 
-    public init(_ name: String,
-                properties: [String: AnalyticsPropertyValue]? = nil) {
+    public init(name: String,
+                properties: AnalyticsProperties? = nil) {
         self.name = name
         self.properties = properties
     }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+ClientBehavior.swift
@@ -62,7 +62,7 @@ extension AWSPinpointAnalyticsPlugin {
     }
 
     public func record(eventWithName eventName: String) {
-        let event = BasicAnalyticsEvent(eventName)
+        let event = BasicAnalyticsEvent(name: eventName)
         record(event: event)
     }
 

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginIntergrationTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginIntergrationTests.swift
@@ -198,7 +198,7 @@ class AWSPinpointAnalyticsPluginIntergrationTests: XCTestCase {
                           "eventPropertyIntKey": 123,
                           "eventPropertyDoubleKey": 12.34,
                           "eventPropertyBoolKey": true] as [String: AnalyticsPropertyValue]
-        let event = BasicAnalyticsEvent("eventName", properties: properties)
+        let event = BasicAnalyticsEvent(name: "eventName", properties: properties)
         Amplify.Analytics.record(event: event)
 
         wait(for: [flushEventsInvoked], timeout: 20)

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginClientBehaviorTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginClientBehaviorTests.swift
@@ -128,7 +128,7 @@ class AWSPinpointAnalyticsPluginClientBehaviorTests: AWSPinpointAnalyticsPluginT
         let expectedPinpointEvent = AWSPinpointEvent(eventType: testName, session: AWSPinpointSession())
         mockPinpoint.createEventResult = expectedPinpointEvent
         expectedPinpointEvent.addProperties(testProperties)
-        let event = BasicAnalyticsEvent(testName, properties: testProperties)
+        let event = BasicAnalyticsEvent(name: testName, properties: testProperties)
 
         let analyticsEventReceived = expectation(description: "Analytics event was received on the hub plugin")
         _ = plugin.listen(to: .analytics, isIncluded: nil) { payload in
@@ -156,7 +156,7 @@ class AWSPinpointAnalyticsPluginClientBehaviorTests: AWSPinpointAnalyticsPluginT
     /// Then: AWSPinpoint.record is not called
     func testRecordEventDispatchesErrorForIsEnabledFalse() {
         analyticsPlugin.isEnabled = false
-        let event = BasicAnalyticsEvent(testName, properties: testProperties)
+        let event = BasicAnalyticsEvent(name: testName, properties: testProperties)
 
         analyticsPlugin.record(event: event)
 
@@ -174,7 +174,7 @@ class AWSPinpointAnalyticsPluginClientBehaviorTests: AWSPinpointAnalyticsPluginT
         let expectedPinpointEvent = AWSPinpointEvent(eventType: testName, session: AWSPinpointSession())
         mockPinpoint.createEventResult = expectedPinpointEvent
         expectedPinpointEvent.addProperties(testProperties)
-        let event = BasicAnalyticsEvent(testName, properties: testProperties)
+        let event = BasicAnalyticsEvent(name: testName, properties: testProperties)
 
         let analyticsEventReceived = expectation(description: "Analytics event was received on the hub plugin")
         _ = plugin.listen(to: .analytics, isIncluded: nil) { payload in

--- a/AmplifyTestCommon/Mocks/MockAnalyticsCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAnalyticsCategoryPlugin.swift
@@ -41,7 +41,7 @@ class MockAnalyticsCategoryPlugin: MessageReporter, AnalyticsCategoryPlugin {
         notify("record(event:\(event.name))")
     }
 
-    func registerGlobalProperties(_ properties: [String: AnalyticsPropertyValue]) {
+    func registerGlobalProperties(_ properties: AnalyticsProperties) {
         notify("registerGlobalProperties")
     }
 

--- a/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryClientAPITests.swift
@@ -60,7 +60,7 @@ class AnalyticsCategoryClientAPITests: XCTestCase {
     }
 
     func testRecordWithEvent() throws {
-        let event = BasicAnalyticsEvent("test")
+        let event = BasicAnalyticsEvent(name: "test")
         let expectedMessage = "record(event:test)"
         let methodInvoked = expectation(description: "Expected method was invoked on plugin")
         plugin.listeners.append { message in
@@ -93,6 +93,18 @@ class AnalyticsCategoryClientAPITests: XCTestCase {
             }
         }
         analytics.unregisterGlobalProperties()
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testUnregisterGlobalPropertiesWithVariadicParameter() throws {
+        let expectedMessage = "unregisterGlobalProperties(_:)"
+        let methodInvoked = expectation(description: "Expected method was invoked on plugin")
+        plugin.listeners.append { message in
+            if message == expectedMessage {
+                methodInvoked.fulfill()
+            }
+        }
+        analytics.unregisterGlobalProperties("one", "two")
         waitForExpectations(timeout: 1.0)
     }
 

--- a/AmplifyTests/CoreTests/NotificationListeningAnalyticsPlugin.swift
+++ b/AmplifyTests/CoreTests/NotificationListeningAnalyticsPlugin.swift
@@ -40,7 +40,7 @@ class NotificationListeningAnalyticsPlugin: AnalyticsCategoryPlugin {
         // Do nothing
     }
 
-    func registerGlobalProperties(_ properties: [String: AnalyticsPropertyValue]) {
+    func registerGlobalProperties(_ properties: AnalyticsProperties) {
         // Do nothing
     }
 


### PR DESCRIPTION
*Description of changes:*
- Added `unregisterGlobalProperties(_ keys: String...)` at the Category level. Because Amplify.Analytics.methods will call into the plugin. A variadic parameter turns into an array so there isn't an easy way to pass it in to call the plugin's method with variadic parameter. This way, the Analytics Category provides a helper method which calls into the `unregisterGlobalProperties(Set of strings)`, and plugin only needs to implement the single unregister method.
- Using typealias for map of property values, `AnalyticsPropertyValues`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
