### PR TITLE
fix(Core): Fix plugin configuration validation

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -69,8 +69,6 @@
 		21420AA0237222A900FA140C /* AWSAuthorizationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21420A8D237222A900FA140C /* AWSAuthorizationType.swift */; };
 		2144226C234BDD9B009357F7 /* StorageUploadFileRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2144226B234BDD9B009357F7 /* StorageUploadFileRequest.swift */; };
 		2144226E234BDE23009357F7 /* StorageUploadFileOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2144226D234BDE23009357F7 /* StorageUploadFileOperation.swift */; };
-		214F49CD24898E8500DA616C /* Article.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49CB24898E8400DA616C /* Article.swift */; };
-		214F49CE24898E8500DA616C /* Article+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49CC24898E8500DA616C /* Article+Schema.swift */; };
 		214F49772486D8A200DA616C /* UserFollowers+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49712486D8A100DA616C /* UserFollowers+Schema.swift */; };
 		214F49782486D8A200DA616C /* UserFollowing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49722486D8A200DA616C /* UserFollowing.swift */; };
 		214F49792486D8A200DA616C /* UserFollowing+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49732486D8A200DA616C /* UserFollowing+Schema.swift */; };
@@ -78,6 +76,8 @@
 		214F497B2486D8A200DA616C /* User+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49752486D8A200DA616C /* User+Schema.swift */; };
 		214F497C2486D8A200DA616C /* UserFollowers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49762486D8A200DA616C /* UserFollowers.swift */; };
 		214F497E2486DA5000DA616C /* GraphQLRequestOptionalAssociationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F497D2486DA5000DA616C /* GraphQLRequestOptionalAssociationTests.swift */; };
+		214F49CD24898E8500DA616C /* Article.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49CB24898E8400DA616C /* Article.swift */; };
+		214F49CE24898E8500DA616C /* Article+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49CC24898E8500DA616C /* Article+Schema.swift */; };
 		21558E3E237BB4BF0032A5BB /* GraphQLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21558E3D237BB4BF0032A5BB /* GraphQLRequest.swift */; };
 		21558E40237CB8640032A5BB /* GraphQLError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21558E3F237CB8640032A5BB /* GraphQLError.swift */; };
 		216879FE23636A0A004A056E /* RepeatingTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216879FD23636A0A004A056E /* RepeatingTimer.swift */; };
@@ -712,8 +712,6 @@
 		21420A8D237222A900FA140C /* AWSAuthorizationType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSAuthorizationType.swift; sourceTree = "<group>"; };
 		2144226B234BDD9B009357F7 /* StorageUploadFileRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageUploadFileRequest.swift; sourceTree = "<group>"; };
 		2144226D234BDE23009357F7 /* StorageUploadFileOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageUploadFileOperation.swift; sourceTree = "<group>"; };
-		214F49CB24898E8400DA616C /* Article.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Article.swift; sourceTree = "<group>"; };
-		214F49CC24898E8500DA616C /* Article+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Article+Schema.swift"; sourceTree = "<group>"; };
 		214F49712486D8A100DA616C /* UserFollowers+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserFollowers+Schema.swift"; sourceTree = "<group>"; };
 		214F49722486D8A200DA616C /* UserFollowing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserFollowing.swift; sourceTree = "<group>"; };
 		214F49732486D8A200DA616C /* UserFollowing+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserFollowing+Schema.swift"; sourceTree = "<group>"; };
@@ -721,6 +719,8 @@
 		214F49752486D8A200DA616C /* User+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "User+Schema.swift"; sourceTree = "<group>"; };
 		214F49762486D8A200DA616C /* UserFollowers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserFollowers.swift; sourceTree = "<group>"; };
 		214F497D2486DA5000DA616C /* GraphQLRequestOptionalAssociationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRequestOptionalAssociationTests.swift; sourceTree = "<group>"; };
+		214F49CB24898E8400DA616C /* Article.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Article.swift; sourceTree = "<group>"; };
+		214F49CC24898E8500DA616C /* Article+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Article+Schema.swift"; sourceTree = "<group>"; };
 		21558E3D237BB4BF0032A5BB /* GraphQLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRequest.swift; sourceTree = "<group>"; };
 		21558E3F237CB8640032A5BB /* GraphQLError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLError.swift; sourceTree = "<group>"; };
 		215F4BCAAB89FA54AA121BDE /* Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin.release.xcconfig"; path = "Target Support Files/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin.release.xcconfig"; sourceTree = "<group>"; };
@@ -2805,9 +2805,9 @@
 		FAC2354C227A056600424678 /* CategoryTests */ = {
 			isa = PBXGroup;
 			children = (
-				B4F3E9F624314E1300F23296 /* Auth */,
 				FAC2355D227A056600424678 /* Analytics */,
 				FAC23555227A056600424678 /* API */,
+				B4F3E9F624314E1300F23296 /* Auth */,
 				FAD3937B23820CE200463F5E /* DataStore */,
 				FAC23584227A442000424678 /* Hub */,
 				FAC23559227A056600424678 /* Logging */,
@@ -2927,9 +2927,9 @@
 			isa = PBXGroup;
 			children = (
 				FA607FE1233D131B00DFEA24 /* AmplifyOperationHubTests.swift */,
-				FACF52052329652600646E10 /* DefaultPluginTests */,
 				FAC23585227A443200424678 /* HubCategoryConfigurationTests.swift */,
 				FAC23587227A446C00424678 /* HubClientAPITests.swift */,
+				FACF52052329652600646E10 /* DefaultPluginTests */,
 			);
 			path = Hub;
 			sourceTree = "<group>";

--- a/Amplify/Categories/API/Internal/APICategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/API/Internal/APICategory+CategoryConfigurable.swift
@@ -16,10 +16,7 @@ extension AmplifyAPICategory: CategoryConfigurable {
             throw error
         }
 
-        for (pluginKey, pluginConfiguration) in configuration.plugins {
-            let plugin = try getPlugin(for: pluginKey)
-            try plugin.configure(using: pluginConfiguration)
-        }
+        try Amplify.configure(plugins: Array(plugins.values), using: configuration)
 
         isConfigured = true
     }

--- a/Amplify/Categories/Analytics/Internal/AnalyticsCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Analytics/Internal/AnalyticsCategory+CategoryConfigurable.swift
@@ -16,10 +16,7 @@ extension AnalyticsCategory: CategoryConfigurable {
             throw error
         }
 
-        for (pluginKey, pluginConfiguration) in configuration.plugins {
-            let plugin = try getPlugin(for: pluginKey)
-            try plugin.configure(using: pluginConfiguration)
-        }
+        try Amplify.configure(plugins: Array(plugins.values), using: configuration)
 
         isConfigured = true
     }

--- a/Amplify/Categories/Auth/Internal/AuthCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Auth/Internal/AuthCategory+CategoryConfigurable.swift
@@ -18,10 +18,7 @@ extension AuthCategory: CategoryConfigurable {
             throw error
         }
 
-        for (pluginKey, pluginConfiguration) in configuration.plugins {
-            let plugin = try getPlugin(for: pluginKey)
-            try plugin.configure(using: pluginConfiguration)
-        }
+        try Amplify.configure(plugins: Array(plugins.values), using: configuration)
 
         isConfigured = true
     }

--- a/Amplify/Categories/DataStore/Internal/DataStoreCategory+Configurable.swift
+++ b/Amplify/Categories/DataStore/Internal/DataStoreCategory+Configurable.swift
@@ -24,10 +24,7 @@ extension DataStoreCategory: CategoryConfigurable {
             throw error
         }
 
-        for (pluginKey, pluginConfiguration) in configuration.plugins {
-            let plugin = try getPlugin(for: pluginKey)
-            try plugin.configure(using: pluginConfiguration)
-        }
+        try Amplify.configure(plugins: Array(plugins.values), using: configuration)
 
         isConfigured = true
     }

--- a/Amplify/Categories/Hub/Internal/HubCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Hub/Internal/HubCategory+CategoryConfigurable.swift
@@ -18,10 +18,7 @@ extension HubCategory: CategoryConfigurable {
             throw error
         }
 
-        for (pluginKey, pluginConfiguration) in configuration.plugins {
-            let plugin = try getPlugin(for: pluginKey)
-            try plugin.configure(using: pluginConfiguration)
-        }
+        try Amplify.configure(plugins: Array(plugins.values), using: configuration)
 
         configurationState = .configured
     }

--- a/Amplify/Categories/Logging/Internal/LoggingCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Logging/Internal/LoggingCategory+CategoryConfigurable.swift
@@ -26,18 +26,7 @@ extension LoggingCategory: CategoryConfigurable {
                 throw error
             }
 
