### PR TITLE
fix: enum fixes for query predicates and graphql input

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -291,6 +291,7 @@
 		B996FC4423FF2FA8006D0F68 /* Encodable+AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B996FC4323FF2FA8006D0F68 /* Encodable+AnyEncodable.swift */; };
 		B996FC4D24059918006D0F68 /* Model+Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = B996FC4C24059918006D0F68 /* Model+Enum.swift */; };
 		B9A329CC243559BF00C5B80C /* TimeInterval+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A329CB243559BF00C5B80C /* TimeInterval+Helper.swift */; };
+		B9AA09F12473CA29000E6FBB /* PostStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AA09F02473CA29000E6FBB /* PostStatus.swift */; };
 		B9B64A9F23FCBF7E00730B68 /* ModelValueConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B64A9E23FCBF7E00730B68 /* ModelValueConverter.swift */; };
 		B9DCA263240F217C00075E22 /* AnyEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DCA262240F217C00075E22 /* AnyEncodableTests.swift */; };
 		B9FAA10B23878122009414B4 /* ModelField+Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FAA10A23878122009414B4 /* ModelField+Association.swift */; };
@@ -1004,6 +1005,7 @@
 		B996FC4323FF2FA8006D0F68 /* Encodable+AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+AnyEncodable.swift"; sourceTree = "<group>"; };
 		B996FC4C24059918006D0F68 /* Model+Enum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Model+Enum.swift"; sourceTree = "<group>"; };
 		B9A329CB243559BF00C5B80C /* TimeInterval+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Helper.swift"; sourceTree = "<group>"; };
+		B9AA09F02473CA29000E6FBB /* PostStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostStatus.swift; sourceTree = "<group>"; };
 		B9B64A9E23FCBF7E00730B68 /* ModelValueConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelValueConverter.swift; sourceTree = "<group>"; };
 		B9DCA262240F217C00075E22 /* AnyEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodableTests.swift; sourceTree = "<group>"; };
 		B9FAA10A23878122009414B4 /* ModelField+Association.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModelField+Association.swift"; sourceTree = "<group>"; };
@@ -2111,8 +2113,8 @@
 		B952182D237E21B900F53237 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				B952182F237E21B900F53237 /* schema.graphql */,
 				FAF512AD23986791001ADF4E /* AmplifyModels.swift */,
-				B9FAA10C23878BD6009414B4 /* Associations */,
 				210B3E35245CB86500F43848 /* Blog.swift */,
 				210B3E38245CB88D00F43848 /* Blog+Schema.swift */,
 				B9521830237E21B900F53237 /* Comment.swift */,
@@ -2121,7 +2123,8 @@
 				B9521832237E21B900F53237 /* Post.swift */,
 				B9521831237E21B900F53237 /* Post+Schema.swift */,
 				2129BE002394627B006363A1 /* PostCommentModelRegistration.swift */,
-				B952182F237E21B900F53237 /* schema.graphql */,
+				B9AA09F02473CA29000E6FBB /* PostStatus.swift */,
+				B9FAA10C23878BD6009414B4 /* Associations */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -2889,12 +2892,12 @@
 			isa = PBXGroup;
 			children = (
 				FACA36062327FBD4000E74F6 /* AmplifyTestCommon.h */,
-				FA9D6C20238DF06B00C7DD9F /* Helpers */,
 				FACA36072327FBD4000E74F6 /* Info.plist */,
-				FAC23577227A056F00424678 /* Mocks */,
-				B952182D237E21B900F53237 /* Models */,
 				21F40A3F23A295470074678E /* TestCommonConstants.swift */,
 				FACF52032329633500646E10 /* TestExtensions.swift */,
+				FA9D6C20238DF06B00C7DD9F /* Helpers */,
+				FAC23577227A056F00424678 /* Mocks */,
+				B952182D237E21B900F53237 /* Models */,
 			);
 			path = AmplifyTestCommon;
 			sourceTree = "<group>";
