### PR TITLE
refactor(Auth): Added an API to the event of every Auth api hub events

### DIFF
--- a/Amplify/Categories/Auth/Models/AuthEventName.swift
+++ b/Amplify/Categories/Auth/Models/AuthEventName.swift
@@ -9,9 +9,12 @@ import Foundation
 
 public extension HubPayload.EventName.Auth {
 
+    /// eventName emitted when a user is successfully signedIn to Auth category
     static let signedIn = "Auth.signedIn"
 
+    /// eventName emitted when a user is signedOut from Auth category
     static let signedOut = "Auth.signedOut"
 
+    /// eventName emitted when the current session has expired
     static let sessionExpired = "Auth.sessionExpired"
 }

--- a/Amplify/Categories/Auth/Operation/AuthChangePasswordOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthChangePasswordOperation.swift
@@ -16,5 +16,5 @@ public protocol AuthChangePasswordOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let changePassword = "Auth.changePassword"
+    static let changePasswordAPI = "Auth.changePasswordAPI"
 }

--- a/Amplify/Categories/Auth/Operation/AuthConfirmResetPasswordOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthConfirmResetPasswordOperation.swift
@@ -16,5 +16,5 @@ public protocol AuthConfirmResetPasswordOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let confirmResetPassword = "Auth.confirmResetPassword"
+    static let confirmResetPasswordAPI = "Auth.confirmResetPasswordAPI"
 }

--- a/Amplify/Categories/Auth/Operation/AuthConfirmSignInOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthConfirmSignInOperation.swift
@@ -12,5 +12,5 @@ public protocol AuthConfirmSignInOperation: AmplifyOperation<AuthConfirmSignInRe
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let confirmSignIn = "Auth.confirmSignIn"
+    static let confirmSignInAPI = "Auth.confirmSignInAPI"
 }

--- a/Amplify/Categories/Auth/Operation/AuthConfirmSignUpOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthConfirmSignUpOperation.swift
@@ -12,5 +12,5 @@ public protocol AuthConfirmSignUpOperation: AmplifyOperation<AuthConfirmSignUpRe
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let confirmSignUp = "Auth.confirmSignUp"
+    static let confirmSignUpAPI = "Auth.confirmSignUpAPI"
 }

--- a/Amplify/Categories/Auth/Operation/AuthFetchDevicesOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthFetchDevicesOperation.swift
@@ -16,5 +16,5 @@ public protocol AuthFetchDevicesOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let fetchDevices = "Auth.fetchDevices"
+    static let fetchDevicesAPI = "Auth.fetchDevicesAPI"
 }

--- a/Amplify/Categories/Auth/Operation/AuthFetchSessionOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthFetchSessionOperation.swift
@@ -12,5 +12,5 @@ public protocol AuthFetchSessionOperation: AmplifyOperation<AuthFetchSessionRequ
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let fetchSession = "Auth.fetchSession"
+    static let fetchSessionAPI = "Auth.fetchSessionAPI"
 }

--- a/Amplify/Categories/Auth/Operation/AuthForgetDeviceOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthForgetDeviceOperation.swift
@@ -16,5 +16,5 @@ public protocol AuthForgetDeviceOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let forgetDevice = "Auth.forgetDevice"
+    static let forgetDeviceAPI = "Auth.forgetDeviceAPI"
 }

--- a/Amplify/Categories/Auth/Operation/AuthRememberDeviceOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthRememberDeviceOperation.swift
@@ -16,5 +16,5 @@ public protocol AuthRememberDeviceOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let rememberDevice = "Auth.rememberDevice"
+    static let rememberDeviceAPI = "Auth.rememberDeviceAPI"
 }

--- a/Amplify/Categories/Auth/Operation/AuthResendSignUpCodeOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthResendSignUpCodeOperation.swift
@@ -14,5 +14,5 @@ public protocol AuthResendSignUpCodeOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let resendSignUpCode = "Auth.resendSignUpCode"
+    static let resendSignUpCodeAPI = "Auth.resendSignUpCodeAPI"
 }

--- a/Amplify/Categories/Auth/Operation/AuthResetPasswordOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthResetPasswordOperation.swift
@@ -16,5 +16,5 @@ public protocol AuthResetPasswordOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let resetPassword = "Auth.resetPassword"
+    static let resetPasswordAPI = "Auth.resetPasswordAPI"
 }

