### PR TITLE
refactor(Auth): Rename the escape hatch enums type

### DIFF
--- a/AmplifyPlugins/Auth/AWSAuthPlugin/AWSAuthPlugin.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/AWSAuthPlugin.swift
@@ -34,7 +34,7 @@ final public class AWSAuthPlugin: AuthCategoryPlugin {
         return "awsCognitoAuthPlugin"
     }
 
-    public func getEscapeHatch() -> AWSAuthService {
+    public func getEscapeHatch() -> AWSCognitoAuthService {
         if let internalAuthorizationProvider = authorizationProvider as? AuthorizationProviderAdapter,
             let awsMobileClientProvider = internalAuthorizationProvider.awsMobileClient as? AWSMobileClientAdapter {
             return .awsMobileClient(awsMobileClientProvider.awsMobileClient)

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Models/AWSAuthService.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Models/AWSAuthService.swift
@@ -7,7 +7,7 @@
 
 import AWSMobileClient
 
-public enum AWSAuthService {
+public enum AWSCognitoAuthService {
 
     case awsMobileClient(AWSMobileClient)
 


### PR DESCRIPTION
The escape hatch enum type was conflicting with the AWSPluginsCore class type. This was causing build failures in packages that are using both AWSAuthPlugin and AWSPluginsCore.

Conflicting class - [link](https://github.com/aws-amplify/amplify-ios/blob/master/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
