### PR TITLE
fix(Auth): Import Foundation to fix compile error

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthAWSCredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthAWSCredentialsProvider.swift
@@ -6,6 +6,7 @@
 //
 
 import Amplify
+import Foundation
 
 public protocol AuthAWSCredentialsProvider {
     func getAWSCredentials() -> Result<AuthAWSCredentials, AuthError>


### PR DESCRIPTION
The `AuthAWSTemporaryCredentials` protocol declares an `expiration` property of type `Date`, but the file doesn't import Foundation, which causes a compilation error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