--- a/Amplify/Categories/Auth/Operation/AuthSignInOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthSignInOperation.swift
@@ -12,5 +12,5 @@ public protocol AuthSignInOperation: AmplifyOperation<AuthSignInRequest, AuthSig
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let signIn = "Auth.signIn"
+    static let signInAPI = "Auth.signInAPI"
 }

--- a/Amplify/Categories/Auth/Operation/AuthSignOutOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthSignOutOperation.swift
@@ -16,5 +16,5 @@ public protocol AuthSignOutOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let signOut = "Auth.signOut"
+    static let signOutAPI = "Auth.signOutAPI"
 }

--- a/Amplify/Categories/Auth/Operation/AuthSignUpOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthSignUpOperation.swift
@@ -16,5 +16,5 @@ public protocol AuthSignUpOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let signUp = "Auth.signUp"
+    static let signUpAPI = "Auth.signUpAPI"
 }

--- a/Amplify/Categories/Auth/Operation/AuthSocialWebUISignInOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthSocialWebUISignInOperation.swift
@@ -16,5 +16,5 @@ public protocol AuthSocialWebUISignInOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let socialWebUISignIn = "Auth.socialWebUISignIn"
+    static let socialWebUISignInAPI = "Auth.socialWebUISignInAPI"
 }

--- a/Amplify/Categories/Auth/Operation/AuthWebUISignInOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthWebUISignInOperation.swift
@@ -16,5 +16,5 @@ public protocol AuthWebUISignInOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let webUISignIn = "Auth.webUISignIn"
+    static let webUISignInAPI = "Auth.webUISignInAPI"
 }

--- a/Amplify/Categories/Auth/Operation/UserOperations/AuthAttributeResendConfirmationCodeOperation.swift
+++ b/Amplify/Categories/Auth/Operation/UserOperations/AuthAttributeResendConfirmationCodeOperation.swift
@@ -14,5 +14,5 @@ public protocol AuthAttributeResendConfirmationCodeOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let attributeResendConfirmationCode = "Auth.attributeResendConfirmationCode"
+    static let attributeResendConfirmationCodeAPI = "Auth.attributeResendConfirmationCodeAPI"
 }

--- a/Amplify/Categories/Auth/Operation/UserOperations/AuthConfirmUserAttributeOperation.swift
+++ b/Amplify/Categories/Auth/Operation/UserOperations/AuthConfirmUserAttributeOperation.swift
@@ -16,5 +16,5 @@ public protocol AuthConfirmUserAttributeOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let confirmUserAttributes = "Auth.confirmUserAttributes"
+    static let confirmUserAttributesAPI = "Auth.confirmUserAttributesAPI"
 }

--- a/Amplify/Categories/Auth/Operation/UserOperations/AuthFetchUserAttributeOperation.swift
+++ b/Amplify/Categories/Auth/Operation/UserOperations/AuthFetchUserAttributeOperation.swift
@@ -14,5 +14,5 @@ public protocol AuthFetchUserAttributeOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let fetchUserAttributes = "Auth.fetchUserAttributes"
+    static let fetchUserAttributesAPI = "Auth.fetchUserAttributesAPI"
 }

--- a/Amplify/Categories/Auth/Operation/UserOperations/AuthUpdateUserAttributeOperation.swift
+++ b/Amplify/Categories/Auth/Operation/UserOperations/AuthUpdateUserAttributeOperation.swift
@@ -14,5 +14,5 @@ public protocol AuthUpdateUserAttributeOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let updateUserAttribute = "Auth.updateUserAttribute"
+    static let updateUserAttributeAPI = "Auth.updateUserAttributeAPI"
 }

--- a/Amplify/Categories/Auth/Operation/UserOperations/AuthUpdateUserAttributesOperation.swift
+++ b/Amplify/Categories/Auth/Operation/UserOperations/AuthUpdateUserAttributesOperation.swift
@@ -14,5 +14,5 @@ public protocol AuthUpdateUserAttributesOperation: AmplifyOperation<
 public extension HubPayload.EventName.Auth {
 
     /// eventName for HubPayloads emitted by this operation
-    static let updateUserAttributes = "Auth.updateUserAttributes"
+    static let updateUserAttributesAPI = "Auth.updateUserAttributesAPI"
 }

