### PR TITLE
fix(auth): User pool token, user sub should be returned for signedIn user with no identityPool config

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedInSession.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedInSession.swift
@@ -112,7 +112,7 @@ extension AuthorizationProviderAdapter {
                 if let urlError = error as NSError?, urlError.domain == NSURLErrorDomain {
                     self.fetchSignedInSessionWithOfflineError(completionHandler)
 
-                } else if !self.identityPoolConfigured(error: error!) {
+                } else if self.isErrorCausedByMisconfiguredIdentityPool(error!) {
                     self.fetchSignedInSessionWithNoIdentityPool(withTokensResult: tokenResult,
                                                                 userSubResult: userSubResult,
                                                                 completionHandler)
@@ -221,17 +221,17 @@ extension AuthorizationProviderAdapter {
         completionHandler(.success(authSession))
     }
 
-    /// Check if the error is related to improper configuration of Cognito Identity Pool
-    private func identityPoolConfigured(error: Error) -> Bool {
+    /// Check if the error is caused by improper configuration of Cognito Identity Pool
+    private func isErrorCausedByMisconfiguredIdentityPool(_ error: Error) -> Bool {
         if let awsMobileClientError = error as? AWSMobileClientError,
             case .cognitoIdentityPoolNotConfigured = awsMobileClientError {
-            return false
+            return true
         }
         if let cognitoIdentityPoolError = error as NSError?,
             cognitoIdentityPoolError.domain == AWSCognitoIdentityErrorDomain,
             cognitoIdentityPoolError.code == AWSCognitoIdentityErrorType.notAuthorized.rawValue {
-            return false
+            return true
         }
-        return true
+        return false
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedInSession.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedInSession.swift
@@ -221,7 +221,6 @@ extension AuthorizationProviderAdapter {
         completionHandler(.success(authSession))
     }
 
-    /// Check if the error is caused by improper configuration of Cognito Identity Pool
     private func isErrorCausedByMisconfiguredIdentityPool(_ error: Error) -> Bool {
         if let awsMobileClientError = error as? AWSMobileClientError,
             case .cognitoIdentityPoolNotConfigured = awsMobileClientError {

--- a/AmplifyPlugins/Auth/Podfile.lock
+++ b/AmplifyPlugins/Auth/Podfile.lock
@@ -9,16 +9,16 @@ PODS:
     - Amplify (= 1.0.4)
     - AWSCore (~> 2.14.0)
     - AWSPluginsCore (= 1.0.4)
-  - AWSAuthCore (2.14.0):
-    - AWSCore (= 2.14.0)
-  - AWSCognitoIdentityProvider (2.14.0):
+  - AWSAuthCore (2.14.2):
+    - AWSCore (= 2.14.2)
+  - AWSCognitoIdentityProvider (2.14.2):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.14.0)
+    - AWSCore (= 2.14.2)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.14.0)
-  - AWSMobileClient (2.14.0):
-    - AWSAuthCore (= 2.14.0)
-    - AWSCognitoIdentityProvider (= 2.14.0)
+  - AWSCore (2.14.2)
+  - AWSMobileClient (2.14.2):
+    - AWSAuthCore (= 2.14.2)
+    - AWSCognitoIdentityProvider (= 2.14.2)
   - AWSPluginsCore (1.0.4):
     - Amplify (= 1.0.4)
     - AWSCore (~> 2.14.0)
@@ -26,7 +26,7 @@ PODS:
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
-  - SwiftFormat/CLI (0.44.14)
+  - SwiftFormat/CLI (0.44.16)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -74,15 +74,15 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Amplify: 7626e435f3e78ac3508252557e375f994d5d5154
   AmplifyTestCommon: fb6f2e2e876cd4ec582c55e9bf7cb0bfe2ae21e9
-  AWSAuthCore: 6b337af04751dcbb4bc50f18dbed0343ba345e17
-  AWSCognitoIdentityProvider: bd4cf5f70b9224b1ea42b423a75716cafb8f7ac4
+  AWSAuthCore: 7ab6f5ab60ba8bb91a4868581946a993cbbae76d
+  AWSCognitoIdentityProvider: 609856c741ef86037055223b3a46f4eeb49319d0
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: 6398ca88010f34653a07d54a252affe920a99965
-  AWSMobileClient: 0f4ae3f60722fc2cec7ca926fd442ff55a2154a5
+  AWSCore: 80da498ab0979e77dbdc7690a61ceaaccfb0499a
+  AWSMobileClient: b80f21439aa95df2375e7acdde76d2f60c12f4b7
   AWSPluginsCore: 646f8c2d831a52f2293da0dfd59a31eee61f6ad5
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
-  SwiftFormat: a5ab293a7f6a812bec6f4ffc5507b7ed08f7f6e1
+  SwiftFormat: c44bd17c23f237956f67205a422a1bd352d42e4c
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 371cf67fe35ebb5167d0880bad12b01618a0fb0e


### PR DESCRIPTION
*Description of changes:*

Amplify can be used with only Cognito User Pool configured. With the configuration structure shown below. In this case while calling the api `fetchAuthSession` the returned result doesnot provide the right values for usersub and cognito tokens. This PR fixes this behavior.

```

{
    "UserAgent": "aws-amplify-cli/2.0",
    "Version": "1.0",
    "auth": {
        "plugins": {
            "awsCognitoAuthPlugin": {
                "UserAgent": "aws-amplify/cli",
                "Version": "0.1.0",
                "IdentityManager": {
                    "Default": {}
                },
                
                "CognitoUserPool": {
                    "Default": {
                        "PoolId": "xx",
                        "AppClientId": "xx",
                        "AppClientSecret": "xx",
                        "Region": "xx"
                    }
                },
                "Auth": {
                    "Default": {
                        "OAuth": {
                            ...
                            
                        },
                        "authenticationFlowType": "USER_SRP_AUTH"
                    }
                }
            }
        }
    }
}

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
