### PR TITLE
Fix pod lib lint error with Podspecs with local variables

### DIFF
--- a/AWSPluginsCore.podspec
+++ b/AWSPluginsCore.podspec
@@ -6,7 +6,12 @@
 #  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
 #
 
-load 'build-support/dependencies.rb'
+# Version definitions
+$AMPLIFY_VERSION = '1.0.1'
+$AMPLIFY_RELEASE_TAG = "v#{$AMPLIFY_VERSION}"
+
+$AWS_SDK_VERSION = '2.13.4'
+$OPTIMISTIC_AWS_SDK_VERSION = "~> #{$AWS_SDK_VERSION}"
 
 Pod::Spec.new do |s|
   s.name         = 'AWSPluginsCore'
@@ -19,7 +24,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/aws-amplify/amplify-ios'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => release_tag() }
+  s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => $AMPLIFY_RELEASE_TAG }
 
   s.platform     = :ios, '11.0'
   s.swift_version = '5.0'
@@ -27,10 +32,10 @@ Pod::Spec.new do |s|
   s.source_files = 'AmplifyPlugins/Core/AWSPluginsCore/**/*.swift'
 
   s.dependency 'Amplify', $AMPLIFY_VERSION
-  s.dependency 'AWSMobileClient', optimistic_version($AWS_SDK_VERSION)
+  s.dependency 'AWSMobileClient', $OPTIMISTIC_AWS_SDK_VERSION
 
   # This is technically redundant, but adding it here allows Xcode to find it
   # during initial indexing and prevent build errors after a fresh install
-  s.dependency 'AWSCore', optimistic_version($AWS_SDK_VERSION)
+  s.dependency 'AWSCore', $OPTIMISTIC_AWS_SDK_VERSION
 
 end

--- a/AWSPredictionsPlugin.podspec
+++ b/AWSPredictionsPlugin.podspec
@@ -1,4 +1,9 @@
-load 'build-support/dependencies.rb'
+# Version definitions
+$AMPLIFY_VERSION = '1.0.1'
+$AMPLIFY_RELEASE_TAG = "v#{$AMPLIFY_VERSION}"
+
+$AWS_SDK_VERSION = '2.13.4'
+$OPTIMISTIC_AWS_SDK_VERSION = "~> #{$AWS_SDK_VERSION}"
 
 Pod::Spec.new do |s|
   s.name         = 'AWSPredictionsPlugin'
@@ -11,24 +16,24 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/aws-amplify/amplify-ios'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => release_tag() }
+  s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => $AMPLIFY_RELEASE_TAG }
 
   s.platform     = :ios, '13.0'
   s.swift_version = '5.0'
 
   s.source_files = 'AmplifyPlugins/Predictions/AWSPredictionsPlugin/**/*.swift'
 
-  s.dependency 'AWSComprehend', optimistic_version($AWS_SDK_VERSION)
+  s.dependency 'AWSComprehend', $OPTIMISTIC_AWS_SDK_VERSION
   s.dependency 'AWSPluginsCore', $AMPLIFY_VERSION
-  s.dependency 'AWSPolly', optimistic_version($AWS_SDK_VERSION)
-  s.dependency 'AWSRekognition', optimistic_version($AWS_SDK_VERSION)
-  s.dependency 'AWSTextract', optimistic_version($AWS_SDK_VERSION)
-  s.dependency 'AWSTranscribeStreaming', optimistic_version($AWS_SDK_VERSION)
-  s.dependency 'AWSTranslate', optimistic_version($AWS_SDK_VERSION)
+  s.dependency 'AWSPolly', $OPTIMISTIC_AWS_SDK_VERSION
+  s.dependency 'AWSRekognition', $OPTIMISTIC_AWS_SDK_VERSION
+  s.dependency 'AWSTextract', $OPTIMISTIC_AWS_SDK_VERSION
+  s.dependency 'AWSTranscribeStreaming', $OPTIMISTIC_AWS_SDK_VERSION
+  s.dependency 'AWSTranslate', $OPTIMISTIC_AWS_SDK_VERSION
   s.dependency 'CoreMLPredictionsPlugin', $AMPLIFY_VERSION
 
   # This is technically redundant, but adding it here allows Xcode to find it
   # during initial indexing and prevent build errors after a fresh install
-  s.dependency 'AWSCore', optimistic_version($AWS_SDK_VERSION)
+  s.dependency 'AWSCore', $OPTIMISTIC_AWS_SDK_VERSION
 
 end

--- a/Amplify.podspec
+++ b/Amplify.podspec
@@ -10,9 +10,6 @@
 $AMPLIFY_VERSION = '1.0.1'
 $AMPLIFY_RELEASE_TAG = "v#{$AMPLIFY_VERSION}"
 
