### PR TITLE
fix(storage): delete file if key not found on download

### DIFF
--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginAccessLevelTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginAccessLevelTests.swift
@@ -341,9 +341,9 @@ class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase {
         let signInInvoked = expectation(description: "sign in completed")
         _ = Amplify.Auth.signIn(username: username, password: password) { event in
             switch event {
-            case .completed:
+            case .success:
                 signInInvoked.fulfill()
-            case .failed(let error):
+            case .failure(let error):
                 XCTFail("Failed to Sign in user \(error)")
             default:
                 XCTFail("Unexpected event")
@@ -357,7 +357,7 @@ class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase {
         var resultOptional: String?
         _ = Amplify.Auth.fetchAuthSession(listener: { event in
             switch event {
-            case .completed(let authSession):
+            case .success(let authSession):
                 guard let cognitoAuthSession = authSession as? AuthCognitoIdentityProvider else {
                     XCTFail("Could not get auth session as AuthCognitoIdentityProvider")
                     return
@@ -369,7 +369,7 @@ class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase {
                 case .failure(let error):
                     XCTFail("Failed to get auth session \(error)")
                 }
-            case .failed(let error):
+            case .failure(let error):
                 XCTFail("Failed to get auth session \(error)")
             default:
                 XCTFail("Unexpected event")
@@ -387,9 +387,9 @@ class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase {
         let signOutCompleted = expectation(description: "sign out completed")
         Amplify.Auth.signOut { event in
             switch event {
-            case .completed:
+            case .success:
                 signOutCompleted.fulfill()
-            case .failed(let error):
+            case .failure(let error):
                 XCTFail("Could not sign out user \(error)")
             default:
                 XCTFail("Unexpected event")


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/285

*Description of changes:*
When downloading to file using TransferUtility, and the key cannot be found in S3, the file is populated with the error message from the response. This ensures that the behavior is, when key is not found, the file is removed so there isn't incorrect data like the error message

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
