### PR TITLE
chore: 1.0.0-rc.1 release prep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,8 +189,8 @@ workflows:
       - plugin_unit_test:
           name: unit_test_auth
           path: Auth
-          workspace: AWSAuthPlugin
-          scheme: AWSAuthPlugin
+          workspace: AWSCognitoAuthPlugin
+          scheme: AWSCognitoAuthPlugin
           requires:
             - install_gems
       - plugin_unit_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,13 +173,6 @@ workflows:
           requires:
             - install_gems
       - plugin_unit_test:
-          name: unit_test_api
-          path: API
-          workspace: APICategoryPlugin
-          scheme: AWSAPICategoryPlugin
-          requires:
-            - install_gems
-      - plugin_unit_test:
           name: unit_test_analytics
           path: Analytics
           workspace: AnalyticsCategoryPlugin
@@ -187,17 +180,24 @@ workflows:
           requires:
             - install_gems
       - plugin_unit_test:
-          name: unit_test_storage
-          path: Storage
-          workspace: StoragePlugin
-          scheme: AWSS3StoragePlugin
+          name: unit_test_api
+          path: API
+          workspace: APICategoryPlugin
+          scheme: AWSAPICategoryPlugin
           requires:
             - install_gems
       - plugin_unit_test:
-          name: unit_test_predictions
-          path: Predictions
-          workspace: PredictionsCategoryPlugin
-          scheme: AWSPredictionsPlugin
+          name: unit_test_auth
+          path: Auth
+          workspace: AWSAuthPlugin
+          scheme: AWSAuthPlugin
+          requires:
+            - install_gems
+      - plugin_unit_test:
+          name: unit_test_datastore
+          path: DataStore
+          workspace: DataStoreCategoryPlugin
+          scheme: AWSDataStoreCategoryPlugin
           requires:
             - install_gems
       - plugin_unit_test:
@@ -208,10 +208,17 @@ workflows:
           requires:
             - install_gems
       - plugin_unit_test:
-          name: unit_test_datastore
-          path: DataStore
-          workspace: DataStoreCategoryPlugin
-          scheme: AWSDataStoreCategoryPlugin
+          name: unit_test_predictions
+          path: Predictions
+          workspace: PredictionsCategoryPlugin
+          scheme: AWSPredictionsPlugin
+          requires:
+            - install_gems
+      - plugin_unit_test:
+          name: unit_test_storage
+          path: Storage
+          workspace: StoragePlugin
+          scheme: AWSS3StoragePlugin
           requires:
             - install_gems
       - deploy:
@@ -221,8 +228,10 @@ workflows:
                 - release
           requires:
             - build_test_amplify
-            - unit_test_api
             - unit_test_analytics
-            - unit_test_storage
-            - unit_test_predictions
+            - unit_test_api
+            - unit_test_auth
+            - unit_test_core_ml
             - unit_test_datastore
+            - unit_test_predictions
+            - unit_test_storage

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ __pycache__/
 *awsconfiguration.json
 *amplifyconfiguration.json
 credentials-mc.json
+

--- a/AWSPluginsCore.podspec
+++ b/AWSPluginsCore.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
 
   s.name         = 'AWSPluginsCore'
-  s.version      = '0.11.0'
+  s.version      = '1.0.0-rc.1'
   s.summary      = 'Amazon Web Services Amplify for iOS.'
 
   s.description  = 'AWS Amplify for iOS provides a declarative library for application development using cloud services'
@@ -17,15 +17,16 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://aws.amazon.com/amplify/'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '11.0'
   s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => s.version}
-  
-  s.requires_arc = true
-  
-  AWS_SDK_VERSION = "~> 2.13.0"
+
+  s.platform     = :ios, '11.0'
+  s.swift_version = '5.0'
+
+  AWS_SDK_VERSION = "~> 2.13.4"
 
   s.source_files = 'AmplifyPlugins/Core/AWSPluginsCore/**/*.swift'
-  s.dependency 'Amplify', '0.11.0'
+
+  s.dependency 'Amplify', '1.0.0-rc.1'
   s.dependency 'AWSMobileClient', AWS_SDK_VERSION
   s.dependency 'AWSCore', AWS_SDK_VERSION
 

--- a/AWSPredictionsPlugin.podspec
+++ b/AWSPredictionsPlugin.podspec
@@ -1,29 +1,31 @@
 Pod::Spec.new do |s|
 
