### PR TITLE
ci: update to latest release_actions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/aws-amplify/amplify-ci-support
-  revision: 96a3d15ad39b56bce95b10bc97cbfea08d44c139
+  revision: d6ccaffae0c1fd6426d9209fffa04f7300377726
   branch: master
   glob: src/fastlane/release_actions/*.gemspec
   specs:
-    fastlane-plugin-release_actions (1.0.2)
+    fastlane-plugin-release_actions (1.0.3)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
issue with getting last tag correctly has been fixed in release_actions. Updating the version here

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
