### PR TITLE
feat: [API] auth directive integration tests

### DIFF
--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
@@ -8,6 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		13066F229854831AA628ECEC /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithUserPoolIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DD6386039136045F18D44AC /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithUserPoolIntegrationTests.framework */; };
+		21233D032469B06B00039337 /* SocialNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21233D022469B06B00039337 /* SocialNote.swift */; };
+		21233D052469DF1200039337 /* GraphQLAuthDirectiveIntegrationTests+Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21233D042469DF1200039337 /* GraphQLAuthDirectiveIntegrationTests+Support.swift */; };
+		21233D092469EBA000039337 /* GraphQLAuthDirectiveIntegrationTests-credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = 21233D062469EBA000039337 /* GraphQLAuthDirectiveIntegrationTests-credentials.json */; };
+		21233D0A2469EBA000039337 /* GraphQLAuthDirectiveIntegrationTests-awsconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21233D072469EBA000039337 /* GraphQLAuthDirectiveIntegrationTests-awsconfiguration.json */; };
+		21233D0B2469EBA000039337 /* GraphQLAuthDirectiveIntegrationTests-amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21233D082469EBA000039337 /* GraphQLAuthDirectiveIntegrationTests-amplifyconfiguration.json */; };
+		21233D0D2469EBBE00039337 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 21233D0C2469EBBE00039337 /* README.md */; };
 		2129BE3E239486D2006363A1 /* AnyModel+JSONInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2129BE3D239486D2006363A1 /* AnyModel+JSONInit.swift */; };
 		21409C4F2384BA7E000A53C9 /* APIOperationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21409C4E2384BA7E000A53C9 /* APIOperationResponse.swift */; };
 		21409C5E2384DE2C000A53C9 /* AWSAPIPlugin+GraphQLModelBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21409C5D2384DE2C000A53C9 /* AWSAPIPlugin+GraphQLModelBehavior.swift */; };
@@ -38,6 +44,7 @@
 		219A88A523EE054000BBC5F2 /* RESTWithUserPoolIntegrationTests-credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = 219A88A423EE054000BBC5F2 /* RESTWithUserPoolIntegrationTests-credentials.json */; };
 		219A88A723EE05C200BBC5F2 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 219A88A623EE05C200BBC5F2 /* README.md */; };
 		21A3EFC623A946590095D8E6 /* GraphQLWithUserPoolIntegrationTests-credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = 21A3EFC523A946580095D8E6 /* GraphQLWithUserPoolIntegrationTests-credentials.json */; };
+		21A3FDBB2464BB5F00E76120 /* GraphQLAuthDirectiveIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A3FDBA2464BB5F00E76120 /* GraphQLAuthDirectiveIntegrationTests.swift */; };
 		21D38B9B240C517C00EC2A8D /* AWSOIDCAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D38B9A240C517C00EC2A8D /* AWSOIDCAuthProvider.swift */; };
 		21D5286724169E74005186BA /* IAMAuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D5286624169E74005186BA /* IAMAuthInterceptor.swift */; };
 		21D7A0DF237B54D90057D00D /* AWSGraphQLOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A08D237B54D90057D00D /* AWSGraphQLOperation.swift */; };
