### PR TITLE
chore: Remove hardcoded version from .jazzy.yml

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,5 +1,4 @@
 module: Amplify
-module_version: 1.0.0
 podspec: Amplify.podspec
 
 exclude:


### PR DESCRIPTION
Invoking Jazzy with `jazzy --config .jazzy.yaml --module Amplify --podspec Amplify.podspec --output docs` will cause Jazzy to pick up the module version from the podspec file, so there is no need to specify it in the config.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