-            guard let pluginConfiguration = configuration.plugins[plugin.key] else {
-                throw LoggingError.configuration(
-                    "No configuration found for added plugin `\(plugin.key)`",
-                    """
-                    Either fix the configuration file to specify the plugin's key value of '\(plugin.key)',
-                    or add a plugin with one of the keys specified in the configuration:
-                    \(configuration.plugins.keys.joined(separator: ", "))
-                    """
-                )
-            }
-
-            try plugin.configure(using: pluginConfiguration)
+            try plugin.configure(using: configuration.plugins[plugin.key])
             self.plugin = plugin
             configurationState = .configured
         }

--- a/Amplify/Categories/Predictions/Internal/PredictionsCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Predictions/Internal/PredictionsCategory+CategoryConfigurable.swift
@@ -16,10 +16,7 @@ extension PredictionsCategory: CategoryConfigurable {
             throw error
         }
 
-        for (pluginKey, pluginConfiguration) in configuration.plugins {
-            let plugin = try getPlugin(for: pluginKey)
-            try plugin.configure(using: pluginConfiguration)
-        }
+        try Amplify.configure(plugins: Array(plugins.values), using: configuration)
 
         isConfigured = true
     }

--- a/Amplify/Categories/Storage/Internal/StorageCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Storage/Internal/StorageCategory+CategoryConfigurable.swift
@@ -16,10 +16,7 @@ extension StorageCategory: CategoryConfigurable {
             throw error
         }
 
-        for (pluginKey, pluginConfiguration) in configuration.plugins {
-            let plugin = try getPlugin(for: pluginKey)
-            try plugin.configure(using: pluginConfiguration)
-        }
+        try Amplify.configure(plugins: Array(plugins.values), using: configuration)
 
         isConfigured = true
     }

--- a/Amplify/Core/Configuration/AmplifyConfiguration.swift
+++ b/Amplify/Core/Configuration/AmplifyConfiguration.swift
@@ -145,4 +145,22 @@ extension Amplify {
 
         try configurable.configure(using: configuration)
     }
+
+    /// Configures a list of plugins with the specified CategoryConfiguration. If any configurations do not match the
+    /// specified plugins, emits a log warning.
+    static func configure(plugins: [Plugin], using configuration: CategoryConfiguration) throws {
+        var pluginConfigurations = configuration.plugins
+
+        for plugin in plugins {
+            let pluginConfiguration = pluginConfigurations[plugin.key]
+            try plugin.configure(using: pluginConfiguration)
+            pluginConfigurations.removeValue(forKey: plugin.key)
+        }
+
+        for unusedPluginKey in pluginConfigurations.keys {
+            log.warn("No plugin found for configuration key `\(unusedPluginKey)`. Add a plugin for that key.")
+        }
+
+    }
+
 }

--- a/Amplify/Core/Configuration/AmplifyConfiguration.swift
+++ b/Amplify/Core/Configuration/AmplifyConfiguration.swift
@@ -160,7 +160,6 @@ extension Amplify {
         for unusedPluginKey in pluginConfigurations.keys {
             log.warn("No plugin found for configuration key `\(unusedPluginKey)`. Add a plugin for that key.")
         }
-
     }
 
 }

--- a/Amplify/Core/Plugin/Plugin.swift
+++ b/Amplify/Core/Plugin/Plugin.swift
@@ -20,7 +20,7 @@ public protocol Plugin: CategoryTypeable, Resettable {
     /// handling potential conflicts with globally-specified options.
     /// - Throws:
     ///   - PluginError.pluginConfigurationError: If the plugin encounters an error during configuration
-    func configure(using configuration: Any) throws
+    func configure(using configuration: Any?) throws
 }
 
 /// Convenience typealias to clarify when Strings are being used as plugin keys

--- a/Amplify/DefaultPlugins/AWSHubPlugin/AWSHubPlugin.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/AWSHubPlugin.swift
@@ -34,8 +34,8 @@ final public class AWSHubPlugin: HubCategoryPlugin {
     }
 
     /// For protocol conformance only--this plugin has no applicable configurations
-    public func configure(using configuration: Any) throws {
-        return
+    public func configure(using configuration: Any?) throws {
+        // Do nothing
     }
 
     /// Removes listeners and empties the message queue

--- a/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/AWSUnifiedLoggingPlugin.swift
+++ b/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/AWSUnifiedLoggingPlugin.swift
@@ -45,8 +45,8 @@ final public class AWSUnifiedLoggingPlugin: LoggingCategoryPlugin {
     }
 
     /// For protocol conformance only--this plugin has no applicable configurations
-    public func configure(using configuration: Any) throws {
-        return
+    public func configure(using configuration: Any?) throws {
+        // Do nothing
     }
 
     /// Removes listeners and empties the message queue

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
@@ -922,6 +922,7 @@
 		B4DFA5BE237A611D0013E17B /* AWSAPICategoryPluginTests */ = {
 			isa = PBXGroup;
 			children = (
+				B4DFA5DD237A611D0013E17B /* Info.plist */,
 				B4DFA5DE237A611D0013E17B /* AWSAPICategoryPlugin+ConfigureTests.swift */,
 				B4DFA5CC237A611D0013E17B /* AWSAPICategoryPlugin+GraphQLBehaviorTests.swift */,
 				B4DFA5C9237A611D0013E17B /* AWSAPICategoryPlugin+InterceptorBehaviorTests.swift */,
@@ -932,7 +933,6 @@
 				B4DFA5CB237A611D0013E17B /* AWSAPICategoryPluginTestBase.swift */,
 				FA9554E1238B6C1200D42A43 /* Concurrency */,
 				B4DFA5C6237A611D0013E17B /* Configuration */,
-				B4DFA5DD237A611D0013E17B /* Info.plist */,
 				B4DFA5D9237A611D0013E17B /* Interceptor */,
 				B4DFA5BF237A611D0013E17B /* Mocks */,
 				B4DFA5C3237A611D0013E17B /* Operation */,

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Configure.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Configure.swift
@@ -17,16 +17,16 @@ public extension AWSAPIPlugin {
     /// - Parameter configuration: The configuration specified for this plugin
     /// - Throws:
     ///   - PluginError.pluginConfigurationError: If one of the required configuration values is invalid or empty
-    func configure(using configuration: Any) throws {
+    func configure(using configuration: Any?) throws {
 
         guard let jsonValue = configuration as? JSONValue else {
             throw PluginError.pluginConfigurationError(
                 "Could not cast incoming configuration to JSONValue",
                 """
-                The specified configuration is not convertible to a JSONValue. Review the configuration and ensure it \
-                contains the expected values, and does not use any types that aren't convertible to a corresponding \
-                JSONValue:
-                \(configuration)
+                The specified configuration is either nil, or not convertible to a JSONValue. Review the configuration \
+                and ensure it contains the expected values, and does not use any types that aren't convertible to a \
+                corresponding JSONValue:
+                \(String(describing: configuration))
                 """
             )
         }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -22,10 +22,9 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
             try Amplify.configure(amplifyConfig)
             XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")
         } catch {
-            if case PluginError.pluginConfigurationError = error {
-                // Pass
-            } else {
+            guard case PluginError.pluginConfigurationError = error else {
                 XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")
+                return
             }
         }
     }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Configure.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Configure.swift
@@ -18,7 +18,7 @@ extension AWSPinpointAnalyticsPlugin {
     /// - Parameter configuration: The configuration specified for this plugin
     /// - Throws:
     ///   - PluginError.pluginConfigurationError: If one of the configuration values is invalid or empty
-    public func configure(using configuration: Any) throws {
+    public func configure(using configuration: Any?) throws {
         guard let config = configuration as? JSONValue else {
             throw PluginError.pluginConfigurationError(
                 AnalyticsPluginErrorConstant.decodeConfigurationError.errorDescription,

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginConfigureTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginConfigureTests.swift
@@ -58,4 +58,5 @@ class AWSPinpointAnalyticsPluginConfigureTests: AWSPinpointAnalyticsPluginTestBa
             XCTFail("Failed to configure analytics plugin")
         }
     }
+
 }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Configuration/AWSPinpointAnalyticsPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Configuration/AWSPinpointAnalyticsPluginConfigurationTests.swift
@@ -428,10 +428,9 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
             try Amplify.configure(amplifyConfig)
             XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")
         } catch {
-            if case PluginError.pluginConfigurationError = error {
-                // Pass
-            } else {
+            guard case PluginError.pluginConfigurationError = error else {
                 XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")
+                return
             }
         }
     }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Configuration/AWSPinpointAnalyticsPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Configuration/AWSPinpointAnalyticsPluginConfigurationTests.swift
@@ -417,4 +417,23 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
             XCTAssertEqual(errorDescription, AnalyticsPluginErrorConstant.invalidRegion.errorDescription)
         }
     }
+
+    func testThrowsOnMissingConfig() throws {
+        let plugin = AWSPinpointAnalyticsPlugin()
+        try Amplify.add(plugin: plugin)
+
+        let categoryConfig = AnalyticsCategoryConfiguration(plugins: ["NonExistentPlugin": true])
+        let amplifyConfig = AmplifyConfiguration(analytics: categoryConfig)
+        do {
+            try Amplify.configure(amplifyConfig)
+            XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")
+        } catch {
+            if case PluginError.pluginConfigurationError = error {
+                // Pass
+            } else {
+                XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")
+            }
+        }
+    }
+
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		B4F3EA4F243A782700F23296 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3EA4C243A782700F23296 /* ViewController.swift */; };
 		B4F3EA50243A782700F23296 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3EA4D243A782700F23296 /* AppDelegate.swift */; };
 		B4F3EA51243A782700F23296 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3EA4E243A782700F23296 /* SceneDelegate.swift */; };
+		FA6B0EA8249443C90062AA59 /* AWSCognitoAuthPluginConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B0EA7249443C90062AA59 /* AWSCognitoAuthPluginConfigTests.swift */; };
 		FECB988C412E46FD5961894A /* Pods_AWSCognitoAuthPlugin_AWSCognitoAuthPluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1674B6AE81501F6E278CE00B /* Pods_AWSCognitoAuthPlugin_AWSCognitoAuthPluginTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -278,6 +279,7 @@
 		C49A4C812B0F973F5536DCC8 /* Pods-AWSAuthPlugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAuthPlugin.release.xcconfig"; path = "Target Support Files/Pods-AWSAuthPlugin/Pods-AWSAuthPlugin.release.xcconfig"; sourceTree = "<group>"; };
 		C5E50D8021B9740CB511898D /* Pods-AWSAuthPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAuthPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSAuthPlugin/Pods-AWSAuthPlugin.debug.xcconfig"; sourceTree = "<group>"; };
 		E9289652B314AA0AA1F31BC8 /* Pods-HostApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp.release.xcconfig"; path = "Target Support Files/Pods-HostApp/Pods-HostApp.release.xcconfig"; sourceTree = "<group>"; };
+		FA6B0EA7249443C90062AA59 /* AWSCognitoAuthPluginConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSCognitoAuthPluginConfigTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -606,6 +608,7 @@
 			isa = PBXGroup;
 			children = (
 				B41D0FE02475A3A10049D08D /* Info.plist */,
+				FA6B0EA7249443C90062AA59 /* AWSCognitoAuthPluginConfigTests.swift */,
 				B41D0FDE2475A3A10049D08D /* HubEventTests */,
 				B41D0FDC2475A3A10049D08D /* Utils */,
 			);
