### PR TITLE
Add Embedded type to store schema info for custom types

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -69,8 +69,6 @@
 		21420AA0237222A900FA140C /* AWSAuthorizationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21420A8D237222A900FA140C /* AWSAuthorizationType.swift */; };
 		2144226C234BDD9B009357F7 /* StorageUploadFileRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2144226B234BDD9B009357F7 /* StorageUploadFileRequest.swift */; };
 		2144226E234BDE23009357F7 /* StorageUploadFileOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2144226D234BDE23009357F7 /* StorageUploadFileOperation.swift */; };
-		214F49CD24898E8500DA616C /* Article.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49CB24898E8400DA616C /* Article.swift */; };
-		214F49CE24898E8500DA616C /* Article+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49CC24898E8500DA616C /* Article+Schema.swift */; };
 		214F49772486D8A200DA616C /* UserFollowers+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49712486D8A100DA616C /* UserFollowers+Schema.swift */; };
 		214F49782486D8A200DA616C /* UserFollowing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49722486D8A200DA616C /* UserFollowing.swift */; };
 		214F49792486D8A200DA616C /* UserFollowing+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49732486D8A200DA616C /* UserFollowing+Schema.swift */; };
@@ -78,11 +76,20 @@
 		214F497B2486D8A200DA616C /* User+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49752486D8A200DA616C /* User+Schema.swift */; };
 		214F497C2486D8A200DA616C /* UserFollowers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49762486D8A200DA616C /* UserFollowers.swift */; };
 		214F497E2486DA5000DA616C /* GraphQLRequestOptionalAssociationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F497D2486DA5000DA616C /* GraphQLRequestOptionalAssociationTests.swift */; };
+		214F49CD24898E8500DA616C /* Article.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49CB24898E8400DA616C /* Article.swift */; };
+		214F49CE24898E8500DA616C /* Article+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49CC24898E8500DA616C /* Article+Schema.swift */; };
 		21558E3E237BB4BF0032A5BB /* GraphQLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21558E3D237BB4BF0032A5BB /* GraphQLRequest.swift */; };
 		21558E40237CB8640032A5BB /* GraphQLError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21558E3F237CB8640032A5BB /* GraphQLError.swift */; };
 		216879FE23636A0A004A056E /* RepeatingTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216879FD23636A0A004A056E /* RepeatingTimer.swift */; };
 		21687A3E236371C4004A056E /* AnalyticsCategory+HubPayloadEventName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21687A3D236371C4004A056E /* AnalyticsCategory+HubPayloadEventName.swift */; };
 		21687A41236371E1004A056E /* AnalyticsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21687A40236371E1004A056E /* AnalyticsError.swift */; };
+		216E45ED248E914F0035E3CE /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216E45EA248E914E0035E3CE /* Category.swift */; };
+		216E45EE248E914F0035E3CE /* Todo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216E45EB248E914F0035E3CE /* Todo.swift */; };
+		216E45EF248E914F0035E3CE /* Todo+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216E45EC248E914F0035E3CE /* Todo+Schema.swift */; };
+		216E45F1248E971E0035E3CE /* GraphQLRequestNonModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216E45F0248E971E0035E3CE /* GraphQLRequestNonModelTests.swift */; };
+		216E460824913D430035E3CE /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216E460724913D430035E3CE /* Color.swift */; };
+		216E460A249183230035E3CE /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216E4609249183230035E3CE /* Section.swift */; };
+		216E461A249189050035E3CE /* Embedded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216E4619249189050035E3CE /* Embedded.swift */; };
 		217855C3237F84D700A30D19 /* RESTRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217855C2237F84D700A30D19 /* RESTRequest.swift */; };
 		2183A56323EA4A7800232880 /* GraphQLSubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212CE72023EA184F007D8E71 /* GraphQLSubscriptionTests.swift */; };
 		2183A56423EA4A7F00232880 /* GraphQLGetQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212CE71A23EA1847007D8E71 /* GraphQLGetQueryTests.swift */; };