-    s.name         = 'AWSPredictionsPlugin'
-    s.version      = '0.11.0'
-    s.summary      = 'Amazon Web Services Amplify for iOS.'
-  
-    s.description  = 'AWS Amplify for iOS provides a declarative library for application development using cloud services'
-  
-    s.homepage     = 'https://aws.amazon.com/amplify/'
-    s.license      = 'Apache License, Version 2.0'
-    s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-    s.platform     = :ios, '13.0'
-    s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => s.version}
-    
-    s.requires_arc = true
+  s.name         = 'AWSPredictionsPlugin'
+  s.version      = '1.0.0-rc.1'
+  s.summary      = 'Amazon Web Services Amplify for iOS.'
 
-    AWS_SDK_VERSION = '~> 2.13.0'
-    AMPLIFY_VERSION = '0.11.0'
-    
-    s.source_files = 'AmplifyPlugins/Predictions/AWSPredictionsPlugin/**/*.swift'
-    s.dependency 'AWSComprehend', AWS_SDK_VERSION
-    s.dependency 'AWSPluginsCore', AMPLIFY_VERSION
-    s.dependency 'AWSPolly', AWS_SDK_VERSION
-    s.dependency 'AWSRekognition', AWS_SDK_VERSION
-    s.dependency 'AWSTextract', AWS_SDK_VERSION
-    s.dependency 'AWSTranscribeStreaming', AWS_SDK_VERSION
-    s.dependency 'AWSTranslate', AWS_SDK_VERSION
-    s.dependency 'CoreMLPredictionsPlugin', AMPLIFY_VERSION
-  end
+  s.description  = 'AWS Amplify for iOS provides a declarative library for application development using cloud services'
+
+  s.homepage     = 'https://aws.amazon.com/amplify/'
+  s.license      = 'Apache License, Version 2.0'
+  s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
+  s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => s.version}
+
+  s.platform     = :ios, '13.0'
+  s.swift_version = '5.0'
+
+  AWS_SDK_VERSION = '~> 2.13.4'
+  AMPLIFY_VERSION = '1.0.0-rc.1'
+
+  s.source_files = 'AmplifyPlugins/Predictions/AWSPredictionsPlugin/**/*.swift'
+
+  s.dependency 'AWSComprehend', AWS_SDK_VERSION
+  s.dependency 'AWSPluginsCore', AMPLIFY_VERSION
+  s.dependency 'AWSPolly', AWS_SDK_VERSION
+  s.dependency 'AWSRekognition', AWS_SDK_VERSION
+  s.dependency 'AWSTextract', AWS_SDK_VERSION
+  s.dependency 'AWSTranscribeStreaming', AWS_SDK_VERSION
+  s.dependency 'AWSTranslate', AWS_SDK_VERSION
+  s.dependency 'CoreMLPredictionsPlugin', AMPLIFY_VERSION
+
+end

--- a/Amplify.podspec
+++ b/Amplify.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
 
   s.name         = 'Amplify'
-  s.version      = '0.11.0'
+  s.version      = '1.0.0-rc.1'
   s.summary      = 'Amazon Web Services Amplify for iOS.'
 
   s.description  = 'AWS Amplify for iOS provides a declarative library for application development using cloud services'
@@ -17,13 +17,14 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://aws.amazon.com/amplify/'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '11.0'
   s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => s.version}
-  
-  s.requires_arc = true
+
+  s.platform     = :ios, '11.0'
+  s.swift_version = '5.0'
+
   s.source_files = 'Amplify/**/*.swift'
   s.default_subspec = 'Default'
-  
+
   s.subspec 'Default' do |default|
     default.preserve_path = 'AmplifyTools'
     default.script_phase = {

--- a/Amplify/Info.plist
+++ b/Amplify/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>1.0.0.rc.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyFunctionalTests/Info.plist
+++ b/AmplifyFunctionalTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>1.0.0.rc.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/AmplifyPlugins.podspec
+++ b/AmplifyPlugins.podspec
@@ -9,27 +9,33 @@
 Pod::Spec.new do |s|
 
   s.name         = 'AmplifyPlugins'
-  s.version      = '0.11.0'
+  s.version      = '1.0.0-rc.1'
   s.summary      = 'Amazon Web Services Amplify for iOS.'
 
   s.description  = 'AWS Amplify for iOS provides a declarative library for application development using cloud services'
-  
-  s.homepage     = 'http://aws.amazon.com/mobile/sdk'
+
+  s.homepage     = 'https://aws.amazon.com/amplify/'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '11.0'
   s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => s.version}
