### PR TITLE
fix(tools): require min version or use @latest

### DIFF
--- a/AmplifyTools/amplify-tools.sh
+++ b/AmplifyTools/amplify-tools.sh
@@ -98,7 +98,7 @@ checkMinVersionCompatibility "${AMP_CLI_VERSION_CURRENT}" "${AMP_CLI_VERSION_MIN
 AMP_CLI_VERSION_INVALID=${VERSION_INVALID}
 
 if [ ${AMP_CLI_VERSION_INVALID} -eq 1 ]; then
-    echo "ERROR: Minimum version required of Amplify CLI is not installed."
+    echo "error: Minimum version required of Amplify CLI is not installed."
     echo "  Min required version: (${AMP_CLI_VERSION_MINIMUM})"
     echo "  Found Version: (${AMP_CLI_VERSION_CURRENT})"
     echo ""

--- a/AmplifyTools/amplify-tools.sh
+++ b/AmplifyTools/amplify-tools.sh
@@ -52,9 +52,7 @@ stripEscapeUtil() {
 VERSION_INVALID=
 checkMinVersionCompatibility() {
     VERSION_INVALID=0
-    #Workaround using npx -q strip-ansi-cli
-    # 1.  I would prefer to use sed, but sed on mac does not support special characters on mac
-    # 2.  We should actually fix this in the CLI
+
     stripEscapeUtil "${1}"
     CURR_VERSION_SAFE="${STRIP_ESCAPE_RESULT}"
     CURR_VERSION_MAJOR=`echo "${CURR_VERSION_SAFE}" | tr  '.' ' ' | awk '{print $1}'`

--- a/AmplifyTools/amplify-tools.sh
+++ b/AmplifyTools/amplify-tools.sh
@@ -8,11 +8,45 @@
 set -e
 export PATH=$PATH:$(npm bin -g)
 
+MIN_SUPPORTED_VERSION_MAJOR=2
+MIN_SUPPORTED_VERSION_MINOR=17
+MIN_SUPPORTED_VERSION_PATCH=1
+
+CURR_VERSION=`npx -q amplify-app --version`
+CURR_VERSION_MAJOR=`echo ${CURR_VERSION} | tr  '.' ' ' | awk '{print $1}'`
+CURR_VERSION_MINOR=`echo ${CURR_VERSION} | tr  '.' ' ' | awk '{print $2}'`
+CURR_VERSION_PATCH=`echo ${CURR_VERSION} | tr  '.' ' ' | awk '{print $3}'`
+LOCAL_AMPAPP_VERSION_INVALID=0
+
+checkVersionAmplifyApp() {
+    if [ ${CURR_VERSION_MAJOR} -lt ${MIN_SUPPORTED_VERSION_MAJOR} ]; then
+	LOCAL_AMPAPP_VERSION_INVALID=1
+	return
+    else
+	if [ ${CURR_VERSION_MINOR} -lt ${MIN_SUPPORTED_VERSION_MINOR} ]; then
+	    LOCAL_AMPAPP_VERSION_INVALID=1
+	    return
+	else
+	    if [ ${CURR_VERSION_PATCH} -lt ${MIN_SUPPORTED_VERSION_PATCH} ]; then
+		LOCAL_AMPAPP_VERSION_INVALID=1
+		return
+	    fi
+	fi
+    fi
+}
+checkVersionAmplifyApp
+
+if [ ${LOCAL_AMPAPP_VERSION_INVALID} -eq 1 ]; then
+    NPX_AMP_APPCMD="npx amplify-app@latest"
+else
+    NPX_AMP_APPCMD="npx amplify-app"
+fi
+
 if ! which node >/dev/null; then
   echo "warning: Node is not installed. Visit https://nodejs.org/en/download/ to install it"
   exit 1
 elif ! test -f ./amplifytools.xcconfig; then
-  npx amplify-app --platform ios
+  ${NPX_AMP_APPCMD} --platform ios
 fi
 
 . amplifytools.xcconfig
@@ -28,7 +62,7 @@ if $amplifyModelgen; then
   echo "modelgen is set to true, generating Swift models from schema.graphql..."
   amplify codegen model
   # calls amplify-app again so the Xcode project is updated with the generated models
-  npx amplify-app --platform ios
+  ${NPX_AMP_APPCMD} --platform ios
 fi
 
 if [ -z "$amplifyAccessKey" ] || [ -z "$amplifySecretKey" ] || [ -z "$amplifyRegion" ]; then


### PR DESCRIPTION
In attempts of addressing:
https://github.com/aws-amplify/amplify-ios/issues/502

If customers have an older version of amplify-app installed on their machines, we will exec the command:
```
npx amplify-app@latest
```

Otherwise, we will execute:
```
npx amplify-app
```

Forcing latest did not seem like the right thing to do.  Also, when running npx, there isn't a good way of status-ing where the command (amplify-app) is being pulled from ( a local repo, or... online. etc..)


In addition to checking the version of `amplify-app`, I extended this to check the version of amplify-cli per the request of @drochetti.  We will fail a build if customers do not have a minimum version required for `amplify-cli`.  Upon failing a build, they will be greeted with this message in Xcode:
<img width="855" alt="Screen Shot 2020-06-03 at 1 50 33 PM" src="https://user-images.githubusercontent.com/1911939/83687847-3ffbb680-a5a1-11ea-90bd-2ee256c72fd3.png">


Fully open to suggestions on this one!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
