### PR TITLE
fix(datastore): query predicate API and integration tests fixes #487

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
@@ -19,21 +19,16 @@ extension DataStoreCategory: DataStoreBaseBehavior {
     }
 
     public func query<M: Model>(_ modelType: M.Type,
-                                where predicate: QueryPredicateFactory? = nil,
+                                where predicate: QueryPredicate? = nil,
                                 paginate paginationInput: QueryPaginationInput? = nil,
                                 completion: DataStoreCallback<[M]>) {
         plugin.query(modelType, where: predicate, paginate: paginationInput, completion: completion)
     }
 
     public func delete<M: Model>(_ model: M,
+                                 where predicate: QueryPredicate? = nil,
                                  completion: @escaping DataStoreCallback<Void>) {
-        plugin.delete(model, completion: completion)
-    }
-
-    public func delete<M: Model>(_ modelType: M.Type,
-                                 where predicate: @escaping QueryPredicateFactory,
-                                 completion: @escaping DataStoreCallback<Void>) {
-        plugin.delete(modelType, where: predicate, completion: completion)
+        plugin.delete(model, where: predicate, completion: completion)
     }
 
     public func delete<M: Model>(_ modelType: M.Type,

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -7,8 +7,6 @@
 
 import Combine
 
-public typealias QueryPredicateFactory = () -> QueryPredicate
-
 public typealias DataStoreCategoryBehavior = DataStoreBaseBehavior & DataStoreSubscribeBehavior
 
 public protocol DataStoreBaseBehavior {
@@ -23,15 +21,12 @@ public protocol DataStoreBaseBehavior {
                          completion: DataStoreCallback<M?>)
 
     func query<M: Model>(_ modelType: M.Type,
-                         where predicate: QueryPredicateFactory?,
+                         where predicate: QueryPredicate?,
                          paginate paginationInput: QueryPaginationInput?,
                          completion: DataStoreCallback<[M]>)
 
     func delete<M: Model>(_ model: M,
-                          completion: @escaping DataStoreCallback<Void>)
-
-    func delete<M: Model>(_ modelType: M.Type,
-                          where predicate: @escaping QueryPredicateFactory,
+                          where predicate: QueryPredicate?,
                           completion: @escaping DataStoreCallback<Void>)
 
     func delete<M: Model>(_ modelType: M.Type,

--- a/Amplify/Categories/DataStore/Model/Collection/List+LazyLoad.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+LazyLoad.swift
@@ -45,7 +45,7 @@ extension List {
             name = targetName ?? name
         }
 
-        let predicate: QueryPredicateFactory = { field(name) == associatedId }
+        let predicate: QueryPredicate = field(name) == associatedId
         Amplify.DataStore.query(Element.self, where: predicate) {
             switch $0 {
             case .success(let elements):

--- a/Amplify/Core/Category/CategoryType.swift
+++ b/Amplify/Core/Category/CategoryType.swift
@@ -61,7 +61,7 @@ public extension CategoryType {
             return "Storage"
         }
     }
-    
+
     var category: Category {
         switch self {
         case .analytics:

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
@@ -35,7 +35,7 @@ class GraphQLCreateMutationTests: XCTestCase {
     func testCreateGraphQLMutationFromSimpleModel() {
         let post = Post(title: "title",
                         content: "content",
-                        createdAt: Date(),
+                        createdAt: .now(),
                         status: .private)
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
@@ -84,8 +84,8 @@ class GraphQLCreateMutationTests: XCTestCase {
     ///     - it contains an `input` of type `CreateCommentInput`
     ///     - it has a list of fields with a `postId`
     func testCreateGraphQLMutationFromModelWithAssociation() {
-        let post = Post(title: "title", content: "content", createdAt: Date())
-        let comment = Comment(content: "comment", createdAt: Date(), post: post)
+        let post = Post(title: "title", content: "content", createdAt: .now())
+        let comment = Comment(content: "comment", createdAt: .now(), post: post)
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Comment.self, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
         documentBuilder.add(decorator: ModelDecorator(model: comment))
@@ -136,7 +136,7 @@ class GraphQLCreateMutationTests: XCTestCase {
     ///     - it contains an `input` of type `CreatePostInput`
     ///     - it has a list of fields with no nested models
     func testCreateGraphQLMutationFromSimpleModelWithSyncEnabled() {
-        let post = Post(title: "title", content: "content", createdAt: Date())
+        let post = Post(title: "title", content: "content", createdAt: .now())
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
         documentBuilder.add(decorator: ModelDecorator(model: post))
@@ -187,8 +187,8 @@ class GraphQLCreateMutationTests: XCTestCase {
     ///     - it contains an `input` of type `CreateCommentInput`
     ///     - it has a list of fields with a `postId`
     func testCreateGraphQLMutationFromModelWithAssociationWithSyncEnabled() {
-        let post = Post(title: "title", content: "content", createdAt: Date())
-        let comment = Comment(content: "comment", createdAt: Date(), post: post)
+        let post = Post(title: "title", content: "content", createdAt: .now())
+        let comment = Comment(content: "comment", createdAt: .now(), post: post)
 
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Comment.self, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDeleteMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDeleteMutationTests.swift
@@ -33,7 +33,7 @@ class GraphQLDeleteMutationTests: XCTestCase {
     ///     - it contains an `input` of type `ID!`
     ///     - it has a list of fields with no nested models
     func testDeleteGraphQLMutationFromSimpleModel() {
-        let post = Post(title: "title", content: "content", createdAt: Date())
+        let post = Post(title: "title", content: "content", createdAt: .now())
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .delete))
         documentBuilder.add(decorator: ModelIdDecorator(id: post.id))
@@ -79,7 +79,7 @@ class GraphQLDeleteMutationTests: XCTestCase {
     ///     - it contains an `input` of type `ID!`
     ///     - it has a list of fields with no nested models
     func testDeleteGraphQLMutationFromSimpleModelWithVersion() {
-        let post = Post(title: "title", content: "content", createdAt: Date())
+        let post = Post(title: "title", content: "content", createdAt: .now())
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .delete))
         documentBuilder.add(decorator: ModelIdDecorator(id: post.id))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLUpdateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLUpdateMutationTests.swift
@@ -33,7 +33,7 @@ class GraphQLUpdateMutationTests: XCTestCase {
     ///     - it contains an `input` of type `UpdatePostInput`
     ///     - it has a list of fields with no nested models
     func testUpdateGraphQLMutationFromSimpleModel() {
-        let post = Post(title: "title", content: "content", createdAt: Date())
+        let post = Post(title: "title", content: "content", createdAt: .now())
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .update))
         documentBuilder.add(decorator: ModelDecorator(model: post))
@@ -80,7 +80,7 @@ class GraphQLUpdateMutationTests: XCTestCase {
     ///     - it contains an `input` of type `UpdatePostInput`
     ///     - it has a list of fields with no nested models
     func testUpdateGraphQLMutationFromSimpleModelWithVersion() {
-        let post = Post(title: "title", content: "content", createdAt: Date())
+        let post = Post(title: "title", content: "content", createdAt: .now())
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .update))
         documentBuilder.add(decorator: ModelDecorator(model: post))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAnyModelWithSyncTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAnyModelWithSyncTests.swift
@@ -22,7 +22,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
     }
 
     func testQueryGraphQLRequest() throws {
-        let post = Post(title: "title", content: "content", createdAt: Date())
+        let post = Post(title: "title", content: "content", createdAt: .now())
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: post.modelName, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
         documentBuilder.add(decorator: ModelIdDecorator(id: post.id))
@@ -60,7 +60,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
     }
 
     func testCreateMutationGraphQLRequest() throws {
-        let post = Post(title: "title", content: "content", createdAt: Date())
+        let post = Post(title: "title", content: "content", createdAt: .now())
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: post.modelName,
                                                                operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
@@ -103,7 +103,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
     }
 
     func testUpdateMutationGraphQLRequest() throws {
-        let post = Post(title: "title", content: "content", createdAt: Date())
+        let post = Post(title: "title", content: "content", createdAt: .now())
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: post.modelName,
                                                                operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .update))
@@ -146,7 +146,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
     }
 
     func testDeleteMutationGraphQLRequest() throws {
-        let post = Post(title: "title", content: "content", createdAt: Date())
+        let post = Post(title: "title", content: "content", createdAt: .now())
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: post.modelName,
                                                                operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .delete))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthRuleTests.swift
@@ -21,7 +21,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
     }
 
     func testQueryGraphQLRequest() throws {
-        let blog = Blog(content: "content", createdAt: Date(), owner: nil, authorNotes: nil)
+        let blog = Blog(content: "content", createdAt: .now(), owner: nil, authorNotes: nil)
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: blog.modelName, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
         documentBuilder.add(decorator: ModelIdDecorator(id: blog.id))
@@ -57,7 +57,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
     }
 
     func testCreateMutationGraphQLRequest() throws {
-        let blog = Blog(content: "content", createdAt: Date(), owner: nil, authorNotes: nil)
+        let blog = Blog(content: "content", createdAt: .now(), owner: nil, authorNotes: nil)
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: blog.modelName, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
         documentBuilder.add(decorator: ModelDecorator(model: blog))
@@ -98,7 +98,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
     }
 
     func testUpdateMutationGraphQLRequest() throws {
-        let blog = Blog(content: "content", createdAt: Date(), owner: nil, authorNotes: nil)
+        let blog = Blog(content: "content", createdAt: .now(), owner: nil, authorNotes: nil)
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: blog.modelName, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .update))
         documentBuilder.add(decorator: ModelDecorator(model: blog))
@@ -138,7 +138,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
     }
 
     func testDeleteMutationGraphQLRequest() throws {
-        let blog = Blog(content: "content", createdAt: Date(), owner: nil, authorNotes: nil)
+        let blog = Blog(content: "content", createdAt: .now(), owner: nil, authorNotes: nil)
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: blog.modelName, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .delete))
         documentBuilder.add(decorator: ModelIdDecorator(id: blog.id))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestModelTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestModelTests.swift
@@ -32,7 +32,7 @@ class GraphQLRequestModelTests: XCTestCase {
     ///     - the `responseType` is correct
     ///     - the `variables` is non-nil
     func testCreateMutationGraphQLRequest() {
-        let post = Post(title: "title", content: "content", createdAt: Date())
+        let post = Post(title: "title", content: "content", createdAt: .now())
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
         documentBuilder.add(decorator: ModelDecorator(model: post))
@@ -46,7 +46,7 @@ class GraphQLRequestModelTests: XCTestCase {
     }
 
     func testUpdateMutationGraphQLRequest() {
-        let post = Post(title: "title", content: "content", createdAt: Date())
+        let post = Post(title: "title", content: "content", createdAt: .now())
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .update))
         documentBuilder.add(decorator: ModelDecorator(model: post))
@@ -60,7 +60,7 @@ class GraphQLRequestModelTests: XCTestCase {
     }
 
     func testDeleteMutationGraphQLRequest() {
-        let post = Post(title: "title", content: "content", createdAt: Date())
+        let post = Post(title: "title", content: "content", createdAt: .now())
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .delete))
         documentBuilder.add(decorator: ModelDecorator(model: post))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/QueryPredicateGraphQLTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/QueryPredicateGraphQLTests.swift
@@ -14,7 +14,7 @@ class QueryPredicateGraphQLTests: XCTestCase {
 
     func testPredicateToGraphQLValues() throws {
         let post = Post.keys
-        guard let date = "2019-11-23T02:06:50.689Z".iso8601Date else {
+        guard let date = try? Temporal.DateTime(iso8601String: "2019-11-23T02:06:50.689Z") else {
             XCTFail("Failed to set up date")
             return
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -61,7 +61,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                 byId id: String,
                                 completion: DataStoreCallback<M?>) {
         reinitStorageEngineIfNeeded()
-        let predicate: QueryPredicateFactory = { field("id") == id }
+        let predicate: QueryPredicate = field("id") == id
         query(modelType, where: predicate, paginate: .firstResult) {
             switch $0 {
             case .success(let models):
@@ -78,12 +78,12 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
 
     public func query<M: Model>(_ modelType: M.Type,
-                                where predicateFactory: QueryPredicateFactory? = nil,
+                                where predicate: QueryPredicate? = nil,
                                 paginate paginationInput: QueryPaginationInput? = nil,
                                 completion: DataStoreCallback<[M]>) {
         reinitStorageEngineIfNeeded()
         storageEngine.query(modelType,
-                            predicate: predicateFactory?(),
+                            predicate: predicate,
                             paginationInput: paginationInput,
                             completion: completion)
     }
@@ -98,15 +98,17 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
 
     public func delete<M: Model>(_ model: M,
+                                 where predicate: QueryPredicate? = nil,
                                  completion: @escaping DataStoreCallback<Void>) {
         reinitStorageEngineIfNeeded()
+        // TODO: handle query predicate like in the update flow
         storageEngine.delete(type(of: model), withId: model.id) { result in
             self.onDeleteCompletion(result: result, completion: completion)
         }
     }
 
     public func delete<M: Model>(_ modelType: M.Type,
-                                 where predicate: @escaping QueryPredicateFactory,
+                                 where predicate: QueryPredicate,
                                  completion: @escaping DataStoreCallback<Void>) {
         reinitStorageEngineIfNeeded()
         let onCompletion: DataStoreCallback<[M]> = { result in
@@ -121,7 +123,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
             }
         }
         storageEngine.delete(modelType,
-                             predicate: predicate(),
+                             predicate: predicate,
                              completion: onCompletion)
     }
 

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -36,15 +36,10 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
     }
 
     func query<M: Model>(_ modelType: M.Type,
-                         where predicate: QueryPredicateFactory?,
+                         where predicate: QueryPredicate?,
                          paginate paginationInput: QueryPaginationInput?,
                          completion: (DataStoreResult<[M]>) -> Void) {
         notify("queryByPredicate")
-    }
-
-    func delete<M: Model>(_ model: M,
-                          completion: (DataStoreResult<Void>) -> Void) {
-        notify("deleteByModel")
     }
 
     func delete<M: Model>(_ modelType: M.Type,
@@ -53,8 +48,8 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         notify("deleteById")
     }
 
-    func delete<M: Model>(_ model: M.Type,
-                          where predicate: @escaping QueryPredicateFactory,
+    func delete<M: Model>(_ model: M,
+                          where predicate: QueryPredicate? = nil,
                           completion: @escaping DataStoreCallback<Void>) {
         notify("deleteByPredicate")
     }

--- a/AmplifyTestCommon/Models/Blog.swift
+++ b/AmplifyTestCommon/Models/Blog.swift
@@ -12,13 +12,13 @@ import Foundation
 public struct Blog: Model {
     public let id: String
     public var content: String
-    public var createdAt: Date
+    public var createdAt: Temporal.DateTime
     public var owner: String?
     public var authorNotes: String?
 
     public init(id: String = UUID().uuidString,
                 content: String,
-                createdAt: Date,
+                createdAt: Temporal.DateTime,
                 owner: String?,
                 authorNotes: String?) {
         self.id = id

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -24,7 +24,7 @@ DEPENDENCIES:
   - SwiftLint
 
 SPEC REPOS:
-  trunk:
+  https://cdn.cocoapods.org/:
     - AWSAuthCore
     - AWSCognitoIdentityProvider
     - AWSCognitoIdentityProviderASF

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -24,7 +24,7 @@ DEPENDENCIES:
   - SwiftLint
 
 SPEC REPOS:
-  trunk:
+  https://cdn.cocoapods.org/:
     - AWSAuthCore
     - AWSCognitoIdentityProvider
     - AWSCognitoIdentityProviderASF


### PR DESCRIPTION
*Issue #, if available:* #487 

Change the QueryPredicate from a `() -> QueryPredicate` to `QueryPredicate?`:

```swift
// before
Amplify.DataStore.query(Todo.self, where: { Todo.keys.title.beingsWith("Amplify") })

// after
Amplify.DataStore.query(Todo.self, where: Todo.keys.title.beingsWith("Amplify"))
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