-$AWS_SDK_VERSION = '2.13.4'
-$OPTIMISTIC_AWS_SDK_VERSION = "~> #{$AWS_SDK_VERSION}"
-
 Pod::Spec.new do |s|
   s.name         = 'Amplify'
   s.version      = $AMPLIFY_VERSION

--- a/Amplify.podspec
+++ b/Amplify.podspec
@@ -6,7 +6,12 @@
 #  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
 #
 
-load 'build-support/dependencies.rb'
+# Version definitions
+$AMPLIFY_VERSION = '1.0.1'
+$AMPLIFY_RELEASE_TAG = "v#{$AMPLIFY_VERSION}"
+
+$AWS_SDK_VERSION = '2.13.4'
+$OPTIMISTIC_AWS_SDK_VERSION = "~> #{$AWS_SDK_VERSION}"
 
 Pod::Spec.new do |s|
   s.name         = 'Amplify'
@@ -18,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/aws-amplify/amplify-ios'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => release_tag() }
+  s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => $AMPLIFY_RELEASE_TAG }
 
   s.platform     = :ios, '11.0'
   s.swift_version = '5.0'

--- a/AmplifyPlugins.podspec
+++ b/AmplifyPlugins.podspec
@@ -6,7 +6,12 @@
 #  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
 #
 
-load 'build-support/dependencies.rb'
+# Version definitions
+$AMPLIFY_VERSION = '1.0.1'
+$AMPLIFY_RELEASE_TAG = "v#{$AMPLIFY_VERSION}"
+
+$AWS_SDK_VERSION = '2.13.4'
+$OPTIMISTIC_AWS_SDK_VERSION = "~> #{$AWS_SDK_VERSION}"
 
 Pod::Spec.new do |s|
   s.name         = 'AmplifyPlugins'
@@ -18,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/aws-amplify/amplify-ios'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => release_tag() }
+  s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => $AMPLIFY_RELEASE_TAG }
 
   s.platform = :ios, '11.0'
   s.swift_version = '5.0'
@@ -27,7 +32,7 @@ Pod::Spec.new do |s|
 
   # This is technically redundant, but adding it here allows Xcode to find it
   # during initial indexing and prevent build errors after a fresh install
-  s.dependency 'AWSCore', optimistic_version($AWS_SDK_VERSION)
+  s.dependency 'AWSCore', $OPTIMISTIC_AWS_SDK_VERSION
 
   s.subspec 'AWSAPIPlugin' do |ss|
     ss.source_files = 'AmplifyPlugins/API/AWSAPICategoryPlugin/**/*.swift'
@@ -37,11 +42,11 @@ Pod::Spec.new do |s|
 
   s.subspec 'AWSCognitoAuthPlugin' do |ss|
     ss.source_files = 'AmplifyPlugins/Auth/AWSCognitoAuthPlugin/**/*.swift'
-    ss.dependency 'AWSMobileClient', optimistic_version($AWS_SDK_VERSION)
+    ss.dependency 'AWSMobileClient', $OPTIMISTIC_AWS_SDK_VERSION
 
     # This is technically redundant, but adding it here allows Xcode to find it
     # during initial indexing and prevent build errors after a fresh install
-    s.dependency 'AWSAuthCore', optimistic_version($AWS_SDK_VERSION)
+    s.dependency 'AWSAuthCore', $OPTIMISTIC_AWS_SDK_VERSION
 
   end
 
@@ -52,12 +57,12 @@ Pod::Spec.new do |s|
 
   s.subspec 'AWSPinpointAnalyticsPlugin' do |ss|
     ss.source_files = 'AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/**/*.swift'
-    ss.dependency 'AWSPinpoint', optimistic_version($AWS_SDK_VERSION)
+    ss.dependency 'AWSPinpoint', $OPTIMISTIC_AWS_SDK_VERSION
   end
 
   s.subspec 'AWSS3StoragePlugin' do |ss|
     ss.source_files = 'AmplifyPlugins/Storage/AWSS3StoragePlugin/**/*.swift'
-    ss.dependency 'AWSS3', optimistic_version($AWS_SDK_VERSION)
+    ss.dependency 'AWSS3', $OPTIMISTIC_AWS_SDK_VERSION
   end
 
 end

--- a/AmplifyPlugins/API/Podfile
+++ b/AmplifyPlugins/API/Podfile
@@ -25,7 +25,7 @@ target "HostApp" do
   include_test_utilities!
   pod 'AmplifyTestCommon', :path => '../../'
   pod 'Amplify', :path => '../../'
