### PR TITLE
feat: [DataStore] Add AuthRule support in Model schema

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		210922572359693900CEC295 /* BasicAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210922562359693800CEC295 /* BasicAnalyticsEvent.swift */; };
 		2109225A23596BCD00CEC295 /* AnalyticsCategoryBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2109225923596BCD00CEC295 /* AnalyticsCategoryBehavior.swift */; };
 		210A8C2623F4999E003F4D91 /* AWSMobileClientError+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210A8C2523F4999E003F4D91 /* AWSMobileClientError+Extension.swift */; };
+		210B3E34245CB73400F43848 /* AuthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210B3E33245CB73400F43848 /* AuthRule.swift */; };
+		210B3E36245CB86500F43848 /* Blog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210B3E35245CB86500F43848 /* Blog.swift */; };
+		210B3E39245CB88D00F43848 /* Blog+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210B3E38245CB88D00F43848 /* Blog+Schema.swift */; };
 		210DBC122332B3C0009B9E51 /* StorageDownloadFileOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210DBC112332B3C0009B9E51 /* StorageDownloadFileOperation.swift */; };
 		210DBC142332B3C6009B9E51 /* StorageGetURLOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210DBC132332B3C6009B9E51 /* StorageGetURLOperation.swift */; };
 		210DBC162332B3CB009B9E51 /* StorageDownloadDataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210DBC152332B3CB009B9E51 /* StorageDownloadDataOperation.swift */; };
@@ -535,6 +538,9 @@
 		210922562359693800CEC295 /* BasicAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicAnalyticsEvent.swift; sourceTree = "<group>"; };
 		2109225923596BCD00CEC295 /* AnalyticsCategoryBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsCategoryBehavior.swift; sourceTree = "<group>"; };
 		210A8C2523F4999E003F4D91 /* AWSMobileClientError+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSMobileClientError+Extension.swift"; sourceTree = "<group>"; };
+		210B3E33245CB73400F43848 /* AuthRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRule.swift; sourceTree = "<group>"; };
+		210B3E35245CB86500F43848 /* Blog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Blog.swift; sourceTree = "<group>"; };
+		210B3E38245CB88D00F43848 /* Blog+Schema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+Schema.swift"; sourceTree = "<group>"; };
 		210DBC112332B3C0009B9E51 /* StorageDownloadFileOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageDownloadFileOperation.swift; sourceTree = "<group>"; };
 		210DBC132332B3C6009B9E51 /* StorageGetURLOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageGetURLOperation.swift; sourceTree = "<group>"; };
 		210DBC152332B3CB009B9E51 /* StorageDownloadDataOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageDownloadDataOperation.swift; sourceTree = "<group>"; };
@@ -1342,11 +1348,11 @@
 			children = (
 				212CE70723E9E990007D8E71 /* ConflictResolutionDecorator.swift */,
 				212CE71223E9F2ED007D8E71 /* DirectiveNameDecorator.swift */,
+				212CE70823E9E990007D8E71 /* FilterDecorator.swift */,
 				219A888023EB629800BBC5F2 /* ModelBasedGraphQLDocumentDecorator.swift */,
 				212CE70A23E9E991007D8E71 /* ModelDecorator.swift */,
 				212CE70623E9E990007D8E71 /* ModelIdDecorator.swift */,
 				212CE70923E9E991007D8E71 /* PaginationDecorator.swift */,
-				212CE70823E9E990007D8E71 /* FilterDecorator.swift */,
 			);
 			path = Decorator;
 			sourceTree = "<group>";
@@ -1779,6 +1785,7 @@
 				FAA64FC22397294500B9C3C6 /* ModelSchema+Attributes.swift */,
 				B92E03AA2367CE7A006CEB8D /* ModelSchema+Definition.swift */,
 				B9B64A9E23FCBF7E00730B68 /* ModelValueConverter.swift */,
+				210B3E33245CB73400F43848 /* AuthRule.swift */,
 			);
 			path = Schema;
 			sourceTree = "<group>";
@@ -1786,15 +1793,17 @@
 		B952182D237E21B900F53237 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				B952182F237E21B900F53237 /* schema.graphql */,
 				FAF512AD23986791001ADF4E /* AmplifyModels.swift */,
