### PR TITLE
refactor(Auth): Renamed confirmSignUp, resendSignUpCode and forgetDevice apis

### DIFF
--- a/Amplify/Categories/Auth/AuthCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategory+ClientBehavior.swift
@@ -19,21 +19,21 @@ extension AuthCategory: AuthCategoryBehavior {
                              listener: listener)
     }
 
-    public func confirmSignUp(username: String,
+    public func confirmSignUp(for username: String,
                               confirmationCode: String,
                               options: AuthConfirmSignUpOperation.Request.Options? = nil,
                               listener: AuthConfirmSignUpOperation.ResultListener?) -> AuthConfirmSignUpOperation {
-        return plugin.confirmSignUp(username: username,
+        return plugin.confirmSignUp(for: username,
                                     confirmationCode: confirmationCode,
                                     options: options,
                                     listener: listener)
     }
 
-    public func resendSignUpCode(username: String,
+    public func resendSignUpCode(for username: String,
                                  options: AuthResendSignUpCodeOperation.Request.Options? = nil,
                                  listener: AuthResendSignUpCodeOperation.ResultListener?)
         -> AuthResendSignUpCodeOperation {
-            return plugin.resendSignUpCode(username: username,
+            return plugin.resendSignUpCode(for: username,
                                            options: options,
                                            listener: listener)
     }

--- a/Amplify/Categories/Auth/AuthCategory+DeviceBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategory+DeviceBehavior.swift
@@ -16,13 +16,13 @@ extension AuthCategory: AuthCategoryDeviceBehavior {
                                    listener: listener)
     }
 
-    public func forget(
-        device: AuthDevice? = nil,
+    public func forgetDevice(
+        _ device: AuthDevice? = nil,
         options: AuthForgetDeviceOperation.Request.Options? = nil,
         listener: AuthForgetDeviceOperation.ResultListener?) -> AuthForgetDeviceOperation {
-        return plugin.forget(device: device,
-                             options: options,
-                             listener: listener)
+        return plugin.forgetDevice(device,
+                                   options: options,
+                                   listener: listener)
     }
 
     public func rememberDevice(

--- a/Amplify/Categories/Auth/AuthCategoryBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategoryBehavior.swift
@@ -39,7 +39,7 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
     ///   - confirmationCode: Confirmation code received to the user.
     ///   - options: Parameters specific to plugin behavior
     ///   - listener: Triggered when the operation completes.
-    func confirmSignUp(username: String,
+    func confirmSignUp(for username: String,
                        confirmationCode: String,
                        options: AuthConfirmSignUpOperation.Request.Options?,
                        listener: AuthConfirmSignUpOperation.ResultListener?) -> AuthConfirmSignUpOperation
@@ -50,7 +50,7 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
     ///   - username: Username of the user to be confirmed.
     ///   - options: Parameters specific to plugin behavior.
     ///   - listener: Triggered when the operation completes.
-    func resendSignUpCode(username: String,
+    func resendSignUpCode(for username: String,
                           options: AuthResendSignUpCodeOperation.Request.Options?,
                           listener: AuthResendSignUpCodeOperation.ResultListener?) -> AuthResendSignUpCodeOperation
 

--- a/Amplify/Categories/Auth/AuthCategoryDeviceBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategoryDeviceBehavior.swift
@@ -23,8 +23,8 @@ public protocol AuthCategoryDeviceBehavior {
     ///   - authDevice: Device to be forgotten
     ///   - options: Parameters specific to plugin behavior.
     ///   - listener: Triggered when the operation completes.
-    func forget(
-        device: AuthDevice?,
+    func forgetDevice(
+        _ device: AuthDevice?,
         options: AuthForgetDeviceOperation.Request.Options?,
         listener: AuthForgetDeviceOperation.ResultListener?) -> AuthForgetDeviceOperation
 

--- a/Amplify/Categories/Auth/Request/AuthForgetDeviceRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthForgetDeviceRequest.swift
@@ -34,4 +34,3 @@ public extension AuthForgetDeviceRequest {
         }
     }
 }
-

--- a/Amplify/Categories/Predictions/Models/LanguageType.swift
+++ b/Amplify/Categories/Predictions/Models/LanguageType.swift
@@ -7,12 +7,11 @@
 
 import Foundation
 
+// swiftlint:disable file_length
+// swiftlint:disable type_body_length
 /// Language type supported by Predictions category
 ///
 /// The associated value represents the iso language code.
-
-// swiftlint:disable file_length
-// swiftlint:disable type_body_length
 public enum LanguageType: String {
     case afar = "aa"
     case abkhazian = "ab"

--- a/AmplifyPlugins/Auth/AWSAuthPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 		B41B896424672AB40092F96D /* AWSAuthPlugin+UserBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41B896124672AB40092F96D /* AWSAuthPlugin+UserBehavior.swift */; };
 		B41B896524672AB40092F96D /* AWSAuthPlugin+ClientBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41B896224672AB40092F96D /* AWSAuthPlugin+ClientBehavior.swift */; };
 		B41B896B2468DB700092F96D /* SignedOutAuthSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41B896A2468DB700092F96D /* SignedOutAuthSessionTests.swift */; };
+		B41D0F2024746ACC0049D08D /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = B41B89672468DB0E0092F96D /* amplifyconfiguration.json */; };
+		B41D0F2324746B6B0049D08D /* AuthSignUpTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41D0F2224746B6B0049D08D /* AuthSignUpTests.swift */; };
+		B41D0F26247476580049D08D /* AuthDeviceOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41D0F25247476580049D08D /* AuthDeviceOperationTests.swift */; };
 		B42B3D38246ADDAE007211E0 /* AWSAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42B3D37246ADDAE007211E0 /* AWSAuthService.swift */; };
 		B42B3D3D246AE2B6007211E0 /* AWSAuthPlugin+InvalidateCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42B3D3C246AE2B6007211E0 /* AWSAuthPlugin+InvalidateCredentials.swift */; };
 		B439F2AB2448836500C30CBB /* AuthSignInRequest+Validate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B439F2AA2448836500C30CBB /* AuthSignInRequest+Validate.swift */; };
