### PR TITLE
fix(Auth): Hub event for successful signIn for webUI signIn

### DIFF
--- a/Amplify/Categories/Auth/Operation/AuthSocialWebUISignInOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthSocialWebUISignInOperation.swift
@@ -16,5 +16,5 @@ public protocol AuthSocialWebUISignInOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let socialWebUISgnIn = "Auth.socialWebUISignIn"
+    static let socialWebUISignIn = "Auth.socialWebUISignIn"
 }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		B41D0F2024746ACC0049D08D /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = B41B89672468DB0E0092F96D /* amplifyconfiguration.json */; };
 		B41D0F2324746B6B0049D08D /* AuthSignUpTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41D0F2224746B6B0049D08D /* AuthSignUpTests.swift */; };
 		B41D0F26247476580049D08D /* AuthDeviceOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41D0F25247476580049D08D /* AuthDeviceOperationTests.swift */; };
+		B41D0F2924758D4C0049D08D /* AuthHubEventHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41D0F2824758D4C0049D08D /* AuthHubEventHandlerTests.swift */; };
 		B42B3D38246ADDAE007211E0 /* AWSAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42B3D37246ADDAE007211E0 /* AWSAuthService.swift */; };
 		B42B3D3D246AE2B6007211E0 /* AWSAuthPlugin+InvalidateCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42B3D3C246AE2B6007211E0 /* AWSAuthPlugin+InvalidateCredentials.swift */; };
 		B439F2AB2448836500C30CBB /* AuthSignInRequest+Validate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B439F2AA2448836500C30CBB /* AuthSignInRequest+Validate.swift */; };
