### PR TITLE
chore: Pin to SwiftFormat 0.44.17

### DIFF
--- a/AmplifyPlugins/API/Podfile.lock
+++ b/AmplifyPlugins/API/Podfile.lock
@@ -35,7 +35,7 @@ PODS:
     - CwlCatchException
   - ReachabilitySwift (5.0.0)
   - Starscream (3.1.1)
-  - SwiftFormat/CLI (0.45.2)
+  - SwiftFormat/CLI (0.44.17)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -48,7 +48,7 @@ DEPENDENCIES:
   - CwlCatchException (from `https://github.com/mattgallagher/CwlCatchException.git`, tag `1.2.0`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `1.2.0`)
   - ReachabilitySwift (~> 5.0.0)
-  - SwiftFormat/CLI
+  - SwiftFormat/CLI (= 0.44.17)
   - SwiftLint
 
 SPEC REPOS:
@@ -103,7 +103,7 @@ SPEC CHECKSUMS:
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
-  SwiftFormat: 07a1794c1331daaefc1ca6c2ff1da38ee9ca090a
+  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 31880f143dde88382b42400953bbeb67ca4f2ae3

--- a/AmplifyPlugins/Analytics/Podfile.lock
+++ b/AmplifyPlugins/Analytics/Podfile.lock
@@ -33,7 +33,7 @@ PODS:
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
-  - SwiftFormat/CLI (0.45.2)
+  - SwiftFormat/CLI (0.44.17)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - AWSPluginsCore (from `../../`)
   - CwlCatchException (from `https://github.com/mattgallagher/CwlCatchException.git`, tag `1.2.0`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `1.2.0`)
-  - SwiftFormat/CLI
+  - SwiftFormat/CLI (= 0.44.17)
   - SwiftLint
 
 SPEC REPOS:
@@ -95,7 +95,7 @@ SPEC CHECKSUMS:
   AWSPluginsCore: 817b179b67eda4d93662daaf2ec6a95272bb2740
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
-  SwiftFormat: 07a1794c1331daaefc1ca6c2ff1da38ee9ca090a
+  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 48d1574dddce5cef7bdb7b05b06fc588ee22956e

--- a/AmplifyPlugins/Auth/Podfile.lock
+++ b/AmplifyPlugins/Auth/Podfile.lock
@@ -26,7 +26,7 @@ PODS:
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
-  - SwiftFormat/CLI (0.45.2)
+  - SwiftFormat/CLI (0.44.17)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -36,7 +36,7 @@ DEPENDENCIES:
   - AWSPluginsCore (from `../../`)
   - CwlCatchException (from `https://github.com/mattgallagher/CwlCatchException.git`, tag `1.2.0`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `1.2.0`)
-  - SwiftFormat/CLI
+  - SwiftFormat/CLI (= 0.44.17)
   - SwiftLint
 
 SPEC REPOS:
@@ -82,7 +82,7 @@ SPEC CHECKSUMS:
   AWSPluginsCore: 817b179b67eda4d93662daaf2ec6a95272bb2740
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
-  SwiftFormat: 07a1794c1331daaefc1ca6c2ff1da38ee9ca090a
+  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 371cf67fe35ebb5167d0880bad12b01618a0fb0e

--- a/AmplifyPlugins/DataStore/Podfile.lock
+++ b/AmplifyPlugins/DataStore/Podfile.lock
@@ -44,7 +44,7 @@ PODS:
     - SQLite.swift/standard (= 0.12.2)
   - SQLite.swift/standard (0.12.2)
   - Starscream (3.1.1)
-  - SwiftFormat/CLI (0.45.2)
+  - SwiftFormat/CLI (0.44.17)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -57,7 +57,7 @@ DEPENDENCIES:
   - CwlCatchException (from `https://github.com/mattgallagher/CwlCatchException.git`, tag `1.2.0`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `1.2.0`)
   - SQLite.swift (~> 0.12.0)