@@ -103,7 +106,6 @@
 		B4F3EA4F243A782700F23296 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3EA4C243A782700F23296 /* ViewController.swift */; };
 		B4F3EA50243A782700F23296 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3EA4D243A782700F23296 /* AppDelegate.swift */; };
 		B4F3EA51243A782700F23296 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3EA4E243A782700F23296 /* SceneDelegate.swift */; };
-		FAEA8E63247439D40091B37E /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = FAEA8E62247439D40091B37E /* amplifyconfiguration.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -152,6 +154,8 @@
 		B41B896224672AB40092F96D /* AWSAuthPlugin+ClientBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSAuthPlugin+ClientBehavior.swift"; sourceTree = "<group>"; };
 		B41B89672468DB0E0092F96D /* amplifyconfiguration.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = amplifyconfiguration.json; sourceTree = "<group>"; };
 		B41B896A2468DB700092F96D /* SignedOutAuthSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedOutAuthSessionTests.swift; sourceTree = "<group>"; };
+		B41D0F2224746B6B0049D08D /* AuthSignUpTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSignUpTests.swift; sourceTree = "<group>"; };
+		B41D0F25247476580049D08D /* AuthDeviceOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthDeviceOperationTests.swift; sourceTree = "<group>"; };
 		B42B3D37246ADDAE007211E0 /* AWSAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAuthService.swift; sourceTree = "<group>"; };
 		B42B3D3C246AE2B6007211E0 /* AWSAuthPlugin+InvalidateCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSAuthPlugin+InvalidateCredentials.swift"; sourceTree = "<group>"; };
 		B439F2AA2448836500C30CBB /* AuthSignInRequest+Validate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AuthSignInRequest+Validate.swift"; sourceTree = "<group>"; };
@@ -322,6 +326,22 @@
 				B41B896A2468DB700092F96D /* SignedOutAuthSessionTests.swift */,
 			);
 			path = AuthSessionTests;
