### PR TITLE
chore: Update SDK dependencies

### DIFF
--- a/AmplifyPlugins/API/Podfile.lock
+++ b/AmplifyPlugins/API/Podfile.lock
@@ -14,8 +14,8 @@ PODS:
     - Amplify (= 1.0.5)
     - AWSCore (~> 2.15.0)
     - AWSPluginsCore (= 1.0.5)
-  - AppSyncRealTimeClient (1.1.6):
-    - Starscream (= 3.0.6)
+  - AppSyncRealTimeClient (1.4.0):
+    - Starscream (~> 3.1.0)
   - AWSAuthCore (2.15.0):
     - AWSCore (= 2.15.0)
   - AWSCognitoIdentityProvider (2.15.0):
@@ -34,15 +34,15 @@ PODS:
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
   - ReachabilitySwift (5.0.0)
-  - Starscream (3.0.6)
-  - SwiftFormat/CLI (0.44.17)
+  - Starscream (3.1.1)
+  - SwiftFormat/CLI (0.45.2)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
   - Amplify (from `../../`)
   - AmplifyPlugins/AWSCognitoAuthPlugin (from `../../`)
   - AmplifyTestCommon (from `../../`)
-  - AppSyncRealTimeClient (~> 1.1.0)
+  - AppSyncRealTimeClient (~> 1.4.0)
   - AWSMobileClient (~> 2.15.0)
   - AWSPluginsCore (from `../../`)
   - CwlCatchException (from `https://github.com/mattgallagher/CwlCatchException.git`, tag `1.2.0`)
@@ -90,9 +90,9 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Amplify: f780a637316aebf3a17ae4062fc352559f1a3455
-  AmplifyPlugins: 02790520946156c558948cbdf3040209e966e157
+  AmplifyPlugins: 3d7198e31f0844f89a9e642d9f5fa81bfff1a13d
   AmplifyTestCommon: 3c0cd92e7b02968e5143bf675b05d48a86f10ab3
-  AppSyncRealTimeClient: 4a2ccdc1722750a1f4d76e216f9bfb1cf12f10de
+  AppSyncRealTimeClient: 1e14f5584218e63b00fffbc093ad1934701a4b68
   AWSAuthCore: 284f1bc07187fad68ba52a0af088fe84f7af538e
   AWSCognitoIdentityProvider: 451b1a39c5c73afa9fc2bf8d29cb0892e9b3b34c
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
@@ -102,10 +102,10 @@ SPEC CHECKSUMS:
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
-  Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
-  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
+  Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
+  SwiftFormat: 07a1794c1331daaefc1ca6c2ff1da38ee9ca090a
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
-PODFILE CHECKSUM: 36210dbb4ee100c2203d947149c3f0c7628db7a3
+PODFILE CHECKSUM: 31880f143dde88382b42400953bbeb67ca4f2ae3
 
 COCOAPODS: 1.9.3

--- a/AmplifyPlugins/Analytics/Podfile.lock
+++ b/AmplifyPlugins/Analytics/Podfile.lock
@@ -33,7 +33,7 @@ PODS:
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
-  - SwiftFormat/CLI (0.44.17)
+  - SwiftFormat/CLI (0.45.2)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -84,7 +84,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Amplify: f780a637316aebf3a17ae4062fc352559f1a3455
-  AmplifyPlugins: 02790520946156c558948cbdf3040209e966e157
+  AmplifyPlugins: 3d7198e31f0844f89a9e642d9f5fa81bfff1a13d
   AmplifyTestCommon: 3c0cd92e7b02968e5143bf675b05d48a86f10ab3
   AWSAuthCore: 284f1bc07187fad68ba52a0af088fe84f7af538e
   AWSCognitoIdentityProvider: 451b1a39c5c73afa9fc2bf8d29cb0892e9b3b34c
@@ -95,7 +95,7 @@ SPEC CHECKSUMS:
   AWSPluginsCore: 817b179b67eda4d93662daaf2ec6a95272bb2740
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
-  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
+  SwiftFormat: 07a1794c1331daaefc1ca6c2ff1da38ee9ca090a
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 48d1574dddce5cef7bdb7b05b06fc588ee22956e

--- a/AmplifyPlugins/Auth/Podfile.lock
+++ b/AmplifyPlugins/Auth/Podfile.lock
@@ -26,7 +26,7 @@ PODS:
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
-  - SwiftFormat/CLI (0.44.17)
+  - SwiftFormat/CLI (0.45.2)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -82,7 +82,7 @@ SPEC CHECKSUMS:
   AWSPluginsCore: 817b179b67eda4d93662daaf2ec6a95272bb2740
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
-  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
+  SwiftFormat: 07a1794c1331daaefc1ca6c2ff1da38ee9ca090a
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 371cf67fe35ebb5167d0880bad12b01618a0fb0e

--- a/AmplifyPlugins/DataStore/Podfile.lock
+++ b/AmplifyPlugins/DataStore/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - Amplify/Default (= 1.0.5)
   - Amplify/Default (1.0.5)
   - AmplifyPlugins/AWSAPIPlugin (1.0.5):
