### PR TITLE
Accessing Http Response Data when Http status code is 4xx or 5xx

### DIFF
--- a/Amplify/Categories/API/Error/APIError.swift
+++ b/Amplify/Categories/API/Error/APIError.swift
@@ -29,7 +29,7 @@ public enum APIError {
     case networkError(ErrorDescription, UserInfo? = nil, Error? = nil)
 
     /// A non 2xx response from the service.
-    case httpStatusError(StatusCode, HTTPURLResponse)
+    case httpStatusError(StatusCode, HTTPURLResponse, Data?)
 
     /// An error to encapsulate an error received by a dependent plugin
     case pluginError(AmplifyError)
@@ -54,7 +54,7 @@ extension APIError: AmplifyError {
         case .networkError(let errorDescription, _, _):
             return errorDescription
 
-        case .httpStatusError(let statusCode, _):
+        case .httpStatusError(let statusCode, _, _):
             return "The HTTP response status code is [\(statusCode)]."
 
         case .pluginError(let error):

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/APIOperationResponse.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/APIOperationResponse.swift
@@ -11,10 +11,12 @@ import Amplify
 struct APIOperationResponse {
     let urlError: URLError?
     let httpURLResponse: HTTPURLResponse?
+    let responseData: Data?
 
-    public init(error: Error?, response: URLResponse?) {
+    public init(error: Error?, response: URLResponse?, data: Data? = nil) {
         self.urlError = error as? URLError
         self.httpURLResponse = response as? HTTPURLResponse
+        self.responseData = data
     }
 }
 
@@ -32,7 +34,7 @@ extension APIOperationResponse {
 
             let successStatusCodes = 200 ..< 300
             if !successStatusCodes.contains(statusCode) {
-                throw APIError.httpStatusError(statusCode, response)
+                throw APIError.httpStatusError(statusCode, response, responseData)
             }
         case (.some(let error), .some(let response)):
             let userInfo = ["HTTPURLResponse": response]

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSAPIOperation+APIOperation.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSAPIOperation+APIOperation.swift
@@ -23,7 +23,7 @@ extension AWSRESTOperation: APIOperation {
             return
         }
 
-        let apiOperationResponse = APIOperationResponse(error: nil, response: response)
+        let apiOperationResponse = APIOperationResponse(error: nil, response: response, data: data)
         do {
             try apiOperationResponse.validate()
         } catch let error as APIError {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithIAMIntegrationTests/RESTWithIAMIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithIAMIntegrationTests/RESTWithIAMIntegrationTests.swift
@@ -66,7 +66,7 @@ class RESTWithIAMIntegrationTests: XCTestCase {
             case .success(let data):
                 XCTFail("Unexpected .complted event: \(data)")
             case .failure(let error):
-                guard case let .httpStatusError(statusCode, _) = error else {
+                guard case let .httpStatusError(statusCode, _, _) = error else {
                     XCTFail("Error should be httpStatusError")
                     return
                 }
@@ -138,7 +138,7 @@ class RESTWithIAMIntegrationTests: XCTestCase {
             case .success(let data):
                 XCTFail("Unexpected .completed event: \(data)")
             case .failure(let error):
-                guard case let .httpStatusError(statusCode, _) = error else {
+                guard case let .httpStatusError(statusCode, _, _) = error else {
                     XCTFail("Error should be httpStatusError")
                     return
                 }
@@ -159,7 +159,7 @@ class RESTWithIAMIntegrationTests: XCTestCase {
             case .success(let data):
                 XCTFail("Unexpected .completed event: \(data)")
             case .failure(let error):
-                guard case let .httpStatusError(statusCode, _) = error else {
+                guard case let .httpStatusError(statusCode, _, _) = error else {
                     XCTFail("Error should be httpStatusError")
                     return
                 }


### PR DESCRIPTION
Adding responseData property to APIOperationResponse in order to reach http data in case of http failure. (4xx & 5xx).
APIError.httpStatusError supports Data (optional)

*Issue #, if available:* #655 

*Description of changes:* Adding one extra parameter in _APIError_ enum and _APIOperationResponse_ struct. APIOperationResponse now pass its _Optional< Data >_ by throwing error (_APIError.httpStatusError_)
And a minor change in the test class (_RESTWithIAMIntegrationTests.swift_)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
