### PR TITLE
fix: AmplifyTools: npx amplify-app

### DIFF
--- a/AmplifyTools/amplify-tools.sh
+++ b/AmplifyTools/amplify-tools.sh
@@ -28,7 +28,7 @@ if $amplifyModelgen; then
   echo "modelgen is set to true, generating Swift models from schema.graphql..."
   amplify codegen model
   # calls amplify-app again so the Xcode project is updated with the generated models
-  amplify-app --platform ios
+  npx amplify-app --platform ios
 fi
 
 if [ -z "$amplifyAccessKey" ] || [ -z "$amplifySecretKey" ] || [ -z "$amplifyRegion" ]; then


### PR DESCRIPTION
*Description of changes:*

- update `amplify-app --platform ios` to use npx

*Testing done*
AmplifyTools local pod path
`pod 'Amplify/Tools', :path => '~/aws-amplify/amplify-ios'`

Couldn't get it building successfully until i made this change: https://github.com/aws-amplify/amplify-ios/pull/494 updates to use amplifyxc.config.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
