### PR TITLE
fix(auth): missing initializers for AWSAuth*Options

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		3AB72AEC1B90671D652C3F96 /* Pods_HostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 234C2AFA9205B1766FB8E090 /* Pods_HostApp.framework */; };
 		8337B0CA31C0E650D640B82C /* Pods_HostApp_AWSCognitoAuthPluginIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 242DDB230CE2BA243E395217 /* Pods_HostApp_AWSCognitoAuthPluginIntegrationTests.framework */; };
 		B40F165D24784AE300CDB920 /* AWSCognitoAuthPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B43DC7452410572400D40275 /* AWSCognitoAuthPlugin.framework */; };
-		B40F167A24784B3400CDB920 /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = B40F166524784B3400CDB920 /* amplifyconfiguration.json */; };
 		B40F167C24784B3400CDB920 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = B40F166824784B3400CDB920 /* README.md */; };
 		B40F167D24784B3400CDB920 /* AuthSignInHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40F166A24784B3400CDB920 /* AuthSignInHelper.swift */; };
 		B40F167E24784B3400CDB920 /* AuthConfigurationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40F166B24784B3400CDB920 /* AuthConfigurationHelper.swift */; };
@@ -114,6 +113,7 @@
 		B4F3EA4F243A782700F23296 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3EA4C243A782700F23296 /* ViewController.swift */; };
 		B4F3EA50243A782700F23296 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3EA4D243A782700F23296 /* AppDelegate.swift */; };
 		B4F3EA51243A782700F23296 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3EA4E243A782700F23296 /* SceneDelegate.swift */; };
+		D8D4514C24C7AF2600EE2086 /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = D8D4514B24C7AF2500EE2086 /* amplifyconfiguration.json */; };
 		FA6B0EA8249443C90062AA59 /* AWSCognitoAuthPluginConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B0EA7249443C90062AA59 /* AWSCognitoAuthPluginConfigTests.swift */; };
 		FECB988C412E46FD5961894A /* Pods_AWSCognitoAuthPlugin_AWSCognitoAuthPluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1674B6AE81501F6E278CE00B /* Pods_AWSCognitoAuthPlugin_AWSCognitoAuthPluginTests.framework */; };
 /* End PBXBuildFile section */
@@ -159,7 +159,6 @@
 		8B2FC5990A6ABD808EA9B984 /* Pods-AWSAuthPlugin-AWSAuthPluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAuthPlugin-AWSAuthPluginTests.release.xcconfig"; path = "Target Support Files/Pods-AWSAuthPlugin-AWSAuthPluginTests/Pods-AWSAuthPlugin-AWSAuthPluginTests.release.xcconfig"; sourceTree = "<group>"; };
 		94AE978618BF1C30FD808FB6 /* Pods-HostApp-AWSAuthPluginIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAuthPluginIntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAuthPluginIntegrationTests/Pods-HostApp-AWSAuthPluginIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B40F165824784AE300CDB920 /* AWSCognitoAuthPluginIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSCognitoAuthPluginIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		B40F166524784B3400CDB920 /* amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = amplifyconfiguration.json; sourceTree = "<group>"; };
 		B40F166724784B3400CDB920 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B40F166824784B3400CDB920 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		B40F166A24784B3400CDB920 /* AuthSignInHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthSignInHelper.swift; sourceTree = "<group>"; };
@@ -278,6 +277,7 @@
 		B4F3EA4E243A782700F23296 /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		C49A4C812B0F973F5536DCC8 /* Pods-AWSAuthPlugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAuthPlugin.release.xcconfig"; path = "Target Support Files/Pods-AWSAuthPlugin/Pods-AWSAuthPlugin.release.xcconfig"; sourceTree = "<group>"; };
 		C5E50D8021B9740CB511898D /* Pods-AWSAuthPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAuthPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSAuthPlugin/Pods-AWSAuthPlugin.debug.xcconfig"; sourceTree = "<group>"; };
+		D8D4514B24C7AF2500EE2086 /* amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = amplifyconfiguration.json; sourceTree = "<group>"; };
 		E9289652B314AA0AA1F31BC8 /* Pods-HostApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp.release.xcconfig"; path = "Target Support Files/Pods-HostApp/Pods-HostApp.release.xcconfig"; sourceTree = "<group>"; };
 		FA6B0EA7249443C90062AA59 /* AWSCognitoAuthPluginConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSCognitoAuthPluginConfigTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -341,7 +341,7 @@
 		B40F166424784B3400CDB920 /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
-				B40F166524784B3400CDB920 /* amplifyconfiguration.json */,
+				D8D4514B24C7AF2500EE2086 /* amplifyconfiguration.json */,
 			);
 			path = Configuration;
 			sourceTree = "<group>";
