### PR TITLE
fix(Auth): Crash in WebUI signout

### DIFF
--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Dependency/AuthenticationProviderAdapter+SignOut.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Dependency/AuthenticationProviderAdapter+SignOut.swift
@@ -10,9 +10,23 @@ import AWSMobileClient
 
 extension AuthenticationProviderAdapter {
 
-    func signOut(request: AuthSignOutRequest,
-                 completionHandler: @escaping (Result<Void, AmplifyAuthError>) -> Void) {
+    func signOut(request: AuthSignOutRequest, completionHandler: @escaping (Result<Void, AmplifyAuthError>) -> Void) {
 
+        // If user is signed in through HostedUI the signout require UI to complete. So calling this in main thread.
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.signOutWithUI(completionHandler)
+        }
+    }
+
+    private func signOutWithUI(_ completionHandler: @escaping (Result<Void, AmplifyAuthError>) -> Void) {
+
+        // Stop the execution here if we are not running on the main thread.
+        // There is no point on returning an error back to the developer, because
+        // they do not control how the UI is presented.
+        dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
         let signOutOptions = SignOutOptions(signOutGlobally: true, invalidateTokens: true)
         awsMobileClient.signOut(options: signOutOptions) { error in
             guard error == nil else {


### PR DESCRIPTION
If the user is signed in through the webUI calling SignOut require the api to be called in main thread.
This change make sure that signOut happens in main thread.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