+				B9FAA10C23878BD6009414B4 /* Associations */,
+				210B3E35245CB86500F43848 /* Blog.swift */,
+				210B3E38245CB88D00F43848 /* Blog+Schema.swift */,
 				B9521830237E21B900F53237 /* Comment.swift */,
 				B952182E237E21B900F53237 /* Comment+Schema.swift */,
 				FAA2E8BB239FFC7700E420EA /* MockModels.swift */,
 				B9521832237E21B900F53237 /* Post.swift */,
 				B9521831237E21B900F53237 /* Post+Schema.swift */,
 				2129BE002394627B006363A1 /* PostCommentModelRegistration.swift */,
-				B9FAA10C23878BD6009414B4 /* Associations */,
+				B952182F237E21B900F53237 /* schema.graphql */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3678,6 +3687,7 @@
 				FA09B9332321A305000E064D /* HubCategory+CategoryConfigurable.swift in Sources */,
 				B92E03B02367CE7A006CEB8D /* DataStoreCallback.swift in Sources */,
 				B92E03BA2367CE7A006CEB8D /* Model+Codable.swift in Sources */,
+				210B3E34245CB73400F43848 /* AuthRule.swift in Sources */,
 				FA8EE781238628490097E4F1 /* Persistable.swift in Sources */,
 				FA5BF25F2385A0500070C843 /* Category+Logging.swift in Sources */,
 				FACBA78D23949588006349C8 /* Model+DateFormatting.swift in Sources */,
@@ -3917,9 +3927,11 @@
 				FACA36152327FC39000E74F6 /* MessageReporter.swift in Sources */,
 				FAF512AE23986791001ADF4E /* AmplifyModels.swift in Sources */,
 				B9FAA11C23879B35009414B4 /* Book.swift in Sources */,
+				210B3E39245CB88D00F43848 /* Blog+Schema.swift in Sources */,
 				B9FAA11423878CEA009414B4 /* UserProfile+Schema.swift in Sources */,
 				FACA361D2327FC84000E74F6 /* MockAPICategoryPlugin.swift in Sources */,
 				B9FAA11023878C5E009414B4 /* UserProfile.swift in Sources */,
+				210B3E36245CB86500F43848 /* Blog.swift in Sources */,
 				B9FAA12023879BD0009414B4 /* BookAuthor+Schema.swift in Sources */,
 				21F40A4023A295470074678E /* TestCommonConstants.swift in Sources */,
 				B9521835237E21BA00F53237 /* Comment.swift in Sources */,

--- a/Amplify/Categories/DataStore/Model/Schema/AuthRule.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/AuthRule.swift
@@ -1,0 +1,61 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+public enum AuthStrategy {
+    case owner
+    case groups
+    case `private`
+    case `public`
+}
+
+public enum AuthProvider {
+    case apiKey
+    case iam
+    case oidc
+    case userPools
+}
+
+public enum ModelOperation {
+    case create
+    case update
+    case delete
+    case read
+}
+
+public typealias AuthRules = [AuthRule]
+
+public struct AuthRule {
+    public let allow: AuthStrategy
+    public let field: CodingKey?
+    public let provider: AuthProvider?
+    public let ownerField: CodingKey?
+    public let identityClaim: String?
+    public let groupClaim: String?
+    public let groups: [String]
+    public let groupsField: CodingKey?
+    public let operations: [ModelOperation]
+
+    public init(allow: AuthStrategy,
+                field: CodingKey? = nil,
+                provider: AuthProvider? = nil,
+                ownerField: CodingKey? = nil,
+                identityClaim: String? = nil,
+                groupClaim: String? = nil,
+                groups: [String] = [],
+                groupsField: CodingKey? = nil,
+                operations: [ModelOperation] = []) {
+        self.allow = allow
+        self.field = field
+        self.provider = provider
+        self.ownerField = ownerField
+        self.identityClaim = identityClaim
+        self.groupClaim = groupClaim
+        self.groups = groups
+        self.groupsField = groupsField
+        self.operations = operations
+    }
+}

--- a/Amplify/Categories/DataStore/Model/Schema/Model+Schema.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/Model+Schema.swift
@@ -44,4 +44,24 @@ extension Model {
         define(&definition)
         return definition.build()
     }
+
+    public static func rule(allow: AuthStrategy,
+                            field: CodingKey? = nil,
+                            provider: AuthProvider? = nil,
+                            ownerField: CodingKey? = nil,
+                            identityClaim: String? = nil,
+                            groupClaim: String? = nil,
+                            groups: [String] = [],
+                            groupsField: CodingKey? = nil,
+                            operations: [ModelOperation] = []) -> AuthRule {
+        return AuthRule(allow: allow,
+                        field: field,
+                        provider: provider,
+                        ownerField: ownerField,
+                        identityClaim: identityClaim,
+                        groupClaim: groupClaim,
+                        groups: groups,
+                        groupsField: groupsField,
+                        operations: operations)
+    }
 }

