### PR TITLE
fix: Plugins that are not configured correctly will be error at initial step

### DIFF
--- a/Amplify/Categories/API/Internal/APICategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/API/Internal/APICategory+CategoryConfigurable.swift
@@ -7,7 +7,7 @@
 
 extension AmplifyAPICategory: CategoryConfigurable {
 
-    func configure(using configuration: CategoryConfiguration) throws {
+    func configure(using configuration: CategoryConfiguration?) throws {
         guard !isConfigured else {
             let error = ConfigurationError.amplifyAlreadyConfigured(
                 "\(categoryType.displayName) has already been configured.",
@@ -22,10 +22,7 @@ extension AmplifyAPICategory: CategoryConfigurable {
     }
 
     func configure(using amplifyConfiguration: AmplifyConfiguration) throws {
-        guard let configuration = categoryConfiguration(from: amplifyConfiguration) else {
-            return
-        }
-        try configure(using: configuration)
+        try configure(using: categoryConfiguration(from: amplifyConfiguration))
     }
 
 }

--- a/Amplify/Categories/Analytics/Internal/AnalyticsCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Analytics/Internal/AnalyticsCategory+CategoryConfigurable.swift
@@ -7,7 +7,7 @@
 
 extension AnalyticsCategory: CategoryConfigurable {
 
-    func configure(using configuration: CategoryConfiguration) throws {
+    func configure(using configuration: CategoryConfiguration?) throws {
         guard !isConfigured else {
             let error = ConfigurationError.amplifyAlreadyConfigured(
                 "\(categoryType.displayName) has already been configured.",

--- a/Amplify/Categories/Analytics/Internal/AnalyticsCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Analytics/Internal/AnalyticsCategory+CategoryConfigurable.swift
@@ -22,10 +22,7 @@ extension AnalyticsCategory: CategoryConfigurable {
     }
 
     func configure(using amplifyConfiguration: AmplifyConfiguration) throws {
-        guard let configuration = categoryConfiguration(from: amplifyConfiguration) else {
-            return
-        }
-        try configure(using: configuration)
+        try configure(using: categoryConfiguration(from: amplifyConfiguration))
     }
 
 }

--- a/Amplify/Categories/Auth/Internal/AuthCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Auth/Internal/AuthCategory+CategoryConfigurable.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension AuthCategory: CategoryConfigurable {
 
-    func configure(using configuration: CategoryConfiguration) throws {
+    func configure(using configuration: CategoryConfiguration?) throws {
         guard !isConfigured else {
             let error = ConfigurationError.amplifyAlreadyConfigured(
                 "\(categoryType.displayName) has already been configured.",

--- a/Amplify/Categories/Auth/Internal/AuthCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Auth/Internal/AuthCategory+CategoryConfigurable.swift
@@ -24,9 +24,6 @@ extension AuthCategory: CategoryConfigurable {
     }
 
     func configure(using amplifyConfiguration: AmplifyConfiguration) throws {
-        guard let configuration = categoryConfiguration(from: amplifyConfiguration) else {
-            return
-        }
-        try configure(using: configuration)
+        try configure(using: categoryConfiguration(from: amplifyConfiguration))
     }
 }

--- a/Amplify/Categories/DataStore/Internal/DataStoreCategory+Configurable.swift
+++ b/Amplify/Categories/DataStore/Internal/DataStoreCategory+Configurable.swift
@@ -15,7 +15,7 @@ extension DataStoreCategory: CategoryConfigurable {
         }
     }
 
-    func configure(using configuration: CategoryConfiguration) throws {
+    func configure(using configuration: CategoryConfiguration?) throws {
         guard !isConfigured else {
             let error = ConfigurationError.amplifyAlreadyConfigured(
                 "\(categoryType.displayName) has already been configured.",

--- a/Amplify/Categories/Hub/Internal/HubCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Hub/Internal/HubCategory+CategoryConfigurable.swift
@@ -9,7 +9,7 @@ extension HubCategory: CategoryConfigurable {
 
     /// Configures the HubCategory using the incoming CategoryConfiguration. If the incoming configuration does not
     /// specify a Hub plugin, then we will inject the AWSHubPlugin.
-    func configure(using configuration: CategoryConfiguration) throws {
+    func configure(using configuration: CategoryConfiguration?) throws {
         guard configurationState != .configured else {
             let error = ConfigurationError.amplifyAlreadyConfigured(
                 "\(categoryType.displayName) has already been configured.",

--- a/Amplify/Categories/Hub/Internal/HubCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Hub/Internal/HubCategory+CategoryConfigurable.swift
@@ -24,10 +24,7 @@ extension HubCategory: CategoryConfigurable {
     }
 
     func configure(using amplifyConfiguration: AmplifyConfiguration) throws {
-        guard let configuration = categoryConfiguration(from: amplifyConfiguration) else {
-            return
-        }
-        try configure(using: configuration)
+        try configure(using: categoryConfiguration(from: amplifyConfiguration))
     }
 
 }

--- a/Amplify/Categories/Logging/Internal/LoggingCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Logging/Internal/LoggingCategory+CategoryConfigurable.swift
@@ -33,10 +33,7 @@ extension LoggingCategory: CategoryConfigurable {
     }
 
     func configure(using amplifyConfiguration: AmplifyConfiguration) throws {
-        guard let configuration = categoryConfiguration(from: amplifyConfiguration) else {
-            return
-        }
-        try configure(using: configuration)
+        try configure(using: categoryConfiguration(from: amplifyConfiguration))
     }
 
 }

--- a/Amplify/Categories/Logging/Internal/LoggingCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Logging/Internal/LoggingCategory+CategoryConfigurable.swift
@@ -8,7 +8,7 @@
 extension LoggingCategory: CategoryConfigurable {
 
     /// Configures the LoggingCategory using the incoming CategoryConfiguration.
-    func configure(using configuration: CategoryConfiguration) throws {
+    func configure(using configuration: CategoryConfiguration?) throws {
         try concurrencyQueue.sync {
             let plugin: LoggingCategoryPlugin
             switch configurationState {
@@ -26,7 +26,7 @@ extension LoggingCategory: CategoryConfigurable {
                 throw error
             }
 
-            try plugin.configure(using: configuration.plugins[plugin.key])
+            try plugin.configure(using: configuration?.plugins[plugin.key])
             self.plugin = plugin
             configurationState = .configured
         }

--- a/Amplify/Categories/Predictions/Internal/PredictionsCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Predictions/Internal/PredictionsCategory+CategoryConfigurable.swift
@@ -22,10 +22,7 @@ extension PredictionsCategory: CategoryConfigurable {
     }
 
     func configure(using amplifyConfiguration: AmplifyConfiguration) throws {
-        guard let configuration = categoryConfiguration(from: amplifyConfiguration) else {
-            return
-        }
-        try configure(using: configuration)
+        try configure(using: categoryConfiguration(from: amplifyConfiguration))
     }
 
 }

--- a/Amplify/Categories/Predictions/Internal/PredictionsCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Predictions/Internal/PredictionsCategory+CategoryConfigurable.swift
@@ -7,7 +7,7 @@
 
 extension PredictionsCategory: CategoryConfigurable {
 
-    func configure(using configuration: CategoryConfiguration) throws {
+    func configure(using configuration: CategoryConfiguration?) throws {
         guard !isConfigured else {
             let error = ConfigurationError.amplifyAlreadyConfigured(
                 "\(categoryType.displayName) has already been configured.",

--- a/Amplify/Categories/Storage/Internal/StorageCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Storage/Internal/StorageCategory+CategoryConfigurable.swift
@@ -22,10 +22,7 @@ extension StorageCategory: CategoryConfigurable {
     }
 
     func configure(using amplifyConfiguration: AmplifyConfiguration) throws {
-        guard let configuration = categoryConfiguration(from: amplifyConfiguration) else {
-            return
-        }
-        try configure(using: configuration)
+        try configure(using: categoryConfiguration(from: amplifyConfiguration))
     }
 
 }

--- a/Amplify/Categories/Storage/Internal/StorageCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Storage/Internal/StorageCategory+CategoryConfigurable.swift
@@ -7,7 +7,7 @@
 
 extension StorageCategory: CategoryConfigurable {
 
-    func configure(using configuration: CategoryConfiguration) throws {
+    func configure(using configuration: CategoryConfiguration?) throws {
         guard !isConfigured else {
             let error = ConfigurationError.amplifyAlreadyConfigured(
                 "\(categoryType.displayName) has already been configured.",

--- a/Amplify/Core/Configuration/AmplifyConfiguration.swift
+++ b/Amplify/Core/Configuration/AmplifyConfiguration.swift
@@ -148,17 +148,19 @@ extension Amplify {
 
     /// Configures a list of plugins with the specified CategoryConfiguration. If any configurations do not match the
     /// specified plugins, emits a log warning.
-    static func configure(plugins: [Plugin], using configuration: CategoryConfiguration) throws {
-        var pluginConfigurations = configuration.plugins
+    static func configure(plugins: [Plugin], using configuration: CategoryConfiguration?) throws {
+        var pluginConfigurations = configuration?.plugins
 
         for plugin in plugins {
-            let pluginConfiguration = pluginConfigurations[plugin.key]
+            let pluginConfiguration = pluginConfigurations?[plugin.key]
             try plugin.configure(using: pluginConfiguration)
-            pluginConfigurations.removeValue(forKey: plugin.key)
+            pluginConfigurations?.removeValue(forKey: plugin.key)
         }
 
-        for unusedPluginKey in pluginConfigurations.keys {
-            log.warn("No plugin found for configuration key `\(unusedPluginKey)`. Add a plugin for that key.")
+        if let pluginKeys = pluginConfigurations?.keys {
+            for unusedPluginKey in pluginKeys {
+                log.warn("No plugin found for configuration key `\(unusedPluginKey)`. Add a plugin for that key.")
+            }
         }
     }
 

--- a/Amplify/Core/Configuration/Internal/CategoryConfigurable.swift
+++ b/Amplify/Core/Configuration/Internal/CategoryConfigurable.swift
@@ -13,7 +13,7 @@ protocol CategoryConfigurable: class, CategoryTypeable {
     /// Configures the category and added plugins using `configuration`
     ///
     /// - Parameter configuration: The CategoryConfiguration
-    func configure(using configuration: CategoryConfiguration) throws
+    func configure(using configuration: CategoryConfiguration?) throws
 
     /// Convenience method for configuring the category using the top-level AmplifyConfiguration
     ///

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Configure.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Configure.swift
@@ -35,8 +35,7 @@ public extension AWSAPIPlugin {
 
         let pluginConfig = try AWSAPICategoryPluginConfiguration(jsonValue: jsonValue, authService: authService)
 
-        configure(authService: authService,
-                  pluginConfig: pluginConfig)
+        configure(authService: authService, pluginConfig: pluginConfig)
 
         log.info("Configure finished")
     }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ConfigureTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ConfigureTests.swift
@@ -35,7 +35,21 @@ class AWSAPICategoryPluginConfigureTests: AWSAPICategoryPluginTestBase {
         do {
             try apiPlugin.configure(using: apiPluginConfig)
         } catch {
-            XCTFail("Failed to configure storage plugin: \(error)")
+            XCTFail("Failed to configure api plugin: \(error)")
+        }
+    }
+
+    func testConfigureFailureForNilConfiguration() throws {
+        let plugin = AWSAPIPlugin()
+        do {
+            try plugin.configure(using: nil)
+            XCTFail("Api configuration should not succeed")
+        } catch {
+            guard let apiError = error as? PluginError,
+                case .pluginConfigurationError(_, _, _) = apiError else {
+                    XCTFail("Should throw invalidConfiguration exception. But received \(error) ")
+                    return
+            }
         }
     }
 

--- a/AmplifyPlugins/API/Podfile.lock
+++ b/AmplifyPlugins/API/Podfile.lock
@@ -16,16 +16,16 @@ PODS:
     - AWSPluginsCore (= 1.0.4)
   - AppSyncRealTimeClient (1.1.6):
     - Starscream (= 3.0.6)
-  - AWSAuthCore (2.14.0):
-    - AWSCore (= 2.14.0)
-  - AWSCognitoIdentityProvider (2.14.0):
+  - AWSAuthCore (2.14.2):
+    - AWSCore (= 2.14.2)
+  - AWSCognitoIdentityProvider (2.14.2):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.14.0)
+    - AWSCore (= 2.14.2)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.14.0)
-  - AWSMobileClient (2.14.0):
-    - AWSAuthCore (= 2.14.0)
-    - AWSCognitoIdentityProvider (= 2.14.0)
+  - AWSCore (2.14.2)
+  - AWSMobileClient (2.14.2):
+    - AWSAuthCore (= 2.14.2)
+    - AWSCognitoIdentityProvider (= 2.14.2)
   - AWSPluginsCore (1.0.4):
     - Amplify (= 1.0.4)
     - AWSCore (~> 2.14.0)
@@ -35,7 +35,7 @@ PODS:
     - CwlCatchException
   - ReachabilitySwift (5.0.0)
   - Starscream (3.0.6)
-  - SwiftFormat/CLI (0.44.14)
+  - SwiftFormat/CLI (0.44.17)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -93,17 +93,17 @@ SPEC CHECKSUMS:
   AmplifyPlugins: aba4f9e4432ebc089aaea45722d2c5711d3e58f4
   AmplifyTestCommon: fb6f2e2e876cd4ec582c55e9bf7cb0bfe2ae21e9
   AppSyncRealTimeClient: 4a2ccdc1722750a1f4d76e216f9bfb1cf12f10de
-  AWSAuthCore: 6b337af04751dcbb4bc50f18dbed0343ba345e17
-  AWSCognitoIdentityProvider: bd4cf5f70b9224b1ea42b423a75716cafb8f7ac4
+  AWSAuthCore: 7ab6f5ab60ba8bb91a4868581946a993cbbae76d
+  AWSCognitoIdentityProvider: 609856c741ef86037055223b3a46f4eeb49319d0
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: 6398ca88010f34653a07d54a252affe920a99965
-  AWSMobileClient: 0f4ae3f60722fc2cec7ca926fd442ff55a2154a5
+  AWSCore: 80da498ab0979e77dbdc7690a61ceaaccfb0499a
+  AWSMobileClient: b80f21439aa95df2375e7acdde76d2f60c12f4b7
   AWSPluginsCore: 646f8c2d831a52f2293da0dfd59a31eee61f6ad5
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
-  SwiftFormat: a5ab293a7f6a812bec6f4ffc5507b7ed08f7f6e1
+  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 36210dbb4ee100c2203d947149c3f0c7628db7a3

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginConfigureTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginConfigureTests.swift
@@ -65,8 +65,8 @@ class AWSPinpointAnalyticsPluginConfigureTests: AWSPinpointAnalyticsPluginTestBa
             try plugin.configure(using: nil)
             XCTFail("Analytics configuration should not succeed")
         } catch {
-            guard let apiError = error as? PluginError,
-                case .pluginConfigurationError(_, _, _) = apiError else {
+            guard let pluginError = error as? PluginError,
+                case .pluginConfigurationError(_, _, _) = pluginError else {
                     XCTFail("Should throw invalidConfiguration exception. But received \(error) ")
                     return
             }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginConfigureTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginConfigureTests.swift
@@ -59,4 +59,17 @@ class AWSPinpointAnalyticsPluginConfigureTests: AWSPinpointAnalyticsPluginTestBa
         }
     }
 
+    func testConfigureFailureForNilConfiguration() throws {
+        let plugin = AWSPinpointAnalyticsPlugin()
+        do {
+            try plugin.configure(using: nil)
+            XCTFail("Analytics configuration should not succeed")
+        } catch {
+            guard let apiError = error as? PluginError,
+                case .pluginConfigurationError(_, _, _) = apiError else {
+                    XCTFail("Should throw invalidConfiguration exception. But received \(error) ")
+                    return
+            }
+        }
+    }
 }

--- a/AmplifyPlugins/Analytics/Podfile.lock
+++ b/AmplifyPlugins/Analytics/Podfile.lock
@@ -14,18 +14,18 @@ PODS:
     - Amplify (= 1.0.4)
     - AWSCore (~> 2.14.0)
     - AWSPluginsCore (= 1.0.4)
-  - AWSAuthCore (2.14.0):
-    - AWSCore (= 2.14.0)
-  - AWSCognitoIdentityProvider (2.14.0):
+  - AWSAuthCore (2.14.2):
+    - AWSCore (= 2.14.2)
+  - AWSCognitoIdentityProvider (2.14.2):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.14.0)
+    - AWSCore (= 2.14.2)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.14.0)
-  - AWSMobileClient (2.14.0):
-    - AWSAuthCore (= 2.14.0)
-    - AWSCognitoIdentityProvider (= 2.14.0)
-  - AWSPinpoint (2.14.0):
-    - AWSCore (= 2.14.0)
+  - AWSCore (2.14.2)
+  - AWSMobileClient (2.14.2):
+    - AWSAuthCore (= 2.14.2)
+    - AWSCognitoIdentityProvider (= 2.14.2)
+  - AWSPinpoint (2.14.2):
+    - AWSCore (= 2.14.2)
   - AWSPluginsCore (1.0.4):
     - Amplify (= 1.0.4)
     - AWSCore (~> 2.14.0)
@@ -33,7 +33,7 @@ PODS:
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
-  - SwiftFormat/CLI (0.44.14)
+  - SwiftFormat/CLI (0.44.17)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -86,16 +86,16 @@ SPEC CHECKSUMS:
   Amplify: 7626e435f3e78ac3508252557e375f994d5d5154
   AmplifyPlugins: aba4f9e4432ebc089aaea45722d2c5711d3e58f4
   AmplifyTestCommon: fb6f2e2e876cd4ec582c55e9bf7cb0bfe2ae21e9
-  AWSAuthCore: 6b337af04751dcbb4bc50f18dbed0343ba345e17
-  AWSCognitoIdentityProvider: bd4cf5f70b9224b1ea42b423a75716cafb8f7ac4
+  AWSAuthCore: 7ab6f5ab60ba8bb91a4868581946a993cbbae76d
+  AWSCognitoIdentityProvider: 609856c741ef86037055223b3a46f4eeb49319d0
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: 6398ca88010f34653a07d54a252affe920a99965
-  AWSMobileClient: 0f4ae3f60722fc2cec7ca926fd442ff55a2154a5
-  AWSPinpoint: 8e7824c3095a9575543350cc3f291036b0d3173d
+  AWSCore: 80da498ab0979e77dbdc7690a61ceaaccfb0499a
+  AWSMobileClient: b80f21439aa95df2375e7acdde76d2f60c12f4b7
+  AWSPinpoint: ce47d17a9d67885d83276cf0ee92edfe809c007f
   AWSPluginsCore: 646f8c2d831a52f2293da0dfd59a31eee61f6ad5
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
-  SwiftFormat: a5ab293a7f6a812bec6f4ffc5507b7ed08f7f6e1
+  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 48d1574dddce5cef7bdb7b05b06fc588ee22956e

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -140,7 +140,7 @@ extension AuthenticationProviderAdapter {
 
         // Get top most view controller to present a navController
         var parentViewController = window.rootViewController
-        while ((parentViewController?.presentedViewController) != nil) {
+        while (parentViewController?.presentedViewController) != nil {
             parentViewController = parentViewController?.presentedViewController
         }
 

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AWSCognitoAuthPluginConfigTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AWSCognitoAuthPluginConfigTests.swift
@@ -180,8 +180,8 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
             try plugin.configure(using: nil)
             XCTFail("Auth configuration should not succeed")
         } catch {
-            guard let apiError = error as? PluginError,
-                case .pluginConfigurationError(_, _, _) = apiError else {
+            guard let pluginError = error as? PluginError,
+                case .pluginConfigurationError(_, _, _) = pluginError else {
                     XCTFail("Should throw invalidConfiguration exception. But received \(error) ")
                     return
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AWSCognitoAuthPluginConfigTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AWSCognitoAuthPluginConfigTests.swift
@@ -166,4 +166,26 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
         }
     }
 
+    /// Test Auth configuration with nil value
+    ///
+    /// - Given: Given a nil config for user pool and identity pool
+    /// - When:
+    ///    - I configure auth with the given configuration
+    /// - Then:
+    ///    - I should get an exception.
+    ///
+    func testConfigureFailureForNilConfiguration() throws {
+        let plugin = AWSCognitoAuthPlugin()
+        do {
+            try plugin.configure(using: nil)
+            XCTFail("Auth configuration should not succeed")
+        } catch {
+            guard let apiError = error as? PluginError,
+                case .pluginConfigurationError(_, _, _) = apiError else {
+                    XCTFail("Should throw invalidConfiguration exception. But received \(error) ")
+                    return
+            }
+        }
+    }
+
 }

--- a/AmplifyPlugins/Auth/Podfile.lock
+++ b/AmplifyPlugins/Auth/Podfile.lock
@@ -26,7 +26,7 @@ PODS:
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
-  - SwiftFormat/CLI (0.44.16)
+  - SwiftFormat/CLI (0.44.17)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -82,7 +82,7 @@ SPEC CHECKSUMS:
   AWSPluginsCore: 646f8c2d831a52f2293da0dfd59a31eee61f6ad5
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
-  SwiftFormat: c44bd17c23f237956f67205a422a1bd352d42e4c
+  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 371cf67fe35ebb5167d0880bad12b01618a0fb0e

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/ConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/ConfigurationTests.swift
@@ -1,0 +1,30 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@testable import Amplify
+@testable import AWSDataStoreCategoryPlugin
+
+class AWSAPICategoryPluginConfigureTests: XCTestCase {
+
+    func testConfigureSuccessForNilConfiguration() throws {
+        let storageEngine = MockStorageEngineBehavior()
+        let dataStorePublisher = DataStorePublisher()
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        storageEngine: storageEngine,
+                                        dataStorePublisher: dataStorePublisher,
+                                        validAPIPluginKey: "MockAPICategoryPlugin",
+                                        validAuthPluginKey: "MockAuthCategoryPlugin")
+        do {
+            try plugin.configure(using: nil)
+
+        } catch {
+            XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		A209418EED69D7B1BB8A55C2 /* Pods_AWSDataStoreCategoryPlugin_AWSDataStoreCategoryPluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C63AE18F2569D004E94BD550 /* Pods_AWSDataStoreCategoryPlugin_AWSDataStoreCategoryPluginTests.framework */; };
 		A569484A6FBAE7EC7ADF3FD4 /* Pods_AWSDataStoreCategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A1D332BE6CF885805360B3D /* Pods_AWSDataStoreCategoryPlugin.framework */; };
 		B10BF4A52A1C9840C208C8A8 /* Pods_HostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 19AFF6D00CF3AF927BA90382 /* Pods_HostApp.framework */; };
+		B40EF02824BF68C900F2264C /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40EF02724BF68C900F2264C /* ConfigurationTests.swift */; };
 		B912D1B824296F1E0028F05C /* QueryPaginationInput+SQLite.swift in Sources */ = {isa = PBXBuildFile; fileRef = B912D1B724296F1E0028F05C /* QueryPaginationInput+SQLite.swift */; };
 		B912D1BA242984D10028F05C /* QueryPaginationInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B912D1B9242984D10028F05C /* QueryPaginationInputTests.swift */; };
 		B9334BA22433AF3E00C9F407 /* DataStoreConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9334BA12433AF3E00C9F407 /* DataStoreConfiguration.swift */; };
@@ -292,6 +293,7 @@
 		6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSInitialSyncOrchestrator.swift; sourceTree = "<group>"; };
 		9D42A96449A4B73735566C07 /* Pods-AWSDataStoreCategoryPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSDataStoreCategoryPlugin/Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; sourceTree = "<group>"; };
 		9F987EC33AAD7C0904A598CA /* Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B40EF02724BF68C900F2264C /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		B912D1B724296F1E0028F05C /* QueryPaginationInput+SQLite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QueryPaginationInput+SQLite.swift"; sourceTree = "<group>"; };
 		B912D1B9242984D10028F05C /* QueryPaginationInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPaginationInputTests.swift; sourceTree = "<group>"; };
 		B9334BA12433AF3E00C9F407 /* DataStoreConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreConfiguration.swift; sourceTree = "<group>"; };
@@ -747,6 +749,7 @@
 				2149E5F6238869CF00873955 /* SQLStatementTests.swift */,
 				FA3841EC23889D8F0070AD5B /* StateMachineTests.swift */,
 				2129BE4923948A97006363A1 /* StorageAdapterMutationSyncTests.swift */,
+				B40EF02724BF68C900F2264C /* ConfigurationTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1511,6 +1514,7 @@
 				B9E010E4239167E000DCE8C8 /* TestModelRegistration.swift in Sources */,
 				6B3381BC239778E90036F046 /* AWSMutationDatabaseAdapterTests.swift in Sources */,
 				2149E5FC238869CF00873955 /* LocalSubscriptionTests.swift in Sources */,
+				B40EF02824BF68C900F2264C /* ConfigurationTests.swift in Sources */,
 				FA23345C23955CEF009BEFE9 /* NoOpMutationQueue.swift in Sources */,
 				B996FC4923FF3E92006D0F68 /* ExampleWithEveryType+Schema.swift in Sources */,
 				2129BE4A23948A97006363A1 /* StorageAdapterMutationSyncTests.swift in Sources */,

--- a/AmplifyPlugins/DataStore/Podfile.lock
+++ b/AmplifyPlugins/DataStore/Podfile.lock
@@ -22,16 +22,16 @@ PODS:
     - AWSPluginsCore (= 1.0.4)
   - AppSyncRealTimeClient (1.1.6):
     - Starscream (= 3.0.6)
-  - AWSAuthCore (2.14.0):
-    - AWSCore (= 2.14.0)
-  - AWSCognitoIdentityProvider (2.14.0):
+  - AWSAuthCore (2.14.2):
+    - AWSCore (= 2.14.2)
+  - AWSCognitoIdentityProvider (2.14.2):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.14.0)
+    - AWSCore (= 2.14.2)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.14.0)
-  - AWSMobileClient (2.14.0):
-    - AWSAuthCore (= 2.14.0)
-    - AWSCognitoIdentityProvider (= 2.14.0)
+  - AWSCore (2.14.2)
+  - AWSMobileClient (2.14.2):
+    - AWSAuthCore (= 2.14.2)
+    - AWSCognitoIdentityProvider (= 2.14.2)
   - AWSPluginsCore (1.0.4):
     - Amplify (= 1.0.4)
     - AWSCore (~> 2.14.0)
@@ -44,7 +44,7 @@ PODS:
     - SQLite.swift/standard (= 0.12.2)
   - SQLite.swift/standard (0.12.2)
   - Starscream (3.0.6)
-  - SwiftFormat/CLI (0.44.14)
+  - SwiftFormat/CLI (0.44.17)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -103,18 +103,18 @@ SPEC CHECKSUMS:
   AmplifyPlugins: aba4f9e4432ebc089aaea45722d2c5711d3e58f4
   AmplifyTestCommon: fb6f2e2e876cd4ec582c55e9bf7cb0bfe2ae21e9
   AppSyncRealTimeClient: 4a2ccdc1722750a1f4d76e216f9bfb1cf12f10de
-  AWSAuthCore: 6b337af04751dcbb4bc50f18dbed0343ba345e17
-  AWSCognitoIdentityProvider: bd4cf5f70b9224b1ea42b423a75716cafb8f7ac4
+  AWSAuthCore: 7ab6f5ab60ba8bb91a4868581946a993cbbae76d
+  AWSCognitoIdentityProvider: 609856c741ef86037055223b3a46f4eeb49319d0
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: 6398ca88010f34653a07d54a252affe920a99965
-  AWSMobileClient: 0f4ae3f60722fc2cec7ca926fd442ff55a2154a5
+  AWSCore: 80da498ab0979e77dbdc7690a61ceaaccfb0499a
+  AWSMobileClient: b80f21439aa95df2375e7acdde76d2f60c12f4b7
   AWSPluginsCore: 646f8c2d831a52f2293da0dfd59a31eee61f6ad5
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
-  SwiftFormat: a5ab293a7f6a812bec6f4ffc5507b7ed08f7f6e1
+  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 04860e414d616b67d24ed3346a60700f427764b9

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
@@ -198,13 +198,13 @@ class PredictionsPluginConfigurationTests: XCTestCase {
     }
 
     func testConfigureFailureForNilConfiguration() throws {
-        let plugin = AWSAPIPlugin()
+        let plugin = AWSPredictionsPlugin()
         do {
             try plugin.configure(using: nil)
             XCTFail("Predictions configuration should not succeed")
         } catch {
-            guard let apiError = error as? PluginError,
-                case .pluginConfigurationError(_, _, _) = apiError else {
+            guard let pluginError = error as? PluginError,
+                case .pluginConfigurationError(_, _, _) = pluginError else {
                     XCTFail("Should throw invalidConfiguration exception. But received \(error) ")
                     return
             }

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
@@ -197,4 +197,17 @@ class PredictionsPluginConfigurationTests: XCTestCase {
         }
     }
 
+    func testConfigureFailureForNilConfiguration() throws {
+        let plugin = AWSAPIPlugin()
+        do {
+            try plugin.configure(using: nil)
+            XCTFail("Predictions configuration should not succeed")
+        } catch {
+            guard let apiError = error as? PluginError,
+                case .pluginConfigurationError(_, _, _) = apiError else {
+                    XCTFail("Should throw invalidConfiguration exception. But received \(error) ")
+                    return
+            }
+        }
+    }
 }

--- a/AmplifyPlugins/Predictions/Podfile.lock
+++ b/AmplifyPlugins/Predictions/Podfile.lock
@@ -9,36 +9,36 @@ PODS:
     - Amplify (= 1.0.4)
     - AWSCore (~> 2.14.0)
     - AWSPluginsCore (= 1.0.4)
-  - AWSAuthCore (2.14.0):
-    - AWSCore (= 2.14.0)
-  - AWSCognitoIdentityProvider (2.14.0):
+  - AWSAuthCore (2.14.2):
+    - AWSCore (= 2.14.2)
+  - AWSCognitoIdentityProvider (2.14.2):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.14.0)
+    - AWSCore (= 2.14.2)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSComprehend (2.14.0):
-    - AWSCore (= 2.14.0)
-  - AWSCore (2.14.0)
-  - AWSMobileClient (2.14.0):
-    - AWSAuthCore (= 2.14.0)
-    - AWSCognitoIdentityProvider (= 2.14.0)
+  - AWSComprehend (2.14.2):
+    - AWSCore (= 2.14.2)
+  - AWSCore (2.14.2)
+  - AWSMobileClient (2.14.2):
+    - AWSAuthCore (= 2.14.2)
+    - AWSCognitoIdentityProvider (= 2.14.2)
   - AWSPluginsCore (1.0.4):
     - Amplify (= 1.0.4)
     - AWSCore (~> 2.14.0)
     - AWSMobileClient (~> 2.14.0)
-  - AWSPolly (2.14.0):
-    - AWSCore (= 2.14.0)
-  - AWSRekognition (2.14.0):
-    - AWSCore (= 2.14.0)
-  - AWSTextract (2.14.0):
-    - AWSCore (= 2.14.0)
-  - AWSTranscribeStreaming (2.14.0):
-    - AWSCore (= 2.14.0)
-  - AWSTranslate (2.14.0):
-    - AWSCore (= 2.14.0)
+  - AWSPolly (2.14.2):
+    - AWSCore (= 2.14.2)
+  - AWSRekognition (2.14.2):
+    - AWSCore (= 2.14.2)
+  - AWSTextract (2.14.2):
+    - AWSCore (= 2.14.2)
+  - AWSTranscribeStreaming (2.14.2):
+    - AWSCore (= 2.14.2)
+  - AWSTranslate (2.14.2):
+    - AWSCore (= 2.14.2)
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
-  - SwiftFormat/CLI (0.44.14)
+  - SwiftFormat/CLI (0.44.17)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -97,21 +97,21 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Amplify: 7626e435f3e78ac3508252557e375f994d5d5154
   AmplifyTestCommon: fb6f2e2e876cd4ec582c55e9bf7cb0bfe2ae21e9
-  AWSAuthCore: 6b337af04751dcbb4bc50f18dbed0343ba345e17
-  AWSCognitoIdentityProvider: bd4cf5f70b9224b1ea42b423a75716cafb8f7ac4
+  AWSAuthCore: 7ab6f5ab60ba8bb91a4868581946a993cbbae76d
+  AWSCognitoIdentityProvider: 609856c741ef86037055223b3a46f4eeb49319d0
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSComprehend: b3ae5469831cf0652fcbc03adeeac935ba896199
-  AWSCore: 6398ca88010f34653a07d54a252affe920a99965
-  AWSMobileClient: 0f4ae3f60722fc2cec7ca926fd442ff55a2154a5
+  AWSComprehend: 6fe232b8598c1e6efbf6f61a072ec7e3902fc1ae
+  AWSCore: 80da498ab0979e77dbdc7690a61ceaaccfb0499a
+  AWSMobileClient: b80f21439aa95df2375e7acdde76d2f60c12f4b7
   AWSPluginsCore: 646f8c2d831a52f2293da0dfd59a31eee61f6ad5
-  AWSPolly: b716120b1a7b495dff9d5d580be4f8bd973387f0
-  AWSRekognition: dd59c06a8225fa8eb3f1b2e5648a6741c2d2a38e
-  AWSTextract: efda2c333155e996f82e37f19ce4f0a5fdc4fc9d
-  AWSTranscribeStreaming: 7ca3aa03279688071f8307bc68fedd5d33c98ffa
-  AWSTranslate: 72bafddafcaa3e23cd43f0a973efcff68cc0885f
+  AWSPolly: 501792203b5b8ff924422ef59e3f55d95fe60797
+  AWSRekognition: 7918b1a54b0baf1964f22d3f053f7e6021bab6df
+  AWSTextract: 7029f7c42f84a26788ea0a5eceb7664c0f52d08a
+  AWSTranscribeStreaming: c320b6556248700b6fc91f8ec7f368aca2695d17
+  AWSTranslate: 94d5e2581252b6be9671d5c6904c9422b018a161
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
-  SwiftFormat: a5ab293a7f6a812bec6f4ffc5507b7ed08f7f6e1
+  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 095ccf7b80adbc9a0c0c70e2143f57a0c7d8d7b5

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginBaseConfigTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginBaseConfigTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-import Amplify
+@testable import Amplify
 import AWSS3StoragePlugin
 
 class AWSS3StoragePluginBaseConfigTests: XCTestCase {
@@ -26,6 +26,11 @@ class AWSS3StoragePluginBaseConfigTests: XCTestCase {
                 return
             }
         }
+    }
+
+    override func tearDown() {
+        // Need this to avoid plugin already configured exception in the subsequent tests
+        Amplify.reset()
     }
 
 }

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginConfigureTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginConfigureTests.swift
@@ -77,8 +77,8 @@ class AWSS3StoragePluginConfigureTests: AWSS3StoragePluginTests {
             try storagePlugin.configure(using: nil)
             XCTFail("Storage configuration should not succeed")
         } catch {
-            guard let apiError = error as? PluginError,
-                case .pluginConfigurationError(_, _, _) = apiError else {
+            guard let pluginError = error as? PluginError,
+                case .pluginConfigurationError(_, _, _) = pluginError else {
                     XCTFail("Should throw invalidConfiguration exception. But received \(error) ")
                     return
             }

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginConfigureTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginConfigureTests.swift
@@ -72,6 +72,19 @@ class AWSS3StoragePluginConfigureTests: AWSS3StoragePluginTests {
         }
     }
 
+    func testConfigureFailureForNilConfiguration() throws {
+        do {
+            try storagePlugin.configure(using: nil)
+            XCTFail("Storage configuration should not succeed")
+        } catch {
+            guard let apiError = error as? PluginError,
+                case .pluginConfigurationError(_, _, _) = apiError else {
+                    XCTFail("Should throw invalidConfiguration exception. But received \(error) ")
+                    return
+            }
+        }
+    }
+
     func testConfigureThrowsErrorForMissingBucketConfig() {
         let region = JSONValue.init(stringLiteral: testRegion)
         let storagePluginConfig = JSONValue.init(

--- a/AmplifyPlugins/Storage/Podfile.lock
+++ b/AmplifyPlugins/Storage/Podfile.lock
@@ -14,26 +14,26 @@ PODS:
     - Amplify (= 1.0.4)
     - AWSCore (~> 2.14.0)
     - AWSPluginsCore (= 1.0.4)
-  - AWSAuthCore (2.14.0):
-    - AWSCore (= 2.14.0)
-  - AWSCognitoIdentityProvider (2.14.0):
+  - AWSAuthCore (2.14.2):
+    - AWSCore (= 2.14.2)
+  - AWSCognitoIdentityProvider (2.14.2):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.14.0)
+    - AWSCore (= 2.14.2)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.14.0)
-  - AWSMobileClient (2.14.0):
-    - AWSAuthCore (= 2.14.0)
-    - AWSCognitoIdentityProvider (= 2.14.0)
+  - AWSCore (2.14.2)
+  - AWSMobileClient (2.14.2):
+    - AWSAuthCore (= 2.14.2)
+    - AWSCognitoIdentityProvider (= 2.14.2)
   - AWSPluginsCore (1.0.4):
     - Amplify (= 1.0.4)
     - AWSCore (~> 2.14.0)
     - AWSMobileClient (~> 2.14.0)
-  - AWSS3 (2.14.0):
-    - AWSCore (= 2.14.0)
+  - AWSS3 (2.14.2):
+    - AWSCore (= 2.14.2)
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
-  - SwiftFormat/CLI (0.44.14)
+  - SwiftFormat/CLI (0.44.17)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -86,16 +86,16 @@ SPEC CHECKSUMS:
   Amplify: 7626e435f3e78ac3508252557e375f994d5d5154
   AmplifyPlugins: aba4f9e4432ebc089aaea45722d2c5711d3e58f4
   AmplifyTestCommon: fb6f2e2e876cd4ec582c55e9bf7cb0bfe2ae21e9
-  AWSAuthCore: 6b337af04751dcbb4bc50f18dbed0343ba345e17
-  AWSCognitoIdentityProvider: bd4cf5f70b9224b1ea42b423a75716cafb8f7ac4
+  AWSAuthCore: 7ab6f5ab60ba8bb91a4868581946a993cbbae76d
+  AWSCognitoIdentityProvider: 609856c741ef86037055223b3a46f4eeb49319d0
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: 6398ca88010f34653a07d54a252affe920a99965
-  AWSMobileClient: 0f4ae3f60722fc2cec7ca926fd442ff55a2154a5
+  AWSCore: 80da498ab0979e77dbdc7690a61ceaaccfb0499a
+  AWSMobileClient: b80f21439aa95df2375e7acdde76d2f60c12f4b7
   AWSPluginsCore: 646f8c2d831a52f2293da0dfd59a31eee61f6ad5
-  AWSS3: 947204f8280a28864e899f7544176ff53a0e87e9
+  AWSS3: 2ea579ed91fb01a187f7d8d827e3936da488531e
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
-  SwiftFormat: a5ab293a7f6a812bec6f4ffc5507b7ed08f7f6e1
+  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 23c3028505a2f56c001d01c66c1622dff6f8dd8e


### PR DESCRIPTION
*Issue https://github.com/aws-amplify/amplify-ios/issues/480*

*Description of changes:*

This change allows to call configure method of each plugin with a nil value. ie even if the corresponding configuration is not present in the configuration file, plugin's configure will be called.

*Issue we are solving:*

Suppose that I added two plugins to my project `AWSAPIPlugin` and `AWSDataStorePlugin`, but forgot to add any configuration for API in my `amplifyconfiguration.json`. Since there is no configuration the current logic does not invoke the `configure(:)` function of `AWSAPIPlugin`. So we end up using a not-configured plugin and end up in unintended error or crash like this - https://github.com/aws-amplify/amplify-ios/issues/480

*Thought process behind this change:*

All category in Amplify conforms to the protocol - [CategoryConfigurable](https://github.com/aws-amplify/amplify-ios/blob/ff8e86c0b8c00a0a1032219a2ee825291761a099/Amplify/Core/Configuration/Internal/CategoryConfigurable.swift#L8), which could infer that the plugins added to every category is [configurable](https://github.com/aws-amplify/amplify-ios/blob/ff8e86c0b8c00a0a1032219a2ee825291761a099/Amplify/Core/Plugin/Plugin.swift#L23). Since each added plugin is configurable it should be given a chance to configure even if the corresponding configuration is missing. This will give the plugin a chance to decide whether it can work in a non-configuration based situation or throw an error.

*Other changes in this PR*
- Fixed an error in storage unit test that caused it to fail when whole storage unit test is executed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