-  - SwiftFormat/CLI
+  - SwiftFormat/CLI (= 0.44.17)
   - SwiftLint
 
 SPEC REPOS:
@@ -114,7 +114,7 @@ SPEC CHECKSUMS:
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
   Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
-  SwiftFormat: 07a1794c1331daaefc1ca6c2ff1da38ee9ca090a
+  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 04860e414d616b67d24ed3346a60700f427764b9

--- a/AmplifyPlugins/Predictions/Podfile.lock
+++ b/AmplifyPlugins/Predictions/Podfile.lock
@@ -38,7 +38,7 @@ PODS:
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
-  - SwiftFormat/CLI (0.45.2)
+  - SwiftFormat/CLI (0.44.17)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -53,7 +53,7 @@ DEPENDENCIES:
   - AWSTranslate (~> 2.15.0)
   - CwlCatchException (from `https://github.com/mattgallagher/CwlCatchException.git`, tag `1.2.0`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `1.2.0`)
-  - SwiftFormat/CLI
+  - SwiftFormat/CLI (= 0.44.17)
   - SwiftLint
 
 SPEC REPOS:
@@ -111,7 +111,7 @@ SPEC CHECKSUMS:
   AWSTranslate: b342d8f7f0005805423bb60b83619376ad011350
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
-  SwiftFormat: 07a1794c1331daaefc1ca6c2ff1da38ee9ca090a
+  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 095ccf7b80adbc9a0c0c70e2143f57a0c7d8d7b5

--- a/AmplifyPlugins/Storage/Podfile.lock
+++ b/AmplifyPlugins/Storage/Podfile.lock
@@ -33,7 +33,7 @@ PODS:
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
-  - SwiftFormat/CLI (0.45.2)
+  - SwiftFormat/CLI (0.44.17)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - AWSS3 (~> 2.15.0)
   - CwlCatchException (from `https://github.com/mattgallagher/CwlCatchException.git`, tag `1.2.0`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `1.2.0`)
-  - SwiftFormat/CLI
+  - SwiftFormat/CLI (= 0.44.17)
   - SwiftLint
 
 SPEC REPOS:
@@ -95,7 +95,7 @@ SPEC CHECKSUMS:
   AWSS3: e54ce8e29744663f0e5f3e90d610880974fc59fa
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
-  SwiftFormat: 07a1794c1331daaefc1ca6c2ff1da38ee9ca090a
+  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: 23c3028505a2f56c001d01c66c1622dff6f8dd8e

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -12,14 +12,14 @@ PODS:
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
-  - SwiftFormat/CLI (0.45.2)
+  - SwiftFormat/CLI (0.44.17)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
   - AWSMobileClient (~> 2.15.0)
   - CwlCatchException (from `https://github.com/mattgallagher/CwlCatchException.git`, tag `1.2.0`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `1.2.0`)
-  - SwiftFormat/CLI
+  - SwiftFormat/CLI (= 0.44.17)
   - SwiftLint
 
 SPEC REPOS:
@@ -56,7 +56,7 @@ SPEC CHECKSUMS:
   AWSMobileClient: 633ec8c81dadec097e1fdb62e372e0af9b6dd706
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
-  SwiftFormat: 07a1794c1331daaefc1ca6c2ff1da38ee9ca090a
+  SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
 PODFILE CHECKSUM: a2acde35ab1bc6b80b362106cfda70905a6a840f

--- a/build-support/dependencies.rb
+++ b/build-support/dependencies.rb
@@ -13,7 +13,8 @@ $OPTIMISTIC_AWS_SDK_VERSION = "~> #{$AWS_SDK_VERSION}"
 
 # Include common tooling
 def include_build_tools!
-  pod 'SwiftFormat/CLI'
+  # Pin to 0.44.17 until we resolve closing braces
+  pod 'SwiftFormat/CLI', '0.44.17'
   pod 'SwiftLint'
 end
 


### PR DESCRIPTION
Pin to SwiftFormat 0.44.17 pending context-sensitive brace rules in SwiftLint



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
