### PR TITLE
fix(tools): run amplify tools with space in project folder

### DIFF
--- a/Amplify.podspec
+++ b/Amplify.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
     ss.preserve_path = 'AmplifyTools'
     ss.script_phase = {
       :name => 'AmplifyTools',
-      :script => 'mkdir -p ${PODS_ROOT}/AmplifyTools; cp -vf "${PODS_TARGET_SRCROOT}/AmplifyTools/amplify-tools.sh" ${PODS_ROOT}/AmplifyTools/.',
+      :script => 'mkdir -p "${PODS_ROOT}/AmplifyTools"; cp -vf "${PODS_TARGET_SRCROOT}/AmplifyTools/amplify-tools.sh" "${PODS_ROOT}/AmplifyTools/."',
       :execution_position => :before_compile
     }
   end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## Unreleased Changes
+* Allow Amplify tools to run if the project folder has a space char
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 


### PR DESCRIPTION
Addressing issue filed here:
https://github.com/aws-amplify/amplify-ios/issues/492


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
