### PR TITLE
fix(api): cognito user pool intercept with accessToken

### DIFF
--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
@@ -37,7 +37,6 @@
 		219A888F23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219A888E23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.swift */; };
 		219A889123ECF8A500BBC5F2 /* AWSAPICategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B478F5FB2374DBF400C4F92B /* AWSAPICategoryPlugin.framework */; };
 		219A88A223EE034F00BBC5F2 /* RESTWithUserPoolIntegrationTests-amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 219A889F23EE01A700BBC5F2 /* RESTWithUserPoolIntegrationTests-amplifyconfiguration.json */; };
-		219A88A323EE034F00BBC5F2 /* RESTWithUserPoolIntegrationTests-awsconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 219A889E23EE01A600BBC5F2 /* RESTWithUserPoolIntegrationTests-awsconfiguration.json */; };
 		219A88A523EE054000BBC5F2 /* RESTWithUserPoolIntegrationTests-credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = 219A88A423EE054000BBC5F2 /* RESTWithUserPoolIntegrationTests-credentials.json */; };
 		219A88A723EE05C200BBC5F2 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 219A88A623EE05C200BBC5F2 /* README.md */; };
 		21A3EFC623A946590095D8E6 /* GraphQLWithUserPoolIntegrationTests-credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = 21A3EFC523A946580095D8E6 /* GraphQLWithUserPoolIntegrationTests-credentials.json */; };
@@ -302,7 +301,6 @@
 		219A888C23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RESTWithUserPoolIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		219A888E23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTWithUserPoolIntegrationTests.swift; sourceTree = "<group>"; };
 		219A889023ECF8A500BBC5F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		219A889E23EE01A600BBC5F2 /* RESTWithUserPoolIntegrationTests-awsconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "RESTWithUserPoolIntegrationTests-awsconfiguration.json"; sourceTree = "<group>"; };
 		219A889F23EE01A700BBC5F2 /* RESTWithUserPoolIntegrationTests-amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "RESTWithUserPoolIntegrationTests-amplifyconfiguration.json"; sourceTree = "<group>"; };
 		219A88A423EE054000BBC5F2 /* RESTWithUserPoolIntegrationTests-credentials.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "RESTWithUserPoolIntegrationTests-credentials.json"; sourceTree = "<group>"; };
 		219A88A623EE05C200BBC5F2 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -700,7 +698,6 @@
 				219A889023ECF8A500BBC5F2 /* Info.plist */,
 				219A88A623EE05C200BBC5F2 /* README.md */,
 				219A889F23EE01A700BBC5F2 /* RESTWithUserPoolIntegrationTests-amplifyconfiguration.json */,
-				219A889E23EE01A600BBC5F2 /* RESTWithUserPoolIntegrationTests-awsconfiguration.json */,
 				219A88A423EE054000BBC5F2 /* RESTWithUserPoolIntegrationTests-credentials.json */,
 				219A888E23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.swift */,
 			);
@@ -1432,7 +1429,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				219A88A223EE034F00BBC5F2 /* RESTWithUserPoolIntegrationTests-amplifyconfiguration.json in Resources */,
-				219A88A323EE034F00BBC5F2 /* RESTWithUserPoolIntegrationTests-awsconfiguration.json in Resources */,
 				21598CE3239FF54E00529F29 /* RESTWithIAMIntegrationTests-amplifyconfiguration.json in Resources */,
 				21233D0B2469EBA000039337 /* GraphQLAuthDirectiveIntegrationTests-amplifyconfiguration.json in Resources */,
 				B478F6E32374E0CF00C4F92B /* Main.storyboard in Resources */,

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/README.md
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/README.md
@@ -50,24 +50,28 @@ type SocialNote
 
 ```json
 {
-    "user1": "<USER EMAIL>",
-    "passwordUser1": "<PASSWORD>"
-    "user2": "<USER2 EMAIL>",
-    "passwordUser2": "<PASSWORD>"
+    "user1": "[USER EMAIL]",
+    "passwordUser1": "[PASSWORD]"
+    "user2": "[USER2 EMAIL]",
+    "passwordUser2": "[PASSWORD]"
 }
 
 ```
 
-7. `amplify console auth`
-```perl
-? Which console `User Pool`
+7. Create a two new users in the userpool. First, retrieve the Cognito User Pool's Pool Id, you can find this in `amplifyconfiguration.json` under
 ```