@@ -4323,6 +4326,7 @@
 				B9FAA11423878CEA009414B4 /* UserProfile+Schema.swift in Sources */,
 				FACA361D2327FC84000E74F6 /* MockAPICategoryPlugin.swift in Sources */,
 				B9FAA11023878C5E009414B4 /* UserProfile.swift in Sources */,
+				B9AA09F12473CA29000E6FBB /* PostStatus.swift in Sources */,
 				210B3E36245CB86500F43848 /* Blog.swift in Sources */,
 				B9FAA12023879BD0009414B4 /* BookAuthor+Schema.swift in Sources */,
 				21F40A4023A295470074678E /* TestCommonConstants.swift in Sources */,

--- a/Amplify/Categories/DataStore/Query/ModelKey.swift
+++ b/Amplify/Categories/DataStore/Query/ModelKey.swift
@@ -62,7 +62,15 @@ extension CodingKey where Self: ModelKey {
         return field(stringValue).eq(value)
     }
 
+    public func eq(_ value: EnumPersistable) -> QueryPredicateOperation {
+        return field(stringValue).eq(value)
+    }
+
     public static func == (key: Self, value: Persistable?) -> QueryPredicateOperation {
+        return key.eq(value)
+    }
+
+    public static func == (key: Self, value: EnumPersistable) -> QueryPredicateOperation {
         return key.eq(value)
     }
 
@@ -112,7 +120,15 @@ extension CodingKey where Self: ModelKey {
         return field(stringValue).ne(value)
     }
 
+    public func ne(_ value: EnumPersistable) -> QueryPredicateOperation {
+        return field(stringValue).ne(value)
+    }
+
     public static func != (key: Self, value: Persistable?) -> QueryPredicateOperation {
+        return key.ne(value)
+    }
+
+    public static func != (key: Self, value: EnumPersistable) -> QueryPredicateOperation {
         return key.ne(value)
     }
 

