### PR TITLE
feat: [DataStore][AuthDirective] SyncToCloud not authenticated error handling

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreError.swift
+++ b/Amplify/Categories/DataStore/DataStoreError.swift
@@ -10,7 +10,7 @@ import Foundation
 // MARK: - Enum
 
 public enum DataStoreError: Error {
-    case api(AmplifyError)
+    case api(AmplifyError, MutationEvent? = nil)
     case configuration(ErrorDescription, RecoverySuggestion, Error? = nil)
     case conflict(DataStoreSyncConflict)
     case invalidCondition(ErrorDescription, RecoverySuggestion, Error? = nil)
@@ -30,7 +30,7 @@ extension DataStoreError: AmplifyError {
 
     public var errorDescription: ErrorDescription {
         switch self {
-        case .api(let error):
+        case .api(let error, _):
             return error.errorDescription
         case .conflict:
             return "A conflict occurred syncing a local model with the remote API"
@@ -57,7 +57,7 @@ extension DataStoreError: AmplifyError {
 
     public var recoverySuggestion: RecoverySuggestion {
         switch self {
-        case .api(let error):
+        case .api(let error, _):
             return error.recoverySuggestion
         case .conflict:
             return "See this error's associated value for the details of the conflict"
@@ -85,7 +85,7 @@ extension DataStoreError: AmplifyError {
 
     public var underlyingError: Error? {
         switch self {
-        case .api(let amplifyError):
+        case .api(let amplifyError, _):
             return amplifyError
         case .configuration(_, _, let underlyingError),
              .invalidCondition(_, _, let underlyingError),

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
@@ -52,7 +52,7 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
             return
         }
 
-        if let apiError = apiError, isNotAuthenticated(apiError: apiError) {
+        if let apiError = apiError, isAuthServiceError(apiError: apiError) {
             dataStoreConfiguration.errorHandler(DataStoreError.api(apiError, mutationEvent))
             finish(result: .success(nil))
             return
@@ -95,10 +95,10 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
         }
     }
 
-    private func isNotAuthenticated(apiError: APIError) -> Bool {
+    private func isAuthServiceError(apiError: APIError) -> Bool {
         if case let .operationError(_, _, underlyingError) = apiError,
             let authError = underlyingError as? AuthError,
-            case .notAuthenticated = authError {
+            case .service = authError {
             return true
         }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
@@ -11,15 +11,17 @@ import Foundation
 import AWSPluginsCore
 
 /// Checks the GraphQL error response for specific error scenarios related to data synchronziation to the local store.
-/// 1. When there is a "conditional request failed" error, then emit to the Hub a 'conditionalSaveFailed' event.
-/// 2. When there is a "conflict unahandled" error, trigger the conflict handler and reconcile the state of the system.
+/// 1. When there is an APIError which is for an unauthenticated user, call the error handler.
+/// 2. When there is a "conditional request failed" error, then emit to the Hub a 'conditionalSaveFailed' event.
+/// 3. When there is a "conflict unahandled" error, trigger the conflict handler and reconcile the state of the system.
 @available(iOS 13.0, *)
 class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
 
     private let dataStoreConfiguration: DataStoreConfiguration
     private let storageAdapter: StorageEngineAdapter
     private let mutationEvent: MutationEvent
-    private let graphQLResponseError: GraphQLResponseError<MutationSync<AnyModel>>
+    private let graphQLResponseError: GraphQLResponseError<MutationSync<AnyModel>>?
+    private let apiError: APIError?
     private let completion: (Result<MutationEvent?, Error>) -> Void
     private var mutationOperation: GraphQLOperation<MutationSync<AnyModel>>?
     private weak var api: APICategoryGraphQLBehavior?
@@ -28,13 +30,15 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
          mutationEvent: MutationEvent,
          api: APICategoryGraphQLBehavior,
          storageAdapter: StorageEngineAdapter,
-         graphQLResponseError: GraphQLResponseError<MutationSync<AnyModel>>,
+         graphQLResponseError: GraphQLResponseError<MutationSync<AnyModel>>? = nil,
+         apiError: APIError? = nil,
          completion: @escaping (Result<MutationEvent?, Error>) -> Void) {
         self.dataStoreConfiguration = dataStoreConfiguration
         self.mutationEvent = mutationEvent
         self.api = api
         self.storageAdapter = storageAdapter
         self.graphQLResponseError = graphQLResponseError
+        self.apiError = apiError
         self.completion = completion
         super.init()
     }
@@ -48,13 +52,20 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
             return
         }
 
-        guard case let .error(graphQLErrors) = graphQLResponseError else {
+        if let apiError = apiError, isNotAuthenticated(apiError: apiError) {
+            dataStoreConfiguration.errorHandler(DataStoreError.api(apiError, mutationEvent))
             finish(result: .success(nil))
             return
         }
 
+        guard let graphQLResponseError = graphQLResponseError,
+            case let .error(graphQLErrors) = graphQLResponseError else {
+                finish(result: .success(nil))
+                return
+        }
+
         guard graphQLErrors.count == 1 else {
-            log.error("Received more than one error response: \(graphQLResponseError)")
+            log.error("Received more than one error response: \(String(describing: graphQLResponseError))")
             finish(result: .success(nil))
             return
         }
@@ -82,6 +93,16 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
             log.debug("GraphQLError missing extensions and errorType \(graphQLError)")
             finish(result: .success(nil))
         }
+    }
+
+    private func isNotAuthenticated(apiError: APIError) -> Bool {
+        if case let .operationError(_, _, underlyingError) = apiError,
+            let authError = underlyingError as? AuthError,
+            case .notAuthenticated = authError {
+            return true
+        }
+
+        return false
     }
 
     private func processConflictUnhandled(_ extensions: [String: JSONValue]) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -31,6 +31,62 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
         ModelRegistry.register(modelType: Comment.self)
     }
 
+    /// - Given: APIError
+    /// - When:
+    ///    - APIError is .notAuthenticated
+    /// - Then:
+    ///    - `DataStoreErrorHandler` is called
+    func testProcessMutationErrorFromCloudOperationSuccessForNotAuthenticatedAPIError() throws {
+        let localPost = Post(title: "localTitle", content: "localContent", createdAt: Date())
+        let mutationEvent = try MutationEvent(model: localPost, mutationType: .update)
+        let authError = AuthError.notAuthenticated("User is not authenticated", "Authenticate user", nil)
+        let apiError = APIError.operationError("not signed in", "Sign In User", authError)
+        let expectCompletion = expectation(description: "Expect to complete error processing")
+        let completion: (Result<MutationEvent?, Error>) -> Void = { result in
+            guard case .success(let mutationEventOptional) = result else {
+                XCTFail("Should have been successful")
+                return
+            }
+            XCTAssertNil(mutationEventOptional)
+            expectCompletion.fulfill()
+        }
+        let expectErrorHandlerCalled = expectation(description: "Expect error handler called")
+        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+            guard let dataStoreError = error as? DataStoreError,
+                case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
+                    XCTFail("Expected API error with mutationEvent")
+                    return
+            }
+            guard let actualAPIError = amplifyError as? APIError,
+                case let .operationError(_, _, underlyingError) = actualAPIError,
+                let authError = underlyingError as? AuthError,
+                case .notAuthenticated = authError else {
+                    XCTFail("Should be `notAuthenticated` error")
+                    return
+            }
+            guard let actualMutationEvent = mutationEventOptional else {
+                XCTFail("Missing mutationEvent for api error")
+                return
+            }
+            XCTAssertEqual(actualMutationEvent.id, mutationEvent.id)
+
+            expectErrorHandlerCalled.fulfill()
+        })
+
+        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: configuration,
+                                                               mutationEvent: mutationEvent,
+                                                               api: mockAPIPlugin,
+                                                               storageAdapter: storageAdapter,
+                                                               apiError: apiError,
+                                                               completion: completion)
+
+        let queue = OperationQueue()
+        queue.addOperation(operation)
+
+        wait(for: [expectErrorHandlerCalled], timeout: defaultAsyncWaitTimeout)
+        wait(for: [expectCompletion], timeout: defaultAsyncWaitTimeout)
+    }
+
     func testProcessMutationErrorFromCloudOperationSuccessForUnknownError() throws {
         let localPost = Post(title: "localTitle", content: "localContent", createdAt: Date())
         let remotePost = Post(id: localPost.id, title: "remoteTitle", content: "remoteContent", createdAt: Date())

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -36,10 +36,10 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     ///    - APIError is .notAuthenticated
     /// - Then:
     ///    - `DataStoreErrorHandler` is called
-    func testProcessMutationErrorFromCloudOperationSuccessForNotAuthenticatedAPIError() throws {
+    func testProcessMutationErrorFromCloudOperationSuccessForAuthServiceAPIError() throws {
         let localPost = Post(title: "localTitle", content: "localContent", createdAt: Date())
         let mutationEvent = try MutationEvent(model: localPost, mutationType: .update)
-        let authError = AuthError.notAuthenticated("User is not authenticated", "Authenticate user", nil)
+        let authError = AuthError.service("User is not authenticated", "Authenticate user", nil)
         let apiError = APIError.operationError("not signed in", "Sign In User", authError)
         let expectCompletion = expectation(description: "Expect to complete error processing")
         let completion: (Result<MutationEvent?, Error>) -> Void = { result in
@@ -60,8 +60,8 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             guard let actualAPIError = amplifyError as? APIError,
                 case let .operationError(_, _, underlyingError) = actualAPIError,
                 let authError = underlyingError as? AuthError,
-                case .notAuthenticated = authError else {
-                    XCTFail("Should be `notAuthenticated` error")
+                case .service = authError else {
+                    XCTFail("Should be `service` error")
                     return
             }
             guard let actualMutationEvent = mutationEventOptional else {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Scenario: 'Owner' is not signed in, persists to local store via DataStore.save()/DataStore.delete(), the mutationEvent is then attempted to call API.mutate. the mutate fails with `notAuthenticated` error.

This change checks for unauthenticated calls to API and propagates the error and corresponding MutationEvent to the developer using `DataStoreConfiguration.errorHandler`.

The error provided to the developer is
```
public enum DataStoreError: Error {
    case api(AmplifyError, MutationEvent? = nil)
```
With the mutation event, the developer can see that the API call failed for some particular DataStore call. The developer can decide what to do. For example, 
- delete the data using the mutation event's model identifier, if it were a `.create` mutation type.
- prompt the user for sign in the user, and oncall back, reattempt to the DataStore.save()/DataStore.delete()

Another Scenario to consider: 'Other' retrieves data from local store, and attempts to update it. The update is successful on local store, however the mutationEvent is attempted fails with conditional save failed. This is already propagated to the Hub as a `HubPayload.EventName.DataStore.conditionalSaveFailed` event

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
