### PR TITLE
fix: Refactor Blog to contain Post, migrate auth rule scenario to Article Model

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -78,6 +78,8 @@
 		214F497B2486D8A200DA616C /* User+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49752486D8A200DA616C /* User+Schema.swift */; };
 		214F497C2486D8A200DA616C /* UserFollowers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49762486D8A200DA616C /* UserFollowers.swift */; };
 		214F497E2486DA5000DA616C /* GraphQLRequestOptionalAssociationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F497D2486DA5000DA616C /* GraphQLRequestOptionalAssociationTests.swift */; };
+		214F49CD24898E8500DA616C /* Article.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49CB24898E8400DA616C /* Article.swift */; };
+		214F49CE24898E8500DA616C /* Article+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49CC24898E8500DA616C /* Article+Schema.swift */; };
 		21558E3E237BB4BF0032A5BB /* GraphQLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21558E3D237BB4BF0032A5BB /* GraphQLRequest.swift */; };
 		21558E40237CB8640032A5BB /* GraphQLError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21558E3F237CB8640032A5BB /* GraphQLError.swift */; };
 		216879FE23636A0A004A056E /* RepeatingTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216879FD23636A0A004A056E /* RepeatingTimer.swift */; };
@@ -720,6 +722,8 @@
 		214F49752486D8A200DA616C /* User+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "User+Schema.swift"; sourceTree = "<group>"; };
 		214F49762486D8A200DA616C /* UserFollowers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserFollowers.swift; sourceTree = "<group>"; };
 		214F497D2486DA5000DA616C /* GraphQLRequestOptionalAssociationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRequestOptionalAssociationTests.swift; sourceTree = "<group>"; };
+		214F49CB24898E8400DA616C /* Article.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Article.swift; sourceTree = "<group>"; };
+		214F49CC24898E8500DA616C /* Article+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Article+Schema.swift"; sourceTree = "<group>"; };
 		21558E3D237BB4BF0032A5BB /* GraphQLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRequest.swift; sourceTree = "<group>"; };
 		21558E3F237CB8640032A5BB /* GraphQLError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLError.swift; sourceTree = "<group>"; };
 		215F4BCAAB89FA54AA121BDE /* Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin.release.xcconfig"; path = "Target Support Files/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin.release.xcconfig"; sourceTree = "<group>"; };
@@ -2198,6 +2202,8 @@
 			isa = PBXGroup;
 			children = (
 				FAF512AD23986791001ADF4E /* AmplifyModels.swift */,
+				214F49CB24898E8400DA616C /* Article.swift */,
+				214F49CC24898E8500DA616C /* Article+Schema.swift */,
 				B9FAA10C23878BD6009414B4 /* Associations */,
 				210B3E35245CB86500F43848 /* Blog.swift */,
 				210B3E38245CB88D00F43848 /* Blog+Schema.swift */,
@@ -4417,6 +4423,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214F49CD24898E8500DA616C /* Article.swift in Sources */,
 				B9FAA116238799D3009414B4 /* Author.swift in Sources */,
 				B9521833237E21BA00F53237 /* Comment+Schema.swift in Sources */,
 				FA176ED7238503C200C5C5F9 /* HubListenerTestUtilities.swift in Sources */,
@@ -4459,6 +4466,7 @@
 				214F49782486D8A200DA616C /* UserFollowing.swift in Sources */,
 				21F40A3C23A2952C0074678E /* AuthHelper.swift in Sources */,
 				B4F3E9FA24314ECC00F23296 /* MockAuthCategoryPlugin.swift in Sources */,