-  pod "AWSMobileClient", optimistic_version($AWS_SDK_VERSION)
+  pod "AWSMobileClient", $OPTIMISTIC_AWS_SDK_VERSION
 
   target "AWSAPICategoryPluginTestCommon" do
     inherit! :complete

--- a/AmplifyPlugins/Analytics/Podfile
+++ b/AmplifyPlugins/Analytics/Podfile
@@ -8,7 +8,7 @@ include_build_tools!
 target 'AWSPinpointAnalyticsPlugin' do
     pod 'Amplify', :path => '../../'
     pod 'AWSPluginsCore', :path => '../../'
-    pod "AWSPinpoint", optimistic_version($AWS_SDK_VERSION)
+    pod "AWSPinpoint", $OPTIMISTIC_AWS_SDK_VERSION
 end
 
 target "HostApp" do

--- a/AmplifyPlugins/Auth/Podfile
+++ b/AmplifyPlugins/Auth/Podfile
@@ -8,7 +8,7 @@ include_build_tools!
 target 'AWSCognitoAuthPlugin' do
   pod 'Amplify', :path => '../../'
   pod 'AWSPluginsCore', :path => '../../'
-  pod "AWSMobileClient", optimistic_version($AWS_SDK_VERSION)
+  pod "AWSMobileClient", $OPTIMISTIC_AWS_SDK_VERSION
 
   target "AWSCognitoAuthPluginTests" do
     inherit! :complete

--- a/AmplifyPlugins/DataStore/Podfile
+++ b/AmplifyPlugins/DataStore/Podfile
@@ -24,7 +24,7 @@ target "HostApp" do
   include_test_utilities!
   pod 'AmplifyTestCommon', :path => '../../'
   pod 'Amplify', :path => '../../'
-  pod "AWSMobileClient", optimistic_version($AWS_SDK_VERSION)
+  pod "AWSMobileClient", $OPTIMISTIC_AWS_SDK_VERSION
 
   target "AWSDataStoreCategoryPluginIntegrationTests" do
     inherit! :complete

--- a/AmplifyPlugins/Predictions/Podfile
+++ b/AmplifyPlugins/Predictions/Podfile
@@ -8,12 +8,12 @@ include_build_tools!
 target 'AWSPredictionsPlugin' do
   pod 'Amplify', :path => '../../'
   pod 'AWSPluginsCore', :path => '../../'
-  pod "AWSTranslate", optimistic_version($AWS_SDK_VERSION)
-  pod "AWSRekognition", optimistic_version($AWS_SDK_VERSION)
-  pod "AWSPolly", optimistic_version($AWS_SDK_VERSION)
-  pod "AWSComprehend", optimistic_version($AWS_SDK_VERSION)
-  pod "AWSTranscribeStreaming", optimistic_version($AWS_SDK_VERSION)
-  pod "AWSTextract", optimistic_version($AWS_SDK_VERSION)
+  pod "AWSTranslate", $OPTIMISTIC_AWS_SDK_VERSION
+  pod "AWSRekognition", $OPTIMISTIC_AWS_SDK_VERSION
+  pod "AWSPolly", $OPTIMISTIC_AWS_SDK_VERSION
+  pod "AWSComprehend", $OPTIMISTIC_AWS_SDK_VERSION
+  pod "AWSTranscribeStreaming", $OPTIMISTIC_AWS_SDK_VERSION
+  pod "AWSTextract", $OPTIMISTIC_AWS_SDK_VERSION
 end
 
 target 'CoreMLPredictionsPlugin' do

--- a/AmplifyPlugins/Storage/Podfile
+++ b/AmplifyPlugins/Storage/Podfile
@@ -8,7 +8,7 @@ include_build_tools!
 target 'AWSS3StoragePlugin' do
 	pod 'Amplify', :path => '../../'
   pod 'AWSPluginsCore', :path => '../../'
-  pod "AWSS3", optimistic_version($AWS_SDK_VERSION)
+  pod "AWSS3", $OPTIMISTIC_AWS_SDK_VERSION
 
   target "AWSS3StoragePluginTests" do
     inherit! :complete

--- a/AmplifyTestCommon.podspec
+++ b/AmplifyTestCommon.podspec
@@ -6,7 +6,12 @@
 #  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
 #
 
-load 'build-support/dependencies.rb'
+# Version definitions
+$AMPLIFY_VERSION = '1.0.1'
+$AMPLIFY_RELEASE_TAG = "v#{$AMPLIFY_VERSION}"
+
+$AWS_SDK_VERSION = '2.13.4'
+$OPTIMISTIC_AWS_SDK_VERSION = "~> #{$AWS_SDK_VERSION}"
 
 Pod::Spec.new do |s|
   s.name         = "AmplifyTestCommon"
