### PR TITLE
fix(datastore): wrong keyPath in lazy list initialization

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Statement+Model.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Statement+Model.swift
@@ -90,7 +90,7 @@ extension Statement: StatementModelConvertible {
                 let associations = schema.fields.values.filter {
                     $0.isArray && $0.hasAssociation
                 }
-                let prefix = field.name.replacingOccurrences(of: field.name, with: "")
+                let prefix = column.replacingOccurrences(of: field.name, with: "")
                 associations.forEach { association in
                     let associatedField = association.associatedField?.name
                     let lazyList = List<AnyModel>.lazyInit(associatedId: id,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## Unreleased
+
+### Bug Fixes
+
+* **DataStore:** Fixed a DataStore issue where lazy `List<M>` initialization would fail for relationships 3+ levels deep ([#534](https://github.com/aws-amplify/amplify-ios/pull/534))
+
 ## 1.0.1 (2020-06-05)
 
 ### Bug Fixes


### PR DESCRIPTION
Fixed a *caca* that slipped through the cracks in the 1.0.1 release.

This will fix initialization of `List<M>` in 3+ level deep relationships.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