+				214F49CE24898E8500DA616C /* Article+Schema.swift in Sources */,
 				FA1846EE23998E44009B9D01 /* MockAPIResponders.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/README.md
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/README.md
@@ -37,6 +37,7 @@ type Post @model {
     draft: Boolean
     rating: Float
     status: PostStatus
+    blog: Blog @connection(name: "BlogPost")
     comments: [Comment] @connection(name: "PostComment")
 }
 
@@ -44,7 +45,14 @@ type Comment @model {
     id: ID!
     content: String!
     createdAt: AWSDateTime!
-    post: Post @connection(name: "PostComment")
+    post: Post! @connection(name: "PostComment")
+}
+
+type Blog @model {
+    id: ID!
+    title: String!
+    createdAt: AWSDateTime!
+    posts: [Post] @connection(name: "BlogPost")
 }
 ```
 

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLSyncBased/README.md
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLSyncBased/README.md
@@ -41,6 +41,7 @@ type Post @model {
     draft: Boolean
     rating: Float
     status: PostStatus
+    blog: Blog @connection(name: "BlogPost")
     comments: [Comment] @connection(name: "PostComment")
 }
 
@@ -48,7 +49,14 @@ type Comment @model {
     id: ID!
     content: String!
     createdAt: AWSDateTime!
-    post: Post @connection(name: "PostComment")
+    post: Post! @connection(name: "PostComment")
+}
+
+type Blog @model {
+    id: ID!
+    title: String!
+    createdAt: AWSDateTime!
+    posts: [Post] @connection(name: "BlogPost")
 }
 ```
 

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
@@ -52,6 +52,12 @@ class GraphQLCreateMutationTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+            }
             __typename
           }
         }
@@ -105,6 +111,12 @@ class GraphQLCreateMutationTests: XCTestCase {
               status
               title
               updatedAt
+              blog {
+                id
+                createdAt
+                title
+                __typename
+              }
               __typename
             }
             __typename
@@ -153,6 +165,15 @@ class GraphQLCreateMutationTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+              _version
+              _deleted
+              _lastChangedAt
+            }
             __typename
             _version
             _deleted
@@ -210,6 +231,15 @@ class GraphQLCreateMutationTests: XCTestCase {
               status
               title
               updatedAt
+              blog {
+                id
+                createdAt
+                title
+                __typename
+                _version
+                _deleted
+                _lastChangedAt
+              }
               __typename
               _version
               _deleted

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDeleteMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDeleteMutationTests.swift
@@ -49,6 +49,12 @@ class GraphQLDeleteMutationTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+            }
             __typename
           }
         }
@@ -96,6 +102,15 @@ class GraphQLDeleteMutationTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+              _version
+              _deleted
+              _lastChangedAt
+            }
             __typename
             _version
             _deleted

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLGetQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLGetQueryTests.swift
@@ -45,6 +45,12 @@ class GraphQLGetQueryTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+            }
             __typename
           }
         }
@@ -75,6 +81,15 @@ class GraphQLGetQueryTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+              _version
+              _deleted
+              _lastChangedAt
+            }
             __typename
             _version
             _deleted
@@ -121,6 +136,12 @@ class GraphQLGetQueryTests: XCTestCase {
               status
               title
               updatedAt
+              blog {
+                id
+                createdAt
+                title
+                __typename
+              }
               __typename
             }
             __typename
@@ -157,6 +178,15 @@ class GraphQLGetQueryTests: XCTestCase {
               status
               title
               updatedAt
+              blog {
+                id
+                createdAt
+                title
+                __typename
+                _version
+                _deleted
+                _lastChangedAt
+              }
               __typename
               _version
               _deleted

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLListQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLListQueryTests.swift
@@ -57,6 +57,12 @@ class GraphQLListQueryTests: XCTestCase {
               status
               title
               updatedAt
+              blog {
+                id
+                createdAt
+                title
+                __typename
+              }
               __typename
             }
             nextToken
@@ -137,6 +143,15 @@ class GraphQLListQueryTests: XCTestCase {
               status
               title
               updatedAt
+              blog {
+                id
+                createdAt
+                title
+                __typename
+                _version
+                _deleted
+                _lastChangedAt
+              }
               __typename
               _version
               _deleted

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSubscriptionTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSubscriptionTests.swift
@@ -47,6 +47,12 @@ class GraphQLSubscriptionTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+            }
             __typename
           }
         }
@@ -72,6 +78,15 @@ class GraphQLSubscriptionTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+              _version
+              _deleted
+              _lastChangedAt
+            }
             __typename
             _version
             _deleted
@@ -111,6 +126,12 @@ class GraphQLSubscriptionTests: XCTestCase {
               status
               title
               updatedAt
+              blog {
+                id
+                createdAt
+                title
+                __typename
+              }
               __typename
             }
             __typename
@@ -142,6 +163,15 @@ class GraphQLSubscriptionTests: XCTestCase {
               status
               title
               updatedAt
+              blog {
+                id
+                createdAt
+                title
+                __typename
+                _version
+                _deleted
+                _lastChangedAt
+              }
               __typename
               _version
               _deleted
@@ -182,6 +212,12 @@ class GraphQLSubscriptionTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+            }
             __typename
           }
         }
@@ -207,6 +243,15 @@ class GraphQLSubscriptionTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+              _version
+              _deleted
+              _lastChangedAt
+            }
             __typename
             _version
             _deleted
@@ -241,6 +286,12 @@ class GraphQLSubscriptionTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+            }
             __typename
           }
         }
@@ -266,6 +317,15 @@ class GraphQLSubscriptionTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+              _version
+              _deleted
+              _lastChangedAt
+            }
             __typename
             _version
             _deleted

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSyncQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSyncQueryTests.swift
@@ -54,6 +54,15 @@ class GraphQLSyncQueryTests: XCTestCase {
               status
               title
               updatedAt
+              blog {
+                id
+                createdAt
+                title
+                __typename
+                _version
+                _deleted
+                _lastChangedAt
+              }
               __typename
               _version
               _deleted
@@ -102,6 +111,15 @@ class GraphQLSyncQueryTests: XCTestCase {
                 status
                 title
                 updatedAt
+                blog {
+                  id
+                  createdAt
+                  title
+                  __typename
+                  _version
+                  _deleted
+                  _lastChangedAt
+                }
                 __typename
                 _version
                 _deleted

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLUpdateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLUpdateMutationTests.swift
@@ -49,6 +49,12 @@ class GraphQLUpdateMutationTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+            }
             __typename
           }
         }
@@ -97,6 +103,15 @@ class GraphQLUpdateMutationTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+              _version
+              _deleted
+              _lastChangedAt
+            }
             __typename
             _version
             _deleted

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAnyModelWithSyncTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAnyModelWithSyncTests.swift
@@ -39,6 +39,15 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+              _version
+              _deleted
+              _lastChangedAt
+            }
             __typename
             _version
             _deleted
@@ -78,6 +87,15 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+              _version
+              _deleted
+              _lastChangedAt
+            }
             __typename
             _version
             _deleted
@@ -121,6 +139,15 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+              _version
+              _deleted
+              _lastChangedAt
+            }
             __typename
             _version
             _deleted
@@ -164,6 +191,15 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+              _version
+              _deleted
+              _lastChangedAt
+            }
             __typename
             _version
             _deleted
@@ -205,6 +241,15 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
             status
             title
             updatedAt
+            blog {
+              id
+              createdAt
+              title
+              __typename
+              _version
+              _deleted
+              _lastChangedAt
+            }
             __typename
             _version
             _deleted
@@ -243,6 +288,15 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
               status
               title
               updatedAt
+              blog {
+                id
+                createdAt
+                title
+                __typename
+                _version
+                _deleted
+                _lastChangedAt
+              }
               __typename
               _version
               _deleted

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthRuleTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class GraphQLRequestAuthRuleTests: XCTestCase {
 
     override func setUp() {
-        ModelRegistry.register(modelType: Blog.self)
+        ModelRegistry.register(modelType: Article.self)
     }
 
     override func tearDown() {
@@ -21,16 +21,16 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
     }
 
     func testQueryGraphQLRequest() throws {
-        let blog = Blog(content: "content", createdAt: .now(), owner: nil, authorNotes: nil)
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: blog.modelName, operationType: .query)
+        let article = Article(content: "content", createdAt: .now(), owner: nil, authorNotes: nil)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: article.modelName, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
-        documentBuilder.add(decorator: ModelIdDecorator(id: blog.id))
+        documentBuilder.add(decorator: ModelIdDecorator(id: article.id))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.query))
         let document = documentBuilder.build()
         let documentStringValue = """
-        query GetBlog($id: ID!) {
-          getBlog(id: $id) {
+        query GetArticle($id: ID!) {
+          getArticle(id: $id) {
             id
             authorNotes
             content
@@ -44,7 +44,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
         }
         """
 
-        let request = GraphQLRequest<MutationSyncResult?>.query(modelName: blog.modelName, byId: blog.id)
+        let request = GraphQLRequest<MutationSyncResult?>.query(modelName: article.modelName, byId: article.id)
 
         XCTAssertEqual(document.stringValue, request.document)
         XCTAssertEqual(documentStringValue, request.document)
@@ -53,20 +53,20 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
             XCTFail("The request doesn't contain variables")
             return
         }
-        XCTAssertEqual(variables["id"] as? String, blog.id)
+        XCTAssertEqual(variables["id"] as? String, article.id)
     }
 
     func testCreateMutationGraphQLRequest() throws {
-        let blog = Blog(content: "content", createdAt: .now(), owner: nil, authorNotes: nil)
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: blog.modelName, operationType: .mutation)
+        let article = Article(content: "content", createdAt: .now(), owner: nil, authorNotes: nil)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: article.modelName, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
-        documentBuilder.add(decorator: ModelDecorator(model: blog))
+        documentBuilder.add(decorator: ModelDecorator(model: article))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.mutation))
         let document = documentBuilder.build()
         let documentStringValue = """
-        mutation CreateBlog($input: CreateBlogInput!) {
-          createBlog(input: $input) {
+        mutation CreateArticle($input: CreateArticleInput!) {
+          createArticle(input: $input) {
             id
             authorNotes
             content
@@ -79,7 +79,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
           }
         }
         """
-        let request = GraphQLRequest<MutationSyncResult>.createMutation(of: blog)
+        let request = GraphQLRequest<MutationSyncResult>.createMutation(of: article)
 
         XCTAssertEqual(document.stringValue, request.document)
         XCTAssertEqual(documentStringValue, request.document)
@@ -93,21 +93,21 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
             XCTFail("The document variables property doesn't contain a valid input")
             return
         }
-        XCTAssert(input["content"] as? String == blog.content)
+        XCTAssert(input["content"] as? String == article.content)
         XCTAssertFalse(input.keys.contains("owner"))
     }
 
     func testUpdateMutationGraphQLRequest() throws {
-        let blog = Blog(content: "content", createdAt: .now(), owner: nil, authorNotes: nil)
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: blog.modelName, operationType: .mutation)
+        let article = Article(content: "content", createdAt: .now(), owner: nil, authorNotes: nil)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: article.modelName, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .update))
-        documentBuilder.add(decorator: ModelDecorator(model: blog))
+        documentBuilder.add(decorator: ModelDecorator(model: article))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.mutation))
         let document = documentBuilder.build()
         let documentStringValue = """
-        mutation UpdateBlog($input: UpdateBlogInput!) {
-          updateBlog(input: $input) {
+        mutation UpdateArticle($input: UpdateArticleInput!) {
+          updateArticle(input: $input) {
             id
             authorNotes
             content
@@ -120,7 +120,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
           }
         }
         """
-        let request = GraphQLRequest<MutationSyncResult>.updateMutation(of: blog)
+        let request = GraphQLRequest<MutationSyncResult>.updateMutation(of: article)
 
         XCTAssertEqual(document.stringValue, request.document)
         XCTAssertEqual(documentStringValue, request.document)
@@ -133,21 +133,21 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
             XCTFail("The document variables property doesn't contain a valid input")
             return
         }
-        XCTAssert(input["content"] as? String == blog.content)
+        XCTAssert(input["content"] as? String == article.content)
         XCTAssertFalse(input.keys.contains("owner"))
     }
 
     func testDeleteMutationGraphQLRequest() throws {
-        let blog = Blog(content: "content", createdAt: .now(), owner: nil, authorNotes: nil)
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: blog.modelName, operationType: .mutation)
+        let article = Article(content: "content", createdAt: .now(), owner: nil, authorNotes: nil)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: article.modelName, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .delete))
-        documentBuilder.add(decorator: ModelIdDecorator(id: blog.id))
+        documentBuilder.add(decorator: ModelIdDecorator(id: article.id))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.mutation))
         let document = documentBuilder.build()
         let documentStringValue = """
-        mutation DeleteBlog($input: DeleteBlogInput!) {
-          deleteBlog(input: $input) {
+        mutation DeleteArticle($input: DeleteArticleInput!) {
+          deleteArticle(input: $input) {
             id
             authorNotes
             content
@@ -161,7 +161,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
         }
         """
 
-        let request = GraphQLRequest<MutationSyncResult>.deleteMutation(modelName: blog.modelName, id: blog.id)
+        let request = GraphQLRequest<MutationSyncResult>.deleteMutation(modelName: article.modelName, id: article.id)
 
         XCTAssertEqual(document.stringValue, request.document)
         XCTAssertEqual(documentStringValue, request.document)
@@ -174,13 +174,13 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
             XCTFail("The document variables property doesn't contain a valid input")
             return
         }
-        XCTAssertEqual(input["id"] as? String, blog.id)
+        XCTAssertEqual(input["id"] as? String, article.id)
         XCTAssertFalse(input.keys.contains("owner"))
         XCTAssertFalse(input.keys.contains("authorNotes"))
     }
 
     func testOnCreateSubscriptionGraphQLRequest() throws {
-        let modelType = Blog.self as Model.Type
+        let modelType = Article.self as Model.Type
         let ownerId = "111"
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
@@ -188,8 +188,8 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, ownerId)))
         let document = documentBuilder.build()
         let documentStringValue = """
-        subscription OnCreateBlog($owner: String!) {
-          onCreateBlog(owner: $owner) {
+        subscription OnCreateArticle($owner: String!) {
+          onCreateArticle(owner: $owner) {
             id
             authorNotes
             content
@@ -221,15 +221,15 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
     }
 
     func testOnUpdateSubscriptionGraphQLRequest() throws {
-        let modelType = Blog.self as Model.Type
+        let modelType = Article.self as Model.Type
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onUpdate))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onUpdate, "111")))
         let document = documentBuilder.build()
         let documentStringValue = """
-        subscription OnUpdateBlog {
-          onUpdateBlog {
+        subscription OnUpdateArticle {
+          onUpdateArticle {
             id
             authorNotes
             content
@@ -253,15 +253,15 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
     }
 
     func testOnDeleteSubscriptionGraphQLRequest() throws {
-        let modelType = Blog.self as Model.Type
+        let modelType = Article.self as Model.Type
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onDelete))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onDelete, "111")))
         let document = documentBuilder.build()
         let documentStringValue = """
-        subscription OnDeleteBlog {
-          onDeleteBlog {
+        subscription OnDeleteArticle {
+          onDeleteArticle {
             id
             authorNotes
             content
@@ -285,7 +285,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
     }
 
     func testSyncQueryGraphQLRequest() throws {
-        let modelType = Blog.self as Model.Type
+        let modelType = Article.self as Model.Type
         let nextToken = "nextToken"
         let limit = 100
         let lastSync = 123
@@ -296,8 +296,8 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
         documentBuilder.add(decorator: AuthRuleDecorator(.query))
         let document = documentBuilder.build()
         let documentStringValue = """
-        query SyncBlogs($lastSync: AWSTimestamp, $limit: Int, $nextToken: String) {
-          syncBlogs(lastSync: $lastSync, limit: $limit, nextToken: $nextToken) {
+        query SyncArticles($lastSync: AWSTimestamp, $limit: Int, $nextToken: String) {
+          syncArticles(lastSync: $lastSync, limit: $limit, nextToken: $nextToken) {
             items {
               id
               authorNotes

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
@@ -12,9 +12,10 @@ import Foundation
 struct TestModelRegistration: AmplifyModelRegistration {
 
     func registerModels(registry: ModelRegistry.Type) {
-        // Post and Comment
+        // Blog, Post, Comment
         registry.register(modelType: Post.self)
         registry.register(modelType: Comment.self)
+        registry.register(modelType: Blog.self)
 
         // Mock Models
         registry.register(modelType: MockSynced.self)

--- a/AmplifyTestCommon/Models/Article+Schema.swift
+++ b/AmplifyTestCommon/Models/Article+Schema.swift
@@ -1,0 +1,47 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Article {
+    // MARK: - CodingKeys
+    public enum CodingKeys: String, ModelKey {
+        case id
+        case content
+        case createdAt
+        case owner
+        case authorNotes
+    }
+
+    public static let keys = CodingKeys.self
+    //  MARK: - ModelSchema
+
+    public static let schema = defineSchema { model in
+        let article = Article.keys
+
+        model.pluralName = "Articles"
+
+        model.authRules = [
+            rule(allow: .owner, ownerField: "owner", operations: [.create, .read]),
+            rule(allow: .groups, groups: ["Admin"]),
+        ]
+
+        model.fields(
+            .id(),
+            .field(article.content, is: .required, ofType: .string),
+            .field(article.createdAt, is: .required, ofType: .dateTime),
+            .field(article.owner, is: .optional, ofType: .string),
+            .field(article.authorNotes,
+                   is: .optional,
+                   ofType: .string,
+                   authRules: [rule(allow: .owner, ownerField: "owner", operations: [.update])]
+            )
+        )
+    }
+}

--- a/AmplifyTestCommon/Models/Article.swift
+++ b/AmplifyTestCommon/Models/Article.swift
@@ -1,0 +1,30 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Article: Model {
+    public let id: String
+    public var content: String
+    public var createdAt: Temporal.DateTime
+    public var owner: String?
+    public var authorNotes: String?
+
+    public init(id: String = UUID().uuidString,
+                content: String,
+                createdAt: Temporal.DateTime,
+                owner: String?,
+                authorNotes: String?) {
+        self.id = id
+        self.content = content
+        self.createdAt = createdAt
+        self.owner = owner
+        self.authorNotes = authorNotes
+    }
+}

--- a/AmplifyTestCommon/Models/Blog+Schema.swift
+++ b/AmplifyTestCommon/Models/Blog+Schema.swift
@@ -10,38 +10,27 @@ import Amplify
 import Foundation
 
 extension Blog {
-    // MARK: - CodingKeys
-    public enum CodingKeys: String, ModelKey {
-        case id
-        case content
-        case createdAt
-        case owner
-        case authorNotes
-    }
+  // MARK: - CodingKeys
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case title
+    case createdAt
+    case posts
+  }
 
-    public static let keys = CodingKeys.self
-    //  MARK: - ModelSchema
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema
 
-    public static let schema = defineSchema { model in
-        let blog = Blog.keys
+  public static let schema = defineSchema { model in
+    let blog = Blog.keys
 
-        model.pluralName = "Blogs"
+    model.pluralName = "Blogs"
 
-        model.authRules = [
-            rule(allow: .owner, ownerField: "owner", operations: [.create, .read]),
-            rule(allow: .groups, groups: ["Admin"]),
-        ]
-
-        model.fields(
-            .id(),
-            .field(blog.content, is: .required, ofType: .string),
-            .field(blog.createdAt, is: .required, ofType: .dateTime),
-            .field(blog.owner, is: .optional, ofType: .string),
-            .field(blog.authorNotes,
-                   is: .optional,
-                   ofType: .string,
-                   authRules: [rule(allow: .owner, ownerField: "owner", operations: [.update])]
-            )
-        )
+    model.fields(
+      .id(),
+      .field(blog.title, is: .required, ofType: .string),
+      .field(blog.createdAt, is: .required, ofType: .dateTime),
+      .hasMany(blog.posts, is: .optional, ofType: Post.self, associatedWith: Post.keys.blog)
+    )
     }
 }

--- a/AmplifyTestCommon/Models/Blog.swift
+++ b/AmplifyTestCommon/Models/Blog.swift
@@ -10,21 +10,18 @@ import Amplify
 import Foundation
 
 public struct Blog: Model {
-    public let id: String
-    public var content: String
-    public var createdAt: Temporal.DateTime
-    public var owner: String?
-    public var authorNotes: String?
+  public let id: String
+  public var title: String
+  public var createdAt: Temporal.DateTime
+  public var posts: List<Post>?
 
-    public init(id: String = UUID().uuidString,
-                content: String,
-                createdAt: Temporal.DateTime,
-                owner: String?,
-                authorNotes: String?) {
-        self.id = id
-        self.content = content
-        self.createdAt = createdAt
-        self.owner = owner
-        self.authorNotes = authorNotes
-    }
+  public init(id: String = UUID().uuidString,
+      title: String,
+      createdAt: Temporal.DateTime,
+      posts: List<Post>? = []) {
+      self.id = id
+      self.title = title
+      self.createdAt = createdAt
+      self.posts = posts
+  }
 }

--- a/AmplifyTestCommon/Models/Post+Schema.swift
+++ b/AmplifyTestCommon/Models/Post+Schema.swift
@@ -20,6 +20,7 @@ extension Post {
     case draft
     case rating
     case status
+    case blog
     case comments
   }
 
@@ -40,6 +41,7 @@ extension Post {
       .field(post.draft, is: .optional, ofType: .bool),
       .field(post.rating, is: .optional, ofType: .double),
       .field(post.status, is: .optional, ofType: .enum(type: PostStatus.self)),
+      .belongsTo(post.blog, is: .optional, ofType: Blog.self, targetName: "postBlogId"),
       .hasMany(post.comments, is: .optional, ofType: Comment.self, associatedWith: Comment.keys.post)
     )
     }

--- a/AmplifyTestCommon/Models/Post.swift
+++ b/AmplifyTestCommon/Models/Post.swift
@@ -18,6 +18,7 @@ public struct Post: Model {
   public var draft: Bool?
   public var rating: Double?
   public var status: PostStatus?
+  public var blog: Blog?
   public var comments: List<Comment>?
 
   public init(id: String = UUID().uuidString,
@@ -28,6 +29,7 @@ public struct Post: Model {
       draft: Bool? = nil,
       rating: Double? = nil,
       status: PostStatus? = nil,
+      blog: Blog? = nil,
       comments: List<Comment>? = []) {
       self.id = id
       self.title = title
@@ -37,6 +39,7 @@ public struct Post: Model {
       self.draft = draft
       self.rating = rating
       self.status = status
+      self.blog = blog
       self.comments = comments
   }
 }

--- a/AmplifyTestCommon/Models/schema.graphql
+++ b/AmplifyTestCommon/Models/schema.graphql
@@ -13,6 +13,7 @@ type Post @model {
     draft: Boolean
     rating: Float
     status: PostStatus
+    blog: Blog @connection(name: "BlogPost")
     comments: [Comment] @connection(name: "PostComment")
 }
 
@@ -23,21 +24,12 @@ type Comment @model {
     post: Post! @connection(name: "PostComment")
 }
 
-type Blog
-    @model
-    @auth(rules: [
-        { allow: owner, ownerField: "owner", operations: [create, read] },
-        { allow: groups, groups: ["Admin"] }
-    ]) {
+type Blog @model {
     id: ID!
-    content: String!
+    title: String!
     createdAt: AWSDateTime!
-    owner: String
-    authorsNotes: String @auth( rules: [
-        { allow: owner, ownerField: "owner", operations: [update] }
-    ])
+    posts: [Post] @connection(name: "BlogPost")
 }
-
 
 type User @model {
     id: ID!
@@ -56,4 +48,19 @@ type UserFollowers @model {
   id: ID!
   user: User @connection(name: "followers")
   followersUser: User @connection
+}
+
+type Article
+    @model
+    @auth(rules: [
+        { allow: owner, ownerField: "owner", operations: [create, read] },
+        { allow: groups, groups: ["Admin"] }
+    ]) {
+    id: ID!
+    content: String!
+    createdAt: AWSDateTime!
+    owner: String
+    authorsNotes: String @auth( rules: [
+        { allow: owner, ownerField: "owner", operations: [update] }
+    ])
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This builds on top of https://github.com/aws-amplify/amplify-ios/pull/509 which creates selection sets for optional associations. 

Updates Blog to remove dependency on auth rules. Created a new Arcticle Model for the auth rule related tests. Post optionally contains a Blog, this makes it less impactful for updating the tests and also means that a post can be created without a blog, and then once the user is ready, they can create a blog separately and add posts to it.

DataStore tests are failing and requires some updates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