--- a/Amplify/Categories/DataStore/Query/QueryField.swift
+++ b/Amplify/Categories/DataStore/Query/QueryField.swift
@@ -35,21 +35,25 @@ public protocol QueryFieldOperation {
     func between(start: Persistable, end: Persistable) -> QueryPredicateOperation
     func contains(_ value: String) -> QueryPredicateOperation
     func eq(_ value: Persistable?) -> QueryPredicateOperation
+    func eq(_ value: EnumPersistable) -> QueryPredicateOperation
     func ge(_ value: Persistable) -> QueryPredicateOperation
     func gt(_ value: Persistable) -> QueryPredicateOperation
     func le(_ value: Persistable) -> QueryPredicateOperation
     func lt(_ value: Persistable) -> QueryPredicateOperation
     func ne(_ value: Persistable?) -> QueryPredicateOperation
+    func ne(_ value: EnumPersistable) -> QueryPredicateOperation
 
     // MARK: - Operators
 
     static func ~= (key: Self, value: String) -> QueryPredicateOperation
     static func == (key: Self, value: Persistable?) -> QueryPredicateOperation
+    static func == (key: Self, value: EnumPersistable) -> QueryPredicateOperation
     static func >= (key: Self, value: Persistable) -> QueryPredicateOperation
     static func > (key: Self, value: Persistable) -> QueryPredicateOperation
     static func <= (key: Self, value: Persistable) -> QueryPredicateOperation
     static func < (key: Self, value: Persistable) -> QueryPredicateOperation
     static func != (key: Self, value: Persistable?) -> QueryPredicateOperation
+    static func != (key: Self, value: EnumPersistable) -> QueryPredicateOperation
 }
 
 public struct QueryField: QueryFieldOperation {
@@ -86,7 +90,15 @@ public struct QueryField: QueryFieldOperation {
         return QueryPredicateOperation(field: name, operator: .equals(value))
     }
 
+    public func eq(_ value: EnumPersistable) -> QueryPredicateOperation {
+        return QueryPredicateOperation(field: name, operator: .equals(value.rawValue))
+    }
+
     public static func == (key: Self, value: Persistable?) -> QueryPredicateOperation {
+        return key.eq(value)
+    }
+
+    public static func == (key: Self, value: EnumPersistable) -> QueryPredicateOperation {
         return key.eq(value)
     }
 
@@ -136,7 +148,15 @@ public struct QueryField: QueryFieldOperation {
         return QueryPredicateOperation(field: name, operator: .notEqual(value))
     }
 
+    public func ne(_ value: EnumPersistable) -> QueryPredicateOperation {
+        return QueryPredicateOperation(field: name, operator: .notEqual(value.rawValue))
+    }
+
     public static func != (key: Self, value: Persistable?) -> QueryPredicateOperation {
+        return key.ne(value)
+    }
+
+    public static func != (key: Self, value: EnumPersistable) -> QueryPredicateOperation {
         return key.ne(value)
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -20,7 +20,13 @@ extension Model {
         schema.fields.forEach {
             let field = $0.value
             let name = field.graphQLName
-            let value = self[field.name]
+            let fieldValue = self[field.name]
+
+            // swiftlint:disable:next syntactic_sugar
+            guard case .some(Optional<Any>.some(let value)) = fieldValue ?? nil else {
+                input[name] = nil
+                return
+            }
 
             switch field.type {
             case .date, .dateTime:
@@ -29,6 +35,8 @@ extension Model {
                 } else {
                     input[name] = value
                 }
+            case .enum:
+                input[name] = (value as? EnumPersistable)?.rawValue
             case .model:
                 // For Models, append the model name in front in case a targetName is not provided
                 // e.g. "comment" + "PostId"
@@ -39,6 +47,7 @@ extension Model {
                 input[fieldName] = (value as? Model)?.id
             case .collection:
                 // TODO how to handle associations of type "many" (i.e. cascade save)?
+                // This is not supported right now and might be added as a future feature
                 break
             default:
                 input[name] = value

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
@@ -33,7 +33,10 @@ class GraphQLCreateMutationTests: XCTestCase {
     ///     - it contains an `input` of type `CreatePostInput`
     ///     - it has a list of fields with no nested models
     func testCreateGraphQLMutationFromSimpleModel() {
-        let post = Post(title: "title", content: "content", createdAt: Date())
+        let post = Post(title: "title",
+                        content: "content",
+                        createdAt: Date(),
+                        status: .private)
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
         documentBuilder.add(decorator: ModelDecorator(model: post))
@@ -46,6 +49,7 @@ class GraphQLCreateMutationTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename
@@ -64,8 +68,12 @@ class GraphQLCreateMutationTests: XCTestCase {
             XCTFail("The document variables property doesn't contain a valid input")
             return
         }
-        XCTAssert(input["title"] as? String == post.title)
-        XCTAssert(input["content"] as? String == post.content)
+        print("=====================")
+        print(input)
+        print("=====================")
+        XCTAssertEqual(input["title"] as? String, post.title)
+        XCTAssertEqual(input["content"] as? String, post.content)
+        XCTAssertEqual(input["status"] as? String, PostStatus.private.rawValue)
     }
 
     /// - Given: a `Model` instance
@@ -97,6 +105,7 @@ class GraphQLCreateMutationTests: XCTestCase {
               createdAt
               draft
               rating
+              status
               title
               updatedAt
               __typename
@@ -144,6 +153,7 @@ class GraphQLCreateMutationTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename
@@ -200,6 +210,7 @@ class GraphQLCreateMutationTests: XCTestCase {
               createdAt
               draft
               rating
+              status
               title
               updatedAt
               __typename

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
@@ -68,9 +68,6 @@ class GraphQLCreateMutationTests: XCTestCase {
             XCTFail("The document variables property doesn't contain a valid input")
             return
         }
-        print("=====================")
-        print(input)
-        print("=====================")
         XCTAssertEqual(input["title"] as? String, post.title)
         XCTAssertEqual(input["content"] as? String, post.content)
         XCTAssertEqual(input["status"] as? String, PostStatus.private.rawValue)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDeleteMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDeleteMutationTests.swift
@@ -46,6 +46,7 @@ class GraphQLDeleteMutationTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename
@@ -92,6 +93,7 @@ class GraphQLDeleteMutationTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLGetQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLGetQueryTests.swift
@@ -42,6 +42,7 @@ class GraphQLGetQueryTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename
@@ -71,6 +72,7 @@ class GraphQLGetQueryTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename
@@ -116,6 +118,7 @@ class GraphQLGetQueryTests: XCTestCase {
               createdAt
               draft
               rating
+              status
               title
               updatedAt
               __typename
@@ -151,6 +154,7 @@ class GraphQLGetQueryTests: XCTestCase {
               createdAt
               draft
               rating
+              status
               title
               updatedAt
               __typename

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLListQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLListQueryTests.swift
@@ -35,7 +35,10 @@ class GraphQLListQueryTests: XCTestCase {
     ///     - fields are wrapped with `items`
     func testListGraphQLQueryFromSimpleModel() {
         let post = Post.keys
-        let predicate = post.id.eq("id") && (post.title.beginsWith("Title") || post.content.contains("content"))
+        let predicate = post.id.eq("id")
+            && post.status.eq(PostStatus.published)
+            && (post.title.beginsWith("Title")
+            || post.content.contains("content"))
 
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
@@ -51,6 +54,7 @@ class GraphQLListQueryTests: XCTestCase {
               createdAt
               draft
               rating
+              status
               title
               updatedAt
               __typename
@@ -67,7 +71,48 @@ class GraphQLListQueryTests: XCTestCase {
         }
         XCTAssertNotNil(variables["limit"])
         XCTAssertEqual(variables["limit"] as? Int, 1_000)
-        XCTAssertNotNil(variables["filter"])
+
+        guard let filter = variables["filter"] as? GraphQLFilter else {
+            XCTFail("variables should contain a valid filter")
+            return
+        }
+
+        // Test filter for a valid JSON format
+        let filterJSON = try? JSONSerialization.data(withJSONObject: filter,
+                                                     options: .prettyPrinted)
+        XCTAssertNotNil(filterJSON)
+
+        let expectedFilterJSON = """
+        {
+          "and" : [
+            {
+              "id" : {
+                "eq" : "id"
+              }
+            },
+            {
+              "status" : {
+                "eq" : "PUBLISHED"
+              }
+            },
+            {
+              "or" : [
+                {
+                  "title" : {
+                    "beginsWith" : "Title"
+                  }
+                },
+                {
+                  "content" : {
+                    "contains" : "content"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+        """
+        XCTAssertEqual(String(data: filterJSON!, encoding: .utf8), expectedFilterJSON)
     }
 
     func testListGraphQLQueryFromSimpleModelWithSyncEnabled() {
@@ -89,6 +134,7 @@ class GraphQLListQueryTests: XCTestCase {
               createdAt
               draft
               rating
+              status
               title
               updatedAt
               __typename

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSubscriptionTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSubscriptionTests.swift
@@ -43,6 +43,7 @@ class GraphQLSubscriptionTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename
@@ -67,6 +68,7 @@ class GraphQLSubscriptionTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename
@@ -105,6 +107,7 @@ class GraphQLSubscriptionTests: XCTestCase {
               createdAt
               draft
               rating
+              status
               title
               updatedAt
               __typename
@@ -135,6 +138,7 @@ class GraphQLSubscriptionTests: XCTestCase {
               createdAt
               draft
               rating
+              status
               title
               updatedAt
               __typename
@@ -174,6 +178,7 @@ class GraphQLSubscriptionTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename
@@ -198,6 +203,7 @@ class GraphQLSubscriptionTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename
@@ -231,6 +237,7 @@ class GraphQLSubscriptionTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename
@@ -255,6 +262,7 @@ class GraphQLSubscriptionTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSyncQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSyncQueryTests.swift
@@ -51,6 +51,7 @@ class GraphQLSyncQueryTests: XCTestCase {
               createdAt
               draft
               rating
+              status
               title
               updatedAt
               __typename
@@ -98,6 +99,7 @@ class GraphQLSyncQueryTests: XCTestCase {
                 createdAt
                 draft
                 rating
+                status
                 title
                 updatedAt
                 __typename

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLUpdateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLUpdateMutationTests.swift
@@ -46,6 +46,7 @@ class GraphQLUpdateMutationTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename
@@ -93,6 +94,7 @@ class GraphQLUpdateMutationTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAnyModelWithSyncTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAnyModelWithSyncTests.swift
@@ -36,6 +36,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename
@@ -74,6 +75,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename
@@ -116,6 +118,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename
@@ -158,6 +161,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename
@@ -198,6 +202,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
             createdAt
             draft
             rating
+            status
             title
             updatedAt
             __typename
@@ -235,6 +240,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
               createdAt
               draft
               rating
+              status
               title
               updatedAt
               __typename

--- a/AmplifyTestCommon/Models/Post+Schema.swift
+++ b/AmplifyTestCommon/Models/Post+Schema.swift
@@ -19,6 +19,7 @@ extension Post {
     case updatedAt
     case draft
     case rating
+    case status
     case comments
   }
 
@@ -38,6 +39,7 @@ extension Post {
       .field(post.updatedAt, is: .optional, ofType: .dateTime),
       .field(post.draft, is: .optional, ofType: .bool),
       .field(post.rating, is: .optional, ofType: .double),
+      .field(post.status, is: .optional, ofType: .enum(type: PostStatus.self)),
       .hasMany(post.comments, is: .optional, ofType: Comment.self, associatedWith: Comment.keys.post)
     )
     }

--- a/AmplifyTestCommon/Models/Post.swift
+++ b/AmplifyTestCommon/Models/Post.swift
@@ -17,6 +17,7 @@ public struct Post: Model {
   public var updatedAt: Date?
   public var draft: Bool?
   public var rating: Double?
+  public var status: PostStatus?
   public var comments: List<Comment>?
 
   public init(id: String = UUID().uuidString,
@@ -26,6 +27,7 @@ public struct Post: Model {
       updatedAt: Date? = nil,
       draft: Bool? = nil,
       rating: Double? = nil,
+      status: PostStatus? = nil,
       comments: List<Comment>? = []) {
       self.id = id
       self.title = title
@@ -34,6 +36,7 @@ public struct Post: Model {
       self.updatedAt = updatedAt
       self.draft = draft
       self.rating = rating
+      self.status = status
       self.comments = comments
   }
 }

--- a/AmplifyTestCommon/Models/PostStatus.swift
+++ b/AmplifyTestCommon/Models/PostStatus.swift
@@ -1,0 +1,16 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+
+public enum PostStatus: String, EnumPersistable {
+
+    case `private` = "PRIVATE"
+    case draft = "DRAFT"
+    case published = "PUBLISHED"
+
+}

--- a/AmplifyTestCommon/Models/schema.graphql
+++ b/AmplifyTestCommon/Models/schema.graphql
@@ -1,3 +1,9 @@
+enum PostStatus {
+    PRIVATE
+    DRAFT
+    PUBLISHED
+}
+
 type Post @model {
     id: ID!
     title: String!
@@ -6,6 +12,7 @@ type Post @model {
     updatedAt: AWSDateTime
     draft: Boolean
     rating: Float
+    status: PostStatus
     comments: [Comment] @connection(name: "PostComment")
 }
 


### PR DESCRIPTION
**Notes:**

- add support for `EnumPersistable` on `QueryPredicate`
- fix enum conversion on `GraphQLInput`
- add more tests around enum values

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