@@ -712,8 +719,6 @@
 		21420A8D237222A900FA140C /* AWSAuthorizationType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSAuthorizationType.swift; sourceTree = "<group>"; };
 		2144226B234BDD9B009357F7 /* StorageUploadFileRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageUploadFileRequest.swift; sourceTree = "<group>"; };
 		2144226D234BDE23009357F7 /* StorageUploadFileOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageUploadFileOperation.swift; sourceTree = "<group>"; };
-		214F49CB24898E8400DA616C /* Article.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Article.swift; sourceTree = "<group>"; };
-		214F49CC24898E8500DA616C /* Article+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Article+Schema.swift"; sourceTree = "<group>"; };
 		214F49712486D8A100DA616C /* UserFollowers+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserFollowers+Schema.swift"; sourceTree = "<group>"; };
 		214F49722486D8A200DA616C /* UserFollowing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserFollowing.swift; sourceTree = "<group>"; };
 		214F49732486D8A200DA616C /* UserFollowing+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserFollowing+Schema.swift"; sourceTree = "<group>"; };
@@ -721,12 +726,21 @@
 		214F49752486D8A200DA616C /* User+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "User+Schema.swift"; sourceTree = "<group>"; };
 		214F49762486D8A200DA616C /* UserFollowers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserFollowers.swift; sourceTree = "<group>"; };
 		214F497D2486DA5000DA616C /* GraphQLRequestOptionalAssociationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRequestOptionalAssociationTests.swift; sourceTree = "<group>"; };
+		214F49CB24898E8400DA616C /* Article.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Article.swift; sourceTree = "<group>"; };
+		214F49CC24898E8500DA616C /* Article+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Article+Schema.swift"; sourceTree = "<group>"; };
 		21558E3D237BB4BF0032A5BB /* GraphQLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRequest.swift; sourceTree = "<group>"; };
 		21558E3F237CB8640032A5BB /* GraphQLError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLError.swift; sourceTree = "<group>"; };
 		215F4BCAAB89FA54AA121BDE /* Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin.release.xcconfig"; path = "Target Support Files/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin.release.xcconfig"; sourceTree = "<group>"; };
 		216879FD23636A0A004A056E /* RepeatingTimer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepeatingTimer.swift; sourceTree = "<group>"; };
 		21687A3D236371C4004A056E /* AnalyticsCategory+HubPayloadEventName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AnalyticsCategory+HubPayloadEventName.swift"; sourceTree = "<group>"; };
 		21687A40236371E1004A056E /* AnalyticsError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsError.swift; sourceTree = "<group>"; };
+		216E45EA248E914E0035E3CE /* Category.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
+		216E45EB248E914F0035E3CE /* Todo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Todo.swift; sourceTree = "<group>"; };
+		216E45EC248E914F0035E3CE /* Todo+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Todo+Schema.swift"; sourceTree = "<group>"; };
+		216E45F0248E971E0035E3CE /* GraphQLRequestNonModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRequestNonModelTests.swift; sourceTree = "<group>"; };
+		216E460724913D430035E3CE /* Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
+		216E4609249183230035E3CE /* Section.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Section.swift; sourceTree = "<group>"; };
+		216E4619249189050035E3CE /* Embedded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Embedded.swift; sourceTree = "<group>"; };
 		217855C2237F84D700A30D19 /* RESTRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTRequest.swift; sourceTree = "<group>"; };
 		217856BA2383320900A30D19 /* GraphQLQueryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLQueryType.swift; sourceTree = "<group>"; };
 		217856BD2383322700A30D19 /* GraphQLMutationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLMutationType.swift; sourceTree = "<group>"; };
@@ -1514,9 +1528,10 @@
 		2129BE302394828B006363A1 /* GraphQLRequest */ = {
 			isa = PBXGroup;
 			children = (
-				2129BE322394828B006363A1 /* GraphQLRequestModelTests.swift */,
 				219A888623EB89C200BBC5F2 /* GraphQLRequestAnyModelWithSyncTests.swift */,
 				21A3FDB8246494CD00E76120 /* GraphQLRequestAuthRuleTests.swift */,
+				2129BE322394828B006363A1 /* GraphQLRequestModelTests.swift */,
+				216E45F0248E971E0035E3CE /* GraphQLRequestNonModelTests.swift */,
 				214F497D2486DA5000DA616C /* GraphQLRequestOptionalAssociationTests.swift */,
 			);
 			path = GraphQLRequest;
@@ -1623,6 +1638,18 @@
 				21687A40236371E1004A056E /* AnalyticsError.swift */,
 			);
 			path = Error;
