### PR TITLE
fix(Auth): Locally signOut the user if globaly signout fail with notAuthorized

### DIFF
--- a/Amplify/Categories/Auth/Request/AuthSignOutRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthSignOutRequest.swift
@@ -12,6 +12,7 @@ public struct AuthSignOutRequest: AmplifyOperationRequest {
     public var options: Options
 
     public init(options: Options) {
+
         self.options = options
     }
 }
@@ -25,7 +26,11 @@ public extension AuthSignOutRequest {
         /// key/values
         public let pluginOptions: Any?
 
-        public init(pluginOptions: Any? = nil) {
+        public let globalSignOut: Bool
+        
+        public init(globalSignOut: Bool = false,
+                    pluginOptions: Any? = nil) {
+            self.globalSignOut = globalSignOut
             self.pluginOptions = pluginOptions
         }
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Service/AWSMobileClient/AWSMobileClientAdapter.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Service/AWSMobileClient/AWSMobileClientAdapter.swift
@@ -103,6 +103,10 @@ class AWSMobileClientAdapter: AWSMobileClientBehavior {
         awsMobileClient.signOut(options: options, completionHandler: completionHandler)
     }
 
+    func signOut() {
+        awsMobileClient.signOut()
+    }
+    
     func username() -> String? {
         return awsMobileClient.username
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Service/AWSMobileClient/AWSMobileClientAdapter.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Service/AWSMobileClient/AWSMobileClientAdapter.swift
@@ -103,10 +103,10 @@ class AWSMobileClientAdapter: AWSMobileClientBehavior {
         awsMobileClient.signOut(options: options, completionHandler: completionHandler)
     }
 
-    func signOut() {
+    func signOutLocally() {
         awsMobileClient.signOut()
     }
-    
+
     func username() -> String? {
         return awsMobileClient.username
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Service/AWSMobileClient/AWSMobileClientBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Service/AWSMobileClient/AWSMobileClientBehavior.swift
@@ -50,6 +50,8 @@ protocol AWSMobileClientBehavior {
     func signOut(options: SignOutOptions,
                  completionHandler: @escaping ((Error?) -> Void))
 
+    func signOut()
+
     func username() -> String?
 
     func verifyUserAttribute(attributeName: String,

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Service/AWSMobileClient/AWSMobileClientBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Service/AWSMobileClient/AWSMobileClientBehavior.swift
@@ -50,7 +50,7 @@ protocol AWSMobileClientBehavior {
     func signOut(options: SignOutOptions,
                  completionHandler: @escaping ((Error?) -> Void))
 
-    func signOut()
+    func signOutLocally()
 
     func username() -> String?
 


### PR DESCRIPTION
Description:

- Made local signOut as the default behavior
- Added an option to signOutRequest for globalSignOut
- If global signOut fails with notAuthorized error, we do a localSignOut, since it is not a recoverable error.

```swift

      // Global signout
        let options = AuthSignOutRequest.Options(globalSignOut: true)
        Amplify.Auth.signOut(options: options) { (event) in
            switch event {
            case .failure(let error):
                print(error)
            case .success:
                print("success")
            }
        }
        
       // Local signOut
      Amplify.Auth.signOut { (event) in
            switch event {
            case .failure(let error):
                print(error)
            case .success:
                print("success")
            }
        }
```

*Issue #456 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