-  
-  s.requires_arc = true 
 
-  AWS_SDK_VERSION = '~> 2.13.0'
-  AMPLIFY_VERSION = '0.11.0'
-  
+  s.platform = :ios, '11.0'
+  s.swift_version = '5.0'
+
+  AWS_SDK_VERSION = '~> 2.13.4'
+  AMPLIFY_VERSION = '1.0.0-rc.1'
+
   s.subspec 'AWSAPIPlugin' do |ss|
     ss.source_files = 'AmplifyPlugins/API/AWSAPICategoryPlugin/**/*.swift'
     ss.dependency 'AWSPluginsCore', AMPLIFY_VERSION
     ss.dependency 'ReachabilitySwift', '~> 5.0.0'
     ss.dependency 'AppSyncRealTimeClient', "~> 1.1.0"
+  end
+
+  s.subspec 'AWSCognitoAuthPlugin' do |ss|
+    ss.source_files = 'AmplifyPlugins/Auth/AWSCognitoAuthPlugin/**/*.swift'
+    ss.dependency 'AWSPluginsCore', AMPLIFY_VERSION
+    ss.dependency 'AWSMobileClient', AWS_SDK_VERSION
   end
 
   s.subspec 'AWSDataStorePlugin' do |ss|
@@ -48,12 +54,6 @@ Pod::Spec.new do |s|
     ss.source_files = 'AmplifyPlugins/Storage/AWSS3StoragePlugin/**/*.swift'
     ss.dependency 'AWSPluginsCore', AMPLIFY_VERSION
     ss.dependency 'AWSS3', AWS_SDK_VERSION
-  end
-
-  s.subspec 'AWSCognitoAuthPlugin' do |ss|
-    ss.source_files = 'AmplifyPlugins/Auth/AWSCognitoAuthPlugin/**/*.swift'
-    ss.dependency 'AWSPluginsCore', AMPLIFY_VERSION
-    ss.dependency 'AWSMobileClient', AWS_SDK_VERSION
   end
 
 end

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Info.plist
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>1.0.0.rc.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Resources/Info.plist
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Resources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>1.0.0.rc.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyPlugins/Analytics/Podfile
+++ b/AmplifyPlugins/Analytics/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '12.0'
+platform :ios, '11.0'
 use_frameworks!
 
 AWS_SDK_VERSION = "2.13.0"

--- a/AmplifyPlugins/Auth/Podfile
+++ b/AmplifyPlugins/Auth/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '12.0'
+platform :ios, '11.0'
 use_frameworks!
 
 AWS_SDK_VERSION = "2.13.0"

--- a/AmplifyPlugins/Auth/Podfile
+++ b/AmplifyPlugins/Auth/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '11.0'
 use_frameworks!
 
-AWS_SDK_VERSION = "2.13.0"
+AWS_SDK_VERSION = "2.13.4"
 
 pod 'SwiftFormat/CLI'
 pod 'SwiftLint'