--- a/Amplify/Categories/Auth/Request/AuthSignOutRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthSignOutRequest.swift
@@ -27,7 +27,7 @@ public extension AuthSignOutRequest {
         public let pluginOptions: Any?
 
         public let globalSignOut: Bool
-        
+
         public init(globalSignOut: Bool = false,
                     pluginOptions: Any? = nil) {
             self.globalSignOut = globalSignOut

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/HubEvents/AuthHubEventHandler.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/HubEvents/AuthHubEventHandler.swift
@@ -34,42 +34,42 @@ class AuthHubEventHandler: AuthHubEventBehavior {
         _ = Amplify.Hub.listen(to: .auth) {[weak self] payload in
             switch payload.eventName {
 
-            case HubPayload.EventName.Auth.signIn:
+            case HubPayload.EventName.Auth.signInAPI:
                 guard let event = payload.data as? AWSAuthSignInOperation.OperationResult,
                     case let .success(result) = event else {
                         return
                 }
                 self?.handleSignInEvent(result)
 
-            case HubPayload.EventName.Auth.confirmSignIn:
+            case HubPayload.EventName.Auth.confirmSignInAPI:
                 guard let event = payload.data as? AWSAuthConfirmSignInOperation.OperationResult,
                     case let .success(result) = event else {
                         return
                 }
                 self?.handleSignInEvent(result)
 
-            case HubPayload.EventName.Auth.webUISignIn:
+            case HubPayload.EventName.Auth.webUISignInAPI:
                 guard let event = payload.data as? AWSAuthWebUISignInOperation.OperationResult,
                     case let .success(result) = event else {
                         return
                 }
                 self?.handleSignInEvent(result)
 
-            case HubPayload.EventName.Auth.socialWebUISignIn:
+            case HubPayload.EventName.Auth.socialWebUISignInAPI:
                 guard let event = payload.data as? AWSAuthSocialWebUISignInOperation.OperationResult,
                     case let .success(result) = event else {
                         return
                 }
                 self?.handleSignInEvent(result)
 
-            case HubPayload.EventName.Auth.signOut:
+            case HubPayload.EventName.Auth.signOutAPI:
                 guard let event = payload.data as? AWSAuthSignOutOperation.OperationResult,
                     case .success(_) = event else {
                         return
                 }
                 self?.sendUserSignedOutEvent()
 
-            case HubPayload.EventName.Auth.fetchSession:
+            case HubPayload.EventName.Auth.fetchSessionAPI:
                 guard let event = payload.data as? AWSAuthFetchSessionOperation.OperationResult,
                     case let .success(result) = event else {
                         return

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthConfirmResetPasswordOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthConfirmResetPasswordOperation.swift
@@ -22,7 +22,7 @@ public class AWSAuthConfirmResetPasswordOperation: AmplifyOperation<
 
         self.authenticationProvider = authenticationProvider
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.confirmResetPassword,
+                   eventName: HubPayload.EventName.Auth.confirmResetPasswordAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthConfirmSignInOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthConfirmSignInOperation.swift
@@ -23,7 +23,7 @@ public class AWSAuthConfirmSignInOperation: AmplifyOperation<
 
         self.authenticationProvider = authenticationProvider
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.confirmSignIn,
+                   eventName: HubPayload.EventName.Auth.confirmSignInAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthConfirmSignUpOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthConfirmSignUpOperation.swift
@@ -22,7 +22,7 @@ public class AWSAuthConfirmSignUpOperation: AmplifyOperation<
 
         self.authenticationProvider = authenticationProvider
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.confirmSignUp,
+                   eventName: HubPayload.EventName.Auth.confirmSignUpAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthFetchDevicesOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthFetchDevicesOperation.swift
@@ -22,7 +22,7 @@ public class AWSAuthFetchDevicesOperation: AmplifyOperation<
 
         self.deviceService = deviceService
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.fetchDevices,
+                   eventName: HubPayload.EventName.Auth.fetchDevicesAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthFetchSessionOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthFetchSessionOperation.swift
@@ -25,7 +25,7 @@ public class AWSAuthFetchSessionOperation: AmplifyOperation<
         self.authenticationProvider = authenticationProvider
         self.authorizationProvider = authorizationProvider
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.fetchSession,
+                   eventName: HubPayload.EventName.Auth.fetchSessionAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthForgetDeviceOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthForgetDeviceOperation.swift
@@ -22,7 +22,7 @@ public class AWSAuthForgetDeviceOperation: AmplifyOperation<
 
         self.deviceService = deviceService
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.forgetDevice,
+                   eventName: HubPayload.EventName.Auth.forgetDeviceAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthRememberDeviceOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthRememberDeviceOperation.swift
@@ -22,7 +22,7 @@ public class AWSAuthRememberDeviceOperation: AmplifyOperation<
 
         self.deviceService = deviceService
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.rememberDevice,
+                   eventName: HubPayload.EventName.Auth.rememberDeviceAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthResendSignUpCodeOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthResendSignUpCodeOperation.swift
@@ -22,7 +22,7 @@ public class AWSAuthResendSignUpCodeOperation: AmplifyOperation<
 
         self.authenticationProvider = authenticationProvider
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.resendSignUpCode,
+                   eventName: HubPayload.EventName.Auth.resendSignUpCodeAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthResetPasswordOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthResetPasswordOperation.swift
@@ -22,7 +22,7 @@ public class AWSAuthResetPasswordOperation: AmplifyOperation<
 
         self.authenticationProvider = authenticationProvider
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.resetPassword,
+                   eventName: HubPayload.EventName.Auth.resetPasswordAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthSignInOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthSignInOperation.swift
@@ -22,7 +22,7 @@ public class AWSAuthSignInOperation: AmplifyOperation<
 
         self.authenticationProvider = authenticationProvider
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.signIn,
+                   eventName: HubPayload.EventName.Auth.signInAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthSignOutOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthSignOutOperation.swift
@@ -22,7 +22,7 @@ public class AWSAuthSignOutOperation: AmplifyOperation<
 
         self.authenticationProvider = authenticationProvider
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.signOut,
+                   eventName: HubPayload.EventName.Auth.signOutAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthSignUpOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthSignUpOperation.swift
@@ -23,7 +23,7 @@ public class AWSAuthSignUpOperation: AmplifyOperation<
 
         self.authenticationProvider = authenticationProvider
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.signUp,
+                   eventName: HubPayload.EventName.Auth.signUpAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthSocialWebUISignInOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthSocialWebUISignInOperation.swift
@@ -22,7 +22,7 @@ public class AWSAuthSocialWebUISignInOperation: AmplifyOperation<
 
         self.authenticationProvider = authenticationProvider
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.socialWebUISignIn,
+                   eventName: HubPayload.EventName.Auth.socialWebUISignInAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthWebUISignInOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/AWSAuthWebUISignInOperation.swift
@@ -22,7 +22,7 @@ public class AWSAuthWebUISignInOperation: AmplifyOperation<
 
         self.authenticationProvider = authenticationProvider
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.webUISignIn,
+                   eventName: HubPayload.EventName.Auth.webUISignInAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/UserOperations/AWSAuthAttributeResendConfirmationCodeOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/UserOperations/AWSAuthAttributeResendConfirmationCodeOperation.swift
@@ -22,7 +22,7 @@ public class AWSAuthAttributeResendConfirmationCodeOperation: AmplifyOperation<
 
         self.userService = userService
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.attributeResendConfirmationCode,
+                   eventName: HubPayload.EventName.Auth.attributeResendConfirmationCodeAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/UserOperations/AWSAuthChangePasswordOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/UserOperations/AWSAuthChangePasswordOperation.swift
@@ -20,7 +20,7 @@ public class AWSAuthChangePasswordOperation: AmplifyOperation<
          resultListener: ResultListener?) {
         self.userService = userService
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.changePassword,
+                   eventName: HubPayload.EventName.Auth.changePasswordAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/UserOperations/AWSAuthConfirmUserAttributeOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/UserOperations/AWSAuthConfirmUserAttributeOperation.swift
@@ -21,7 +21,7 @@ public class AWSAuthConfirmUserAttributeOperation: AmplifyOperation<
 
         self.userService = userService
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.confirmUserAttributes,
+                   eventName: HubPayload.EventName.Auth.confirmUserAttributesAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/UserOperations/AWSAuthFetchUserAttributeOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/UserOperations/AWSAuthFetchUserAttributeOperation.swift
@@ -21,7 +21,7 @@ public class AWSAuthFetchUserAttributeOperation: AmplifyOperation<
 
         self.userService = userService
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.fetchUserAttributes,
+                   eventName: HubPayload.EventName.Auth.fetchUserAttributesAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/UserOperations/AWSAuthUpdateUserAttributeOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/UserOperations/AWSAuthUpdateUserAttributeOperation.swift
@@ -21,7 +21,7 @@ public class AWSAuthUpdateUserAttributeOperation: AmplifyOperation<
 
         self.userService = userService
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.updateUserAttribute,
+                   eventName: HubPayload.EventName.Auth.updateUserAttributeAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/UserOperations/AWSAuthUpdateUserAttributesOperation.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPlugin/Operations/UserOperations/AWSAuthUpdateUserAttributesOperation.swift
@@ -21,7 +21,7 @@ public class AWSAuthUpdateUserAttributesOperation: AmplifyOperation<
 
         self.userService = userService
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.updateUserAttributes,
+                   eventName: HubPayload.EventName.Auth.updateUserAttributesAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/AWSAuthPluginIntegrationTests/AuthSessionTests/SignedOutAuthSessionTests.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPluginIntegrationTests/AuthSessionTests/SignedOutAuthSessionTests.swift
@@ -89,7 +89,7 @@ class SignedOutAuthSessionTests: AWSAuthBaseTest {
         let authSessionExpectation = expectation(description: "Received event result from fetchAuth")
         let operation = Amplify.Auth.fetchAuthSession {event in
             switch event {
-            case .completed(let result):
+            case .success(let result):
                 XCTAssertFalse(result.isSignedIn, "Session state should be not signed In")
 
                 let tokensResult = (result as? AuthCognitoTokensProvider)?.getCognitoTokens()
@@ -98,10 +98,8 @@ class SignedOutAuthSessionTests: AWSAuthBaseTest {
                         XCTFail("Should produce signedOut error.")
                         return
                 }
-            case .failed(let error):
+            case .failure(let error):
                 XCTFail("Should not receive error \(error)")
-            default:
-                break
             }
             authSessionExpectation.fulfill()
         }

--- a/AmplifyPlugins/Auth/AWSAuthPluginTests/HubEventTests/AuthHubEventHandlerTests.swift
+++ b/AmplifyPlugins/Auth/AWSAuthPluginTests/HubEventTests/AuthHubEventHandlerTests.swift
@@ -98,7 +98,7 @@ class AuthHubEventHandlerTests: XCTestCase {
                                                  authProvider: .amazon,
                                                  options: AuthWebUISignInRequest.Options())
         let mockContext = AmplifyOperationContext(operationId: UUID(), request: mockRequest)
-        let mockPayload = HubPayload(eventName: HubPayload.EventName.Auth.socialWebUISignIn,
+        let mockPayload = HubPayload(eventName: HubPayload.EventName.Auth.socialWebUISignInAPI,
                                      context: mockContext,
                                      data: mockEvent)
         Amplify.Hub.dispatch(to: .auth, payload: mockPayload)
@@ -111,7 +111,7 @@ class AuthHubEventHandlerTests: XCTestCase {
         let mockRequest = AuthWebUISignInRequest(presentationAnchor: UIWindow(),
                                                  options: AuthWebUISignInRequest.Options())
         let mockContext = AmplifyOperationContext(operationId: UUID(), request: mockRequest)
-        let mockPayload = HubPayload(eventName: HubPayload.EventName.Auth.webUISignIn,
+        let mockPayload = HubPayload(eventName: HubPayload.EventName.Auth.webUISignInAPI,
                                      context: mockContext,
                                      data: mockEvent)
         Amplify.Hub.dispatch(to: .auth, payload: mockPayload)
@@ -125,7 +125,7 @@ class AuthHubEventHandlerTests: XCTestCase {
                                             password: "password",
                                             options: AuthSignInRequest.Options())
         let mockContext = AmplifyOperationContext(operationId: UUID(), request: mockRequest)
-        let mockPayload = HubPayload(eventName: HubPayload.EventName.Auth.signIn,
+        let mockPayload = HubPayload(eventName: HubPayload.EventName.Auth.signInAPI,
                                      context: mockContext,
                                      data: mockEvent)
         Amplify.Hub.dispatch(to: .auth, payload: mockPayload)

--- a/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
@@ -186,7 +186,7 @@ AuthChangePasswordOperation {
 
     init(request: Request) {
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.changePassword,
+                   eventName: HubPayload.EventName.Auth.changePasswordAPI,
                    request: request)
     }
 


### PR DESCRIPTION
Auth category emits two types of hub events - 1) Whenever an api completes 1) For specific Auth events like user signedIn, signedOut or session expired. To distinguish between the two, this PR adds API to the end of hub event names that are fired when an api completes it execution. For example:
When `Amplify.Auth.signIn(...)` completes, it sends out an event `HubPayload.EventName.Auth.signInAPI`. On the other hand when a user is successfully signed in into the Auth category, an event of name `HubPayload.EventName.Auth.signedIn` will be fired.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