--- a/Amplify/Categories/DataStore/Model/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/ModelSchema+Definition.swift
@@ -80,13 +80,18 @@ public struct ModelSchemaDefinition {
 
     internal let name: String
     public var pluralName: String?
+    public var authRules: AuthRules
     internal var fields: ModelFields
     internal var attributes: [ModelAttribute]
 
-    init(name: String, pluralName: String? = nil, attributes: [ModelAttribute] = []) {
+    init(name: String,
+         pluralName: String? = nil,
+         authRules: AuthRules = [],
+         attributes: [ModelAttribute] = []) {
         self.name = name
         self.pluralName = pluralName
         self.fields = [:] as ModelFields
+        self.authRules = authRules
         self.attributes = attributes
     }
 
@@ -102,7 +107,11 @@ public struct ModelSchemaDefinition {
     }
 
     internal func build() -> ModelSchema {
-        return ModelSchema(name: name, pluralName: pluralName, attributes: attributes, fields: fields)
+        return ModelSchema(name: name,
+                           pluralName: pluralName,
+                           authRules: authRules,
+                           attributes: attributes,
+                           fields: fields)
     }
 }
 

--- a/Amplify/Categories/DataStore/Model/Schema/ModelSchema.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/ModelSchema.swift
@@ -52,6 +52,7 @@ public struct ModelSchema {
 
     public let name: String
     public let pluralName: String?
+    public let authRules: AuthRules
     public let fields: ModelFields
     public let attributes: [ModelAttribute]
 
@@ -66,10 +67,12 @@ public struct ModelSchema {
 
     init(name: String,
          pluralName: String? = nil,
+         authRules: AuthRules = [],
          attributes: [ModelAttribute] = [],
          fields: ModelFields = [:]) {
         self.name = name
         self.pluralName = pluralName
+        self.authRules = authRules
         self.attributes = attributes
         self.fields = fields
 

--- a/AmplifyTestCommon/Models/Blog+Schema.swift
+++ b/AmplifyTestCommon/Models/Blog+Schema.swift
@@ -1,0 +1,41 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Blog {
+  // MARK: - CodingKeys
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case content
+    case createdAt
+    case owner
+  }
+
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema
+
+  public static let schema = defineSchema { model in
+    let blog = Blog.keys
+
+    model.pluralName = "Blogs"
+
+    model.authRules = [
+        rule(allow: .owner, ownerField: blog.owner, operations: [.create, .update, .delete]),
+        rule(allow: .groups, groups: ["Admin"]),
+    ]
+
+    model.fields(
+        .id(),
+        .field(blog.content, is: .required, ofType: .string),
+        .field(blog.createdAt, is: .required, ofType: .dateTime),
+        .field(blog.owner, is: .optional, ofType: .string)
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/Blog.swift
+++ b/AmplifyTestCommon/Models/Blog.swift
@@ -1,0 +1,27 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Blog: Model {
+    public let id: String
+    public var content: String
+    public var createdAt: Date
+    public var owner: String?
+
+    public init(id: String = UUID().uuidString,
+                content: String,
+                createdAt: Date,
+                owner: String?) {
+        self.id = id
+        self.content = content
+        self.createdAt = createdAt
+        self.owner = owner
+    }
+}

--- a/AmplifyTestCommon/Models/schema.graphql
+++ b/AmplifyTestCommon/Models/schema.graphql
@@ -15,3 +15,14 @@ type Comment @model {
     createdAt: AWSDateTime!
     post: Post @connection(name: "PostComment")
 }
+
+type Blog
+    @model
+    @auth(rules: [
+        { allow: owner, ownerField: "owner", "operations: [create, update, delete] },
+        { allow: groups, groups: ["Admin"] }
+    ]) {
+    id: ID!
+    content: String!
+    createdAt: AWSDateTime!
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This adds the class to contain the metadata about auth directive information on a model. This is information required to align the GraphQL Transform provisioned backend APIs and the generated client library call with the backend.
```
model.authRules = [
        rule(allow: .owner, ownerField: blog.owner, operations: [.create, .update, .delete]),
        rule(allow: .groups, groups: ["Admin"]),
    ]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