--- a/AmplifyPlugins/Core/AWSPluginsCore/Info.plist
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>1.0.0.rc.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -12,7 +12,7 @@ public class AmplifyAWSServiceConfiguration: AWSServiceConfiguration {
     override public class func baseUserAgent() -> String! {
         //TODO: Retrieve this version from a centralized location:
         //https://github.com/aws-amplify/amplify-ios/issues/276
-        let version = "0.11.0"
+        let version = "1.0.0-rc.1"
         let sdkName = "amplify-iOS"
         let systemName = UIDevice.current.systemName.replacingOccurrences(of: " ", with: "-")
         let systemVersion = UIDevice.current.systemVersion

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Info.plist
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>1.0.0.rc.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/Info.plist
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>1.0.0.rc.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Resources/Info.plist
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Resources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>1.0.0.rc.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Resources/Info.plist
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Resources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>1.0.0.rc.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Resources/Info.plist
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Resources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>1.0.0.rc.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyPlugins/Storage/Podfile
+++ b/AmplifyPlugins/Storage/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '12.0'
+platform :ios, '11.0'
 use_frameworks!
 
 AWS_SDK_VERSION = "2.13.0"

--- a/AmplifyTestApp/Info.plist
+++ b/AmplifyTestApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>1.0.0.rc.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/AmplifyTestCommon.podspec
+++ b/AmplifyTestCommon.podspec
@@ -6,27 +6,30 @@
 #  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
 #
 
-Pod::Spec.new do |spec|
+Pod::Spec.new do |s|
 
-  spec.name         = "AmplifyTestCommon"
-  spec.version      = "0.11.0"
-  spec.summary      = "Test resources used by different targets"
-  spec.description  = "Provides different test resources and mock methods"
+  s.name         = "AmplifyTestCommon"
+  s.version      = "1.0.0-rc.1"
+  s.summary      = "Test resources used by different targets"
 
-  spec.homepage     = "https://aws.amazon.com/amplify/"
-  spec.license      = 'Apache License, Version 2.0'
-  spec.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  spec.platform     = :ios, '11.0'
-  spec.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => spec.version}
-  
-  spec.requires_arc = true
+  s.description  = "Provides different test resources and mock methods"
 
-  spec.source_files = 'AmplifyTestCommon/**/*.swift'
-  spec.dependency 'Amplify', '0.11.0'
-  
-  spec.subspec 'AWSPluginsTestCommon' do |subspec|
-    subspec.source_files = 'AmplifyPlugins/Core/AWSPluginsTestCommon/**/*.swift'
-    subspec.dependency 'AWSPluginsCore', '0.11.0'
-    subspec.dependency 'AWSCore'
+  s.homepage     = "https://aws.amazon.com/amplify/"
+  s.license      = 'Apache License, Version 2.0'
+  s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
+  s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => s.version}
+
+  s.platform     = :ios, '11.0'
+  s.swift_version = '5.0'
+
+  s.source_files = 'AmplifyTestCommon/**/*.swift'
+
+  s.dependency 'Amplify', '1.0.0-rc.1'
+
+  s.subspec 'AWSPluginsTestCommon' do |ss|
+    ss.source_files = 'AmplifyPlugins/Core/AWSPluginsTestCommon/**/*.swift'
+    ss.dependency 'AWSPluginsCore', '1.0.0-rc.1'
+    ss.dependency 'AWSCore'
   end
+
 end

--- a/AmplifyTestCommon/Info.plist
+++ b/AmplifyTestCommon/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>1.0.0.rc.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AmplifyTests/Info.plist
+++ b/AmplifyTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>1.0.0.rc.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## 1.0.0-rc.1 (2020-05-20)
+## 1.0.0-rc.1 (2020-05-21)
 
 ### ⚠ BREAKING CHANGES
 

--- a/CircleciScripts/setup_private_specs.sh
+++ b/CircleciScripts/setup_private_specs.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# This script generates a private spec repo in your $HOME/.aws-amplify
+# directory, to enable `pod lib lint`. It also makes it easier to do
+# development against unreleased versions of Amplify, at least until we start
+# releasing nightly builds.
+
 set -e
 
 declare -r LOCAL_SPEC_GIT_ROOT="$HOME/.aws-amplify/amplify-ios/amplify-ios-podspecs.git"