@@ -18,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage     = "hhttps://github.com/aws-amplify/amplify-ios"
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => release_tag() }
+  s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => $AMPLIFY_RELEASE_TAG }
 
   s.platform     = :ios, '11.0'
   s.swift_version = '5.0'
@@ -30,7 +35,7 @@ Pod::Spec.new do |s|
   s.subspec 'AWSPluginsTestCommon' do |ss|
     ss.source_files = 'AmplifyPlugins/Core/AWSPluginsTestCommon/**/*.swift'
     ss.dependency 'AWSPluginsCore', $AMPLIFY_VERSION
-    ss.dependency 'AWSCore', optimistic_version($AWS_SDK_VERSION)
+    ss.dependency 'AWSCore', $OPTIMISTIC_AWS_SDK_VERSION
   end
 
 end

--- a/CoreMLPredictionsPlugin.podspec
+++ b/CoreMLPredictionsPlugin.podspec
@@ -2,9 +2,6 @@
 $AMPLIFY_VERSION = '1.0.1'
 $AMPLIFY_RELEASE_TAG = "v#{$AMPLIFY_VERSION}"
 
-$AWS_SDK_VERSION = '2.13.4'
-$OPTIMISTIC_AWS_SDK_VERSION = "~> #{$AWS_SDK_VERSION}"
-
 Pod::Spec.new do |s|
   s.name         = 'CoreMLPredictionsPlugin'
 

--- a/CoreMLPredictionsPlugin.podspec
+++ b/CoreMLPredictionsPlugin.podspec
@@ -1,4 +1,9 @@
-load 'build-support/dependencies.rb'
+# Version definitions
+$AMPLIFY_VERSION = '1.0.1'
+$AMPLIFY_RELEASE_TAG = "v#{$AMPLIFY_VERSION}"
+
+$AWS_SDK_VERSION = '2.13.4'
+$OPTIMISTIC_AWS_SDK_VERSION = "~> #{$AWS_SDK_VERSION}"
 
 Pod::Spec.new do |s|
   s.name         = 'CoreMLPredictionsPlugin'
@@ -11,7 +16,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/aws-amplify/amplify-ios'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => release_tag() }
+  s.source       = { :git => 'https://github.com/aws-amplify/amplify-ios.git', :tag => $AMPLIFY_RELEASE_TAG }
 
   s.platform     = :ios, '13.0'
   s.swift_version = '5.0'

--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ target "Amplify" do
 
   abstract_target "AmplifyTestConfigs" do
     include_test_utilities!
-    pod "AWSMobileClient", optimistic_version($AWS_SDK_VERSION)
+    pod "AWSMobileClient", $OPTIMISTIC_AWS_SDK_VERSION
     
     target "AmplifyTestCommon" do
     end
@@ -27,7 +27,7 @@ target "Amplify" do
     inherit! :complete
     use_frameworks!
 
-    pod "AWSMobileClient", optimistic_version($AWS_SDK_VERSION)
+    pod "AWSMobileClient", $OPTIMISTIC_AWS_SDK_VERSION
 
     abstract_target "AWSPluginsTestConfigs" do
       include_test_utilities!
@@ -45,6 +45,6 @@ end
 
 target "AmplifyTestApp" do
   use_frameworks!
-  pod "AWSMobileClient", optimistic_version($AWS_SDK_VERSION)
+  pod "AWSMobileClient", $OPTIMISTIC_AWS_SDK_VERSION
   include_test_utilities!
 end

--- a/build-support/dependencies.rb
+++ b/build-support/dependencies.rb
@@ -1,16 +1,15 @@
 # Version definitions
-$AMPLIFY_VERSION = '1.0.1'
-$AWS_SDK_VERSION = '2.13.4'
 
-# http://guides.cocoapods.org/using/the-podfile.html#specifying-pod-versions
-def optimistic_version(pod_version)
-  "~> #{pod_version}"
-end
+# Amplify release version
+$AMPLIFY_VERSION = '1.0.1'
 
 # GitHub tag name for Amplify releases
-def release_tag
-  "v#{$AMPLIFY_VERSION}"
-end
+$AMPLIFY_RELEASE_TAG = "v#{$AMPLIFY_VERSION}"
+
+# AWS SDK version
+# http://guides.cocoapods.org/using/the-podfile.html#specifying-pod-versions
+$AWS_SDK_VERSION = '2.13.4'
+$OPTIMISTIC_AWS_SDK_VERSION = "~> #{$AWS_SDK_VERSION}"
 
 # Include common tooling
 def include_build_tools!


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Removed loading of the ruby script from PodSpec files. There were some unknown DSL errors when running `pod lib lint` as dependnecies aren't referencable by just including the file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