@@ -257,6 +264,12 @@
 		1B13CFC866A30622EDD91AF4 /* Pods_AWSAPICategoryPlugin_AWSAPICategoryPluginTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSAPICategoryPlugin_AWSAPICategoryPluginTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1B30959CE873C097E54BDFD6 /* Pods-GraphQLWithAPIKeyIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GraphQLWithAPIKeyIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-GraphQLWithAPIKeyIntegrationTests/Pods-GraphQLWithAPIKeyIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		1FDC07084023DEF205FF6598 /* Pods-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-AWSAPICategoryPlugin-AWSAPICategoryPluginTests/Pods-AWSAPICategoryPlugin-AWSAPICategoryPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
+		21233D022469B06B00039337 /* SocialNote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialNote.swift; sourceTree = "<group>"; };
+		21233D042469DF1200039337 /* GraphQLAuthDirectiveIntegrationTests+Support.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLAuthDirectiveIntegrationTests+Support.swift"; sourceTree = "<group>"; };
+		21233D062469EBA000039337 /* GraphQLAuthDirectiveIntegrationTests-credentials.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GraphQLAuthDirectiveIntegrationTests-credentials.json"; sourceTree = "<group>"; };
+		21233D072469EBA000039337 /* GraphQLAuthDirectiveIntegrationTests-awsconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GraphQLAuthDirectiveIntegrationTests-awsconfiguration.json"; sourceTree = "<group>"; };
+		21233D082469EBA000039337 /* GraphQLAuthDirectiveIntegrationTests-amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GraphQLAuthDirectiveIntegrationTests-amplifyconfiguration.json"; sourceTree = "<group>"; };
+		21233D0C2469EBBE00039337 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		2129BE3D239486D2006363A1 /* AnyModel+JSONInit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AnyModel+JSONInit.swift"; sourceTree = "<group>"; };
 		21409C4E2384BA7E000A53C9 /* APIOperationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIOperationResponse.swift; sourceTree = "<group>"; };
 		21409C5D2384DE2C000A53C9 /* AWSAPIPlugin+GraphQLModelBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSAPIPlugin+GraphQLModelBehavior.swift"; sourceTree = "<group>"; };
@@ -298,6 +311,7 @@
 		219A88A423EE054000BBC5F2 /* RESTWithUserPoolIntegrationTests-credentials.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "RESTWithUserPoolIntegrationTests-credentials.json"; sourceTree = "<group>"; };
 		219A88A623EE05C200BBC5F2 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		21A3EFC523A946580095D8E6 /* GraphQLWithUserPoolIntegrationTests-credentials.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GraphQLWithUserPoolIntegrationTests-credentials.json"; sourceTree = "<group>"; };
+		21A3FDBA2464BB5F00E76120 /* GraphQLAuthDirectiveIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLAuthDirectiveIntegrationTests.swift; sourceTree = "<group>"; };
 		21D38B9A240C517C00EC2A8D /* AWSOIDCAuthProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSOIDCAuthProvider.swift; sourceTree = "<group>"; };
 		21D5286624169E74005186BA /* IAMAuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAMAuthInterceptor.swift; sourceTree = "<group>"; };
 		21D7A08D237B54D90057D00D /* AWSGraphQLOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSGraphQLOperation.swift; sourceTree = "<group>"; };
@@ -541,6 +555,20 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		21233D012469B04D00039337 /* AuthDirective */ = {
+			isa = PBXGroup;
+			children = (
+				21233D082469EBA000039337 /* GraphQLAuthDirectiveIntegrationTests-amplifyconfiguration.json */,
+				21233D072469EBA000039337 /* GraphQLAuthDirectiveIntegrationTests-awsconfiguration.json */,
+				21233D062469EBA000039337 /* GraphQLAuthDirectiveIntegrationTests-credentials.json */,
+				21A3FDBA2464BB5F00E76120 /* GraphQLAuthDirectiveIntegrationTests.swift */,
+				21233D042469DF1200039337 /* GraphQLAuthDirectiveIntegrationTests+Support.swift */,
+				21233D0C2469EBBE00039337 /* README.md */,
+				21233D022469B06B00039337 /* SocialNote.swift */,
+			);
+			path = AuthDirective;
+			sourceTree = "<group>";
+		};
 		21409C612384F7FD000A53C9 /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -669,9 +697,10 @@
 		217856A023810B9400A30D19 /* GraphQLWithUserPoolIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
-				21A3EFC523A946580095D8E6 /* GraphQLWithUserPoolIntegrationTests-credentials.json */,
+				21233D012469B04D00039337 /* AuthDirective */,
 				21598CF023A0164900529F29 /* GraphQLWithUserPoolIntegrationTests-amplifyconfiguration.json */,
 				21598CF123A0164A00529F29 /* GraphQLWithUserPoolIntegrationTests-awsconfiguration.json */,
+				21A3EFC523A946580095D8E6 /* GraphQLWithUserPoolIntegrationTests-credentials.json */,
 				217856A123810B9400A30D19 /* GraphQLWithUserPoolIntegrationTests.swift */,
 				217856A323810B9400A30D19 /* Info.plist */,
 				21598CE723A0036600529F29 /* README.md */,
@@ -1386,6 +1415,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21233D0D2469EBBE00039337 /* README.md in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1415,9 +1445,11 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21233D0A2469EBA000039337 /* GraphQLAuthDirectiveIntegrationTests-awsconfiguration.json in Resources */,
 				219A88A223EE034F00BBC5F2 /* RESTWithUserPoolIntegrationTests-amplifyconfiguration.json in Resources */,
 				219A88A323EE034F00BBC5F2 /* RESTWithUserPoolIntegrationTests-awsconfiguration.json in Resources */,
 				21598CE3239FF54E00529F29 /* RESTWithIAMIntegrationTests-amplifyconfiguration.json in Resources */,