-
-8. Click on `Users and groups`, Sign up the two new users with the email and a temporary password. 
-
-9. Click on App clients, and keep note of the app client web's `App client id`. This can be used the AWS AppSync console Queries.
-
-10. `amplify console api`
-Click on Queries tab, and click on Log in. This will prompt you to enter the app client id, username, and temporary password. After logging in successfully, it will ask you to enter a new password. Make sure those are the same as the one specified in the credentials json file from step 5. Do this for both users.
+"CognitoUserPool": {
+    "Default": {
+        "PoolId": "[POOL_ID]",
+```
+Run the `admin-create-user` command to create a new user
+```
+aws cognito-idp admin-create-user --user-pool-id [POOL_ID] --username [USER EMAIL]
+```
+Run the `admin-set-user-password` command to confirm the user
+```
+aws cognito-idp admin-set-user-password --user-pool-id [POOL_ID] --username [USER EMAIL] --password [PASSWORD] --permanent
+```
+See https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/index.html#cli-aws-cognito-idp for more details using AWS CLI
 
 You can now run the tests!

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/GraphQLWithUserPoolIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/GraphQLWithUserPoolIntegrationTests.swift
@@ -93,7 +93,7 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
                 XCTAssertEqual(todo.id, expectedId)
                 XCTAssertEqual(todo.name, expectedName)
                 XCTAssertEqual(todo.description, expectedDescription)
-                XCTAssertEqual(todo.typename, String(describing: Todo.self))
+                XCTAssertEqual(todo.typename, String(describing: AWSAPICategoryPluginTestCommon.Todo.self))
 
                 completeInvoked.fulfill()
             case .failure(let error):
@@ -147,7 +147,7 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
                                      variables: CreateTodoMutation.variables(id: expectedId,
                                                                              name: expectedName,
                                                                              description: expectedDescription),
-                                     responseType: Todo?.self,
+                                     responseType: AWSAPICategoryPluginTestCommon.Todo?.self,
                                      decodePath: CreateTodoMutation.decodePath)
 
         let operation = Amplify.API.mutate(request: request) { event in
@@ -166,7 +166,7 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
                 XCTAssertEqual(todo.id, expectedId)
                 XCTAssertEqual(todo.name, expectedName)
                 XCTAssertEqual(todo.description, expectedDescription)
-                XCTAssertEqual(todo.typename, String(describing: Todo.self))
+                XCTAssertEqual(todo.typename, String(describing: AWSAPICategoryPluginTestCommon.Todo.self))
 
                 completeInvoked.fulfill()
             case .failure(let error):
@@ -190,7 +190,7 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
                                      variables: CreateTodoMutation.variables(id: uuid,
                                                                              name: "",
                                                                              description: description),
-                                     responseType: Todo?.self,
+                                     responseType: AWSAPICategoryPluginTestCommon.Todo?.self,
                                      decodePath: CreateTodoMutation.decodePath)
         let operation = Amplify.API.mutate(request: request) { event in
             switch event {
@@ -287,7 +287,7 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
                 XCTAssertEqual(todo.id, todo.id)
                 XCTAssertEqual(todo.name, name)
                 XCTAssertEqual(todo.description, description)
-                XCTAssertEqual(todo.typename, String(describing: Todo.self))
+                XCTAssertEqual(todo.typename, String(describing: AWSAPICategoryPluginTestCommon.Todo.self))
 
                 completeInvoked.fulfill()
             case .failure(let error):
@@ -365,7 +365,7 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
                 XCTAssertEqual(todo.id, todo.id)
                 XCTAssertEqual(todo.name, expectedName)
                 XCTAssertEqual(todo.description, expectedDescription)
-                XCTAssertEqual(todo.typename, String(describing: Todo.self))
+                XCTAssertEqual(todo.typename, String(describing: AWSAPICategoryPluginTestCommon.Todo.self))
                 completeInvoked.fulfill()
             case .failure(let error):
                 XCTFail("Unexpected .failed event: \(error)")
@@ -409,7 +409,7 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
                 XCTAssertEqual(deleteTodo.id, todo.id)
                 XCTAssertEqual(deleteTodo.name, name)
                 XCTAssertEqual(deleteTodo.description, description)
-                XCTAssertEqual(deleteTodo.typename, String(describing: Todo.self))
+                XCTAssertEqual(deleteTodo.typename, String(describing: AWSAPICategoryPluginTestCommon.Todo.self))
                 deleteCompleteInvoked.fulfill()
             case .failure(let error):
                 XCTFail("Unexpected .failed event: \(error)")
@@ -739,9 +739,9 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
 
     // MARK: Common functionality
 
-    func createTodo(id: String, name: String, description: String) -> Todo? {
+    func createTodo(id: String, name: String, description: String) -> AWSAPICategoryPluginTestCommon.Todo? {
         let completeInvoked = expectation(description: "Completd is invoked")
-        var todo: Todo?
+        var todo: AWSAPICategoryPluginTestCommon.Todo?
 
         let request = GraphQLRequest(document: CreateTodoMutation.document,
                                      variables: CreateTodoMutation.variables(id: id,
@@ -770,9 +770,9 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
         return todo
     }
 
-    func updateTodo(id: String, name: String, description: String) -> Todo? {
+    func updateTodo(id: String, name: String, description: String) -> AWSAPICategoryPluginTestCommon.Todo? {
         let completeInvoked = expectation(description: "Completd is invoked")
-        var todo: Todo?
+        var todo: AWSAPICategoryPluginTestCommon.Todo?
 
         let request = GraphQLRequest(document: UpdateTodoMutation.document,
                                      variables: UpdateTodoMutation.variables(id: id,
@@ -801,9 +801,9 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
         return todo
     }
 
-    func deleteTodo(id: String, name: String, description: String) -> Todo? {
+    func deleteTodo(id: String, name: String, description: String) -> AWSAPICategoryPluginTestCommon.Todo? {
         let completeInvoked = expectation(description: "Completd is invoked")
-        var todo: Todo?
+        var todo: AWSAPICategoryPluginTestCommon.Todo?
 
         let request = GraphQLRequest(document: DeleteTodoMutation.document,
                                      variables: DeleteTodoMutation.variables(id: id),

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/README.md
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/README.md
@@ -15,8 +15,11 @@ The following steps show how to set up an API endpoint with APIGateway and Lambd
 ? Choose a Lambda source `Create a new Lambda function`
 ? Provide a friendly name for your resource to be used as a label for this category in the project: `restwithuserpoolinte22de6072`
 ? Provide the AWS Lambda function name: `restwithuserpoolinte22de6072`
+? Choose the runtime that you want to use: `NodeJS`
 ? Choose the function template that you want to use: `Serverless express function (Integration with Amazon API Gateway)`
 ? Do you want to access other resources created in this project from your Lambda function? `No`
+? Do you want to invoke this function on a recurring schedule? `No`
+? Do you want to configure Lambda layers for this function? `No`
 ? Do you want to edit the local lambda function now? `No`
 Succesfully added the Lambda function locally
 ? Restrict API access `No`
@@ -39,7 +42,7 @@ Successfully added resource restwithuserpoolintea05fdd00 locally
 
 4. Provision the resources. Run `amplify push` to provision the API Gateway, Lambda, and the Cognito User Pool.
 
-5. Replace `RESTWithUserPoolIntegrationTests-amplifyconfiguration.json` and `RESTWithPoolIntegrationTests-awsconfiguration.json` with the generated `amplifyconfiguration.json` and `awsconfiguration.json` . 
+5. Replace `RESTWithUserPoolIntegrationTests-amplifyconfiguration.json` with the generated `amplifyconfiguration.json`. 
 
 6. In `RESTWithUserPoolIntegrationTests-amplifyconfiguration.json`. update `authorizationType` to `AMAZON_COGNITO_USER_POOLS` like so
 ```
@@ -62,33 +65,56 @@ Successfully added resource restwithuserpoolintea05fdd00 locally
 
 ```
 
-7. Create a new user in the userpool. One method is to sign up the using `AWSMobileClient` and then open the User Pools console using `amplify console auth`. Select Users and groups, select the user, and click Confirm.
+7. Create a new user in the userpool. First, retrieve the Cognito User Pool's Pool Id, you can find this in `amplifyconfiguration.json` under
+```
+"CognitoUserPool": {
+    "Default": {
+        "PoolId": "[POOL_ID]",
+```
+Run the `admin-create-user` command to create a new user
+```
+aws cognito-idp admin-create-user --user-pool-id [POOL_ID] --username [USER EMAIL]
+```
+Run the `admin-set-user-password` command to confirm the user
+```
+aws cognito-idp admin-set-user-password --user-pool-id [POOL_ID] --username [USER EMAIL] --password [PASSWORD] --permanent
+```
+See https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/index.html#cli-aws-cognito-idp for more details using AWS CLI
 
 8. Update `RESTWithUserPoolIntegrationTests-credentials.json` with a json object containing `user1` and `password` with the crendentials of the user that was created in the previous step 
 
 ```json
 {
-    "user1": "<USER EMAIL>",
-    "password": "<PASSWORD>"
+    "user1": "[USER EMAIL]",
+    "password": "[PASSWORD]"
 }
 
 ```
 
-9. Find your API name. Run `amplify console` to open the AWS Console. The latest deployment activty logs will indicate the API Gateway that is provisioned. There will be a Resource ID that looks like `<api name> (api)`. Navigate to API Gateway console, select your API. 
-
-10. Find your Cognito User Pool name by click on the Authentication tab in the AWS Console.
+9. Retrieve your API name, you can find this in `amplifyconfiguration.json` under
+```
+"api": {
+    "plugins": {
+        "awsAPIPlugin": {
+            "[API NAME]": {
+```
+Run `amplify console` to open the AWS Console. Navigate to API Gateway console, select your API. 
 
 10. Add Cognito User Pool as an authorization mechanism. Select Authorizers, click on "+ Create New Authorizer", 
-- type in a Name
+- type in a Name like `UserPoolAuthorizer`
 - select `Cognito` as the type
-- Select the Cognito UserPool
+- Select the Cognito UserPool, the name corresponds to the name of the user pool at the top left corner when on the User Pool console.
 - For Token Source, enter `Authorization`
 - Once completed, refresh the page.
 
 11. Enable requests to the API with the Cognito User Pool Authorizer as the authorization mechanism. 
 - Select Resources on the left, Under Resources, and each individual resource path, select `Any`. You will see a Test section, Method Request, Method Response, Integration Request, etc
 - Click on Method Request, under Settings, Authorization, click on edit. In the drop down, select the User Pool authorizer, then click on the check mark to save it.
+- Click on the OAuth Scopes and add `aws.cognito.signin.user.admin`. 
 - Repeat this for each of the resource paths
 - Click on Actions, deploy API, and select the deployment stage, and click Deploy.
 
 12. Run the tests.
+
+
+For more details regarding setting up a REST API with Cognito User Pools see  https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-enable-cognito-user-pool.html

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/RESTWithUserPoolIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/RESTWithUserPoolIntegrationTests.swift
@@ -6,64 +6,49 @@
 //
 
 import XCTest
-@testable import Amplify
 import AWSAPICategoryPlugin
-import AWSMobileClient
+import AmplifyPlugins
+
+@testable import Amplify
 @testable import AmplifyTestCommon
 
 class RESTWithUserPoolIntegrationTests: XCTestCase {
+    struct User {
+        let username: String
+        let password: String
+    }
+    let amplifyConfigurationFile = "RESTWithUserPoolIntegrationTests-amplifyconfiguration"
+    let credentialsFile = "RESTWithUserPoolIntegrationTests-credentials"
+    var user1: User!
 
-    static let amplifyConfiguration = "RESTWithUserPoolIntegrationTests-amplifyconfiguration"
-    static let awsconfiguration = "RESTWithUserPoolIntegrationTests-awsconfiguration"
-    static let credentials = "RESTWithUserPoolIntegrationTests-credentials"
-    static var user1: String!
-    static var password: String!
-
-    static override func setUp() {
+    override func setUp() {
         do {
 
-            let credentials = try TestConfigHelper.retrieveCredentials(
-                forResource: RESTWithUserPoolIntegrationTests.credentials)
+            let credentials = try TestConfigHelper.retrieveCredentials(forResource: credentialsFile)
 
             guard let user1 = credentials["user1"], let password = credentials["password"] else {
                 XCTFail("Missing credentials.json data")
                 return
             }
-
-            RESTWithUserPoolIntegrationTests.user1 = user1
-            RESTWithUserPoolIntegrationTests.password = password
-
-            let awsConfiguration = try TestConfigHelper.retrieveAWSConfiguration(
-                forResource: RESTWithUserPoolIntegrationTests.awsconfiguration)
-            AWSInfo.configureDefaultAWSInfo(awsConfiguration)
-        } catch {
-            XCTFail("Error during setup: \(error)")
-        }
-    }
-
-    override func setUp() {
-        do {
-            AuthHelper.initializeMobileClient()
-
-            Amplify.reset()
+            self.user1 = User(username: user1, password: password)
 
             try Amplify.add(plugin: AWSAPIPlugin())
-
-            let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(
-                forResource: RESTWithUserPoolIntegrationTests.amplifyConfiguration)
+            try Amplify.add(plugin: AWSCognitoAuthPlugin())
+            let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: amplifyConfigurationFile)
             try Amplify.configure(amplifyConfig)
         } catch {
             XCTFail("Error during setup: \(error)")
         }
+        signOut()
     }
 
     override func tearDown() {
+        signOut()
         Amplify.reset()
     }
 
     func testGetAPISuccess() {
-        AuthHelper.signIn(username: RESTWithUserPoolIntegrationTests.user1,
-                          password: RESTWithUserPoolIntegrationTests.password)
+        signIn(username: user1.username, password: user1.password)
         let completeInvoked = expectation(description: "request completed")
         let request = RESTRequest(path: "/items")
         _ = Amplify.API.get(request: request) { event in
@@ -80,8 +65,8 @@ class RESTWithUserPoolIntegrationTests: XCTestCase {
         wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testGetAPIFailedWithNotAuthenticated() {
-        AuthHelper.signOut()
+    func testGetAPIFailedWithSignedOutError() {
+        signOut()
         let failedInvoked = expectation(description: "request failed")
         let request = RESTRequest(path: "/items")
         _ = Amplify.API.get(request: request) { event in
@@ -99,8 +84,8 @@ class RESTWithUserPoolIntegrationTests: XCTestCase {
                     return
                 }
 
-                guard case .notAuthorized = authError else {
-                    XCTFail("Error should be AuthError.notAuthorized")
+                guard case .signedOut = authError else {
+                    XCTFail("Error should be AuthError.signedOut")
                     return
                 }
 
@@ -109,5 +94,32 @@ class RESTWithUserPoolIntegrationTests: XCTestCase {
         }
 
         wait(for: [failedInvoked], timeout: TestCommonConstants.networkTimeout)
+    }
+
+    func signIn(username: String, password: String) {
+        let signInInvoked = expectation(description: "sign in completed")
+        _ = Amplify.Auth.signIn(username: username, password: password) { event in
+            switch event {
+            case .success:
+                signInInvoked.fulfill()
+            case .failure(let error):
+                XCTFail("Failed to Sign in user \(error)")
+            }
+        }
+        wait(for: [signInInvoked], timeout: TestCommonConstants.networkTimeout)
+    }
+
+    func signOut() {
+        let signOutCompleted = expectation(description: "sign out completed")
+        _ = Amplify.Auth.signOut { event in
+            switch event {
+            case .success:
+                signOutCompleted.fulfill()
+            case .failure(let error):
+                print("Could not sign out user \(error)")
+                signOutCompleted.fulfill()
+            }
+        }
+        wait(for: [signOutCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/RESTWithUserPoolIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/RESTWithUserPoolIntegrationTests.swift
@@ -66,7 +66,6 @@ class RESTWithUserPoolIntegrationTests: XCTestCase {
     }
 
     func testGetAPIFailedWithSignedOutError() {
-        signOut()
         let failedInvoked = expectation(description: "request failed")
         let request = RESTRequest(path: "/items")
         _ = Amplify.API.get(request: request) { event in

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -72,7 +72,7 @@ public class AWSAuthService: AWSAuthServiceBehavior {
         if let result = (authSession as? AuthCognitoTokensProvider)?.getCognitoTokens() {
             switch result {
             case .success(let tokens):
-                return .success(tokens.idToken)
+                return .success(tokens.accessToken)
             case .failure(let error):
                 return .failure(error)
             }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/618

*Description of changes:*
This updates the Cognito User Pool interceptor to use the accessToken. Android and JS is using accessToken, while iOS was using idToken before. According to the [AWS docs](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-with-identity-providers.html), both can be passed to the service. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