@@ -1320,6 +1323,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA6B0EA8249443C90062AA59 /* AWSCognitoAuthPluginConfigTests.swift in Sources */,
 				B41D0FE32475A3A10049D08D /* AuthHubEventHandlerTests.swift in Sources */,
 				B41D0FE22475A3A10049D08D /* AuthUserAttributeKeyTests.swift in Sources */,
 			);

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -17,10 +17,12 @@ extension AWSCognitoAuthPlugin {
     /// - Parameter configuration: The configuration specified for this plugin
     /// - Throws:
     ///   - PluginError.pluginConfigurationError: If one of the configuration values is invalid or empty
-    public func configure(using configuration: Any) throws {
+    public func configure(using configuration: Any?) throws {
         guard let jsonValueConfiguration = configuration as? JSONValue else {
-            throw AuthError.configuration(AuthPluginErrorConstants.decodeConfigurationError.errorDescription,
-                                          AuthPluginErrorConstants.decodeConfigurationError.recoverySuggestion)
+            throw PluginError.pluginConfigurationError(
+                AuthPluginErrorConstants.decodeConfigurationError.errorDescription,
+                AuthPluginErrorConstants.decodeConfigurationError.recoverySuggestion
+            )
         }
         do {
             // Convert the JSONValue to [String: Any] dictionary to be used by AWSMobileClient

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AWSCognitoAuthPluginConfigTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AWSCognitoAuthPluginConfigTests.swift
@@ -6,18 +6,17 @@
 //
 
 import XCTest
+import Amplify
+import AWSCognitoAuthPlugin
 
-@testable import Amplify
-@testable import AWSAPICategoryPlugin
-
-class AWSAPICategoryPluginConfigurationTests: XCTestCase {
+class AWSCognitoAuthPluginConfigTests: XCTestCase {
 
     func testThrowsOnMissingConfig() throws {
-        let plugin = AWSAPIPlugin()
+        let plugin = AWSCognitoAuthPlugin()
         try Amplify.add(plugin: plugin)
 
-        let categoryConfig = APICategoryConfiguration(plugins: ["NonExistentPlugin": true])
-        let amplifyConfig = AmplifyConfiguration(api: categoryConfig)
+        let categoryConfig = AuthCategoryConfiguration(plugins: ["NonExistentPlugin": true])
+        let amplifyConfig = AmplifyConfiguration(auth: categoryConfig)
         do {
             try Amplify.configure(amplifyConfig)
             XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AWSCognitoAuthPluginConfigTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AWSCognitoAuthPluginConfigTests.swift
@@ -21,10 +21,9 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
             try Amplify.configure(amplifyConfig)
             XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")
         } catch {
-            if case PluginError.pluginConfigurationError = error {
-                // Pass
-            } else {
+            guard case PluginError.pluginConfigurationError = error else {
                 XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")
+                return
             }
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -78,7 +78,7 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
     /// By the time this method gets called, DataStore will already have invoked
     /// `AmplifyModelRegistration.registerModels`, so we can inspect those models to derive isSyncEnabled, and pass
     /// them to `StorageEngine.setUp(models:)`
-    public func configure(using amplifyConfiguration: Any) throws {
+    public func configure(using amplifyConfiguration: Any?) throws {
         modelRegistration.registerModels(registry: ModelRegistry.self)
         resolveSyncEnabled()
         try resolveStorageEngine(dataStoreConfiguration: dataStoreConfiguration)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/AWSDataStorePluginConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/AWSDataStorePluginConfigurationTests.swift
@@ -11,6 +11,8 @@ import AWSDataStoreCategoryPlugin
 
 class AWSDataStorePluginConfigurationTests: XCTestCase {
 
+    // Note this test requires the ability to write a new database in the Documents directcory, so it must be embedded
+    // in a host app
     func testDoesNotThrowOnMissingConfig() throws {
         let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration())
         try Amplify.add(plugin: plugin)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSDataStorePluginConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSDataStorePluginConfigurationTests.swift
@@ -1,0 +1,26 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import Amplify
+import AWSDataStoreCategoryPlugin
+
+class AWSDataStorePluginConfigurationTests: XCTestCase {
+
+    func testDoesNotThrowOnMissingConfig() throws {
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration())
+        try Amplify.add(plugin: plugin)
+
+        let amplifyConfig = AmplifyConfiguration()
+        do {
+            try Amplify.configure(amplifyConfig)
+        } catch {
+            XCTAssertNil(error, "Should not throw even if not supplied with a plugin-specific config.")
+        }
+    }
+
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/DataStoreCategoryConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/DataStoreCategoryConfigurationTests.swift
@@ -1,0 +1,27 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import Amplify
+import AWSDataStoreCategoryPlugin
+
+class AWSDataStorePluginConfigurationTests: XCTestCase {
+
+    func testDoesNotThrowOnMissingConfig() throws {
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration())
+        try Amplify.add(plugin: plugin)
+
+        let categoryConfig = DataStoreCategoryConfiguration(plugins: ["NonExistentPlugin": true])
+        let amplifyConfig = AmplifyConfiguration(dataStore: categoryConfig)
+        do {
+            try Amplify.configure(amplifyConfig)
+        } catch {
+            XCTFail("Should not throw even if not supplied with a plugin-specific config.")
+        }
+    }
+
+}

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		FA0427D02396CDD800D25AB0 /* DataStoreHubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0427CF2396CDD800D25AB0 /* DataStoreHubTests.swift */; };
 		FA1AE9BC23988BE100DE396D /* AWSModelReconciliationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1AE9BB23988BE100DE396D /* AWSModelReconciliationQueue.swift */; };
 		FA23345C23955CEF009BEFE9 /* NoOpMutationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA23345B23955CEF009BEFE9 /* NoOpMutationQueue.swift */; };
+		FA2E6B8D2497C17500779D2F /* AWSDataStorePluginConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B0EA9249445D50062AA59 /* AWSDataStorePluginConfigurationTests.swift */; };
 		FA3841E523889D280070AD5B /* IncomingEventReconciliationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3841E423889D280070AD5B /* IncomingEventReconciliationQueue.swift */; };
 		FA3841E723889D340070AD5B /* ReconcileAndLocalSaveOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3841E623889D340070AD5B /* ReconcileAndLocalSaveOperation.swift */; };
 		FA3841E923889D440070AD5B /* StateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3841E823889D440070AD5B /* StateMachine.swift */; };
@@ -125,7 +126,6 @@
 		FA5D4CEF238AFCBC00D2F54A /* AWSDataStorePlugin+DataStoreSubscribeBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5D4CEE238AFCBC00D2F54A /* AWSDataStorePlugin+DataStoreSubscribeBehavior.swift */; };
 		FA5D76AB2394752900489864 /* AWSMutationDatabaseAdapter+MutationEventIngester.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5D76AA2394752900489864 /* AWSMutationDatabaseAdapter+MutationEventIngester.swift */; };
 		FA60461323980A75009E4B97 /* InitialSyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA60461223980A75009E4B97 /* InitialSyncOperation.swift */; };
-		FA6B0EAA249445D50062AA59 /* AWSDataStorePluginConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B0EA9249445D50062AA59 /* AWSDataStorePluginConfigurationTests.swift */; };
 		FA6C3FEC23988D0900A73110 /* AWSIncomingEventReconciliationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6C3FEB23988D0900A73110 /* AWSIncomingEventReconciliationQueue.swift */; };
 		FA6C3FEE239890B500A73110 /* AWSMutationEventPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6C3FED239890B500A73110 /* AWSMutationEventPublisher.swift */; };
 		FA8D932F239EA5C4001ED336 /* NoOpInitialSyncOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8D932E239EA5C4001ED336 /* NoOpInitialSyncOrchestrator.swift */; };
