### PR TITLE
fix(auth): Fix an issue that prevents signInWithWebUI to present over a presenting vc

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -138,7 +138,7 @@ extension AuthenticationProviderAdapter {
         navController.isNavigationBarHidden = true
         navController.modalPresentationStyle = .overCurrentContext
 
-        // Get a valid controller to present the view controller.
+        // Get top most view controller to present a navController
         var parentViewController = window.rootViewController
         while ((parentViewController?.presentedViewController) != nil) {
             parentViewController = parentViewController?.presentedViewController

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -137,7 +137,14 @@ extension AuthenticationProviderAdapter {
         let navController = UINavigationController(rootViewController: UIViewController())
         navController.isNavigationBarHidden = true
         navController.modalPresentationStyle = .overCurrentContext
-        window.rootViewController?.present(navController, animated: false, completion: {
+
+        // Get a valid controller to present the view controller.
+        var parentViewController = window.rootViewController
+        while ((parentViewController?.presentedViewController) != nil) {
+            parentViewController = parentViewController?.presentedViewController
+        }
+
+        parentViewController?.present(navController, animated: false, completion: {
 
             self.awsMobileClient.showSignIn(navigationController: navController,
                                             signInUIOptions: SignInUIOptions(),


### PR DESCRIPTION
*Issue :*  https://github.com/aws-amplify/amplify-ios/issues/569, https://github.com/aws-amplify/amplify-ios/issues/623

*Description of changes:* 
Amplify.Auth.signInWithWebUI was not presenting properly if there is already a view controller presented. This change will try to figure out the top presenting view controller and then present the sign in UI over it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
