### PR TITLE
refactor(Auth): Refactored AuthUserAttributeKey to be RawRepresentable

### DIFF
--- a/Amplify/Categories/Auth/Models/AuthCodeDeliveryDetails.swift
+++ b/Amplify/Categories/Auth/Models/AuthCodeDeliveryDetails.swift
@@ -15,12 +15,11 @@ public struct AuthCodeDeliveryDetails {
     public let destination: DeliveryDestination
 
     /// Attribute that is confirmed or verified.
-    // TODO: Change to attributeType #172336364
-    public let attributeName: String?
+    public let attributeKey: AuthUserAttributeKey?
 
     public init(destination: DeliveryDestination,
-                attributeName: String? = nil) {
+                attributeKey: AuthUserAttributeKey? = nil) {
         self.destination = destination
-        self.attributeName = attributeName
+        self.attributeKey = attributeKey
     }
 }

--- a/Amplify/Categories/Auth/Models/AuthUserAttribute.swift
+++ b/Amplify/Categories/Auth/Models/AuthUserAttribute.swift
@@ -31,6 +31,7 @@ public enum AuthUserAttributeKey {
     case picture
     case preferredUsername
     case custom(String)
+    case unknown(String)
 }
 
 extension AuthUserAttributeKey: Hashable {}

--- a/AmplifyPlugins/Auth/AWSAuthPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		B4B5CCBA2458C4330019C783 /* AWSAuthPlugin+UserBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B5CCB92458C4330019C783 /* AWSAuthPlugin+UserBehavior.swift */; };
 		B4BD35C7246477870072DFBF /* Tokens+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4BD35C6246477870072DFBF /* Tokens+Extension.swift */; };
 		B4C04A9A2462193700E59DF8 /* AWSAuthChangePasswordOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C04A992462193700E59DF8 /* AWSAuthChangePasswordOperation.swift */; };
+		B4C8EDB8246B5EFD00ED7484 /* AuthUserAttributeKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C8EDB7246B5EFD00ED7484 /* AuthUserAttributeKeyTests.swift */; };
 		B4D0668224635E3A00CF9FE3 /* AWSAuthPlugin+DeviceBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D0668124635E3A00CF9FE3 /* AWSAuthPlugin+DeviceBehavior.swift */; };
 		B4D066842463636C00CF9FE3 /* AWSAuthDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D066832463636C00CF9FE3 /* AWSAuthDevice.swift */; };
 		B4D066862463642A00CF9FE3 /* Device+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D066852463642A00CF9FE3 /* Device+Extension.swift */; };
@@ -196,6 +197,7 @@
 		B4B5CCB92458C4330019C783 /* AWSAuthPlugin+UserBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSAuthPlugin+UserBehavior.swift"; sourceTree = "<group>"; };
 		B4BD35C6246477870072DFBF /* Tokens+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tokens+Extension.swift"; sourceTree = "<group>"; };
 		B4C04A992462193700E59DF8 /* AWSAuthChangePasswordOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAuthChangePasswordOperation.swift; sourceTree = "<group>"; };
+		B4C8EDB7246B5EFD00ED7484 /* AuthUserAttributeKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthUserAttributeKeyTests.swift; sourceTree = "<group>"; };
 		B4D0668124635E3A00CF9FE3 /* AWSAuthPlugin+DeviceBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSAuthPlugin+DeviceBehavior.swift"; sourceTree = "<group>"; };
 		B4D066832463636C00CF9FE3 /* AWSAuthDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAuthDevice.swift; sourceTree = "<group>"; };
 		B4D066852463642A00CF9FE3 /* Device+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Device+Extension.swift"; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 		B43DC7522410572400D40275 /* AWSAuthPluginTests */ = {
 			isa = PBXGroup;
 			children = (
+				B4C8EDB6246B5ED800ED7484 /* Utils */,
 				B43DC7532410572400D40275 /* AWSAuthPluginTests.swift */,
 				B43DC7552410572400D40275 /* Info.plist */,
 			);
@@ -464,6 +467,14 @@
 				B4B5CCB02458AF390019C783 /* AWSAuthUpdateUserAttributesOperation.swift */,
 			);
 			path = UserOperations;