@@ -192,13 +192,6 @@
 			remoteInfo = AWSDataStoreCategoryPlugin;
 		};
 		2149E62823886CF500873955 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 2149E592238867E100873955 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 2149E60423886C7B00873955;
-			remoteInfo = HostApp;
-		};
-		FA6B0EAB249449230062AA59 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 2149E592238867E100873955 /* Project object */;
 			proxyType = 1;
@@ -591,6 +584,7 @@
 			isa = PBXGroup;
 			children = (
 				21233DD7247591D100039337 /* amplifyconfiguration.json */,
+				FA6B0EA9249445D50062AA59 /* AWSDataStorePluginConfigurationTests.swift */,
 				FAB571412395A3E80006A5F8 /* DataStoreEndToEndTests.swift */,
 				2149E62123886CEE00873955 /* Info.plist */,
 				213481BE24213E13001966DE /* README.md */,
@@ -739,7 +733,6 @@
 		FAD2BDF423957F35006EB065 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				FA6B0EA9249445D50062AA59 /* AWSDataStorePluginConfigurationTests.swift */,
 				B9FAA13F238C600A009414B4 /* ListTests.swift */,
 				B912D1B9242984D10028F05C /* QueryPaginationInputTests.swift */,
 				2149E5F0238869CF00873955 /* QueryPredicateTests.swift */,
@@ -932,7 +925,6 @@
 			);
 			dependencies = (
 				2149E5EA2388692E00873955 /* PBXTargetDependency */,
-				FA6B0EAC249449230062AA59 /* PBXTargetDependency */,
 			);
 			name = AWSDataStoreCategoryPluginTests;
 			productName = AWSDataStoreCategoryPluginTests;
@@ -1001,7 +993,6 @@
 					2149E5E22388692E00873955 = {
 						CreatedOnToolsVersion = 11.2.1;
 						LastSwiftMigration = 1120;
-						TestTargetID = 2149E60423886C7B00873955;
 					};
 					2149E60423886C7B00873955 = {
 						CreatedOnToolsVersion = 11.2.1;
@@ -1522,7 +1513,6 @@
 				6B64027923E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift in Sources */,
 				FA0427D02396CDD800D25AB0 /* DataStoreHubTests.swift in Sources */,
 				FA3B3F09238F39DE002EFDB3 /* AWSMutationEventIngesterTests.swift in Sources */,
-				FA6B0EAA249445D50062AA59 /* AWSDataStorePluginConfigurationTests.swift in Sources */,
 				6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */,
 				FA4B8E962391C609009FC10F /* XCTest+AmplifyExtensions.swift in Sources */,
 				FAE4146C239AA40600CE94C2 /* MockSQLiteStorageEngineAdapter.swift in Sources */,
@@ -1576,6 +1566,7 @@
 				FA3841EB23889D6C0070AD5B /* SubscriptionEndToEndTests.swift in Sources */,
 				FAB571422395A3E80006A5F8 /* DataStoreEndToEndTests.swift in Sources */,
 				FAB5714023958C210006A5F8 /* SyncEngineIntegrationTestBase.swift in Sources */,
+				FA2E6B8D2497C17500779D2F /* AWSDataStorePluginConfigurationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1606,11 +1597,6 @@
 			isa = PBXTargetDependency;
 			target = 2149E60423886C7B00873955 /* HostApp */;
 			targetProxy = 2149E62823886CF500873955 /* PBXContainerItemProxy */;
-		};
-		FA6B0EAC249449230062AA59 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 2149E60423886C7B00873955 /* HostApp */;
-			targetProxy = FA6B0EAB249449230062AA59 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1867,7 +1853,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HostApp.app/HostApp";
 			};
 			name = Debug;
 		};
@@ -1889,7 +1874,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HostApp.app/HostApp";
 			};
 			name = Release;
 		};

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		FA5D4CEF238AFCBC00D2F54A /* AWSDataStorePlugin+DataStoreSubscribeBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5D4CEE238AFCBC00D2F54A /* AWSDataStorePlugin+DataStoreSubscribeBehavior.swift */; };
 		FA5D76AB2394752900489864 /* AWSMutationDatabaseAdapter+MutationEventIngester.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5D76AA2394752900489864 /* AWSMutationDatabaseAdapter+MutationEventIngester.swift */; };
 		FA60461323980A75009E4B97 /* InitialSyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA60461223980A75009E4B97 /* InitialSyncOperation.swift */; };
+		FA6B0EAA249445D50062AA59 /* AWSDataStorePluginConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B0EA9249445D50062AA59 /* AWSDataStorePluginConfigurationTests.swift */; };
 		FA6C3FEC23988D0900A73110 /* AWSIncomingEventReconciliationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6C3FEB23988D0900A73110 /* AWSIncomingEventReconciliationQueue.swift */; };
 		FA6C3FEE239890B500A73110 /* AWSMutationEventPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6C3FED239890B500A73110 /* AWSMutationEventPublisher.swift */; };
 		FA8D932F239EA5C4001ED336 /* NoOpInitialSyncOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8D932E239EA5C4001ED336 /* NoOpInitialSyncOrchestrator.swift */; };
@@ -191,6 +192,13 @@
 			remoteInfo = AWSDataStoreCategoryPlugin;
 		};
 		2149E62823886CF500873955 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2149E592238867E100873955 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2149E60423886C7B00873955;
+			remoteInfo = HostApp;
+		};
+		FA6B0EAB249449230062AA59 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 2149E592238867E100873955 /* Project object */;
 			proxyType = 1;
@@ -335,6 +343,7 @@
 		FA5D4CEE238AFCBC00D2F54A /* AWSDataStorePlugin+DataStoreSubscribeBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSDataStorePlugin+DataStoreSubscribeBehavior.swift"; sourceTree = "<group>"; };
 		FA5D76AA2394752900489864 /* AWSMutationDatabaseAdapter+MutationEventIngester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSMutationDatabaseAdapter+MutationEventIngester.swift"; sourceTree = "<group>"; };
 		FA60461223980A75009E4B97 /* InitialSyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialSyncOperation.swift; sourceTree = "<group>"; };
+		FA6B0EA9249445D50062AA59 /* AWSDataStorePluginConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStorePluginConfigurationTests.swift; sourceTree = "<group>"; };
 		FA6C3FEB23988D0900A73110 /* AWSIncomingEventReconciliationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSIncomingEventReconciliationQueue.swift; sourceTree = "<group>"; };
 		FA6C3FED239890B500A73110 /* AWSMutationEventPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMutationEventPublisher.swift; sourceTree = "<group>"; };
 		FA8D932E239EA5C4001ED336 /* NoOpInitialSyncOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoOpInitialSyncOrchestrator.swift; sourceTree = "<group>"; };
@@ -730,6 +739,7 @@
 		FAD2BDF423957F35006EB065 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				FA6B0EA9249445D50062AA59 /* AWSDataStorePluginConfigurationTests.swift */,
 				B9FAA13F238C600A009414B4 /* ListTests.swift */,
 				B912D1B9242984D10028F05C /* QueryPaginationInputTests.swift */,
 				2149E5F0238869CF00873955 /* QueryPredicateTests.swift */,
