### PR TITLE
feat(api): (Integ) SocialNote from codegen

### DIFF
--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/GraphQLAuthDirectiveIntegrationTests+Support.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/GraphQLAuthDirectiveIntegrationTests+Support.swift
@@ -157,16 +157,8 @@ extension GraphQLAuthDirectiveIntegrationTests {
             XCTFail("underlying error should be AuthError, but instead was \(underlyingError ?? "nil")")
             return
         }
-        guard case let .service(_, _, underlyingAuthError) = authError else {
+        guard case .signedOut = authError else {
             XCTFail("Error should be AuthError.service")
-            return
-        }
-        guard let awsCognitoAuthError = underlyingAuthError as? AWSCognitoAuthError else {
-            XCTFail("Error should be AWSCognitoAuthError")
-            return
-        }
-        guard case .signedOut = awsCognitoAuthError else {
-            XCTFail("Error should be .signedOut")
             return
         }
     }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/SocialNote.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/SocialNote.swift
@@ -8,31 +8,43 @@
 import Amplify
 
 public struct SocialNote: Model {
-    public let id: String
-    public var content: String
-    public var owner: String?
-    public init(id: String = UUID().uuidString,
-                content: String,
-                owner: String?) {
-        self.id = id
-        self.content = content
-        self.owner = owner
-    }
-    public enum CodingKeys: String, ModelKey {
-        case id
-        case content
-        case owner
-    }
-    public static let keys = CodingKeys.self
+  public let id: String
+  public var content: String
+  public var owner: String?
 
-    public static let schema = defineSchema { model in
-        let socialNote = SocialNote.keys
-        model.authRules = [
-            rule(allow: .owner, operations: [.create, .update, .delete])
-        ]
-        model.fields(
-            .id(),
-            .field(socialNote.content, is: .required, ofType: .string),
-            .field(socialNote.owner, is: .optional, ofType: .string))
+  public init(id: String = UUID().uuidString,
+      content: String,
+      owner: String? = nil) {
+      self.id = id
+      self.content = content
+      self.owner = owner
+  }
+}
+
+extension SocialNote {
+  // MARK: - CodingKeys
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case content
+    case owner
+  }
+
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema
+
+  public static let schema = defineSchema { model in
+    let socialNote = SocialNote.keys
+
+    model.authRules = [
+      rule(allow: .owner, ownerField: "owner", identityClaim: "cognito:username", operations: [.create, .update, .delete])
+    ]
+
+    model.pluralName = "SocialNotes"
+
+    model.fields(
+      .id(),
+      .field(socialNote.content, is: .required, ofType: .string),
+      .field(socialNote.owner, is: .optional, ofType: .string)
+    )
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This uses the code generated SoocialNote from `amplify codegen models` on @yuth dev branch

- Reordered the ownerField with identityClaim due to contrsuctor for rule has a different ordering of parameters


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