+			sourceTree = "<group>";
+		};
+		216E45E9248E91420035E3CE /* NonModel */ = {
+			isa = PBXGroup;
+			children = (
+				216E460724913D430035E3CE /* Color.swift */,
+				216E45EA248E914E0035E3CE /* Category.swift */,
+				216E45EB248E914F0035E3CE /* Todo.swift */,
+				216E45EC248E914F0035E3CE /* Todo+Schema.swift */,
+				216E4609249183230035E3CE /* Section.swift */,
+			);
+			path = NonModel;
 			sourceTree = "<group>";
 		};
 		21A3FDAD24630D4200E76120 /* Decorator */ = {
@@ -2165,6 +2192,9 @@
 			isa = PBXGroup;
 			children = (
 				2129BE502395A66F006363A1 /* AmplifyModelRegistration.swift */,
+				FA8EE775238626C70097E4F1 /* AnyModel */,
+				B9FAA1232388BE2B009414B4 /* Collection */,
+				216E4619249189050035E3CE /* Embedded.swift */,
 				B92E03A72367CE7A006CEB8D /* Model.swift */,
 				B9FAA17F238FBB5D009414B4 /* Model+Array.swift */,
 				B92E03AC2367CE7A006CEB8D /* Model+Codable.swift */,
@@ -2175,8 +2205,6 @@
 				B92E03A92367CE7A006CEB8D /* ModelRegistry.swift */,
 				FA5D4CF2238AFD7B00D2F54A /* ModelRegistry+Syncable.swift */,
 				FA8EE780238628490097E4F1 /* Persistable.swift */,
-				FA8EE775238626C70097E4F1 /* AnyModel */,
-				B9FAA1232388BE2B009414B4 /* Collection */,
 				B937FBFC23FB4ED300081639 /* Schema */,
 				B91A879A23D1256B0049A12F /* Temporal */,
 			);
@@ -2200,6 +2228,7 @@
 		B952182D237E21B900F53237 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				216E45E9248E91420035E3CE /* NonModel */,
 				FAF512AD23986791001ADF4E /* AmplifyModels.swift */,
 				214F49CB24898E8400DA616C /* Article.swift */,
 				214F49CC24898E8500DA616C /* Article+Schema.swift */,
@@ -3978,6 +4007,7 @@
 				21A3FDB62464590600E76120 /* ModelMultipleOwnerAuthRuleTests.swift in Sources */,
 				2129BE3A2394828B006363A1 /* QueryPredicateGraphQLTests.swift in Sources */,
 				2129BE48239489AC006363A1 /* MutationSyncMetadataTests.swift in Sources */,
+				216E45F1248E971E0035E3CE /* GraphQLRequestNonModelTests.swift in Sources */,
 				21A3FDAF24630D7F00E76120 /* ModelWithOwnerFieldAuthRuleTests.swift in Sources */,
 				2183A56823EA4A8E00232880 /* GraphQLDeleteMutationTests.swift in Sources */,
 				21A3FDB42463C49F00E76120 /* ModelReadUpdateAuthRuleTests.swift in Sources */,
@@ -4022,6 +4052,7 @@
 				B9B64A9F23FCBF7E00730B68 /* ModelValueConverter.swift in Sources */,
 				B92E03B82367CE7A006CEB8D /* ModelSchema+Definition.swift in Sources */,
 				21558E40237CB8640032A5BB /* GraphQLError.swift in Sources */,
+				216E461A249189050035E3CE /* Embedded.swift in Sources */,
 				950A26DD23D15D7E00D92B19 /* PredictionsSpeechToTextOperation.swift in Sources */,
 				B4D3853C236C97360014653D /* PredictionsTranslateTextRequest.swift in Sources */,
 				B452F1D32450EEAE0069F7FA /* AuthResendSignUpCodeOperation.swift in Sources */,
@@ -4425,6 +4456,7 @@
 				B9FAA116238799D3009414B4 /* Author.swift in Sources */,
 				B9521833237E21BA00F53237 /* Comment+Schema.swift in Sources */,
 				FA176ED7238503C200C5C5F9 /* HubListenerTestUtilities.swift in Sources */,
+				216E45EE248E914F0035E3CE /* Todo.swift in Sources */,
 				21F40A3A23A294770074678E /* TestConfigHelper.swift in Sources */,
 				B4BD6B3723708C6700A1F0A7 /* MockPredictionsCategoryPlugin.swift in Sources */,
 				FACA361C2327FC7D000E74F6 /* MockHubCategoryPlugin.swift in Sources */,
@@ -4437,6 +4469,7 @@
 				B9FAA11E23879B9F009414B4 /* Book+Schema.swift in Sources */,
 				FACA361B2327FC74000E74F6 /* MockLoggingCategoryPlugin.swift in Sources */,
 				FACF52042329633500646E10 /* TestExtensions.swift in Sources */,
+				216E460824913D430035E3CE /* Color.swift in Sources */,
 				B9FAA11823879A57009414B4 /* Author+Schema.swift in Sources */,
 				B9521836237E21BA00F53237 /* Post+Schema.swift in Sources */,
 				FA4A955F239ADEBD008E876E /* MockResponder.swift in Sources */,
@@ -4456,6 +4489,7 @@
 				21F40A4023A295470074678E /* TestCommonConstants.swift in Sources */,
 				214F497C2486D8A200DA616C /* UserFollowers.swift in Sources */,
 				B9521835237E21BA00F53237 /* Comment.swift in Sources */,
+				216E45EF248E914F0035E3CE /* Todo+Schema.swift in Sources */,
 				FACA361E2327FC8E000E74F6 /* MockAnalyticsCategoryPlugin.swift in Sources */,
 				2129BE012394627B006363A1 /* PostCommentModelRegistration.swift in Sources */,
 				B9FAA10E23878BF3009414B4 /* UserAccount.swift in Sources */,
@@ -4463,7 +4497,9 @@
 				21F40A3C23A2952C0074678E /* AuthHelper.swift in Sources */,
 				B4F3E9FA24314ECC00F23296 /* MockAuthCategoryPlugin.swift in Sources */,
 				214F49CE24898E8500DA616C /* Article+Schema.swift in Sources */,
+				216E460A249183230035E3CE /* Section.swift in Sources */,
 				FA1846EE23998E44009B9D01 /* MockAPIResponders.swift in Sources */,
+				216E45ED248E914F0035E3CE /* Category.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Amplify/Categories/DataStore/Model/Embedded.swift
+++ b/Amplify/Categories/DataStore/Model/Embedded.swift
@@ -1,0 +1,28 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+// MARK: - CustomCodable
+
+/// All persistent custom types should conform to the CustomCodable protocol.
+public protocol Embedded: Codable {
+
+    /// A reference to the `ModelSchema` associated with this embedded type.
+    static var schema: ModelSchema { get }
+}
+
+extension Embedded {
+    public static func defineSchema(name: String? = nil,
+                                    attributes: ModelAttribute...,
+                                    define: (inout ModelSchemaDefinition) -> Void) -> ModelSchema {
+        var definition = ModelSchemaDefinition(name: name ?? "",
+                                               attributes: attributes)
+        define(&definition)
+        return definition.build()
+    }
+}

--- a/Amplify/Categories/DataStore/Model/Embedded.swift
+++ b/Amplify/Categories/DataStore/Model/Embedded.swift
@@ -7,16 +7,19 @@
 
 import Foundation
 
-// MARK: - CustomCodable
+// MARK: - Embeddable
 
-/// All persistent custom types should conform to the CustomCodable protocol.
-public protocol Embedded: Codable {
+/// A `Embeddable` type can be used in a `Model` as an embedded type. All types embedded in a `Model` as an
+/// `embedded(type:)` or `embeddedCollection(of:)` must comform to the `Embeddable` protocol except for Swift's Basic
+/// types embedded as a collection. A collection of String can be embedded in the `Model` as
+/// `embeddedCollection(of: String.self)` without needing to conform to Embeddable. 
+public protocol Embeddable: Codable {
 
     /// A reference to the `ModelSchema` associated with this embedded type.
     static var schema: ModelSchema { get }
 }
 
-extension Embedded {
+extension Embeddable {
     public static func defineSchema(name: String? = nil,
                                     attributes: ModelAttribute...,
                                     define: (inout ModelSchemaDefinition) -> Void) -> ModelSchema {

--- a/Amplify/Categories/DataStore/Model/Schema/ModelField+Association.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/ModelField+Association.swift
@@ -183,4 +183,25 @@ extension ModelField {
         return false
     }
 
+    public var embeddedType: Embedded.Type? {
+        switch type {
+        case .embedded(let type), .embeddedCollection(let type):
+            if let embeddedType = type as? Embedded.Type {
+                return embeddedType
+            }
+            return nil
+        default:
+            return nil
+        }
+    }
+
+    public var isEmbeddedType: Bool {
+        if case .embedded = type {
+            return true
+        }
+        if case .embeddedCollection = type {
+            return true
+        }
+        return false
+    }
 }

--- a/Amplify/Categories/DataStore/Model/Schema/ModelField+Association.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/ModelField+Association.swift
@@ -183,10 +183,10 @@ extension ModelField {
         return false
     }
 
-    public var embeddedType: Embedded.Type? {
+    public var embeddedType: Embeddable.Type? {
         switch type {
         case .embedded(let type), .embeddedCollection(let type):
-            if let embeddedType = type as? Embedded.Type {
+            if let embeddedType = type as? Embeddable.Type {
                 return embeddedType
             }
             return nil
@@ -196,12 +196,11 @@ extension ModelField {
     }
 
     public var isEmbeddedType: Bool {
-        if case .embedded = type {
+        switch type {
+        case .embedded, .embeddedCollection:
             return true
+        default:
+            return false
         }
-        if case .embeddedCollection = type {
-            return true
-        }
-        return false
     }
 }

--- a/Amplify/Categories/DataStore/Model/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Schema/ModelSchema+Definition.swift
@@ -19,13 +19,14 @@ public enum ModelFieldType {
     case timestamp
     case bool
     case `enum`(type: EnumPersistable.Type)
-    case customType(_ type: Codable.Type)
+    case embedded(type: Codable.Type)
+    case embeddedCollection(of: Codable.Type)
     case model(type: Model.Type)
     case collection(of: Model.Type)
 
     public var isArray: Bool {
         switch self {
-        case .collection:
+        case .collection, .embeddedCollection:
             return true
         default:
             return false
@@ -63,8 +64,8 @@ public enum ModelFieldType {
         if let modelType = type as? Model.Type {
             return .model(type: modelType)
         }
-        if let codableType = type as? Codable.Type {
-            return .customType(codableType)
+        if let embeddedType = type as? Codable.Type {
+            return .embedded(type: embeddedType)
         }
         preconditionFailure("Could not create a ModelFieldType from \(String(describing: type)) MetaType")
     }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
@@ -51,7 +51,7 @@ public struct ConflictResolutionDecorator: ModelBasedGraphQLDocumentDecorator {
     /// Append the correct conflict resolution fields for `model` and `pagination` selection sets.
     private func addConflictResolution(selectionSet: SelectionSet) {
         switch selectionSet.value.fieldType {
-        case .value:
+        case .value, .embedded:
             break
         case .model:
             selectionSet.addChild(settingParentOf: .init(value: .init(name: "_version", fieldType: .value)))

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -49,6 +49,16 @@ extension Model {
                 // TODO how to handle associations of type "many" (i.e. cascade save)?
                 // This is not supported right now and might be added as a future feature
                 break
+            case .embedded, .embeddedCollection:
+                if let encodable = value as? Encodable {
+                    let jsonEncoder = JSONEncoder(dateEncodingStrategy: ModelDateFormatting.encodingStrategy)
+                    do {
+                        let data = try jsonEncoder.encode(encodable.eraseToAnyEncodable())
+                        input[name] = try JSONSerialization.jsonObject(with: data)
+                    } catch {
+                        preconditionFailure("Could not turn into json object from \(value)")
+                    }
+                }
             default:
                 input[name] = value
             }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelMultipleOwnerAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelMultipleOwnerAuthRuleTests.swift
@@ -49,7 +49,7 @@ public struct ModelMultipleOwner: Model {
         model.fields(
             .id(),
             .field(modelMultipleOwner.content, is: .required, ofType: .string),
-            .field(modelMultipleOwner.editors, is: .optional, ofType: .customType([String].self))
+            .field(modelMultipleOwner.editors, is: .optional, ofType: .embeddedCollection(of: String.self))
         )
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestNonModelTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestNonModelTests.swift
@@ -1,0 +1,74 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSPluginsCore
+
+class GraphQLRequestNonModelTests: XCTestCase {
+
+    override func setUp() {
+        ModelRegistry.register(modelType: Todo.self)
+    }
+
+    override func tearDown() {
+        ModelRegistry.reset()
+    }
+
+    func testCreateTodoGraphQLRequest() {
+        let color1 = Color(name: "color1", red: 1, green: 2, blue: 3)
+        let color2 = Color(name: "color2", red: 12, green: 13, blue: 14)
+        let category1 = Category(name: "green", color: color1)
+        let category2 = Category(name: "red", color: color2)
+        let section = Section(name: "section", number: 1.1)
+        let todo = Todo(name: "my first todo",
+                        description: "todo description",
+                        categories: [category1, category2],
+                        section: section)
+        let documentStringValue = """
+        mutation CreateTodo($input: CreateTodoInput!) {
+          createTodo(input: $input) {
+            id
+            categories {
+              color {
+                blue
+                green
+                name
+                red
+                __typename
+              }
+              name
+              __typename
+            }
+            description
+            name
+            section {
+              name
+              number
+              __typename
+            }
+            stickies
+            __typename
+          }
+        }
+        """
+        let request = GraphQLRequest<Todo>.create(todo)
+        XCTAssertEqual(documentStringValue, request.document)
+
+        guard let variables = request.variables else {
+            XCTFail("The request doesn't contain variables")
+            return
+        }
+        guard let input = variables["input"] as? [String: Any] else {
+            XCTFail("The document variables property doesn't contain a valid input")
+            return
+        }
+        XCTAssertEqual(input["id"] as? String, todo.id)
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/ModelGraphQLTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/ModelGraphQLTests.swift
@@ -43,4 +43,33 @@ class ModelGraphQLTests: XCTestCase {
         XCTAssertTrue(graphQLInput.keys.contains("updatedAt"))
         XCTAssertNil(graphQLInput["updatedAt"]!)
     }
+
+    func testTodoModelToGraphQLInputSuccess() {
+        let color = Color(name: "red", red: 255, green: 0, blue: 0)
+        let category = Category(name: "green", color: color)
+        let todo = Todo(name: "name",
+                        description: "description",
+                        categories: [category],
+                        stickies: ["stickie1"])
+
+        let graphQLInput = todo.graphQLInput
+
+        XCTAssertEqual(graphQLInput["id"] as? String, todo.id)
+        XCTAssertEqual(graphQLInput["name"] as? String, todo.name)
+        XCTAssertEqual(graphQLInput["description"] as? String, todo.description)
+        guard let categories = graphQLInput["categories"] as? [[String: Any]] else {
+            XCTFail("Couldn't get array of categories")
+            return
+        }
+        XCTAssertEqual(categories.count, 1)
+        XCTAssertEqual(categories[0]["name"] as? String, category.name)
+        guard let expectedColor = categories[0]["color"] as? [String: Any] else {
+            XCTFail("Couldn't get color in category")
+            return
+        }
+        XCTAssertEqual(expectedColor["name"] as? String, color.name)
+        XCTAssertEqual(expectedColor["red"] as? Int, color.red)
+        XCTAssertEqual(expectedColor["green"] as? Int, color.green)
+        XCTAssertEqual(expectedColor["blue"] as? Int, color.blue)
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/ModelValueConverter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/ModelValueConverter+SQLite.swift
@@ -48,7 +48,7 @@ public struct SQLiteModelValueConverter: ModelValueConverter {
             // collections are not converted to SQL Binding since they represent a model association
             // and the foreign key lives on the other side of the association
             return nil
-        case .customType:
+        case .embedded, .embeddedCollection:
             if let encodable = value as? Encodable {
                 return try SQLiteModelValueConverter.toJSON(encodable)
             }
@@ -77,7 +77,7 @@ public struct SQLiteModelValueConverter: ModelValueConverter {
             return nil
         case .enum:
             return value as? String
-        case .customType:
+        case .embedded, .embeddedCollection:
             if let stringValue = value as? String {
                 return try SQLiteModelValueConverter.fromJSON(stringValue)
             }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/ExampleWithEveryType+Schema.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/ExampleWithEveryType+Schema.swift
@@ -41,8 +41,8 @@ extension ExampleWithEveryType {
             .field(example.boolField, is: .required, ofType: .bool),
             .field(example.dateField, is: .required, ofType: .date),
             .field(example.enumField, is: .required, ofType: .enum(type: ExampleEnum.self)),
-            .field(example.nonModelField, is: .required, ofType: .customType(ExampleNonModelType.self)),
-            .field(example.arrayOfStringsField, is: .required, ofType: .customType([String].self))
+            .field(example.nonModelField, is: .required, ofType: .embedded(type: ExampleNonModelType.self)),
+            .field(example.arrayOfStringsField, is: .required, ofType: .embeddedCollection(of: [String].self))
         )
     }
 

--- a/AmplifyTestCommon/Models/NonModel/Category.swift
+++ b/AmplifyTestCommon/Models/NonModel/Category.swift
@@ -9,7 +9,7 @@
 import Amplify
 import Foundation
 
-public struct Category: Embedded {
+public struct Category: Embeddable {
   var name: String
   var color: Color
 }

--- a/AmplifyTestCommon/Models/NonModel/Category.swift
+++ b/AmplifyTestCommon/Models/NonModel/Category.swift
@@ -1,0 +1,31 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Category: Embedded {
+  var name: String
+  var color: Color
+}
+
+extension Category {
+
+    public enum CodingKeys: CodingKey {
+        case name
+        case color
+    }
+
+    public static let keys = CodingKeys.self
+
+    public static let schema = defineSchema { embedded in
+        let category = Category.keys
+        embedded.fields(.field(category.name, is: .required, ofType: .string),
+                       .field(category.color, is: .required, ofType: .embedded(type: Color.self)))
+    }
+}

--- a/AmplifyTestCommon/Models/NonModel/Color.swift
+++ b/AmplifyTestCommon/Models/NonModel/Color.swift
@@ -1,0 +1,36 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Color: Embedded {
+  var name: String
+  var red: Int
+  var green: Int
+  var blue: Int
+}
+
+extension Color {
+    public enum CodingKeys: CodingKey {
+        case name
+        case red
+        case green
+        case blue
+    }
+
+    public static let keys = CodingKeys.self
+
+    public static let schema = defineSchema { embedded in
+        let color = Color.keys
+        embedded.fields(.field(color.name, is: .required, ofType: .string),
+                       .field(color.red, is: .required, ofType: .int),
+                       .field(color.green, is: .required, ofType: .int),
+                       .field(color.blue, is: .required, ofType: .int))
+    }
+}

--- a/AmplifyTestCommon/Models/NonModel/Color.swift
+++ b/AmplifyTestCommon/Models/NonModel/Color.swift
@@ -9,7 +9,7 @@
 import Amplify
 import Foundation
 
-public struct Color: Embedded {
+public struct Color: Embeddable {
   var name: String
   var red: Int
   var green: Int

--- a/AmplifyTestCommon/Models/NonModel/Section.swift
+++ b/AmplifyTestCommon/Models/NonModel/Section.swift
@@ -1,0 +1,30 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Section: Embedded {
+    var name: String
+    var number: Double
+}
+
+extension Section {
+    public enum CodingKeys: CodingKey {
+        case name
+        case number
+    }
+
+    public static let keys = CodingKeys.self
+
+    public static let schema = defineSchema { embedded in
+        let section = Section.keys
+        embedded.fields(.field(section.name, is: .required, ofType: .string),
+                       .field(section.number, is: .required, ofType: .double))
+    }
+}

--- a/AmplifyTestCommon/Models/NonModel/Section.swift
+++ b/AmplifyTestCommon/Models/NonModel/Section.swift
@@ -9,7 +9,7 @@
 import Amplify
 import Foundation
 
-public struct Section: Embedded {
+public struct Section: Embeddable {
     var name: String
     var number: Double
 }

--- a/AmplifyTestCommon/Models/NonModel/Todo+Schema.swift
+++ b/AmplifyTestCommon/Models/NonModel/Todo+Schema.swift
@@ -1,0 +1,40 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Todo {
+  // MARK: - CodingKeys
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case name
+    case description
+    case categories
+    case section
+    case stickies
+  }
+
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema
+
+  public static let schema = defineSchema { model in
+    let todo = Todo.keys
+
+    model.pluralName = "Todos"
+
+    model.fields(
+      .id(),
+      .field(todo.name, is: .required, ofType: .string),
+      .field(todo.description, is: .optional, ofType: .string),
+      .field(todo.categories, is: .optional, ofType: .embeddedCollection(of: Category.self)),
+      .field(todo.section, is: .optional, ofType: .embedded(type: Section.self)),
+      .field(todo.stickies, is: .optional, ofType: .embeddedCollection(of: String.self))
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/NonModel/Todo.swift
+++ b/AmplifyTestCommon/Models/NonModel/Todo.swift
@@ -1,0 +1,61 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+/*
+The schema used to codegen this model:
+ type Todo @model {
+   id: ID!
+   name: String!
+   description: String
+   categories: [Category]
+   section: Section
+   stickies: [String]
+ }
+
+ type Category {
+   name: ID!
+   color: Color!
+ }
+
+ type Color {
+   name: String!
+   red: Int!
+   green: Int!
+   blue: Int!
+ }
+
+ type Section {
+   name: ID!
+   number: Float!
+ }
+ */
+
+public struct Todo: Model {
+    public let id: String
+    public var name: String
+    public var description: String?
+    public var categories: [Category]?
+    public var section: Section?
+    public var stickies: [String]?
+
+    public init(id: String = UUID().uuidString,
+                name: String,
+                description: String? = nil,
+                categories: [Category]? = [],
+                section: Section? = nil,
+                stickies: [String]? = []) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.categories = categories
+        self.section = section
+        self.stickies = stickies
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- This adds `Embbeded` protocol to return the schema information for embedded types. This means the code generated schema for an embedded type should look something like this:
```
class Category: Embedded {
...
}
extension Category {
    public enum CodingKeys: CodingKey {
        case name
        case color
    }
    public static let keys = CodingKeys.self

    // store info about the field's name, nullability, and their types.
    public static let schema = defineSchema { embedded in
        let category = Category.keys
        embedded.fields(.field(category.name, is: .required, ofType: .string),
                       .field(category.color, is: .required, ofType: .embedded(type: Color.self)))
    }
}
```

- Also introduced a `.embeddedCollection` case to hold embbeded types which are arrays. This was required when checking type at runtime. 
```
    public var embeddedType: Embedded.Type? {
        switch type {
        case .embedded(let type), .embeddedCollectiion(let type):
           // the `type` here is always castable to the Embedded.Type. 
            if let embeddedType = type as? Embedded.Type {
                return embeddedType
            }
```

Testing done so far 
- selection set verification
- graphql query variables input, `graphQLInput`
- sample app without conflict resolution enabled and making calls to `API.create` 
- sample app with conflict resolution enabled and `DataStore.save` is successfully and is synced to the cloud


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