@@ -922,6 +932,7 @@
 			);
 			dependencies = (
 				2149E5EA2388692E00873955 /* PBXTargetDependency */,
+				FA6B0EAC249449230062AA59 /* PBXTargetDependency */,
 			);
 			name = AWSDataStoreCategoryPluginTests;
 			productName = AWSDataStoreCategoryPluginTests;
@@ -990,6 +1001,7 @@
 					2149E5E22388692E00873955 = {
 						CreatedOnToolsVersion = 11.2.1;
 						LastSwiftMigration = 1120;
+						TestTargetID = 2149E60423886C7B00873955;
 					};
 					2149E60423886C7B00873955 = {
 						CreatedOnToolsVersion = 11.2.1;
@@ -1510,6 +1522,7 @@
 				6B64027923E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift in Sources */,
 				FA0427D02396CDD800D25AB0 /* DataStoreHubTests.swift in Sources */,
 				FA3B3F09238F39DE002EFDB3 /* AWSMutationEventIngesterTests.swift in Sources */,
+				FA6B0EAA249445D50062AA59 /* AWSDataStorePluginConfigurationTests.swift in Sources */,
 				6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */,
 				FA4B8E962391C609009FC10F /* XCTest+AmplifyExtensions.swift in Sources */,
 				FAE4146C239AA40600CE94C2 /* MockSQLiteStorageEngineAdapter.swift in Sources */,
@@ -1593,6 +1606,11 @@
 			isa = PBXTargetDependency;
 			target = 2149E60423886C7B00873955 /* HostApp */;
 			targetProxy = 2149E62823886CF500873955 /* PBXContainerItemProxy */;
+		};
+		FA6B0EAC249449230062AA59 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2149E60423886C7B00873955 /* HostApp */;
+			targetProxy = FA6B0EAB249449230062AA59 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1849,6 +1867,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HostApp.app/HostApp";
 			};
 			name = Debug;
 		};