--- a/CircleciScripts/setup_private_specs.sh
+++ b/CircleciScripts/setup_private_specs.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+set -e
+
+declare -r LOCAL_SPEC_GIT_ROOT="$HOME/.aws-amplify/amplify-ios/amplify-ios-podspecs.git"
+declare -r LOCAL_SPEC_REPO_NAME="amplify-ios-local-specs"
+declare -r COCOAPODS_REPO_DIR="${HOME}/.cocoapods/repos/${LOCAL_SPEC_REPO_NAME}"
+
+function init_spec_git_root {
+  # If directory exists, assume it's correctly set up; don't attempt any
+  # repairs or validation
+  if [[ -d "${LOCAL_SPEC_GIT_ROOT}" ]] ; then
+    return 0
+  fi
+
+  mkdir -p "${LOCAL_SPEC_GIT_ROOT}"
+  old_pwd="${PWD}"
+  cd "${LOCAL_SPEC_GIT_ROOT}"
+  git init --bare
+  cd "${old_pwd}"
+}
+
+function init_spec_repo {
+  # If repo exists, assume it's correctly set up; don't attempt any
+  # repairs or validation
+  if [[ -n "$(pod repo list | grep ${LOCAL_SPEC_REPO_NAME})" ]] ; then
+    return 0
+  fi
+
+  init_spec_git_root
+
+  pod repo add --silent "${LOCAL_SPEC_REPO_NAME}" "${LOCAL_SPEC_GIT_ROOT}"
+
+  old_pwd="${PWD}"
+  cd "${COCOAPODS_REPO_DIR}"
+  git commit --allow-empty -m "Empty commit"
+  git push
+  cd "${old_pwd}"
+
+  if [[ -z "$(pod repo list | grep ${LOCAL_SPEC_REPO_NAME})" ]] ; then
+    pod repo add --silent "${LOCAL_SPEC_REPO_NAME}" "${LOCAL_SPEC_GIT_ROOT}"
+  else
+    pod repo update --silent "${LOCAL_SPEC_REPO_NAME}"
+  fi
+}
+
+function update_spec_repo {
+  old_pwd="${PWD}"
+  cd "${COCOAPODS_REPO_DIR}"
+
+  git add .
+  git commit --allow-empty -m "Update specs"
+  git push
+
+  cd "${old_pwd}"
+}
+
+function write_munged_podspec {
+  declare -r src_file=$1
+  declare -r dst_file=$2
+  sed "s/${old_version}/${new_version}/g" "${src_file}" \
+    | sed "s#s.source *=.*#s.source = { :git => 'file://${src_dir}' }#" \
+    > "${dst_file}"
+}
+
+declare -r old_version="$1"
+if [[ -z $old_version ]] ; then
+  echo "Must specify old_version" >&2
+  exit 1
+fi
+
+declare -r new_version="$2"
+if [[ -z $new_version ]] ; then
+  echo "Must specify new_version" >&2
+  exit 1
+fi
+
+init_spec_repo
+
+declare -r src_dir="$PWD"
+
+podspec_file_names=()
+
+while read -r podspec_file ; do
+  podspec_file_name=$( basename "$podspec_file" )
+  podspec_file_names+=("$podspec_file_name")
+  pod_name=$( basename "$podspec_file_name" .podspec )
+
+  dst_dir="${COCOAPODS_REPO_DIR}/${pod_name}/${new_version}"
+  dst_file="${dst_dir}/${podspec_file_name}"
+
+  mkdir -p "${dst_dir}"
+
+  write_munged_podspec "$podspec_file" "$dst_file"
+done < <( find "${src_dir}" -maxdepth 1 -mindepth 1 -name "*.podspec" | sort --ignore-case )
+
+update_spec_repo
+
+echo "Done. You may now validate podspec files by running:"
+for podspec_file_name in "${podspec_file_names[@]}" ; do
+  echo
+  echo "pod lib lint --sources=${LOCAL_SPEC_REPO_NAME},trunk ${podspec_file_name}"
+done
+

--- a/CoreMLPredictionsPlugin.podspec
+++ b/CoreMLPredictionsPlugin.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = 'CoreMLPredictionsPlugin'
-  s.version      = '0.11.0'
+  s.version      = '1.0.0-rc.1'
   s.summary      = 'Amazon Web Services Amplify for iOS.'
 
   s.description  = 'AWS Amplify for iOS provides a declarative library for application development using cloud services'
@@ -9,12 +9,13 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://aws.amazon.com/amplify/'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '13.0'
   s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => s.version}
-  
-  s.requires_arc = true
+
+  s.platform     = :ios, '13.0'
+  s.swift_version = '5.0'
+
   s.source_files = 'AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/**/*.swift'
-  s.dependency 'Amplify', '0.11.0'
+
+  s.dependency 'Amplify', '1.0.0-rc.1'
 
 end
-

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,3 @@
-# Uncomment the next line to define a global platform for your project
 platform :ios, "11.0"
 
 AWS_SDK_VERSION = "2.13.0"


### PR DESCRIPTION
- ci: Enable local lib linting of monorepo
- chore: Bump release to 1.0.0-rc.1
- chore: Update minimum SDK Dependency to 2.13.4
- chore: Podfile cleanup
- chore: Remove unnecessary requires_arc build setting

*Description of changes:*

The newly-added `CircleciScripts/setup_private_specs.sh` script also makes it easier to do app development against unreleased code. We'll add something to the README later. Someday we'll do nightly builds and it won't really be necessary to jump through these hoops for app development with bleeding-edge versions.

The `setup_private_specs.sh` script also makes it possible to lint the pods before the release. It modifies the specs in the private repo so dependencies resolve correctly, but the base file itself is linted directly from the local git working directory. I have validated that all of `Amplify.podspec`, `AmplifyPlugins.podspec`, `AWSPredictionsPlugin.podspec`, and `CoreMLPredictionsPlugin.podspec` pass with `pod lib lint --sources=amplify-ios-local-specs,trunk <podspec>`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