@@ -896,7 +896,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B40F167C24784B3400CDB920 /* README.md in Resources */,
-				B40F167A24784B3400CDB920 /* amplifyconfiguration.json in Resources */,
+				D8D4514C24C7AF2600EE2086 /* amplifyconfiguration.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmResetPasswordOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmResetPasswordOptions.swift
@@ -10,4 +10,8 @@ import Foundation
 public struct AWSAuthConfirmResetPasswordOptions {
 
     public let metadata: [String: String]?
+
+    public init(metadata: [String: String]?) {
+        self.metadata = metadata
+    }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmResetPasswordOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmResetPasswordOptions.swift
@@ -11,7 +11,7 @@ public struct AWSAuthConfirmResetPasswordOptions {
 
     public let metadata: [String: String]?
 
-    public init(metadata: [String: String]?) {
+    public init(metadata: [String: String]? = nil) {
         self.metadata = metadata
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmSignInOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmSignInOptions.swift
@@ -13,7 +13,7 @@ public struct AWSAuthConfirmSignInOptions {
 
     public let metadata: [String: String]?
 
-    public init(userAttributes: [AuthUserAttribute]?, metadata: [String: String]?) {
+    public init(userAttributes: [AuthUserAttribute]? = nil, metadata: [String: String]? = nil) {
         self.userAttributes = userAttributes
         self.metadata = metadata
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmSignInOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmSignInOptions.swift
@@ -12,4 +12,9 @@ public struct AWSAuthConfirmSignInOptions {
     public let userAttributes: [AuthUserAttribute]?
 
     public let metadata: [String: String]?
+
+    public init(userAttributes: [AuthUserAttribute]?, metadata: [String: String]?) {
+        self.userAttributes = userAttributes
+        self.metadata = metadata
+    }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmSignUpOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmSignUpOptions.swift
@@ -13,7 +13,7 @@ public struct AWSAuthConfirmSignUpOptions {
 
     public let metadata: [String: String]?
 
-    public init(validationData: [String: String]?, metadata: [String: String]?) {
+    public init(validationData: [String: String]? = nil, metadata: [String: String]? = nil) {
         self.validationData = validationData
         self.metadata = metadata
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmSignUpOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmSignUpOptions.swift
@@ -12,4 +12,9 @@ public struct AWSAuthConfirmSignUpOptions {
     public let validationData: [String: String]?
 
     public let metadata: [String: String]?
+
+    public init(validationData: [String: String]?, metadata: [String: String]?) {
+        self.validationData = validationData
+        self.metadata = metadata
+    }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthResetPasswordOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthResetPasswordOptions.swift
@@ -11,7 +11,7 @@ public struct AWSAuthResetPasswordOptions {
 
     public let metadata: [String: String]?
 
-    public init(metadata: [String: String]?) {
+    public init(metadata: [String: String]? = nil) {
         self.metadata = metadata
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthResetPasswordOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthResetPasswordOptions.swift
@@ -10,4 +10,8 @@ import Foundation
 public struct AWSAuthResetPasswordOptions {
 
     public let metadata: [String: String]?
+
+    public init(metadata: [String: String]?) {
+        self.metadata = metadata
+    }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignInOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignInOptions.swift
@@ -13,7 +13,7 @@ public struct AWSAuthSignInOptions {
 
     public let metadata: [String: String]?
 
-    public init(validationData: [String: String]?, metadata: [String: String]?) {
+    public init(validationData: [String: String]? = nil, metadata: [String: String]? = nil) {
         self.validationData = validationData
         self.metadata = metadata
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignInOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignInOptions.swift
@@ -12,4 +12,9 @@ public struct AWSAuthSignInOptions {
     public let validationData: [String: String]?
 
     public let metadata: [String: String]?
+
+    public init(validationData: [String: String]?, metadata: [String: String]?) {
+        self.validationData = validationData
+        self.metadata = metadata
+    }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignUpOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignUpOptions.swift
@@ -13,7 +13,7 @@ public struct AWSAuthSignUpOptions {
 
     public let metadata: [String: String]?
 
-    public init(validationData: [String: String]?, metadata: [String: String]?) {
+    public init(validationData: [String: String]? = nil, metadata: [String: String]? = nil) {
         self.validationData = validationData
         self.metadata = metadata
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignUpOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignUpOptions.swift
@@ -12,4 +12,9 @@ public struct AWSAuthSignUpOptions {
     public let validationData: [String: String]?
 
     public let metadata: [String: String]?
+
+    public init(validationData: [String: String]?, metadata: [String: String]?) {
+        self.validationData = validationData
+        self.metadata = metadata
+    }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthWebUISignInOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthWebUISignInOptions.swift
@@ -24,7 +24,7 @@ public struct AWSAuthWebUISignInOptions {
     /// are using Auth0, specify the `federationProviderName` as <your_domain>.auth0.com.
     public let federationProviderName: String?
 
-    public init(idpIdentifier: String?, federationProviderName: String?) {
+    public init(idpIdentifier: String? = nil, federationProviderName: String? = nil) {
         self.idpIdentifier = idpIdentifier
         self.federationProviderName = federationProviderName
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthWebUISignInOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthWebUISignInOptions.swift
@@ -23,4 +23,9 @@ public struct AWSAuthWebUISignInOptions {
     /// `federationProviderName` is required if you are signIn directly with a third party provider. For example if you
     /// are using Auth0, specify the `federationProviderName` as <your_domain>.auth0.com.
     public let federationProviderName: String?
+
+    public init(idpIdentifier: String?, federationProviderName: String?) {
+        self.idpIdentifier = idpIdentifier
+        self.federationProviderName = federationProviderName
+    }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignInTests/AuthUsernamePasswordSignInTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignInTests/AuthUsernamePasswordSignInTests.swift
@@ -26,7 +26,7 @@ class AuthUsernamePasswordSignInTests: AWSAuthBaseTest {
     ///
     /// - Given: A user registered in Cognito user pool
     /// - When:
-    ///    - I invoke Amplify.Auth.signIn with the username password
+    ///    - I invoke Amplify.Auth.signIn with the username and password
     /// - Then:
     ///    - I should get a completed signIn flow.
     ///
@@ -44,6 +44,45 @@ class AuthUsernamePasswordSignInTests: AWSAuthBaseTest {
 
         let operationExpectation = expectation(description: "Operation should complete")
         let operation = Amplify.Auth.signIn(username: username, password: password) { result in
+            defer {
+                operationExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signInResult):
+                XCTAssertTrue(signInResult.isSignedIn, "SignIn should be complete")
+            case .failure(let error):
+                XCTFail("SignIn with a valid username/password should not fail \(error)")
+            }
+        }
+        XCTAssertNotNil(operation, "SignIn operation should not be nil")
+        wait(for: [operationExpectation], timeout: networkTimeout)
+    }
+
+    /// Test successful signIn of a valid user
+    ///
+    /// - Given: A user registered in Cognito user pool
+    /// - When:
+    ///    - I invoke Amplify.Auth.signIn with the username, password and AWSAuthSignInOptions
+    /// - Then:
+    ///    - I should get a completed signIn flow.
+    ///
+    func testSignInWithSignInOptions() {
+
+        let username = "integTest\(UUID().uuidString)"
+        let password = "P123@\(UUID().uuidString)"
+
+        let signUpExpectation = expectation(description: "SignUp operation should complete")
+        AuthSignInHelper.signUpUser(username: username, password: password) { didSucceed, error in
+            signUpExpectation.fulfill()
+            XCTAssertTrue(didSucceed, "Signup operation failed - \(String(describing: error))")
+        }
+        wait(for: [signUpExpectation], timeout: networkTimeout)
+
+        let operationExpectation = expectation(description: "Operation should complete")
+        let awsAuthSignInOptions = AWSAuthSignInOptions(validationData: ["mydata": "myvalue"],
+                                                        metadata: ["mydata": "myvalue"])
+        let options = AuthSignInOperation.Request.Options(pluginOptions: awsAuthSignInOptions)
+        let operation = Amplify.Auth.signIn(username: username, password: password, options: options) { result in
             defer {
                 operationExpectation.fulfill()
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthConfirmSignUpTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthConfirmSignUpTests.swift
@@ -63,20 +63,20 @@ class AuthConfirmSignUpTests: AWSAuthBaseTest {
         let operationExpectation = expectation(description: "Operation should complete")
         let operation = Amplify.Auth.confirmSignUp(for: username,
                                                    confirmationCode: "") { result in
-                                                    defer {
-                                                        operationExpectation.fulfill()
-                                                    }
-                                                    switch result {
-                                                    case .success:
-                                                        XCTFail("""
-                                                    confirmSignUp with validation error should not succeed
-                                                    """)
-                                                    case .failure(let error):
-                                                        guard case .validation(_, _, _, _) = error else {
-                                                            XCTFail("Should return validation error")
-                                                            return
-                                                        }
-                                                    }
+            defer {
+                operationExpectation.fulfill()
+            }
+            switch result {
+            case .success:
+                XCTFail("""
+            confirmSignUp with validation error should not succeed
+            """)
+            case .failure(let error):
+                guard case .validation(_, _, _, _) = error else {
+                    XCTFail("Should return validation error")
+                    return
+                }
+            }
         }
         XCTAssertNotNil(operation, "confirmSignUp operations should not be nil")
         wait(for: [operationExpectation], timeout: networkTimeout)

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthSignUpTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthSignUpTests.swift
@@ -50,6 +50,37 @@ class AuthSignUpTests: AWSAuthBaseTest {
         wait(for: [operationExpectation], timeout: networkTimeout)
     }
 
+    /// Test if user registration is successful.
+    ///
+    /// - Given: A username that is not present in the system
+    /// - When:
+    ///    - I invoke Amplify.Auth.signUp with the username, a random password and AWSAuthSignUpOptions
+    /// - Then:
+    ///    - I should get a signup complete step.
+    ///
+    func testRegisterUserWithSignUpOptions() {
+        let username = "integTest\(UUID().uuidString)"
+        let password = "P123@\(UUID().uuidString)"
+
+        let operationExpectation = expectation(description: "Operation should complete")
+        let awsAuthSignUpOptions = AWSAuthSignUpOptions(validationData: ["mydata": "myvalue"],
+                                                        metadata: ["mydata": "myvalue"])
+        let options = AuthSignUpOperation.Request.Options(pluginOptions: awsAuthSignUpOptions)
+        let operation = Amplify.Auth.signUp(username: username, password: password, options: options) { result in
+            defer {
+                operationExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signUpResult):
+                XCTAssertTrue(signUpResult.isSignupComplete, "Signup should be complete")
+            case .failure(let error):
+                XCTFail("SignUp a new user should not fail \(error)")
+            }
+        }
+        XCTAssertNotNil(operation, "SignUp operations should not be nil")
+        wait(for: [operationExpectation], timeout: networkTimeout)
+    }
+
     /// Test is signUp return validation error
     ///
     /// - Given: An invalid input to signUp like empty username


### PR DESCRIPTION
*Description of changes:*
Bug fix according to issue: https://github.com/aws-amplify/amplify-ios/issues/654

- Added initializers for `AWSAuthConfirmResetPasswordOptions`, `AWSAuthConfirmSignInOptions`, `AWSAuthConfirmSignUpOptions`, `AWSAuthResetPasswordOptions`, `AWSAuthSignInOptions`, `AWSAuthSignUpOptions` and `AWSAuthWebUISignInOptions`
- Added integration tests for `AWSAuthSignInOptions ` and `AWSAuthSignUpOptions` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