+			sourceTree = "<group>";
+		};
+		B41D0F2124746B4E0049D08D /* AuthSignUpTests */ = {
+			isa = PBXGroup;
+			children = (
+				B41D0F2224746B6B0049D08D /* AuthSignUpTests.swift */,
+			);
+			path = AuthSignUpTests;
+			sourceTree = "<group>";
+		};
+		B41D0F24247476430049D08D /* AuthDeviceTests */ = {
+			isa = PBXGroup;
+			children = (
+				B41D0F25247476580049D08D /* AuthDeviceOperationTests.swift */,
+			);
+			path = AuthDeviceTests;
 			sourceTree = "<group>";
 		};
 		B439F2A92448835700C30CBB /* Request */ = {
@@ -561,8 +581,10 @@
 		B4F3EA07243A655A00F23296 /* AWSAuthPluginIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
-				B4919778246A04300062EA7A /* AWSAuthBaseTest.swift */,
+				B41D0F24247476430049D08D /* AuthDeviceTests */,
 				B41B89692468DB4D0092F96D /* AuthSessionTests */,
+				B41D0F2124746B4E0049D08D /* AuthSignUpTests */,
+				B4919778246A04300062EA7A /* AWSAuthBaseTest.swift */,
 				B41B89662468DAE20092F96D /* Configuration */,
 				B491977B246A07D20062EA7A /* Resources */,
 				B49197702469EC550062EA7A /* Support */,
@@ -800,7 +822,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FAEA8E63247439D40091B37E /* amplifyconfiguration.json in Resources */,
+				B41D0F2024746ACC0049D08D /* amplifyconfiguration.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1203,9 +1225,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				B4919779246A04300062EA7A /* AWSAuthBaseTest.swift in Sources */,
+				B41D0F26247476580049D08D /* AuthDeviceOperationTests.swift in Sources */,
 				B49197722469EC970062EA7A /* AuthConfigurationHelper.swift in Sources */,
 				B49197742469EF380062EA7A /* SignedInAuthSessionTests.swift in Sources */,
 				B41B896B2468DB700092F96D /* SignedOutAuthSessionTests.swift in Sources */,
+				B41D0F2324746B6B0049D08D /* AuthSignUpTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/ClientBehavior/AWSAuthPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/ClientBehavior/AWSAuthPlugin+ClientBehavior.swift
@@ -24,7 +24,7 @@ extension AWSAuthPlugin {
         return signUpOperation
     }
 
-    public func confirmSignUp(username: String,
+    public func confirmSignUp(for username: String,
                               confirmationCode: String,
                               options: AuthConfirmSignUpOperation.Request.Options?,
                               listener: AuthConfirmSignUpOperation.ResultListener?) -> AuthConfirmSignUpOperation {
@@ -37,7 +37,7 @@ extension AWSAuthPlugin {
         return operation
     }
 
-    public func resendSignUpCode(username: String,
+    public func resendSignUpCode(for username: String,
                                  options: AuthResendSignUpCodeOperation.Request.Options? = nil,
                                  listener: AuthResendSignUpCodeOperation.ResultListener?)
         -> AuthResendSignUpCodeOperation {

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/ClientBehavior/AWSAuthPlugin+DeviceBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/ClientBehavior/AWSAuthPlugin+DeviceBehavior.swift
@@ -22,8 +22,8 @@ extension AWSAuthPlugin {
         return fetchDeviceOperation
     }
 
-    public func forget(
-        device: AuthDevice? = nil,
+    public func forgetDevice(
+        _ device: AuthDevice? = nil,
         options: AuthForgetDeviceOperation.Request.Options? = nil,
         listener: AuthForgetDeviceOperation.ResultListener?) -> AuthForgetDeviceOperation {
 

--- a/AmplifyPlugins/Auth/AWSAuthPluginIntegrationTests/AuthDeviceTests/AuthDeviceOperationTests.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPluginIntegrationTests/AuthDeviceTests/AuthDeviceOperationTests.swift
@@ -1,0 +1,51 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+import AWSAuthPlugin
+
+class AuthDeviceOperationTests: AWSAuthBaseTest {
+
+    override func setUp() {
+        super.setUp()
+        initializeAmplify()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        Amplify.reset()
+        sleep(2)
+    }
+
+    /// Test if forgetDevice returns deviceNotTracked error for a unknown device
+    ///
+    /// - Given: A test with the device not tracked
+    /// - When:
+    ///    - I invoke forgetDevice
+    /// - Then:
+    ///    - I should get a deviceNotTracked error.
+    ///
+    func testForgetDeviceWithUnknowdevice() {
+        let forgetDeviceExpectation = expectation(description: "Received event result from forgetDevice")
+        _ = Amplify.Auth.forgetDevice { result in
+            switch result {
+            case .success:
+                XCTFail("Confirm signUp with non existing user should not return result")
+            case .failure(let error):
+                guard let cognitoError = error.underlyingError as? AWSCognitoAuthError,
+                    case .deviceNotTracked = cognitoError else {
+                        XCTFail("Should return deviceNotTracked")
+                        return
+                }
+
+            }
+            forgetDeviceExpectation.fulfill()
+        }
+        wait(for: [forgetDeviceExpectation], timeout: networkTimeout)
+    }
+}

--- a/AmplifyPlugins/Auth/AWSAuthPluginIntegrationTests/AuthSignUpTests/AuthSignUpTests.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPluginIntegrationTests/AuthSignUpTests/AuthSignUpTests.swift
@@ -1,0 +1,78 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+import AWSAuthPlugin
+
+class AuthSignUpTests: AWSAuthBaseTest {
+
+    override func setUp() {
+        super.setUp()
+        initializeAmplify()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        Amplify.reset()
+        sleep(2)
+    }
+
+    /// Test if confirmSignUp returns userNotFound error for a non existing user
+    ///
+    /// - Given: A user which is not registered to the configured user pool
+    /// - When:
+    ///    - I invoke confirmSignUp with the user
+    /// - Then:
+    ///    - I should get a userNotFound error.
+    ///
+    func testUserNotFoundConfirmSignUp() {
+        let confirmSignUpExpectation = expectation(description: "Received event result from confirmSignUp")
+        _ = Amplify.Auth.confirmSignUp(for: "user-non-exists", confirmationCode: "232") { result in
+            switch result {
+            case .success:
+                XCTFail("Confirm signUp with non existing user should not return result")
+            case .failure(let error):
+                guard let cognitoError = error.underlyingError as? AWSCognitoAuthError,
+                    case .userNotFound = cognitoError else {
+                        XCTFail("Should return userNotFound")
+                        return
+                }
+
+            }
+            confirmSignUpExpectation.fulfill()
+        }
+        wait(for: [confirmSignUpExpectation], timeout: networkTimeout)
+    }
+
+    /// Test if resendSignUpCode returns userNotFound error for a non existing user
+    ///
+    /// - Given: A user which is not registered to the configured user pool
+    /// - When:
+    ///    - I invoke resendSignUpCode with the user
+    /// - Then:
+    ///    - I should get a userNotFound error.
+    ///
+    func testUsertNotFoundResendSignUpCode() {
+        let resendSignUpCodeExpectation = expectation(description: "Received event result from resendSignUpCode")
+        _ = Amplify.Auth.resendSignUpCode(for: "user-non-exists") { result in
+            switch result {
+            case .success:
+                XCTFail("resendSignUpCode with non existing user should not return result")
+            case .failure(let error):
+                guard let cognitoError = error.underlyingError as? AWSCognitoAuthError,
+                    case .userNotFound = cognitoError else {
+                        XCTFail("Should return userNotFound")
+                        return
+                }
+
+            }
+            resendSignUpCodeExpectation.fulfill()
+        }
+        wait(for: [resendSignUpCodeExpectation], timeout: networkTimeout)
+    }
+}

--- a/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
@@ -24,14 +24,14 @@ class MockAuthCategoryPlugin: MessageReporter, AuthCategoryPlugin {
         fatalError()
     }
 
-    public func confirmSignUp(username: String,
+    public func confirmSignUp(for username: String,
                               confirmationCode: String,
                               options: AuthConfirmSignUpOperation.Request.Options? = nil,
                               listener: AuthConfirmSignUpOperation.ResultListener?) -> AuthConfirmSignUpOperation {
         fatalError()
     }
 
-    public func resendSignUpCode(username: String,
+    public func resendSignUpCode(for username: String,
                                  options: AuthResendSignUpCodeOperation.Request.Options? = nil,
                                  listener: AuthResendSignUpCodeOperation.ResultListener?)
         -> AuthResendSignUpCodeOperation {
@@ -148,8 +148,8 @@ class MockAuthCategoryPlugin: MessageReporter, AuthCategoryPlugin {
         fatalError()
     }
 
-    public func forget(
-        device: AuthDevice? = nil,
+    public func forgetDevice(
+        _ device: AuthDevice? = nil,
         options: AuthForgetDeviceOperation.Request.Options? = nil,
         listener: AuthForgetDeviceOperation.ResultListener?) -> AuthForgetDeviceOperation {
         fatalError()


### PR DESCRIPTION
Issue - https://github.com/aws-amplify/amplify-ios/issues/424

- Renamed confirmSignUp, resendSignUpCode and forgetDevice apis
- Added basic integration test
- Removed build warnings

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
