### PR TITLE
feat: [DataStore] Add AuthRule to field level

### DIFF
--- a/Amplify/Categories/DataStore/Model/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/ModelSchema+Definition.swift
@@ -121,18 +121,21 @@ public enum ModelFieldDefinition {
                type: ModelFieldType,
                nullability: ModelFieldNullability,
                association: ModelAssociation?,
-               attributes: [ModelFieldAttribute])
+               attributes: [ModelFieldAttribute],
+               authRules: AuthRules)
 
     public static func field(_ key: CodingKey,
                              is nullability: ModelFieldNullability = .required,
                              ofType type: ModelFieldType = .string,
                              attributes: [ModelFieldAttribute] = [],
-                             association: ModelAssociation? = nil) -> ModelFieldDefinition {
+                             association: ModelAssociation? = nil,
+                             authRules: AuthRules = []) -> ModelFieldDefinition {
         return .field(name: key.stringValue,
                       type: type,
                       nullability: nullability,
                       association: association,
-                      attributes: attributes)
+                      attributes: attributes,
+                      authRules: authRules)
     }
 
     public static func id(_ key: CodingKey) -> ModelFieldDefinition {
@@ -144,7 +147,8 @@ public enum ModelFieldDefinition {
                       type: .string,
                       nullability: .required,
                       association: nil,
-                      attributes: [.primaryKey])
+                      attributes: [.primaryKey],
+                      authRules: [])
     }
 
     public static func hasMany(_ key: CodingKey,
@@ -183,7 +187,8 @@ public enum ModelFieldDefinition {
                               type,
                               nullability,
                               association,
-                              attributes) = self else {
+                              attributes,
+                              authRules) = self else {
             preconditionFailure("Unexpected enum value found: \(String(describing: self))")
         }
         return ModelField(name: name,
@@ -191,6 +196,7 @@ public enum ModelFieldDefinition {
                           isRequired: nullability.isRequired,
                           isArray: type.isArray,
                           attributes: attributes,
-                          association: association)
+                          association: association,
+                          authRules: authRules)
     }
 }

--- a/Amplify/Categories/DataStore/Model/Schema/ModelSchema.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/ModelSchema.swift
@@ -26,6 +26,7 @@ public struct ModelField {
     public let isArray: Bool
     public let attributes: [ModelFieldAttribute]
     public let association: ModelAssociation?
+    public let authRules: AuthRules
 
     public var isPrimaryKey: Bool {
         return name == "id"
@@ -36,13 +37,15 @@ public struct ModelField {
          isRequired: Bool = false,
          isArray: Bool = false,
          attributes: [ModelFieldAttribute] = [],
-         association: ModelAssociation? = nil) {
+         association: ModelAssociation? = nil,
+         authRules: AuthRules = []) {
         self.name = name
         self.type = type
         self.isRequired = isRequired
         self.isArray = isArray
         self.attributes = attributes
         self.association = association
+        self.authRules = authRules
     }
 }
 

--- a/AmplifyTestCommon/Models/Blog+Schema.swift
+++ b/AmplifyTestCommon/Models/Blog+Schema.swift
@@ -10,32 +10,38 @@ import Amplify
 import Foundation
 
 extension Blog {
-  // MARK: - CodingKeys
-   public enum CodingKeys: String, ModelKey {
-    case id
-    case content
-    case createdAt
-    case owner
-  }
+    // MARK: - CodingKeys
+    public enum CodingKeys: String, ModelKey {
+        case id
+        case content
+        case createdAt
+        case owner
+        case authorNotes
+    }
 
-  public static let keys = CodingKeys.self
-  //  MARK: - ModelSchema
+    public static let keys = CodingKeys.self
+    //  MARK: - ModelSchema
 
-  public static let schema = defineSchema { model in
-    let blog = Blog.keys
+    public static let schema = defineSchema { model in
+        let blog = Blog.keys
 
-    model.pluralName = "Blogs"
+        model.pluralName = "Blogs"
 
-    model.authRules = [
-        rule(allow: .owner, ownerField: blog.owner, operations: [.create, .update, .delete]),
-        rule(allow: .groups, groups: ["Admin"]),
-    ]
+        model.authRules = [
+            rule(allow: .owner, ownerField: blog.owner, operations: [.create, .read]),
+            rule(allow: .groups, groups: ["Admin"]),
+        ]
 
-    model.fields(
-        .id(),
-        .field(blog.content, is: .required, ofType: .string),
-        .field(blog.createdAt, is: .required, ofType: .dateTime),
-        .field(blog.owner, is: .optional, ofType: .string)
-    )
+        model.fields(
+            .id(),
+            .field(blog.content, is: .required, ofType: .string),
+            .field(blog.createdAt, is: .required, ofType: .dateTime),
+            .field(blog.owner, is: .optional, ofType: .string),
+            .field(blog.authorNotes,
+                   is: .optional,
+                   ofType: .string,
+                   authRules: [rule(allow: .owner, ownerField: blog.owner, operations: [.update])]
+            )
+        )
     }
 }

--- a/AmplifyTestCommon/Models/Blog.swift
+++ b/AmplifyTestCommon/Models/Blog.swift
@@ -14,14 +14,17 @@ public struct Blog: Model {
     public var content: String
     public var createdAt: Date
     public var owner: String?
+    public var authorNotes: String?
 
     public init(id: String = UUID().uuidString,
                 content: String,
                 createdAt: Date,
-                owner: String?) {
+                owner: String?,
+                authorNotes: String?) {
         self.id = id
         self.content = content
         self.createdAt = createdAt
         self.owner = owner
+        self.authorNotes = authorNotes
     }
 }

--- a/AmplifyTestCommon/Models/schema.graphql
+++ b/AmplifyTestCommon/Models/schema.graphql
@@ -19,10 +19,14 @@ type Comment @model {
 type Blog
     @model
     @auth(rules: [
-        { allow: owner, ownerField: "owner", "operations: [create, update, delete] },
+        { allow: owner, ownerField: "owner", "operations: [create, read] },
         { allow: groups, groups: ["Admin"] }
     ]) {
     id: ID!
     content: String!
     createdAt: AWSDateTime!
+    owner: String
+    authorsNotes: String @auth( rules: [
+        { allow: owner, ownerField: "owner", operations: [update] }
+    ])
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add support for field level auth directive
```
type Blog
    @model
    @auth(rules: [
        { allow: owner, ownerField: "owner", "operations: [create, update, delete] },
        { allow: owner, ownerField: "owner", "operations: [create, read] },
        { allow: groups, groups: ["Admin"] }
    ]) {
    id: ID!
    content: String!
    createdAt: AWSDateTime!
    owner: String
    authorsNotes: String @auth( rules: [
        { allow: owner, ownerField: "owner", operations: [update] }
    ])
}
```

schema
```
public static let schema = defineSchema { model in
        let blog = Blog.keys

        model.pluralName = "Blogs"

        model.authRules = [
            rule(allow: .owner, ownerField: blog.owner, operations: [.create, .read]),
            rule(allow: .groups, groups: ["Admin"]),
        ]

        model.fields(
            .id(),
            .field(blog.content, is: .required, ofType: .string),
            .field(blog.createdAt, is: .required, ofType: .dateTime),
            .field(blog.owner, is: .optional, ofType: .string),
            .field(blog.authorNotes,
                   is: .optional,
                   ofType: .string,
                   authRules: [rule(allow: .owner, ownerField: blog.owner, operations: [.update])]
            )
        )
    }
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