@@ -1870,6 +1889,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HostApp.app/HostApp";
 			};
 			name = Release;
 		};

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin+Configure.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin+Configure.swift
@@ -20,7 +20,7 @@ extension AWSPredictionsPlugin {
     /// - Parameter configuration: The configuration specified for this plugin
     /// - Throws:
     ///   - PluginError.pluginConfigurationError: If one of the configuration values is invalid or empty
-    public func configure(using configuration: Any) throws {
+    public func configure(using configuration: Any?) throws {
 
         guard let jsonValueConfiguration = configuration as? JSONValue else {
             throw PluginError.pluginConfigurationError(PluginErrorMessage.decodeConfigurationError.errorDescription,

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
@@ -190,10 +190,9 @@ class PredictionsPluginConfigurationTests: XCTestCase {
             try Amplify.configure(amplifyConfig)
             XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")
         } catch {
-            if case PluginError.pluginConfigurationError = error {
-                // Pass
-            } else {
+            guard case PluginError.pluginConfigurationError = error else {
                 XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")
+                return
             }
         }
     }

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
@@ -180,4 +180,22 @@ class PredictionsPluginConfigurationTests: XCTestCase {
         }
     }
 
+    func testThrowsOnMissingConfig() throws {
+        let plugin = AWSPredictionsPlugin()
+        try Amplify.add(plugin: plugin)
+
+        let categoryConfig = PredictionsCategoryConfiguration(plugins: ["NonExistentPlugin": true])
+        let amplifyConfig = AmplifyConfiguration(predictions: categoryConfig)
+        do {
+            try Amplify.configure(amplifyConfig)
+            XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")
+        } catch {
+            if case PluginError.pluginConfigurationError = error {
+                // Pass
+            } else {
+                XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")
+            }
+        }
+    }
+
 }

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/CoreMLPredictionsPlugin+Configure.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/CoreMLPredictionsPlugin+Configure.swift
@@ -10,7 +10,7 @@ import Amplify
 
 extension CoreMLPredictionsPlugin {
 
-    public func configure(using configuration: Any) throws {
+    public func configure(using configuration: Any?) throws {
         guard configuration is JSONValue else {
             let errorDescription = CoreMLPluginErrorString.decodeConfigurationError.errorDescription
             let recoverySuggestion = CoreMLPluginErrorString.decodeConfigurationError.recoverySuggestion

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/CoreMLPredictionsPluginConfigTests.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/CoreMLPredictionsPluginConfigTests.swift
@@ -6,18 +6,17 @@
 //
 
 import XCTest
+import Amplify
+import CoreMLPredictionsPlugin
 
-@testable import Amplify
-@testable import AWSAPICategoryPlugin
-
-class AWSAPICategoryPluginConfigurationTests: XCTestCase {
+class CoreMLPredictionsPluginConfigTests: XCTestCase {
 
     func testThrowsOnMissingConfig() throws {
-        let plugin = AWSAPIPlugin()
+        let plugin = CoreMLPredictionsPlugin()
         try Amplify.add(plugin: plugin)
 
-        let categoryConfig = APICategoryConfiguration(plugins: ["NonExistentPlugin": true])
-        let amplifyConfig = AmplifyConfiguration(api: categoryConfig)
+        let categoryConfig = PredictionsCategoryConfiguration(plugins: ["NonExistentPlugin": true])
+        let amplifyConfig = AmplifyConfiguration(predictions: categoryConfig)
         do {
             try Amplify.configure(amplifyConfig)
             XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/CoreMLPredictionsPluginConfigTests.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/CoreMLPredictionsPluginConfigTests.swift
@@ -21,10 +21,9 @@ class CoreMLPredictionsPluginConfigTests: XCTestCase {
             try Amplify.configure(amplifyConfig)
             XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")
         } catch {
-            if case PluginError.pluginConfigurationError = error {
-                // Pass
-            } else {
+            guard case PluginError.pluginConfigurationError = error else {
                 XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")
+                return
             }
         }
     }

--- a/AmplifyPlugins/Predictions/PredictionsCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Predictions/PredictionsCategoryPlugin.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		B4E26A7C2384536400739926 /* CoreMLIdentifyOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E26A7B2384536400739926 /* CoreMLIdentifyOperation.swift */; };
 		D432BCA8697EDA48BB605DA8 /* Pods_HostApp_AWSPredictionsPluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E04A7C1995F7FD1ABC3831B /* Pods_HostApp_AWSPredictionsPluginTests.framework */; };
 		DB76524284F4CBA1E0804C2B /* Pods_HostApp_CoreMLPredictionsPluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25555FEA808A4F903C517405 /* Pods_HostApp_CoreMLPredictionsPluginTests.framework */; };
+		FA6B0EAE24944B0C0062AA59 /* CoreMLPredictionsPluginConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B0EAD24944B0C0062AA59 /* CoreMLPredictionsPluginConfigTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -398,6 +399,7 @@
 		F0DAAE7DF5495F6DE92F7E15 /* Pods_HostApp_CoreMLPredictionsPluginIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_CoreMLPredictionsPluginIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F3A4D316FA982CF18EC74334 /* Pods-HostApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp.debug.xcconfig"; path = "Target Support Files/Pods-HostApp/Pods-HostApp.debug.xcconfig"; sourceTree = "<group>"; };
 		FA19C59AD570523D98521F67 /* Pods-CoreMLPredictionsPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoreMLPredictionsPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-CoreMLPredictionsPluginTests/Pods-CoreMLPredictionsPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
+		FA6B0EAD24944B0C0062AA59 /* CoreMLPredictionsPluginConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMLPredictionsPluginConfigTests.swift; sourceTree = "<group>"; };
 		FE51434D0E1DB2D8D9116A1B /* Pods-AWSPredictionsPluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSPredictionsPluginTests.release.xcconfig"; path = "Target Support Files/Pods-AWSPredictionsPluginTests/Pods-AWSPredictionsPluginTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -820,11 +822,11 @@
 		B49D1432237B665E00856777 /* AWSPredictionsPluginTests */ = {
 			isa = PBXGroup;
 			children = (
-				B461DF8F238C3D64004DED35 /* Mocks */,
-				B461DF8A238C3B0B004DED35 /* Service */,
-				B42094C12384B5D4000F98A3 /* ConfigurationTests */,
-				B49D1433237B665E00856777 /* Resources */,
 				B49D1435237B665E00856777 /* AWSPredictionsPluginTests.swift */,
+				B42094C12384B5D4000F98A3 /* ConfigurationTests */,
+				B461DF8F238C3D64004DED35 /* Mocks */,
+				B49D1433237B665E00856777 /* Resources */,
+				B461DF8A238C3B0B004DED35 /* Service */,
 			);
 			path = AWSPredictionsPluginTests;
 			sourceTree = "<group>";
@@ -934,6 +936,7 @@
 				B4DFA696237B59450013E17B /* DependencyTests */,
 				B4DFA690237B59450013E17B /* Mocks */,
 				B4DFA693237B59450013E17B /* Resources */,
+				FA6B0EAD24944B0C0062AA59 /* CoreMLPredictionsPluginConfigTests.swift */,
 			);
 			path = CoreMLPredictionsPluginTests;
 			sourceTree = "<group>";
@@ -1926,6 +1929,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B4DFA69E237B59450013E17B /* CoreMLNaturalLanguageAdapterTests.swift in Sources */,
+				FA6B0EAE24944B0C0062AA59 /* CoreMLPredictionsPluginConfigTests.swift in Sources */,
 				B4DFA69F237B59450013E17B /* CoreMLVisionAdapterTests.swift in Sources */,
 				B4DFA6A1237B59450013E17B /* CoreMLPredictionsPluginTestBase.swift in Sources */,
 				B42094C72384BA0A000F98A3 /* MockCoreMLVisionAdapter.swift in Sources */,

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin+Configure.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin+Configure.swift
@@ -20,9 +20,9 @@ extension AWSS3StoragePlugin {
     /// - Parameter configuration: The configuration specified for this plugin
     /// - Throws:
     ///   - PluginError.pluginConfigurationError: If one of the configuration values is invalid or empty
-    public func configure(using configuration: Any) throws {
+    public func configure(using configuration: Any?) throws {
         guard let config = configuration as? JSONValue else {
-            throw StorageError.configuration(PluginErrorConstants.decodeConfigurationError.errorDescription,
+            throw PluginError.pluginConfigurationError(PluginErrorConstants.decodeConfigurationError.errorDescription,
                                                        PluginErrorConstants.decodeConfigurationError.recoverySuggestion)
         }
 

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginBaseConfigTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginBaseConfigTests.swift
@@ -6,18 +6,17 @@
 //
 
 import XCTest
+import Amplify
+import AWSS3StoragePlugin
 
-@testable import Amplify
-@testable import AWSAPICategoryPlugin
-
-class AWSAPICategoryPluginConfigurationTests: XCTestCase {
+class AWSS3StoragePluginBaseConfigTests: XCTestCase {
 
     func testThrowsOnMissingConfig() throws {
-        let plugin = AWSAPIPlugin()
+        let plugin = AWSS3StoragePlugin()
         try Amplify.add(plugin: plugin)
 
-        let categoryConfig = APICategoryConfiguration(plugins: ["NonExistentPlugin": true])
-        let amplifyConfig = AmplifyConfiguration(api: categoryConfig)
+        let categoryConfig = StorageCategoryConfiguration(plugins: ["NonExistentPlugin": true])
+        let amplifyConfig = AmplifyConfiguration(storage: categoryConfig)
         do {
             try Amplify.configure(amplifyConfig)
             XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginBaseConfigTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginBaseConfigTests.swift
@@ -21,10 +21,9 @@ class AWSS3StoragePluginBaseConfigTests: XCTestCase {
             try Amplify.configure(amplifyConfig)
             XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")
         } catch {
-            if case PluginError.pluginConfigurationError = error {
-                // Pass
-            } else {
+            guard case PluginError.pluginConfigurationError = error else {
                 XCTFail("Should have thrown a pluginConfigurationError if not supplied with a plugin-specific config.")
+                return
             }
         }
     }

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginConfigureTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginConfigureTests.swift
@@ -50,7 +50,7 @@ class AWSS3StoragePluginConfigureTests: AWSS3StoragePluginTests {
 
     func testConfigureThrowsErrorForMissingConfiguration() {
         XCTAssertThrowsError(try storagePlugin.configure(using: "")) { error in
-            guard case let StorageError.configuration(errorDescription, _, _) = error else {
+            guard case let PluginError.pluginConfigurationError(errorDescription, _, _) = error else {
                 XCTFail("Expected PluginError pluginConfigurationError, got: \(error)")
                 return
             }

--- a/AmplifyPlugins/Storage/StoragePlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Storage/StoragePlugin.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		B4FEB6FE2375DA1600818CD2 /* AWSS3StorageServiceEscapeHatchBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FEB6D82375DA1500818CD2 /* AWSS3StorageServiceEscapeHatchBehaviorTests.swift */; };
 		B4FEB6FF2375DA1600818CD2 /* AWSS3StorageServiceMultiPartUploadBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FEB6D92375DA1500818CD2 /* AWSS3StorageServiceMultiPartUploadBehaviorTests.swift */; };
 		C7C8E0966435A67F3C443F6A /* Pods_AWSS3StoragePlugin_AWSS3StoragePluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A7357AE068121E124484319 /* Pods_AWSS3StoragePlugin_AWSS3StoragePluginTests.framework */; };
+		FA11225C24944BEB00492048 /* AWSS3StoragePluginBaseConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA11225B24944BEB00492048 /* AWSS3StoragePluginBaseConfigTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -268,6 +269,7 @@
 		E0B21A30E0704D952D3DE1C3 /* Pods-HostApp-AWSS3StoragePluginFunctionalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSS3StoragePluginFunctionalTests.debug.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSS3StoragePluginFunctionalTests/Pods-HostApp-AWSS3StoragePluginFunctionalTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F2499EEE6F1A16D91ABBEC87 /* Pods-AWSPinpointAnalyticsPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSPinpointAnalyticsPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-AWSPinpointAnalyticsPluginTests/Pods-AWSPinpointAnalyticsPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F899D288C85D558A4322DDB6 /* Pods-AWSS3StoragePlugin-AWSS3StoragePluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSS3StoragePlugin-AWSS3StoragePluginTests.release.xcconfig"; path = "Target Support Files/Pods-AWSS3StoragePlugin-AWSS3StoragePluginTests/Pods-AWSS3StoragePlugin-AWSS3StoragePluginTests.release.xcconfig"; sourceTree = "<group>"; };
+		FA11225B24944BEB00492048 /* AWSS3StoragePluginBaseConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3StoragePluginBaseConfigTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -561,6 +563,7 @@
 		B4FEB6AA2375DA1500818CD2 /* AWSS3StoragePluginTests */ = {
 			isa = PBXGroup;
 			children = (
+				FA11225B24944BEB00492048 /* AWSS3StoragePluginBaseConfigTests.swift */,
 				B4FEB6C12375DA1500818CD2 /* AWSS3StoragePluginClientBehaviorTests.swift */,
 				B4FEB6C02375DA1500818CD2 /* AWSS3StoragePluginConfigureTests.swift */,
 				B4FEB6BF2375DA1500818CD2 /* AWSS3StoragePluginResetTests.swift */,
@@ -1205,6 +1208,7 @@
 				B4FEB6F12375DA1600818CD2 /* AWSS3StorageRemoveRequestTests.swift in Sources */,
 				B4FEB6FC2375DA1600818CD2 /* AWSS3StorageServiceDownloadBehaviorTests.swift in Sources */,
 				B4FEB6E12375DA1500818CD2 /* AWSS3StorageGetURLOperationTests.swift in Sources */,
+				FA11225C24944BEB00492048 /* AWSS3StoragePluginBaseConfigTests.swift in Sources */,
 				B4FEB6E52375DA1500818CD2 /* AWSS3StorageOperationTestBase.swift in Sources */,
 				B4FEB6FE2375DA1600818CD2 /* AWSS3StorageServiceEscapeHatchBehaviorTests.swift in Sources */,
 				B4FEB6EE2375DA1500818CD2 /* StorageRequestUtilsGetterTests.swift in Sources */,

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -18,7 +18,7 @@ class MockAPICategoryPlugin: MessageReporter, APICategoryPlugin {
         return "MockAPICategoryPlugin"
     }
 
-    func configure(using configuration: Any) throws {
+    func configure(using configuration: Any?) throws {
         notify("configure")
     }
 

--- a/AmplifyTestCommon/Mocks/MockAnalyticsCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAnalyticsCategoryPlugin.swift
@@ -12,7 +12,7 @@ class MockAnalyticsCategoryPlugin: MessageReporter, AnalyticsCategoryPlugin {
         return "MockAnalyticsCategoryPlugin"
     }
 
-    func configure(using configuration: Any) throws {
+    func configure(using configuration: Any?) throws {
         notify()
     }
 

--- a/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
@@ -165,7 +165,7 @@ class MockAuthCategoryPlugin: MessageReporter, AuthCategoryPlugin {
         return "MockAuthCategoryPlugin"
     }
 
-    func configure(using configuration: Any) throws {
+    func configure(using configuration: Any?) throws {
         notify()
     }
 

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -14,7 +14,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         return "MockDataStoreCategoryPlugin"
     }
 
-    func configure(using configuration: Any) throws {
+    func configure(using configuration: Any?) throws {
         notify()
     }
 

--- a/AmplifyTestCommon/Mocks/MockHubCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockHubCategoryPlugin.swift
@@ -14,7 +14,7 @@ class MockHubCategoryPlugin: MessageReporter, HubCategoryPlugin {
         return "MockHubCategoryPlugin"
     }
 
-    func configure(using configuration: Any) throws {
+    func configure(using configuration: Any?) throws {
         notify()
     }
 

--- a/AmplifyTestCommon/Mocks/MockLoggingCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockLoggingCategoryPlugin.swift
@@ -26,7 +26,7 @@ class MockLoggingCategoryPlugin: MessageReporter, LoggingCategoryPlugin, Logger 
         return "MockLoggingCategoryPlugin"
     }
 
-    func configure(using configuration: Any) throws {
+    func configure(using configuration: Any?) throws {
         notify()
     }
 
@@ -36,27 +36,27 @@ class MockLoggingCategoryPlugin: MessageReporter, LoggingCategoryPlugin, Logger 
     }
 
     func error(_ message: @autoclosure () -> String) {
-        notify()
+        notify("\(#function): \(message())")
     }
 
     func error(error: Error) {
-        notify()
+        notify("error(error:): \(error)")
     }
 
     func warn(_ message: @autoclosure () -> String) {
-        notify()
+        notify("\(#function): \(message())")
     }
 
     func info(_ message: @autoclosure () -> String) {
-        notify()
+        notify("\(#function): \(message())")
     }
 
     func debug(_ message: @autoclosure () -> String) {
-        notify()
+        notify("\(#function): \(message())")
     }
 
     func verbose(_ message: @autoclosure () -> String) {
-        notify()
+        notify("\(#function): \(message())")
     }
 }
 

--- a/AmplifyTestCommon/Mocks/MockPredictionsCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockPredictionsCategoryPlugin.swift
@@ -11,7 +11,7 @@ import Foundation
 
 class MockPredictionsCategoryPlugin: MessageReporter, PredictionsCategoryPlugin {
 
-    func configure(using configuration: Any) throws {
+    func configure(using configuration: Any?) throws {
         notify()
     }
 

--- a/AmplifyTestCommon/Mocks/MockStorageCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockStorageCategoryPlugin.swift
@@ -87,7 +87,7 @@ class MockStorageCategoryPlugin: MessageReporter, StorageCategoryPlugin {
         return "MockStorageCategoryPlugin"
     }
 
-    func configure(using configuration: Any) throws {
+    func configure(using configuration: Any?) throws {
         notify()
     }
 

--- a/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
@@ -316,4 +316,37 @@ class APICategoryConfigurationTests: XCTestCase {
         XCTAssertFalse(category.isConfigured)
     }
 
+    /// Test that Amplify logs a warning if it encounters a plugin configuration key without a corresponding plugin
+    ///
+    /// - Given:
+    ///   - A configuration with a nonexistent plugin key specified
+    /// - When:
+    ///    - I invoke `Amplify.configure()`
+    /// - Then:
+    ///    - I should see a log warning
+    ///
+    func testWarnsOnMissingPlugin() throws {
+        let warningReceived = expectation(description: "Warning message received")
+
+        let loggingPlugin = MockLoggingCategoryPlugin()
+        loggingPlugin.listeners.append { message in
+            if message.starts(with: "warn(_:): No plugin found") {
+                warningReceived.fulfill()
+            }
+        }
+        let loggingConfig = LoggingCategoryConfiguration(
+            plugins: [loggingPlugin.key: true]
+        )
+        try Amplify.add(plugin: loggingPlugin)
+
+        let categoryConfig = APICategoryConfiguration(
+            plugins: ["NonExistentPlugin": true]
+        )
+
+        let amplifyConfig = AmplifyConfiguration(api: categoryConfig, logging: loggingConfig)
+
+        try Amplify.configure(amplifyConfig)
+
+        waitForExpectations(timeout: 0.1)
+    }
 }

--- a/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryConfigurationTests.swift
@@ -259,4 +259,38 @@ class AnalyticsCategoryConfigurationTests: XCTestCase {
         XCTAssertNoThrow(try Amplify.Analytics.configure(using: categoryConfig))
     }
 
+    /// Test that Amplify logs a warning if it encounters a plugin configuration key without a corresponding plugin
+    ///
+    /// - Given:
+    ///   - A configuration with a nonexistent plugin key specified
+    /// - When:
+    ///    - I invoke `Amplify.configure()`
+    /// - Then:
+    ///    - I should see a log warning
+    ///
+    func testWarnsOnMissingPlugin() throws {
+        let warningReceived = expectation(description: "Warning message received")
+
+        let loggingPlugin = MockLoggingCategoryPlugin()
+        loggingPlugin.listeners.append { message in
+            if message.starts(with: "warn(_:): No plugin found") {
+                warningReceived.fulfill()
+            }
+        }
+        let loggingConfig = LoggingCategoryConfiguration(
+            plugins: [loggingPlugin.key: true]
+        )
+        try Amplify.add(plugin: loggingPlugin)
+
+        let categoryConfig = AnalyticsCategoryConfiguration(
+            plugins: ["NonExistentPlugin": true]
+        )
+
+        let amplifyConfig = AmplifyConfiguration(analytics: categoryConfig, logging: loggingConfig)
+
+        try Amplify.configure(amplifyConfig)
+
+        waitForExpectations(timeout: 0.1)
+    }
+
 }

--- a/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
@@ -358,4 +358,38 @@ class AuthCategoryConfigurationTests: XCTestCase {
         XCTAssertNil(exception)
     }
 
+    /// Test that Amplify logs a warning if it encounters a plugin configuration key without a corresponding plugin
+    ///
+    /// - Given:
+    ///   - A configuration with a nonexistent plugin key specified
+    /// - When:
+    ///    - I invoke `Amplify.configure()`
+    /// - Then:
+    ///    - I should see a log warning
+    ///
+    func testWarnsOnMissingPlugin() throws {
+        let warningReceived = expectation(description: "Warning message received")
+
+        let loggingPlugin = MockLoggingCategoryPlugin()
+        loggingPlugin.listeners.append { message in
+            if message.starts(with: "warn(_:): No plugin found") {
+                warningReceived.fulfill()
+            }
+        }
+        let loggingConfig = LoggingCategoryConfiguration(
+            plugins: [loggingPlugin.key: true]
+        )
+        try Amplify.add(plugin: loggingPlugin)
+
+        let categoryConfig = AuthCategoryConfiguration(
+            plugins: ["NonExistentPlugin": true]
+        )
+
+        let amplifyConfig = AmplifyConfiguration(auth: categoryConfig, logging: loggingConfig)
+
+        try Amplify.configure(amplifyConfig)
+
+        waitForExpectations(timeout: 0.1)
+    }
+
 }

--- a/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
@@ -278,4 +278,38 @@ class DataStoreCategoryConfigurationTests: XCTestCase {
         XCTAssertNoThrow(try Amplify.DataStore.configure(using: categoryConfig))
     }
 
+    /// Test that Amplify logs a warning if it encounters a plugin configuration key without a corresponding plugin
+    ///
+    /// - Given:
+    ///   - A configuration with a nonexistent plugin key specified
+    /// - When:
+    ///    - I invoke `Amplify.configure()`
+    /// - Then:
+    ///    - I should see a log warning
+    ///
+    func testWarnsOnMissingPlugin() throws {
+        let warningReceived = expectation(description: "Warning message received")
+
+        let loggingPlugin = MockLoggingCategoryPlugin()
+        loggingPlugin.listeners.append { message in
+            if message.starts(with: "warn(_:): No plugin found") {
+                warningReceived.fulfill()
+            }
+        }
+        let loggingConfig = LoggingCategoryConfiguration(
+            plugins: [loggingPlugin.key: true]
+        )
+        try Amplify.add(plugin: loggingPlugin)
+
+        let categoryConfig = DataStoreCategoryConfiguration(
+            plugins: ["NonExistentPlugin": true]
+        )
+
+        let amplifyConfig = AmplifyConfiguration(dataStore: categoryConfig, logging: loggingConfig)
+
+        try Amplify.configure(amplifyConfig)
+
+        waitForExpectations(timeout: 0.1)
+    }
+
 }

--- a/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
@@ -112,7 +112,7 @@ class MockDispatchingStoragePlugin: StorageCategoryPlugin {
 
     let queue = DispatchQueue(label: "MockDispatchingStoragePlugin.dispatch")
 
-    func configure(using configuration: Any) throws {}
+    func configure(using configuration: Any?) throws {}
 
     func getURL(key: String,
                 options: StorageGetURLRequest.Options? = nil,

--- a/AmplifyTests/CategoryTests/Logging/LoggingCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Logging/LoggingCategoryConfigurationTests.swift
@@ -142,7 +142,7 @@ class LoggingCategoryConfigurationTests: XCTestCase {
         let plugin = MockLoggingCategoryPlugin()
         let methodInvokedOnDefaultPlugin = expectation(description: "test method invoked on default plugin")
         plugin.listeners.append { message in
-            if message == "error(_:)" {
+            if message.starts(with: "error(_:)") {
                 methodInvokedOnDefaultPlugin.fulfill()
             }
         }
@@ -164,7 +164,7 @@ class LoggingCategoryConfigurationTests: XCTestCase {
             expectation(description: "test method should not be invoked on default plugin")
         methodShouldNotBeInvokedOnDefaultPlugin.isInverted = true
         plugin1.listeners.append { message in
-            if message == "error(_:)" {
+            if message.starts(with: "error(_:)") {
                 methodShouldNotBeInvokedOnDefaultPlugin.fulfill()
             }
         }
@@ -174,7 +174,7 @@ class LoggingCategoryConfigurationTests: XCTestCase {
         let methodShouldBeInvokedOnSecondPlugin =
             expectation(description: "test method should be invoked on second plugin")
         plugin2.listeners.append { message in
-            if message == "error(_:)" {
+            if message.starts(with: "error(_:)") {
                 methodShouldBeInvokedOnSecondPlugin.fulfill()
             }
         }

--- a/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryConfigurationTests.swift
@@ -371,4 +371,38 @@ class PredictionsCategoryConfigurationTests: XCTestCase {
         XCTAssertNoThrow(try Amplify.Predictions.configure(using: config))
     }
 
+    /// Test that Amplify logs a warning if it encounters a plugin configuration key without a corresponding plugin
+    ///
+    /// - Given:
+    ///   - A configuration with a nonexistent plugin key specified
+    /// - When:
+    ///    - I invoke `Amplify.configure()`
+    /// - Then:
+    ///    - I should see a log warning
+    ///
+    func testWarnsOnMissingPlugin() throws {
+        let warningReceived = expectation(description: "Warning message received")
+
+        let loggingPlugin = MockLoggingCategoryPlugin()
+        loggingPlugin.listeners.append { message in
+            if message.starts(with: "warn(_:): No plugin found") {
+                warningReceived.fulfill()
+            }
+        }
+        let loggingConfig = LoggingCategoryConfiguration(
+            plugins: [loggingPlugin.key: true]
+        )
+        try Amplify.add(plugin: loggingPlugin)
+
+        let categoryConfig = PredictionsCategoryConfiguration(
+            plugins: ["NonExistentPlugin": true]
+        )
+
+        let amplifyConfig = AmplifyConfiguration(logging: loggingConfig, predictions: categoryConfig)
+
+        try Amplify.configure(amplifyConfig)
+
+        waitForExpectations(timeout: 0.1)
+    }
+
 }

--- a/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
@@ -260,4 +260,38 @@ class StorageCategoryConfigurationTests: XCTestCase {
         XCTAssertNoThrow(try Amplify.Storage.configure(using: categoryConfig))
     }
 
+    /// Test that Amplify logs a warning if it encounters a plugin configuration key without a corresponding plugin
+    ///
+    /// - Given:
+    ///   - A configuration with a nonexistent plugin key specified
+    /// - When:
+    ///    - I invoke `Amplify.configure()`
+    /// - Then:
+    ///    - I should see a log warning
+    ///
+    func testWarnsOnMissingPlugin() throws {
+        let warningReceived = expectation(description: "Warning message received")
+
+        let loggingPlugin = MockLoggingCategoryPlugin()
+        loggingPlugin.listeners.append { message in
+            if message.starts(with: "warn(_:): No plugin found") {
+                warningReceived.fulfill()
+            }
+        }
+        let loggingConfig = LoggingCategoryConfiguration(
+            plugins: [loggingPlugin.key: true]
+        )
+        try Amplify.add(plugin: loggingPlugin)
+
+        let categoryConfig = StorageCategoryConfiguration(
+            plugins: ["NonExistentPlugin": true]
+        )
+
+        let amplifyConfig = AmplifyConfiguration(logging: loggingConfig, storage: categoryConfig)
+
+        try Amplify.configure(amplifyConfig)
+
+        waitForExpectations(timeout: 0.1)
+    }
+
 }

--- a/AmplifyTests/CoreTests/ConfigurationTests.swift
+++ b/AmplifyTests/CoreTests/ConfigurationTests.swift
@@ -16,17 +16,18 @@ class ConfigurationTests: XCTestCase {
         Amplify.reset()
     }
 
+    // Remember, this test must be invoked with a category that doesn't include an Amplify-supplied default plugin
     func testPreconditionFailureInvokingWithNoPlugin() throws {
         let amplifyConfig = AmplifyConfiguration()
         try Amplify.configure(amplifyConfig)
 
-        // Remember, this test must be invoked with a category that doesn't include an Amplify-supplied default plugin
         let exception: BadInstructionException? = catchBadInstruction {
             _ = Amplify.API.get(request: RESTRequest()) { _ in }
         }
         XCTAssertNotNil(exception)
     }
 
+    // Remember, this test must be invoked with a category that doesn't include an Amplify-supplied default plugin
     func testPreconditionFailureInvokingBeforeConfig() throws {
         let plugin = MockAPICategoryPlugin()
         try Amplify.add(plugin: plugin)
@@ -57,24 +58,6 @@ class ConfigurationTests: XCTestCase {
 
         try Amplify.configure(amplifyConfig)
         wait(for: [configureWasInvoked], timeout: 1.0)
-    }
-
-    func testThrowsOnNonExistentPlugin() throws {
-        try Amplify.add(plugin: MockLoggingCategoryPlugin())
-
-        let loggingConfig = LoggingCategoryConfiguration(
-            plugins: ["NonExistentPlugin": true]
-        )
-
-        let amplifyConfig = AmplifyConfiguration(logging: loggingConfig)
-
-        XCTAssertThrowsError(try Amplify.configure(amplifyConfig),
-                             "Throws for nonexistent plugin") { error in
-                                guard case LoggingError.configuration = error else {
-                                    XCTFail("Should have thrown for nonexistent plugin")
-                                    return
-                                }
-        }
     }
 
     func testMultipleConfigureCallsThrowError() throws {

--- a/AmplifyTests/CoreTests/NotificationListeningAnalyticsPlugin.swift
+++ b/AmplifyTests/CoreTests/NotificationListeningAnalyticsPlugin.swift
@@ -16,7 +16,7 @@ class NotificationListeningAnalyticsPlugin: AnalyticsCategoryPlugin {
         self.notificationReceived = notificationReceived
     }
 
-    func configure(using configuration: Any) throws {
+    func configure(using configuration: Any?) throws {
         let isConfigured = HubFilters.forEventName(HubPayload.EventName.Amplify.configured)
 
         var token: UnsubscribeToken?


### PR DESCRIPTION
Previous validation logic threw an error if it encountered a configuration
stanza with no corresponding plugin registered for that key. However, the
current CLI emits some plugin keys in unexpected situations, breaking this
validation. Remediation would require a customer to edit the config file, which
is possibly dangerous, and definitely inconvenient.

This change:
- Replaces the throwing error with a logged warning when the config encounters
  an unmatched plugin key
- Changes the `Plugin.configure` signature to accept an optional `Any?`
  argument, instead of a non-optional. This will let plugins decide if they
  need to throw or not.
- Fixes a data race in hub test code
- Fix AWSCognitoAuthPlugin and AWSS3StoragePlugin to throw a PluginError
  instead of a category-specific error if they encounter an error during
  configuration

*Issue #, if available:*

#540


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
