### PR TITLE
fix:Update CoreML podspec with amplify version

### DIFF
--- a/CoreMLPredictionsPlugin.podspec
+++ b/CoreMLPredictionsPlugin.podspec
@@ -3,7 +3,7 @@ load 'build-support/dependencies.rb'
 Pod::Spec.new do |s|
   s.name         = 'CoreMLPredictionsPlugin'
 
-  s.version      = AMPLIFY_VERSION
+  s.version      = $AMPLIFY_VERSION
   s.summary      = 'Amazon Web Services Amplify for iOS.'
 
   s.description  = 'AWS Amplify for iOS provides a declarative library for application development using cloud services'
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
 
   s.source_files = 'AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/**/*.swift'
 
-  s.dependency 'Amplify', AMPLIFY_VERSION
+  s.dependency 'Amplify', $AMPLIFY_VERSION
 
 end


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add `$` in front of `AMPLIFY_VERSION` for CoreMLPredictionsPlugin.podspec

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
