### PR TITLE
fix(DataStore): Support all Temporal types in predicates

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
@@ -134,31 +134,26 @@ extension QueryOperator {
 
 extension Persistable {
     internal func graphQLValue() -> Any {
-        let value = self
-
-        if let value = value as? Bool {
-            return value
+        switch self {
+        case is Bool:
+            return self
+        case let double as Double:
+            return Decimal(double)
+        case is Int:
+            return self
+        case is String:
+            return self
+        case let temporalDate as Temporal.Date:
+            return temporalDate.iso8601String
+        case let temporalDateTime as Temporal.DateTime:
+            return temporalDateTime.iso8601String
+        case let temporalTime as Temporal.Time:
+            return temporalTime.iso8601String
+        default:
+            preconditionFailure("""
+            Value \(String(describing: self)) of type \(String(describing: type(of: self))) \
+            is not a compatible type.
+            """)
         }
-
-        if let value = value as? Temporal.Date {
-            return value.iso8601String
-        }
-
-        if let value = value as? Double {
-            return Decimal(value)
-        }
-
-        if let value = value as? Int {
-            return value
-        }
-
-        if let value = value as? String {
-            return value
-        }
-
-        preconditionFailure("""
-        Value \(String(describing: value)) of type \(String(describing: type(of: value)))
-        is not a compatible type.
-        """)
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/QueryPredicateGraphQLTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/QueryPredicateGraphQLTests.swift
@@ -176,4 +176,20 @@ class QueryPredicateGraphQLTests: XCTestCase {
 
         XCTAssert(titleFilter["beginsWith"] as? String == "Title")
     }
+
+    func testSupportedPredicateSupportsDate() throws {
+        let date = try Temporal.Date(iso8601String: "2019-11-23")
+        XCTAssertNotNil(Post.keys.createdAt == date)
+    }
+
+    func testSupportedPredicateSupportsDateTime() throws {
+        let dateTime = try Temporal.DateTime(iso8601String: "2019-11-23T02:06:50.689Z")
+        XCTAssertNotNil(Post.keys.createdAt == dateTime)
+    }
+
+    func testSupportedPredicateSupportsTime() throws {
+        let time = try Temporal.Time(iso8601String: "02:06:50.689")
+        XCTAssertNotNil(Post.keys.createdAt == time)
+    }
+
 }


### PR DESCRIPTION
Amplify GraphQL Predicates should support all Temporal types, but only Date was previously supported. This change also reformats the `graphQLValue` to use a more Swifty `switch` statement instead of multiple if/thens.

Note: The assertions in the new unit tests aren't terribly meaningful, but by exercising the code, we can ensure we won't hit a precondition failure due to an unsupported type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
