### PR TITLE
fix: AmplifyTools update to use amplifyxc.config

### DIFF
--- a/AmplifyTools/amplify-tools.sh
+++ b/AmplifyTools/amplify-tools.sh
@@ -11,11 +11,11 @@ export PATH=$PATH:$(npm bin -g)
 if ! which node >/dev/null; then
   echo "warning: Node is not installed. Vist https://nodejs.org/en/download/ to install it"
   exit 1
-elif ! test -f ./amplifytools.xcconfig; then
+elif ! test -f ./amplifyxc.config; then
   npx amplify-app --platform ios
 fi
 
-. amplifytools.xcconfig
+. amplifyxc.config
 amplifyPush=$push
 amplifyModelgen=$modelgen
 amplifyProfile=$profile


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- I see a build failure looking for the `amplifytools.xcconfig file`. looks like the script is checking for `amplifytools.xcconfig` but i can see that amplify-app is generating `amplifyxc.config`. So i updated `amplifytools.xcconfig` to `amplifyxc.config` in the script and ran it again and was successful

there was a change here https://github.com/aws-amplify/amplify-ios/commit/67412ca1513057f7f6e473f37ec9b89230642655

Perhaps I'm using old version of amplify-app?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