+			sourceTree = "<group>";
+		};
+		B4C8EDB6246B5ED800ED7484 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				B4C8EDB7246B5EFD00ED7484 /* AuthUserAttributeKeyTests.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 		B4F3EA07243A655A00F23296 /* AWSAuthPluginIntegrationTests */ = {
@@ -1093,6 +1104,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B43DC7542410572400D40275 /* AWSAuthPluginTests.swift in Sources */,
+				B4C8EDB8246B5EFD00ED7484 /* AuthUserAttributeKeyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/AWSAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/AWSAuthPlugin+Configure.swift
@@ -31,8 +31,12 @@ extension AWSAuthPlugin {
             try awsMobileClient.initialize()
             let authenticationProvider = AuthenticationProviderAdapter(awsMobileClient: awsMobileClient)
             let authorizationProvider = AuthorizationProviderAdapter(awsMobileClient: awsMobileClient)
+            let userService = AuthUserServiceAdapter(awsMobileClient: awsMobileClient)
+            let deviceService = AuthDeviceServiceAdapter(awsMobileClient: awsMobileClient)
             configure(authenticationProvider: authenticationProvider,
-                      authorizationProvider: authorizationProvider)
+                      authorizationProvider: authorizationProvider,
+                      userService: userService,
+                      deviceService: deviceService)
         } catch let authError as AuthError {
             throw authError
         } catch {
@@ -58,9 +62,13 @@ extension AWSAuthPlugin {
     ///   - queue: The queue which operations are stored and dispatched for asychronous processing.
     func configure(authenticationProvider: AuthenticationProviderBehavior,
                    authorizationProvider: AuthorizationProviderBehavior,
+                   userService: AuthUserServiceBehavior,
+                   deviceService: AuthDeviceServiceBehavior,
                    queue: OperationQueue = OperationQueue()) {
         self.authenticationProvider = authenticationProvider
         self.authorizationProvider = authorizationProvider
+        self.userService = userService
+        self.deviceService = deviceService
         self.queue = queue
     }
 }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -73,7 +73,7 @@ extension AuthenticationProviderAdapter {
 
         let userAttributes = (request.options.pluginOptions as? AWSAuthConfirmSignInOptions)?.userAttributes ?? []
         let mobileClientUserAttributes = userAttributes.reduce(into: [String: String]()) {
-            $0[$1.key.toString()] = $1.value
+            $0[$1.key.rawValue] = $1.value
         }
         let clientMetaData = (request.options.pluginOptions as? AWSAuthConfirmSignInOptions)?.metadata
 

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Dependency/AuthenticationProviderAdapter+SignUp.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Dependency/AuthenticationProviderAdapter+SignUp.swift
@@ -20,7 +20,7 @@ extension AuthenticationProviderAdapter {
 
         // Convert the attributes to [String: String]
         let attributes = request.options.userAttributes?.reduce(into: [String: String]()) {
-            $0[$1.key.toString()] = $1.value
+            $0[$1.key.rawValue] = $1.value
         }
         awsMobileClient.signUp(username: request.username,
                                password: password,

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Support/Utils/AuthUserAttributeKey+Extension.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Support/Utils/AuthUserAttributeKey+Extension.swift
@@ -8,75 +8,97 @@
 import Amplify
 
 // swiftlint:disable cyclomatic_complexity
-extension AuthUserAttributeKey {
+extension AuthUserAttributeKey: RawRepresentable {
 
-    func toString() -> String {
-        switch self {
-        case .address:
-            return "address"
-        case .birthDate:
-            return "birthdate"
-        case .email:
-            return "email"
-        case .familyName:
-            return "family_name"
-        case .gender:
-            return "gender"
-        case .givenName:
-            return "given_name"
-        case .locale:
-            return "locale"
-        case .middleName:
-            return "middle_name"
-        case .name:
-            return "name"
-        case .nickname:
-            return "nickname"
-        case .phoneNumber:
-            return "phone_number"
-        case .picture:
-            return "picture"
-        case .preferredUsername:
-            return "preferred_username"
-        case .custom(let attribute):
-            return "custom: \(attribute)"
+    public typealias RawValue = String
+
+    // Values are taken from:
+    // https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html
+    private static let addressRawValue = "address"
+    private static let birthDateRawValue = "birthdate"
+    private static let emailRawValue = "email"
+    private static let familyNameRawValue = "family_name"
+    private static let genderRawValue = "gender"
+    private static let givenNameRawValue = "given_name"
+    private static let localeRawValue = "locale"
+    private static let middleNameRawValue = "middle_name"
+    private static let nameRawValue = "name"
+    private static let nicknameRawValue = "nickname"
+    private static let phoneNumberRawValue = "phone_number"
+    private static let pictureRawValue = "picture"
+    private static let preferredUsernameRawValue = "preferred_username"
+    private static let customAttributePrefix = "custom:"
+
+    public init(rawValue: String) {
+        switch rawValue {
+        case AuthUserAttributeKey.addressRawValue:
+            self = .address
+        case AuthUserAttributeKey.birthDateRawValue:
+            self = .birthDate
+        case AuthUserAttributeKey.emailRawValue:
+            self = .email
+        case AuthUserAttributeKey.familyNameRawValue:
+            self = .familyName
+        case AuthUserAttributeKey.genderRawValue:
+            self = .gender
+        case AuthUserAttributeKey.givenNameRawValue:
+            self = .givenName
+        case AuthUserAttributeKey.localeRawValue:
+            self = .locale
+        case AuthUserAttributeKey.middleNameRawValue:
+            self = .middleName
+        case AuthUserAttributeKey.nameRawValue:
+            self = .name
+        case AuthUserAttributeKey.nicknameRawValue:
+            self = .nickname
+        case AuthUserAttributeKey.phoneNumberRawValue:
+            self = .phoneNumber
+        case AuthUserAttributeKey.pictureRawValue:
+            self = .picture
+        case AuthUserAttributeKey.preferredUsernameRawValue:
+            self = .preferredUsername
+        default:
+            if rawValue.starts(with: AuthUserAttributeKey.customAttributePrefix) {
+                let attribute = String(rawValue.dropFirst(AuthUserAttributeKey.customAttributePrefix.count))
+                self = .custom(attribute)
+            } else {
+                self = .unknown(rawValue)
+            }
         }
     }
-}
 
-extension String {
-
-    func toUserAttributeKey() -> AuthUserAttributeKey {
+    public var rawValue: String {
         switch self {
-        case AuthUserAttributeKey.address.toString():
-            return .address
-        case AuthUserAttributeKey.birthDate.toString():
-            return .birthDate
-        case AuthUserAttributeKey.email.toString():
-            return .email
-        case AuthUserAttributeKey.familyName.toString():
-            return .familyName
-        case AuthUserAttributeKey.gender.toString():
-            return .gender
-        case AuthUserAttributeKey.givenName.toString():
-            return .givenName
-        case AuthUserAttributeKey.locale.toString():
-            return .locale
-        case AuthUserAttributeKey.middleName.toString():
-            return .middleName
-        case AuthUserAttributeKey.name.toString():
-            return .name
-        case AuthUserAttributeKey.nickname.toString():
-            return .nickname
-        case AuthUserAttributeKey.phoneNumber.toString():
-            return .phoneNumber
-        case AuthUserAttributeKey.picture.toString():
-            return .picture
-        case AuthUserAttributeKey.preferredUsername.toString():
-            return .preferredUsername
-        default:
-            return .custom(self)
+        case .address:
+            return AuthUserAttributeKey.addressRawValue
+        case .birthDate:
+            return AuthUserAttributeKey.birthDateRawValue
+        case .email:
+            return AuthUserAttributeKey.emailRawValue
+        case .familyName:
+            return AuthUserAttributeKey.familyNameRawValue
+        case .gender:
+            return AuthUserAttributeKey.genderRawValue
+        case .givenName:
+            return AuthUserAttributeKey.givenNameRawValue
+        case .locale:
+            return AuthUserAttributeKey.localeRawValue
+        case .middleName:
+            return AuthUserAttributeKey.middleNameRawValue
+        case .name:
+            return AuthUserAttributeKey.nameRawValue
+        case .nickname:
+            return AuthUserAttributeKey.nicknameRawValue
+        case .phoneNumber:
+            return AuthUserAttributeKey.phoneNumberRawValue
+        case .picture:
+            return AuthUserAttributeKey.pictureRawValue
+        case .preferredUsername:
+            return AuthUserAttributeKey.preferredUsernameRawValue
+        case .custom(let attribute):
+            return AuthUserAttributeKey.customAttributePrefix + attribute
+        case .unknown(let rawValue):
+            return rawValue
         }
-
     }
 }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Support/Utils/UserCodeDeliveryDetails+Extension.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Support/Utils/UserCodeDeliveryDetails+Extension.swift
@@ -23,9 +23,11 @@ extension UserCodeDeliveryDetails {
 
     func toAuthCodeDeliveryDetails() -> AuthCodeDeliveryDetails {
         let destination = toDeliveryDestination()
-        let attributeName = self.attributeName ?? ""
+        guard let attributeToVerify = attributeName else {
+            return  AuthCodeDeliveryDetails(destination: destination)
+        }
         return  AuthCodeDeliveryDetails(destination: destination,
-                                        attributeName: attributeName)
+                                        attributeKey: AuthUserAttributeKey(rawValue: attributeToVerify))
     }
 
 }

--- a/AmplifyPlugins/Auth/AWSAuthPluginTests/Utils/AuthUserAttributeKeyTests.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPluginTests/Utils/AuthUserAttributeKeyTests.swift
@@ -1,0 +1,104 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import Amplify
+import AWSAuthPlugin
+
+class AuthUserAttributeKeyTests: XCTestCase {
+
+    /// Test if attribute raw value gives us the right value
+    ///
+    /// - Given: Any attribute from the enum AuthUserAttributeKey say .phoneNumber
+    /// - When:
+    ///    - I get rawValue of the enum
+    /// - Then:
+    ///    - The value should be equal to the one defined by Cognito.
+    ///    https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html
+    ///
+    func testSuccessfulRawValue() {
+        let attribute = AuthUserAttributeKey.phoneNumber
+        XCTAssertEqual(attribute.rawValue, "phone_number")
+    }
+
+    /// Test if initializing through a valid raw string gives back an enum
+    ///
+    /// - Given: A valid raw string from the Cognito
+    /// - When:
+    ///    - I create an enum using the raw value
+    /// - Then:
+    ///    - The enum should be mapping to the exact value
+    ///
+    func testInitWithRawValue() {
+        let attribute = AuthUserAttributeKey(rawValue: "middle_name")
+        XCTAssertEqual(attribute, .middleName)
+    }
+
+    /// Test if initializing through a custom raw string gives back an enum
+    ///
+    /// - Given: A custom raw string to be used as custom attribute
+    /// - When:
+    ///    - I create an enum using the raw value
+    /// - Then:
+    ///    - The enum should be custom attribute type
+    ///
+    func testInitWithCustomRawValue() {
+        let attribute = AuthUserAttributeKey(rawValue: "custom:someattribute")
+        switch attribute {
+        case .custom(let attribute):
+            print(attribute)
+        default:
+            XCTFail("Attribute type should be custom")
+        }
+    }
+
+    /// Test if attribute raw value gives us the right value for a custom attribute
+    ///
+    /// - Given: A custom attribute from AuthUserAttributeKey
+    /// - When:
+    ///    - I get rawValue of the enum
+    /// - Then:
+    ///    - The value should be equal to "custom:<value given>"
+    ///
+    func testSuccessfulCustomRawValue() {
+        let customAttributeKey = "someattribute2"
+        let attribute = AuthUserAttributeKey.custom(customAttributeKey)
+        XCTAssertEqual(attribute.rawValue, "custom:\(customAttributeKey)")
+    }
+
+    /// Test if attribute raw value gives us the right value for a unknown attribute
+    ///
+    /// - Given: A unknown attribute from AuthUserAttributeKey
+    /// - When:
+    ///    - I get rawValue of the enum
+    /// - Then:
+    ///    - The value should be equal to "<value given>"
+    ///
+    func testSuccessfulUnknownRawValue() {
+        let customAttributeKey = "someattribute2"
+        let attribute = AuthUserAttributeKey.unknown(customAttributeKey)
+        XCTAssertEqual(attribute.rawValue, customAttributeKey)
+    }
+
+    /// Test if initializing through a unknown raw string gives back an enum
+    ///
+    /// - Given: A raw string wihtout the custom attribute prefix
+    /// - When:
+    ///    - I create an enum using the raw value
+    /// - Then:
+    ///    - The enum should be unknown attribute type
+    ///
+    func testInitWithUnkownRawValue() {
+        let attribute = AuthUserAttributeKey(rawValue: "someattribute")
+        switch attribute {
+        case .unknown(let attribute):
+            print(attribute)
+        default:
+            XCTFail("Attribute type should be custom")
+        }
+    }
+}


### PR DESCRIPTION
- AuthUserAttributeKey to [RawRepresentable](https://developer.apple.com/documentation/swift/rawrepresentable), handles #419 
- Changed String attributeName in CodeDelivery to AuthUserAttributeKey

Update 1

- Added a new case `unknown` to the enum list to track an attribute unknown to the system and not a custom attribute.
- Raw value given in init will always be returned when we call `Enum.rawValue`
- Added missing userService and deviceService to the configuration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