+				21233D0B2469EBA000039337 /* GraphQLAuthDirectiveIntegrationTests-amplifyconfiguration.json in Resources */,
 				B478F6E32374E0CF00C4F92B /* Main.storyboard in Resources */,
 				B478F6E12374E0CF00C4F92B /* Assets.xcassets in Resources */,
 				21598CF223A0164A00529F29 /* GraphQLWithUserPoolIntegrationTests-amplifyconfiguration.json in Resources */,
@@ -1426,6 +1458,7 @@
 				219A88A523EE054000BBC5F2 /* RESTWithUserPoolIntegrationTests-credentials.json in Resources */,
 				21A3EFC623A946590095D8E6 /* GraphQLWithUserPoolIntegrationTests-credentials.json in Resources */,
 				21598CF323A0164A00529F29 /* GraphQLWithUserPoolIntegrationTests-awsconfiguration.json in Resources */,
+				21233D092469EBA000039337 /* GraphQLAuthDirectiveIntegrationTests-credentials.json in Resources */,
 				B478F6E22374E0CF00C4F92B /* LaunchScreen.storyboard in Resources */,
 				21598CE4239FF61300529F29 /* RESTWithIAMIntegrationTests-awsconfiguration.json in Resources */,
 			);
@@ -2082,6 +2115,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21233D052469DF1200039337 /* GraphQLAuthDirectiveIntegrationTests+Support.swift in Sources */,
+				21233D032469B06B00039337 /* SocialNote.swift in Sources */,
+				21A3FDBB2464BB5F00E76120 /* GraphQLAuthDirectiveIntegrationTests.swift in Sources */,
 				217856A223810B9400A30D19 /* GraphQLWithUserPoolIntegrationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/GraphQLWithUserPoolIntegrationTests.xcscheme
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/GraphQLWithUserPoolIntegrationTests.xcscheme
@@ -23,6 +23,9 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "GraphQLWithUserPoolIntegrationTests/testCreateTodoMutationWithMissingInputFromVariables()">
+               </Test>
+               <Test
                   Identifier = "GraphQLWithUserPoolIntegrationTests/testSetUpOnce()">
                </Test>
             </SkippedTests>

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/GraphQLWithUserPoolIntegrationTests.xcscheme
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/GraphQLWithUserPoolIntegrationTests.xcscheme
@@ -23,9 +23,6 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "GraphQLWithUserPoolIntegrationTests/testCreateTodoMutationWithMissingInputFromVariables()">
-               </Test>
-               <Test
                   Identifier = "GraphQLWithUserPoolIntegrationTests/testSetUpOnce()">
                </Test>
             </SkippedTests>

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/BlogPostCommentGraphQLWithAPIKey/BlogPostCommentGraphQLWithAPIKeyTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/BlogPostCommentGraphQLWithAPIKey/BlogPostCommentGraphQLWithAPIKeyTests.swift
@@ -218,8 +218,8 @@ class BlogPostCommentGraphQLWithAPIKeyTests: XCTestCase {
 
     // MARK: Common functionality
 
-    func createBlog(id: String, name: String) -> Blog? {
-        var blog: Blog?
+    func createBlog(id: String, name: String) -> AWSAPICategoryPluginTestCommon.Blog? {
+        var blog: AWSAPICategoryPluginTestCommon.Blog?
         let completeInvoked = expectation(description: "request completed")
         let request = GraphQLRequest(apiName: BlogPostCommentGraphQLWithAPIKeyTests.blogPostGraphQLWithAPIKey,
                                      document: CreateBlogMutation.document,

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/GraphQLAuthDirectiveIntegrationTests+Support.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/GraphQLAuthDirectiveIntegrationTests+Support.swift
@@ -1,0 +1,174 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+import AWSMobileClient
+import AWSAPICategoryPlugin
+@testable import AWSAPICategoryPluginTestCommon
+@testable import AmplifyTestCommon
+import AWSPluginsCore
+
+extension GraphQLAuthDirectiveIntegrationTests {
+    func createNote(_ id: String = UUID().uuidString,
+                    content: String) -> Result<MutationSyncResult, GraphQLResponseError<MutationSyncResult>> {
+        let createdNoteInvoked = expectation(description: "note was created")
+        var result: Result<MutationSyncResult, GraphQLResponseError<MutationSyncResult>>?
+        let note = SocialNote(id: id, content: content, owner: nil)
+        let request = GraphQLRequest<MutationSyncResult>.createMutation(of: note)
+        _ = Amplify.API.mutate(request: request, listener: { event in
+            switch event {
+            case .completed(let data):
+                switch data {
+                case .success(let note):
+                    result = .success(note)
+                case .failure(let error):
+                    result = .failure(error)
+                }
+                createdNoteInvoked.fulfill()
+            case .failed(let error):
+                XCTFail("Got failed, error: \(error)")
+            default:
+                XCTFail("Unexpected event: \(event)")
+            }
+        })
+
+        wait(for: [createdNoteInvoked], timeout: TestCommonConstants.networkTimeout)
+        return result!
+    }
+
+    func updateNote(_ note: SocialNote,
+                    version: Int) -> Result<MutationSyncResult, GraphQLResponseError<MutationSyncResult>> {
+        let updateNoteInvoked = expectation(description: "note was update")
+        var result: Result<MutationSyncResult, GraphQLResponseError<MutationSyncResult>>?
+        let request = GraphQLRequest<MutationSyncResult>.updateMutation(of: note, version: version)
+        _ = Amplify.API.mutate(request: request, listener: { event in
+            switch event {
+            case .completed(let data):
+                switch data {
+                case .success(let note):
+                    result = .success(note)
+                case .failure(let error):
+                    result = .failure(error)
+                }
+                updateNoteInvoked.fulfill()
+            case .failed(let error):
+                XCTFail("Got failed, error: \(error)")
+            default:
+                XCTFail("Unexpected event: \(event)")
+            }
+        })
+
+        wait(for: [updateNoteInvoked], timeout: TestCommonConstants.networkTimeout)
+        return result!
+    }
+
+    func deleteNote(byId id: String,
+                    version: Int) -> Result<MutationSyncResult, GraphQLResponseError<MutationSyncResult>> {
+        let deleteNoteInvoked = expectation(description: "note was deleted")
+        var result: Result<MutationSyncResult, GraphQLResponseError<MutationSyncResult>>?
+        let request = GraphQLRequest<MutationSyncResult>.deleteMutation(modelName: SocialNote.modelName,
+                                                                        id: id,
+                                                                        version: version)
+        _ = Amplify.API.mutate(request: request, listener: { event in
+            switch event {
+            case .completed(let data):
+                switch data {
+                case .success(let note):
+                    result = .success(note)
+                case .failure(let error):
+                    result = .failure(error)
+                }
+                deleteNoteInvoked.fulfill()
+            case .failed(let error):
+                XCTFail("Got failed, error: \(error)")
+            default:
+                XCTFail("Unexpected event: \(event)")
+            }
+        })
+
+        wait(for: [deleteNoteInvoked], timeout: TestCommonConstants.networkTimeout)
+        return result!
+    }
+
+    func queryNote(byId id: String) -> Result<MutationSyncResult?, GraphQLResponseError<MutationSyncResult?>> {
+        let queryNoteInvoked = expectation(description: "note was queried successfully")
+        var result: Result<MutationSyncResult?, GraphQLResponseError<MutationSyncResult?>>?
+        let request = GraphQLRequest<MutationSyncResult?>.query(modelName: SocialNote.modelName, byId: id)
+        _ = Amplify.API.query(request: request) { event in
+            switch event {
+            case .completed(let data):
+                switch data {
+                case .success(let note):
+                    result = .success(note)
+                case .failure(let error):
+                    result = .failure(error)
+                }
+                queryNoteInvoked.fulfill()
+            case .failed(let error):
+                XCTFail("Got failed, error: \(error)")
+            default:
+                XCTFail("Unexpected event: \(event)")
+            }
+        }
+
+        wait(for: [queryNoteInvoked], timeout: TestCommonConstants.networkTimeout)
+        return result!
+    }
+
+    func syncQuery() -> Result<SyncQueryResult, GraphQLResponseError<SyncQueryResult>> {
+        let syncQueryInvoked = expectation(description: "sync query successfully")
+        var result: Result<SyncQueryResult, GraphQLResponseError<SyncQueryResult>>?
+        let request = GraphQLRequest<SyncQueryResult>.syncQuery(modelType: SocialNote.self, limit: 1)
+        _ = Amplify.API.query(request: request) { event in
+            switch event {
+            case .completed(let data):
+                switch data {
+                case .success(let paginatedNotes):
+                    result = .success(paginatedNotes)
+                case .failure(let error):
+                    result = .failure(error)
+                }
+                syncQueryInvoked.fulfill()
+            case .failed(let error):
+                XCTFail("Got failed, error: \(error)")
+            default:
+                XCTFail("Unexpected event: \(event)")
+            }
+        }
+        wait(for: [syncQueryInvoked], timeout: TestCommonConstants.networkTimeout)
+        return result!
+    }
+
+    func getAppSyncError(_ graphQLResponseError: GraphQLResponseError<MutationSyncResult>) -> AppSyncErrorType? {
+        guard case let .error(errors) = graphQLResponseError,
+            let error = errors.first,
+            let extensions = error.extensions,
+            case let .string(errorTypeValue) = extensions["errorType"] else {
+                XCTFail("Other should not be able to update owner's note")
+            return nil
+        }
+        return AppSyncErrorType(errorTypeValue)
+    }
+
+    func assertNotAuthenticated(_ error: APIError) {
+        guard case let .operationError(_, _, underlyingError) = error else {
+            XCTFail("Error should be operationError")
+            return
+        }
+
+        guard let authError = underlyingError as? AuthError else {
+            XCTFail("underlying error should be AuthError, but instead was \(underlyingError ?? "nil")")
+            return
+        }
+
+        guard case .notAuthenticated = authError else {
+            XCTFail("Error should be AuthError.notAuthenticated")
+            return
+        }
+    }
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/GraphQLAuthDirectiveIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/GraphQLAuthDirectiveIntegrationTests.swift
@@ -1,0 +1,244 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+import AWSMobileClient
+import AWSAPICategoryPlugin
+@testable import AWSAPICategoryPluginTestCommon
+@testable import AmplifyTestCommon
+import AWSPluginsCore
+
+class GraphQLAuthDirectiveIntegrationTests: XCTestCase {
+
+    static let amplifyConfiguration = "GraphQLAuthDirectiveIntegrationTests-amplifyconfiguration"
+    static let awsconfiguration = "GraphQLAuthDirectiveIntegrationTests-awsconfiguration"
+    static let credentials = "GraphQLAuthDirectiveIntegrationTests-credentials"
+    static var user1: String!
+    static var user2: String!
+    static var password: String!
+
+    static override func setUp() {
+        do {
+
+            let credentials = try TestConfigHelper.retrieveCredentials(
+                forResource: GraphQLAuthDirectiveIntegrationTests.credentials)
+
+            guard let user1 = credentials["user1"],
+                let user2 = credentials["user2"],
+                let password = credentials["password"] else {
+                    XCTFail("Missing credentials.json data")
+                    return
+            }
+
+            GraphQLAuthDirectiveIntegrationTests.user1 = user1
+            GraphQLAuthDirectiveIntegrationTests.user2 = user2
+            GraphQLAuthDirectiveIntegrationTests.password = password
+
+            let awsConfiguration = try TestConfigHelper.retrieveAWSConfiguration(
+                forResource: GraphQLAuthDirectiveIntegrationTests.awsconfiguration)
+            AWSInfo.configureDefaultAWSInfo(awsConfiguration)
+        } catch {
+            XCTFail("Error during setup: \(error)")
+        }
+    }
+
+    override func setUp() {
+        do {
+            AuthHelper.initializeMobileClient()
+
+            Amplify.reset()
+
+            try Amplify.add(plugin: AWSAPIPlugin())
+
+            let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(
+                forResource: GraphQLAuthDirectiveIntegrationTests.amplifyConfiguration)
+            try Amplify.configure(amplifyConfig)
+
+            ModelRegistry.register(modelType: SocialNote.self)
+        } catch {
+            XCTFail("Error during setup: \(error)")
+        }
+    }
+
+    override func tearDown() {
+        Amplify.reset()
+        AuthHelper.signOut()
+    }
+
+    /// A model with operations [create, update, delete] allows the model to be read by others but not updated or
+    /// deleted. This creates a read-only model.
+    ///
+    /// - When:
+    ///    - Model restricts access to create, update, delete.
+    /// - Then:
+    ///    - Owner can create and update the model
+    ///    - Others can read the owner's model
+    ///    - Others cannot update or delete the owner's model
+    ///    - Owner can delete the model
+    func testModelIsReadOnly() {
+        AuthHelper.signIn(username: GraphQLAuthDirectiveIntegrationTests.user1,
+                          password: GraphQLAuthDirectiveIntegrationTests.password)
+        let id = UUID().uuidString
+        let content = "owner created content"
+        let ownerCreatedNoteResult = createNote(id, content: content)
+        guard case let .success(ownerCreatedNote) = ownerCreatedNoteResult else {
+            XCTFail("Owner should be able to successfully create a note")
+            return
+        }
+        let ownerReadNoteResult = queryNote(byId: ownerCreatedNote.model.id)
+        guard case let .success(ownerReadNoteOptional) = ownerReadNoteResult,
+            let ownerReadNote = ownerReadNoteOptional else {
+            XCTFail("Owner should be able to query for own note")
+            return
+        }
+        let ownerUpdateNote = SocialNote(id: ownerReadNote.model.id, content: "owner updated content", owner: nil)
+        let ownerUpdatedNoteResult = updateNote(ownerUpdateNote, version: ownerReadNote.syncMetadata.version)
+        guard case let .success(ownerUpdatedNote) = ownerUpdatedNoteResult else {
+            XCTFail("Owner should be able to update own note")
+            return
+        }
+        AuthHelper.signOut()
+        AuthHelper.signIn(username: GraphQLAuthDirectiveIntegrationTests.user2,
+                          password: GraphQLAuthDirectiveIntegrationTests.password)
+        let otherReadNoteResult = queryNote(byId: id)
+        guard case let .success(otherReadNoteOptional) = otherReadNoteResult,
+            let otherReadNote = otherReadNoteOptional else {
+            XCTFail("Others should be able to read the note")
+            return
+        }
+        let otherUpdateNote = SocialNote(id: otherReadNote.model.id, content: "other updated content", owner: nil)
+        let otherUpdatedNoteResult = updateNote(otherUpdateNote, version: otherReadNote.syncMetadata.version)
+        guard case let .failure(graphQLResponseErrorOnUpdate) = otherUpdatedNoteResult,
+            let appSyncErrorOnUpdate = getAppSyncError(graphQLResponseErrorOnUpdate) else {
+            XCTFail("Other should not be able to update owner's note")
+            return
+        }
+        XCTAssertEqual(appSyncErrorOnUpdate, .conditionalCheck)
+
+        let otherDeletedNoteResult = deleteNote(byId: id, version: otherReadNote.syncMetadata.version)
+        guard case let .failure(graphQLResponseErrorOnDelete) = otherDeletedNoteResult,
+            let appSyncErrorOnDelete = getAppSyncError(graphQLResponseErrorOnDelete) else {
+            XCTFail("Other should not be able to delete owner's note")
+            return
+        }
+        XCTAssertEqual(appSyncErrorOnDelete, .conditionalCheck)
+
+        AuthHelper.signOut()
+        AuthHelper.signIn(username: GraphQLAuthDirectiveIntegrationTests.user1,
+                          password: GraphQLAuthDirectiveIntegrationTests.password)
+        let ownerDeletedNoteResult = deleteNote(byId: id, version: ownerUpdatedNote.syncMetadata.version)
+        guard case .success = ownerDeletedNoteResult else {
+            XCTFail("Owner should be able to delete own note")
+            return
+        }
+    }
+
+    /// An unauthorized user should not be able to make a mutation
+    func testUnauthorizedMutation() {
+        let failureInvoked = expectation(description: "failure invoked")
+        let note = SocialNote(content: "owner created content", owner: nil)
+        let request = GraphQLRequest<MutationSyncResult>.createMutation(of: note)
+        _ = Amplify.API.mutate(request: request, listener: { event in
+            switch event {
+            case .completed:
+                XCTFail("Should not have completed successfully")
+            case .failed(let error):
+                self.assertNotAuthenticated(error)
+                failureInvoked.fulfill()
+            default:
+                XCTFail("Unexpected case")
+            }
+        })
+
+        wait(for: [failureInvoked], timeout: TestCommonConstants.networkTimeout)
+    }
+
+    func testSyncQuery() {
+        AuthHelper.signIn(username: GraphQLAuthDirectiveIntegrationTests.user1,
+                          password: GraphQLAuthDirectiveIntegrationTests.password)
+        let id = UUID().uuidString
+        let content = "owner created content"
+        let ownerCreatedNoteResult = createNote(id, content: content)
+        guard case .success = ownerCreatedNoteResult else {
+            XCTFail("Owner should be able to successfully create a note")
+            return
+        }
+
+        let syncQueryResult = syncQuery()
+        guard case .success = syncQueryResult else {
+            XCTFail("Owner should be able to execute sync query")
+            return
+        }
+    }
+
+    /// An unauthorized user should not be able to query
+    func testUnauthorizedSyncQuery() {
+        let failureInvoked = expectation(description: "failure invoked")
+        let request = GraphQLRequest<SyncQueryResult>.syncQuery(modelType: SocialNote.self, limit: 1)
+        _ = Amplify.API.query(request: request) { event in
+            switch event {
+            case .completed:
+                XCTFail("Should not have completed successfully")
+            case .failed(let error):
+                self.assertNotAuthenticated(error)
+                failureInvoked.fulfill()
+            default:
+                XCTFail("Unexpected case")
+            }
+        }
+        wait(for: [failureInvoked], timeout: TestCommonConstants.networkTimeout)
+    }
+
+    func testOnCreateSubscriptionOnlyWhenSignedIntoUserPool() {
+        AuthHelper.signIn(username: GraphQLAuthDirectiveIntegrationTests.user1,
+                          password: GraphQLAuthDirectiveIntegrationTests.password)
+        let connectedInvoked = expectation(description: "Connection established")
+        let progressInvoked = expectation(description: "Progress invoked")
+        guard let ownerId = AuthHelper.getUserSub() else {
+            XCTFail("Could not get ownerId for authenticated user")
+            return
+        }
+        let request = GraphQLRequest<MutationSyncResult>.subscription(to: SocialNote.self,
+                                                                      subscriptionType: .onCreate,
+                                                                      ownerId: ownerId)
+        let operation = Amplify.API.subscribe(request: request) { event in
+            switch event {
+            case .inProcess(let graphQLResponse):
+                switch graphQLResponse {
+                case .connection(let state):
+                    if case .connected = state {
+                        connectedInvoked.fulfill()
+                    }
+                case .data(let graphQLResponse):
+                    switch graphQLResponse {
+                    case .success:
+                        progressInvoked.fulfill()
+                    case .failure(let error):
+                        XCTFail(error.errorDescription)
+                    }
+                }
+            case .failed(let error):
+                XCTFail("Unexpected .failed event: \(error)")
+            case .completed:
+                break
+            default:
+                XCTFail("Unexpected event: \(event)")
+            }
+        }
+        wait(for: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+
+        let ownerCreatedNoteResult = createNote(content: "owner created content")
+        guard case .success = ownerCreatedNoteResult else {
+            XCTFail("Owner should be able to successfully create a note")
+            return
+        }
+
+        wait(for: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        operation.cancel()
+    }
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/README.md
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/README.md
@@ -1,0 +1,72 @@
+## GraphQL with UserPool Auth Integration Tests
+
+The following steps demonstrate how to set up an GraphQL endpoint with AppSync. The auth configured will be Cognito UserPools. This set up is used to run the tests in `GraphQLAuthDirectiveIntegrationTests.swift`.
+
+### Set-up
+
+1. `amplify init`
+
+2. `amplify add api`
+
+```perl
+? Please select from one of the below mentioned services: GraphQL
+? Provide API name: `<APIName>`
+? Choose the default authorization type for the API `Amazon Cognito User Pool`
+? Do you want to use the default authentication and security configuration? `Default configuration`
+? How do you want users to be able to sign in? `Email`
+? Do you want to configure advanced settings? `No, I am done.`
+? Do you want to configure advanced settings for the GraphQL API `No, I am done.`
+? Do you have an annotated GraphQL schema? `No`
+? Do you want a guided schema creation? `Yes`
+? What best describes your project: `Single object with fields (e.g., “Todo” with ID, name, description)`
+? Do you want to edit the schema now? `No`
+```
+
+The guided schema provided should look like this: 
+```json
+type SocialNote
+    @model
+    @auth(rules: [
+        { allow: owner, ownerField: "owner", operations: [create, update, delete] },
+    ]) {
+    id: ID!
+    content: String!
+    owner: String
+}
+```
+
+3. `amplify update api`
+? Please select from one of the below mentioned services: `GraphQL`
+? Select from the options below `Enable DataStore for entire API`
+
+4. `amplify push`
+```perl
+? Are you sure you want to continue? `Yes`
+? Do you want to generate code for your newly created GraphQL API `No`
+```
+
+5. Copy `amplifyconfiguration.json` and `awsconfiguration.json` over as `GraphQLAuthDirectiveIntegrationTests-amplifyconfiguration.json` and `GraphQLAuthDirectiveIntegrationTests-awsconfiguration.json`
+6. Create `GraphQLAuthDirectiveIntegrationTests-credentials.json` with a json object containing `user1`, and `password`, used to create the cognito user in the userpool. In step 2, the cognito userpool is configured to allow users to sign up with their email as the username.
+
+```json
+{
+    "user1": "<USER EMAIL>",
+    "user2": "<USER2 EMAIL>",
+    "password": "<PASSWORD>"
+}
+
+```
+
+7. `amplify console auth`
+```perl
+? Which console `User Pool`
+```
+
+8. Click on `Users and groups`, Sign up the two new users with the email and a temporary password. 
+
+9. Click on App clients, and keep note of the app client web's `App client id`. This can be used the AWS AppSync console Queries.
+
+10. `amplify console api`
+Click on Queries tab, and click on Log in. This will prompt you to enter the app client id, username, and temporary password. After logging in successfully, it will ask you to enter a new password. Make sure those are the same as the one specified in the credentials json file from step 5. Do this for both users.
+
+You can now run the tests!

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/README.md
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/README.md
@@ -51,8 +51,9 @@ type SocialNote
 ```json
 {
     "user1": "<USER EMAIL>",
+    "passwordUser1": "<PASSWORD>"
     "user2": "<USER2 EMAIL>",
-    "password": "<PASSWORD>"
+    "passwordUser2": "<PASSWORD>"
 }
 
 ```

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/SocialNote.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/SocialNote.swift
@@ -1,0 +1,38 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+
+public struct SocialNote: Model {
+    public let id: String
+    public var content: String
+    public var owner: String?
+    public init(id: String = UUID().uuidString,
+                content: String,
+                owner: String?) {
+        self.id = id
+        self.content = content
+        self.owner = owner
+    }
+    public enum CodingKeys: String, ModelKey {
+        case id
+        case content
+        case owner
+    }
+    public static let keys = CodingKeys.self
+
+    public static let schema = defineSchema { model in
+        let socialNote = SocialNote.keys
+        model.authRules = [
+            rule(allow: .owner, operations: [.create, .update, .delete])
+        ]
+        model.fields(
+            .id(),
+            .field(socialNote.content, is: .required, ofType: .string),
+            .field(socialNote.owner, is: .optional, ofType: .string))
+    }
+}

--- a/AmplifyTestCommon/Helpers/AuthHelper.swift
+++ b/AmplifyTestCommon/Helpers/AuthHelper.swift
@@ -100,4 +100,8 @@ class AuthHelper {
 
         fatalError("Could not get identityId from result")
     }
+
+    static func getUserSub() -> String? {
+        AWSMobileClient.default().username
+    }
 }

--- a/AmplifyTestCommon/Models/schema.graphql
+++ b/AmplifyTestCommon/Models/schema.graphql
@@ -19,7 +19,7 @@ type Comment @model {
 type Blog
     @model
     @auth(rules: [
-        { allow: owner, ownerField: "owner", "operations: [create, read] },
+        { allow: owner, ownerField: "owner", operations: [create, read] },
         { allow: groups, groups: ["Admin"] }
     ]) {
     id: ID!


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This builds on top of https://github.com/aws-amplify/amplify-ios/pull/423 which provides the graphQL document builders to make the requests.

The integration tests run against a backend provisioined
- with a schema containing a model with auth directive
- cognito user pool as the auth mode.
- conflict resolution enabled

The schema is a read-only model by others other than owner.
```
type SocialNote
    @model
    @auth(rules: [
        { allow: owner, ownerField: "owner", operations: [create, update, delete] },
    ]) {
    id: ID!
    content: String!
    owner: String
}
```

This test mainly executes methods relating to DataStore usage, ensuring expected service behavior and validating how the caller handles the API response, especially when the caller is unauthorized:
- Mutations by owner/other
- syncQuery, when authorized and not authorized
- subscription operation with ownerId in document input

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
