### PR TITLE
feat: AuthRule alignment with codegen

### DIFF
--- a/Amplify/Categories/DataStore/Model/Schema/AuthRule.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/AuthRule.swift
@@ -23,7 +23,6 @@ public typealias AuthRules = [AuthRule]
 
 public struct AuthRule {
     public let allow: AuthStrategy
-    public let field: CodingKey?
     public let ownerField: CodingKey?
     public let identityClaim: String?
     public let groupClaim: String?
@@ -32,7 +31,6 @@ public struct AuthRule {
     public let operations: [ModelOperation]
 
     public init(allow: AuthStrategy,
-                field: CodingKey? = nil,
                 ownerField: CodingKey? = nil,
                 identityClaim: String? = nil,
                 groupClaim: String? = nil,
@@ -40,7 +38,6 @@ public struct AuthRule {
                 groupsField: CodingKey? = nil,
                 operations: [ModelOperation] = []) {
         self.allow = allow
-        self.field = field
         self.ownerField = ownerField
         self.identityClaim = identityClaim
         self.groupClaim = groupClaim

--- a/Amplify/Categories/DataStore/Model/Schema/AuthRule.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/AuthRule.swift
@@ -23,19 +23,19 @@ public typealias AuthRules = [AuthRule]
 
 public struct AuthRule {
     public let allow: AuthStrategy
-    public let ownerField: CodingKey?
+    public let ownerField: String?
     public let identityClaim: String?
     public let groupClaim: String?
     public let groups: [String]
-    public let groupsField: CodingKey?
+    public let groupsField: String?
     public let operations: [ModelOperation]
 
     public init(allow: AuthStrategy,
-                ownerField: CodingKey? = nil,
+                ownerField: String? = nil,
                 identityClaim: String? = nil,
                 groupClaim: String? = nil,
                 groups: [String] = [],
-                groupsField: CodingKey? = nil,
+                groupsField: String? = nil,
                 operations: [ModelOperation] = []) {
         self.allow = allow
         self.ownerField = ownerField

--- a/Amplify/Categories/DataStore/Model/Schema/AuthRule.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/AuthRule.swift
@@ -12,13 +12,6 @@ public enum AuthStrategy {
     case `public`
 }
 
-public enum AuthProvider {
-    case apiKey
-    case iam
-    case oidc
-    case userPools
-}
-
 public enum ModelOperation {
     case create
     case update
@@ -31,31 +24,25 @@ public typealias AuthRules = [AuthRule]
 public struct AuthRule {
     public let allow: AuthStrategy
     public let field: CodingKey?
-    public let provider: AuthProvider?
     public let ownerField: CodingKey?
     public let identityClaim: String?
     public let groupClaim: String?
     public let groups: [String]
-    public let groupsField: CodingKey?
     public let operations: [ModelOperation]
 
     public init(allow: AuthStrategy,
                 field: CodingKey? = nil,
-                provider: AuthProvider? = nil,
                 ownerField: CodingKey? = nil,
                 identityClaim: String? = nil,
                 groupClaim: String? = nil,
                 groups: [String] = [],
-                groupsField: CodingKey? = nil,
                 operations: [ModelOperation] = []) {
         self.allow = allow
         self.field = field
-        self.provider = provider
         self.ownerField = ownerField
         self.identityClaim = identityClaim
         self.groupClaim = groupClaim
         self.groups = groups
-        self.groupsField = groupsField
         self.operations = operations
     }
 }

--- a/Amplify/Categories/DataStore/Model/Schema/AuthRule.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/AuthRule.swift
@@ -28,6 +28,7 @@ public struct AuthRule {
     public let identityClaim: String?
     public let groupClaim: String?
     public let groups: [String]
+    public let groupsField: CodingKey?
     public let operations: [ModelOperation]
 
     public init(allow: AuthStrategy,
@@ -36,6 +37,7 @@ public struct AuthRule {
                 identityClaim: String? = nil,
                 groupClaim: String? = nil,
                 groups: [String] = [],
+                groupsField: CodingKey? = nil,
                 operations: [ModelOperation] = []) {
         self.allow = allow
         self.field = field
@@ -43,6 +45,7 @@ public struct AuthRule {
         self.identityClaim = identityClaim
         self.groupClaim = groupClaim
         self.groups = groups
+        self.groupsField = groupsField
         self.operations = operations
     }
 }

--- a/Amplify/Categories/DataStore/Model/Schema/Model+Schema.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/Model+Schema.swift
@@ -46,7 +46,6 @@ extension Model {
     }
 
     public static func rule(allow: AuthStrategy,
-                            field: CodingKey? = nil,
                             ownerField: CodingKey? = nil,
                             identityClaim: String? = nil,
                             groupClaim: String? = nil,
@@ -54,7 +53,6 @@ extension Model {
                             groupsField: CodingKey? = nil,
                             operations: [ModelOperation] = []) -> AuthRule {
         return AuthRule(allow: allow,
-                        field: field,
                         ownerField: ownerField,
                         identityClaim: identityClaim,
                         groupClaim: groupClaim,

--- a/Amplify/Categories/DataStore/Model/Schema/Model+Schema.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/Model+Schema.swift
@@ -46,11 +46,11 @@ extension Model {
     }
 
     public static func rule(allow: AuthStrategy,
-                            ownerField: CodingKey? = nil,
+                            ownerField: String? = nil,
                             identityClaim: String? = nil,
                             groupClaim: String? = nil,
                             groups: [String] = [],
-                            groupsField: CodingKey? = nil,
+                            groupsField: String? = nil,
                             operations: [ModelOperation] = []) -> AuthRule {
         return AuthRule(allow: allow,
                         ownerField: ownerField,

--- a/Amplify/Categories/DataStore/Model/Schema/Model+Schema.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/Model+Schema.swift
@@ -51,6 +51,7 @@ extension Model {
                             identityClaim: String? = nil,
                             groupClaim: String? = nil,
                             groups: [String] = [],
+                            groupsField: CodingKey? = nil,
                             operations: [ModelOperation] = []) -> AuthRule {
         return AuthRule(allow: allow,
                         field: field,
@@ -58,6 +59,7 @@ extension Model {
                         identityClaim: identityClaim,
                         groupClaim: groupClaim,
                         groups: groups,
+                        groupsField: groupsField,
                         operations: operations)
     }
 }

--- a/Amplify/Categories/DataStore/Model/Schema/Model+Schema.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/Model+Schema.swift
@@ -47,21 +47,17 @@ extension Model {
 
     public static func rule(allow: AuthStrategy,
                             field: CodingKey? = nil,
-                            provider: AuthProvider? = nil,
                             ownerField: CodingKey? = nil,
                             identityClaim: String? = nil,
                             groupClaim: String? = nil,
                             groups: [String] = [],
-                            groupsField: CodingKey? = nil,
                             operations: [ModelOperation] = []) -> AuthRule {
         return AuthRule(allow: allow,
                         field: field,
-                        provider: provider,
                         ownerField: ownerField,
                         identityClaim: identityClaim,
                         groupClaim: groupClaim,
                         groups: groups,
-                        groupsField: groupsField,
                         operations: operations)
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/AuthRule+Extension.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/AuthRule+Extension.swift
@@ -12,7 +12,7 @@ extension AuthRule {
         guard let ownerField = ownerField else {
             return "owner"
         }
-        return ownerField.stringValue
+        return ownerField
     }
 
     func getModelOperationsOrDefault() -> [ModelOperation] {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelMultipleOwnerAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelMultipleOwnerAuthRuleTests.swift
@@ -44,7 +44,7 @@ public struct ModelMultipleOwner: Model {
         let modelMultipleOwner = ModelMultipleOwner.keys
         model.authRules = [
             rule(allow: .owner),
-            rule(allow: .owner, ownerField: modelMultipleOwner.editors, operations: [.update, .read])
+            rule(allow: .owner, ownerField: "editors", operations: [.update, .read])
         ]
         model.fields(
             .id(),

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerFieldAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerFieldAuthRuleTests.swift
@@ -42,7 +42,7 @@ public struct ModelWithOwnerField: Model {
     public static let schema = defineSchema { model in
         let modelWithOwnerField = ModelWithOwnerField.keys
         model.authRules = [
-            rule(allow: .owner, ownerField: modelWithOwnerField.author)
+            rule(allow: .owner, ownerField: "author")
         ]
         model.fields(
             .id(),

--- a/AmplifyTestCommon/Models/Blog+Schema.swift
+++ b/AmplifyTestCommon/Models/Blog+Schema.swift
@@ -28,7 +28,7 @@ extension Blog {
         model.pluralName = "Blogs"
 
         model.authRules = [
-            rule(allow: .owner, ownerField: blog.owner, operations: [.create, .read]),
+            rule(allow: .owner, ownerField: "owner", operations: [.create, .read]),
             rule(allow: .groups, groups: ["Admin"]),
         ]
 
@@ -40,7 +40,7 @@ extension Blog {
             .field(blog.authorNotes,
                    is: .optional,
                    ofType: .string,
-                   authRules: [rule(allow: .owner, ownerField: blog.owner, operations: [.update])]
+                   authRules: [rule(allow: .owner, ownerField: "owner", operations: [.update])]
             )
         )
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- this removes `provider` as that is not needed in the schema, only the API needs to configured with the correct provider at provisioning time.
- moves CodingKey to a String, for the case where developer does not provide an owner field in the model, we need to pass the default values over to the schema (less logic stored in the library), allows CLI to be source of truth for default values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