@@ -156,6 +157,7 @@
 		B41B896A2468DB700092F96D /* SignedOutAuthSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedOutAuthSessionTests.swift; sourceTree = "<group>"; };
 		B41D0F2224746B6B0049D08D /* AuthSignUpTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSignUpTests.swift; sourceTree = "<group>"; };
 		B41D0F25247476580049D08D /* AuthDeviceOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthDeviceOperationTests.swift; sourceTree = "<group>"; };
+		B41D0F2824758D4C0049D08D /* AuthHubEventHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthHubEventHandlerTests.swift; sourceTree = "<group>"; };
 		B42B3D37246ADDAE007211E0 /* AWSAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAuthService.swift; sourceTree = "<group>"; };
 		B42B3D3C246AE2B6007211E0 /* AWSAuthPlugin+InvalidateCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSAuthPlugin+InvalidateCredentials.swift"; sourceTree = "<group>"; };
 		B439F2AA2448836500C30CBB /* AuthSignInRequest+Validate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AuthSignInRequest+Validate.swift"; sourceTree = "<group>"; };
@@ -344,6 +346,14 @@
 			path = AuthDeviceTests;
 			sourceTree = "<group>";
 		};
+		B41D0F2724758D330049D08D /* HubEventTests */ = {
+			isa = PBXGroup;
+			children = (
+				B41D0F2824758D4C0049D08D /* AuthHubEventHandlerTests.swift */,
+			);
+			path = HubEventTests;
+			sourceTree = "<group>";
+		};
 		B439F2A92448835700C30CBB /* Request */ = {
 			isa = PBXGroup;
 			children = (
@@ -420,6 +430,7 @@
 		B43DC7522410572400D40275 /* AWSAuthPluginTests */ = {
 			isa = PBXGroup;
 			children = (
+				B41D0F2724758D330049D08D /* HubEventTests */,
 				B4C8EDB6246B5ED800ED7484 /* Utils */,
 				B43DC7532410572400D40275 /* AWSAuthPluginTests.swift */,
 				B43DC7552410572400D40275 /* Info.plist */,
@@ -1216,6 +1227,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B43DC7542410572400D40275 /* AWSAuthPluginTests.swift in Sources */,
+				B41D0F2924758D4C0049D08D /* AuthHubEventHandlerTests.swift in Sources */,
 				B4C8EDB8246B5EFD00ED7484 /* AuthUserAttributeKeyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Dependency/AuthenticationProviderAdapter+SignOut.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Dependency/AuthenticationProviderAdapter+SignOut.swift
@@ -12,7 +12,7 @@ extension AuthenticationProviderAdapter {
 
     func signOut(request: AuthSignOutRequest, completionHandler: @escaping (Result<Void, AuthError>) -> Void) {
 
-        if (request.options.globalSignOut) {
+        if request.options.globalSignOut {
             // If user is signed in through HostedUI the signout require UI to complete. So calling this in main thread.
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else {

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/HubEvents/AuthHubEventHandler.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/HubEvents/AuthHubEventHandler.swift
@@ -28,6 +28,7 @@ class AuthHubEventHandler: AuthHubEventBehavior {
         dispatchAuthEvent(HubPayload.EventName.Auth.sessionExpired)
     }
 
+    // swiftlint:disable cyclomatic_complexity
     private func setupHubEvents() {
 
         _ = Amplify.Hub.listen(to: .auth) {[weak self] payload in
@@ -42,6 +43,20 @@ class AuthHubEventHandler: AuthHubEventBehavior {
 
             case HubPayload.EventName.Auth.confirmSignIn:
                 guard let event = payload.data as? AWSAuthConfirmSignInOperation.OperationResult,
+                    case let .success(result) = event else {
+                        return
+                }
+                self?.handleSignInEvent(result)
+
+            case HubPayload.EventName.Auth.webUISignIn:
+                guard let event = payload.data as? AWSAuthWebUISignInOperation.OperationResult,
+                    case let .success(result) = event else {
+                        return
+                }
+                self?.handleSignInEvent(result)
+
+            case HubPayload.EventName.Auth.socialWebUISignIn:
+                guard let event = payload.data as? AWSAuthSocialWebUISignInOperation.OperationResult,
                     case let .success(result) = event else {
                         return
                 }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthSocialWebUISignInOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthSocialWebUISignInOperation.swift
@@ -22,7 +22,7 @@ public class AWSAuthSocialWebUISignInOperation: AmplifyOperation<
 
         self.authenticationProvider = authenticationProvider
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.socialWebUISgnIn,
+                   eventName: HubPayload.EventName.Auth.socialWebUISignIn,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPluginTests/HubEventTests/AuthHubEventHandlerTests.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPluginTests/HubEventTests/AuthHubEventHandlerTests.swift
@@ -1,0 +1,135 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+@testable import AWSAuthPlugin
+
+class AuthHubEventHandlerTests: XCTestCase {
+
+    var authHandler: AuthHubEventHandler!
+    override func setUp() {
+        try? Amplify.configure()
+        authHandler = AuthHubEventHandler()
+    }
+
+    override func tearDown() {
+        Amplify.reset()
+        authHandler = nil
+    }
+
+    /// Test whether HubEvent emits a signedIn event for normal signIn operation
+    ///
+    /// - Given: A listener to hub events
+    /// - When:
+    ///    - I mock a succesful sign in operation event
+    /// - Then:
+    ///    - I should receive a signedIn hub event
+    ///
+    func testSignedInHubEvent() {
+
+        let hubEventExpectation = expectation(description: "Should receive the hub event")
+        _ = Amplify.Hub.listen(to: .auth) { payload in
+            switch payload.eventName {
+            case HubPayload.EventName.Auth.signedIn:
+                hubEventExpectation.fulfill()
+            default:
+                break
+            }
+        }
+        mockSuccessfulSignedInEvent()
+        wait(for: [hubEventExpectation], timeout: 10)
+    }
+
+    /// Test whether HubEvent emits a signedIn event for webUI signIn
+    ///
+    /// - Given: A listener to hub events
+    /// - When:
+    ///    - I mock a succesful webui signIn operation event
+    /// - Then:
+    ///    - I should receive a signedIn hub event
+    ///
+    func testWebUISignedInHubEvent() {
+        _ = AuthHubEventHandler()
+        let hubEventExpectation = expectation(description: "Should receive the hub event")
+        _ = Amplify.Hub.listen(to: .auth) { payload in
+            switch payload.eventName {
+            case HubPayload.EventName.Auth.signedIn:
+                hubEventExpectation.fulfill()
+            default:
+                break
+            }
+        }
+        mockSuccessfulWebUISignedInEvent()
+        wait(for: [hubEventExpectation], timeout: 10)
+    }
+
+    /// Test whether HubEvent emits a signedIn event for social provider signIn
+    ///
+    /// - Given: A listener to hub events
+    /// - When:
+    ///    - I mock a succesful social provider webui signIn operation event
+    /// - Then:
+    ///    - I should receive a signedIn hub event
+    ///
+    func testSocialWebUISignedInHubEvent() {
+        _ = AuthHubEventHandler()
+        let hubEventExpectation = expectation(description: "Should receive the hub event")
+        _ = Amplify.Hub.listen(to: .auth) { payload in
+            switch payload.eventName {
+            case HubPayload.EventName.Auth.signedIn:
+                hubEventExpectation.fulfill()
+            default:
+                break
+            }
+        }
+        mockSuccessfulSocialWebUISignedInEvent()
+        wait(for: [hubEventExpectation], timeout: 10)
+    }
+
+    private func mockSuccessfulSocialWebUISignedInEvent() {
+        let mockResult = AuthSignInResult(nextStep: .done)
+        let mockEvent = AWSAuthSocialWebUISignInOperation.OperationResult.success(mockResult)
+        let mockRequest = AuthWebUISignInRequest(presentationAnchor: UIWindow(),
+                                                 authProvider: .amazon,
+                                                 options: AuthWebUISignInRequest.Options())
+        let mockContext = AmplifyOperationContext(operationId: UUID(), request: mockRequest)
+        let mockPayload = HubPayload(eventName: HubPayload.EventName.Auth.socialWebUISignIn,
+                                     context: mockContext,
+                                     data: mockEvent)
+        Amplify.Hub.dispatch(to: .auth, payload: mockPayload)
+
+    }
+
+    private func mockSuccessfulWebUISignedInEvent() {
+        let mockResult = AuthSignInResult(nextStep: .done)
+        let mockEvent = AWSAuthWebUISignInOperation.OperationResult.success(mockResult)
+        let mockRequest = AuthWebUISignInRequest(presentationAnchor: UIWindow(),
+                                                 options: AuthWebUISignInRequest.Options())
+        let mockContext = AmplifyOperationContext(operationId: UUID(), request: mockRequest)
+        let mockPayload = HubPayload(eventName: HubPayload.EventName.Auth.webUISignIn,
+                                     context: mockContext,
+                                     data: mockEvent)
+        Amplify.Hub.dispatch(to: .auth, payload: mockPayload)
+
+    }
+
+    private func mockSuccessfulSignedInEvent() {
+        let mockResult = AuthSignInResult(nextStep: .done)
+        let mockEvent = AWSAuthSignInOperation.OperationResult.success(mockResult)
+        let mockRequest = AuthSignInRequest(username: "username",
+                                            password: "password",
+                                            options: AuthSignInRequest.Options())
+        let mockContext = AmplifyOperationContext(operationId: UUID(), request: mockRequest)
+        let mockPayload = HubPayload(eventName: HubPayload.EventName.Auth.signIn,
+                                     context: mockContext,
+                                     data: mockEvent)
+        Amplify.Hub.dispatch(to: .auth, payload: mockPayload)
+
+    }
+
+}


### PR DESCRIPTION
- Fix for hub event not being fired for successful signIn in webUi and social provider signIn
- Fixed typo for webUI event
- Added Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
