### PR TITLE
ci: Remove swift_version from Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,7 +35,7 @@ platform :ios do
 
     pods.each { |pod|
       UI.message("Pushing pod #{pod[:spec]}")
-      pod_push(path: pod[:spec], allow_warnings: true, swift_version: "5.1")
+      pod_push(path: pod[:spec], allow_warnings: true)
       if pod[:sleep]
         UI.message("Sleeping for #{COCOAPODS_PUSH_WAIT_TIME}s")
         sleep COCOAPODS_PUSH_WAIT_TIME


### PR DESCRIPTION
The Fastfile specified a hardcoded Swift version that a) didn't correspond to any swift versions recognized as options by the Swift compiler, and b) conflicted with the swift version specified in our podspec files. Removing that Fastfile version lets podspec linting use the value from the Podspec file instead of the overridden value from the Fastfile

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