-    - AppSyncRealTimeClient (~> 1.1.0)
+    - AppSyncRealTimeClient (~> 1.4.0)
     - AWSAuthCore (~> 2.15.0)
     - AWSCore (~> 2.15.0)
     - AWSPluginsCore (= 1.0.5)
@@ -20,8 +20,8 @@ PODS:
     - Amplify (= 1.0.5)
     - AWSCore (~> 2.15.0)
     - AWSPluginsCore (= 1.0.5)
-  - AppSyncRealTimeClient (1.1.6):
-    - Starscream (= 3.0.6)
+  - AppSyncRealTimeClient (1.4.0):
+    - Starscream (~> 3.1.0)
   - AWSAuthCore (2.15.0):
     - AWSCore (= 2.15.0)
   - AWSCognitoIdentityProvider (2.15.0):
@@ -43,8 +43,8 @@ PODS:
   - SQLite.swift (0.12.2):
     - SQLite.swift/standard (= 0.12.2)
   - SQLite.swift/standard (0.12.2)
-  - Starscream (3.0.6)
-  - SwiftFormat/CLI (0.44.17)
+  - Starscream (3.1.1)
+  - SwiftFormat/CLI (0.45.2)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -100,9 +100,9 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Amplify: f780a637316aebf3a17ae4062fc352559f1a3455
-  AmplifyPlugins: 02790520946156c558948cbdf3040209e966e157
+  AmplifyPlugins: 3d7198e31f0844f89a9e642d9f5fa81bfff1a13d
   AmplifyTestCommon: 3c0cd92e7b02968e5143bf675b05d48a86f10ab3
-  AppSyncRealTimeClient: 4a2ccdc1722750a1f4d76e216f9bfb1cf12f10de
+  AppSyncRealTimeClient: 1e14f5584218e63b00fffbc093ad1934701a4b68
   AWSAuthCore: 284f1bc07187fad68ba52a0af088fe84f7af538e
   AWSCognitoIdentityProvider: 451b1a39c5c73afa9fc2bf8d29cb0892e9b3b34c
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
@@ -113,8 +113,8 @@ SPEC CHECKSUMS:
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
-  Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
-  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
+  Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
+  SwiftFormat: 07a1794c1331daaefc1ca6c2ff1da38ee9ca090a
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 04860e414d616b67d24ed3346a60700f427764b9

--- a/AmplifyPlugins/Predictions/Podfile.lock
+++ b/AmplifyPlugins/Predictions/Podfile.lock
@@ -38,7 +38,7 @@ PODS:
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
-  - SwiftFormat/CLI (0.44.17)
+  - SwiftFormat/CLI (0.45.2)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -111,7 +111,7 @@ SPEC CHECKSUMS:
   AWSTranslate: b342d8f7f0005805423bb60b83619376ad011350
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
-  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
+  SwiftFormat: 07a1794c1331daaefc1ca6c2ff1da38ee9ca090a
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 095ccf7b80adbc9a0c0c70e2143f57a0c7d8d7b5

--- a/AmplifyPlugins/Storage/Podfile.lock
+++ b/AmplifyPlugins/Storage/Podfile.lock
@@ -33,7 +33,7 @@ PODS:
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
-  - SwiftFormat/CLI (0.44.17)
+  - SwiftFormat/CLI (0.45.2)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -84,7 +84,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Amplify: f780a637316aebf3a17ae4062fc352559f1a3455
-  AmplifyPlugins: 02790520946156c558948cbdf3040209e966e157
+  AmplifyPlugins: 3d7198e31f0844f89a9e642d9f5fa81bfff1a13d
   AmplifyTestCommon: 3c0cd92e7b02968e5143bf675b05d48a86f10ab3
   AWSAuthCore: 284f1bc07187fad68ba52a0af088fe84f7af538e
   AWSCognitoIdentityProvider: 451b1a39c5c73afa9fc2bf8d29cb0892e9b3b34c
@@ -95,7 +95,7 @@ SPEC CHECKSUMS:
   AWSS3: e54ce8e29744663f0e5f3e90d610880974fc59fa
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
-  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
+  SwiftFormat: 07a1794c1331daaefc1ca6c2ff1da38ee9ca090a
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 23c3028505a2f56c001d01c66c1622dff6f8dd8e

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -12,7 +12,7 @@ PODS:
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
-  - SwiftFormat/CLI (0.44.17)
+  - SwiftFormat/CLI (0.45.2)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -56,7 +56,7 @@ SPEC CHECKSUMS:
   AWSMobileClient: 633ec8c81dadec097e1fdb62e372e0af9b6dd706
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
-  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
+  SwiftFormat: 07a1794c1331daaefc1ca6c2ff1da38ee9ca090a
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: a2acde35ab1bc6b80b362106cfda70905a6a840f


### PR DESCRIPTION
Update SDK dependencies including AppSyncRealTimeClient to address https://github.com/aws-amplify/amplify-ios/issues/677.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
