### PR TITLE
chore: update SDK to 2.15.1

### DIFF
--- a/AmplifyPlugins/API/Podfile.lock
+++ b/AmplifyPlugins/API/Podfile.lock
@@ -16,16 +16,16 @@ PODS:
     - AWSPluginsCore (= 1.0.6)
   - AppSyncRealTimeClient (1.4.0):
     - Starscream (~> 3.1.0)
-  - AWSAuthCore (2.15.0):
-    - AWSCore (= 2.15.0)
-  - AWSCognitoIdentityProvider (2.15.0):
+  - AWSAuthCore (2.15.1):
+    - AWSCore (= 2.15.1)
+  - AWSCognitoIdentityProvider (2.15.1):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.15.0)
+    - AWSCore (= 2.15.1)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.15.0)
-  - AWSMobileClient (2.15.0):
-    - AWSAuthCore (= 2.15.0)
-    - AWSCognitoIdentityProvider (= 2.15.0)
+  - AWSCore (2.15.1)
+  - AWSMobileClient (2.15.1):
+    - AWSAuthCore (= 2.15.1)
+    - AWSCognitoIdentityProvider (= 2.15.1)
   - AWSPluginsCore (1.0.6):
     - Amplify (= 1.0.6)
     - AWSCore (~> 2.15.0)
@@ -93,11 +93,11 @@ SPEC CHECKSUMS:
   AmplifyPlugins: 6e3000faae927e45279b0198a531fbb91554efc6
   AmplifyTestCommon: 92e017076ac0437c251f7cd3c401563cab00c1ae
   AppSyncRealTimeClient: 1e14f5584218e63b00fffbc093ad1934701a4b68
-  AWSAuthCore: 284f1bc07187fad68ba52a0af088fe84f7af538e
-  AWSCognitoIdentityProvider: 451b1a39c5c73afa9fc2bf8d29cb0892e9b3b34c
+  AWSAuthCore: d98801d505ea332fd1ec28fbaf3377e0ce02100f
+  AWSCognitoIdentityProvider: 5172f21b3530adbb1549501cd26e126bb211b85c
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: b732e43f2afaef25c3a7dd9408b8c594213397bd
-  AWSMobileClient: 633ec8c81dadec097e1fdb62e372e0af9b6dd706
+  AWSCore: 7dec5eefb9b95739adec68dcb3dba2a6770376a6
+  AWSMobileClient: 23aa8e4a787553742861ea1e3272420a9aaf4938
   AWSPluginsCore: 530a2a531c8cb7f9de8423689746f67108d2ceaa
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961

--- a/AmplifyPlugins/Analytics/Podfile.lock
+++ b/AmplifyPlugins/Analytics/Podfile.lock
@@ -14,18 +14,18 @@ PODS:
     - Amplify (= 1.0.6)
     - AWSCore (~> 2.15.0)
     - AWSPluginsCore (= 1.0.6)
-  - AWSAuthCore (2.15.0):
-    - AWSCore (= 2.15.0)
-  - AWSCognitoIdentityProvider (2.15.0):
+  - AWSAuthCore (2.15.1):
+    - AWSCore (= 2.15.1)
+  - AWSCognitoIdentityProvider (2.15.1):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.15.0)
+    - AWSCore (= 2.15.1)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.15.0)
-  - AWSMobileClient (2.15.0):
-    - AWSAuthCore (= 2.15.0)
-    - AWSCognitoIdentityProvider (= 2.15.0)
-  - AWSPinpoint (2.15.0):
-    - AWSCore (= 2.15.0)
+  - AWSCore (2.15.1)
+  - AWSMobileClient (2.15.1):
+    - AWSAuthCore (= 2.15.1)
+    - AWSCognitoIdentityProvider (= 2.15.1)
+  - AWSPinpoint (2.15.1):
+    - AWSCore (= 2.15.1)
   - AWSPluginsCore (1.0.6):
     - Amplify (= 1.0.6)
     - AWSCore (~> 2.15.0)
@@ -86,12 +86,12 @@ SPEC CHECKSUMS:
   Amplify: e07bbe2b0bbeeec2b36470a842e59c98d0b7effa
   AmplifyPlugins: 6e3000faae927e45279b0198a531fbb91554efc6
   AmplifyTestCommon: 92e017076ac0437c251f7cd3c401563cab00c1ae
-  AWSAuthCore: 284f1bc07187fad68ba52a0af088fe84f7af538e
-  AWSCognitoIdentityProvider: 451b1a39c5c73afa9fc2bf8d29cb0892e9b3b34c
+  AWSAuthCore: d98801d505ea332fd1ec28fbaf3377e0ce02100f
+  AWSCognitoIdentityProvider: 5172f21b3530adbb1549501cd26e126bb211b85c
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: b732e43f2afaef25c3a7dd9408b8c594213397bd
-  AWSMobileClient: 633ec8c81dadec097e1fdb62e372e0af9b6dd706
-  AWSPinpoint: 172d5198789aad98ee27f9a03a3f1c5a5475c97b
+  AWSCore: 7dec5eefb9b95739adec68dcb3dba2a6770376a6
+  AWSMobileClient: 23aa8e4a787553742861ea1e3272420a9aaf4938
+  AWSPinpoint: 21b3509de2a5288054c0a60a8acc7d56f3bbbad4
   AWSPluginsCore: 530a2a531c8cb7f9de8423689746f67108d2ceaa
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961

--- a/AmplifyPlugins/Auth/Podfile.lock
+++ b/AmplifyPlugins/Auth/Podfile.lock
@@ -9,16 +9,16 @@ PODS:
     - Amplify (= 1.0.6)
     - AWSCore (~> 2.15.0)
     - AWSPluginsCore (= 1.0.6)
-  - AWSAuthCore (2.15.0):
-    - AWSCore (= 2.15.0)
-  - AWSCognitoIdentityProvider (2.15.0):
+  - AWSAuthCore (2.15.1):
+    - AWSCore (= 2.15.1)
+  - AWSCognitoIdentityProvider (2.15.1):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.15.0)
+    - AWSCore (= 2.15.1)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.15.0)
-  - AWSMobileClient (2.15.0):
-    - AWSAuthCore (= 2.15.0)
-    - AWSCognitoIdentityProvider (= 2.15.0)
+  - AWSCore (2.15.1)
+  - AWSMobileClient (2.15.1):
+    - AWSAuthCore (= 2.15.1)
+    - AWSCognitoIdentityProvider (= 2.15.1)
   - AWSPluginsCore (1.0.6):
     - Amplify (= 1.0.6)
     - AWSCore (~> 2.15.0)
@@ -74,11 +74,11 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Amplify: e07bbe2b0bbeeec2b36470a842e59c98d0b7effa
   AmplifyTestCommon: 92e017076ac0437c251f7cd3c401563cab00c1ae
-  AWSAuthCore: 284f1bc07187fad68ba52a0af088fe84f7af538e
-  AWSCognitoIdentityProvider: 451b1a39c5c73afa9fc2bf8d29cb0892e9b3b34c
+  AWSAuthCore: d98801d505ea332fd1ec28fbaf3377e0ce02100f
+  AWSCognitoIdentityProvider: 5172f21b3530adbb1549501cd26e126bb211b85c
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: b732e43f2afaef25c3a7dd9408b8c594213397bd
-  AWSMobileClient: 633ec8c81dadec097e1fdb62e372e0af9b6dd706
+  AWSCore: 7dec5eefb9b95739adec68dcb3dba2a6770376a6
+  AWSMobileClient: 23aa8e4a787553742861ea1e3272420a9aaf4938
   AWSPluginsCore: 530a2a531c8cb7f9de8423689746f67108d2ceaa
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961

--- a/AmplifyPlugins/DataStore/Podfile.lock
+++ b/AmplifyPlugins/DataStore/Podfile.lock
@@ -22,16 +22,16 @@ PODS:
     - AWSPluginsCore (= 1.0.6)
   - AppSyncRealTimeClient (1.4.0):
     - Starscream (~> 3.1.0)
-  - AWSAuthCore (2.15.0):
-    - AWSCore (= 2.15.0)
-  - AWSCognitoIdentityProvider (2.15.0):
+  - AWSAuthCore (2.15.1):
+    - AWSCore (= 2.15.1)
+  - AWSCognitoIdentityProvider (2.15.1):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.15.0)
+    - AWSCore (= 2.15.1)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.15.0)
-  - AWSMobileClient (2.15.0):
-    - AWSAuthCore (= 2.15.0)
-    - AWSCognitoIdentityProvider (= 2.15.0)
+  - AWSCore (2.15.1)
+  - AWSMobileClient (2.15.1):
+    - AWSAuthCore (= 2.15.1)
+    - AWSCognitoIdentityProvider (= 2.15.1)
   - AWSPluginsCore (1.0.6):
     - Amplify (= 1.0.6)
     - AWSCore (~> 2.15.0)
@@ -103,11 +103,11 @@ SPEC CHECKSUMS:
   AmplifyPlugins: 6e3000faae927e45279b0198a531fbb91554efc6
   AmplifyTestCommon: 92e017076ac0437c251f7cd3c401563cab00c1ae
   AppSyncRealTimeClient: 1e14f5584218e63b00fffbc093ad1934701a4b68
-  AWSAuthCore: 284f1bc07187fad68ba52a0af088fe84f7af538e
-  AWSCognitoIdentityProvider: 451b1a39c5c73afa9fc2bf8d29cb0892e9b3b34c
+  AWSAuthCore: d98801d505ea332fd1ec28fbaf3377e0ce02100f
+  AWSCognitoIdentityProvider: 5172f21b3530adbb1549501cd26e126bb211b85c
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: b732e43f2afaef25c3a7dd9408b8c594213397bd
-  AWSMobileClient: 633ec8c81dadec097e1fdb62e372e0af9b6dd706
+  AWSCore: 7dec5eefb9b95739adec68dcb3dba2a6770376a6
+  AWSMobileClient: 23aa8e4a787553742861ea1e3272420a9aaf4938
   AWSPluginsCore: 530a2a531c8cb7f9de8423689746f67108d2ceaa
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961

--- a/AmplifyPlugins/Predictions/Podfile.lock
+++ b/AmplifyPlugins/Predictions/Podfile.lock
@@ -9,32 +9,32 @@ PODS:
     - Amplify (= 1.0.6)
     - AWSCore (~> 2.15.0)
     - AWSPluginsCore (= 1.0.6)
-  - AWSAuthCore (2.15.0):
-    - AWSCore (= 2.15.0)
-  - AWSCognitoIdentityProvider (2.15.0):
+  - AWSAuthCore (2.15.1):
+    - AWSCore (= 2.15.1)
+  - AWSCognitoIdentityProvider (2.15.1):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.15.0)
+    - AWSCore (= 2.15.1)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSComprehend (2.15.0):
-    - AWSCore (= 2.15.0)
-  - AWSCore (2.15.0)
-  - AWSMobileClient (2.15.0):
-    - AWSAuthCore (= 2.15.0)
-    - AWSCognitoIdentityProvider (= 2.15.0)
+  - AWSComprehend (2.15.1):
+    - AWSCore (= 2.15.1)
+  - AWSCore (2.15.1)
+  - AWSMobileClient (2.15.1):
+    - AWSAuthCore (= 2.15.1)
+    - AWSCognitoIdentityProvider (= 2.15.1)
   - AWSPluginsCore (1.0.6):
     - Amplify (= 1.0.6)
     - AWSCore (~> 2.15.0)
     - AWSMobileClient (~> 2.15.0)
-  - AWSPolly (2.15.0):
-    - AWSCore (= 2.15.0)
-  - AWSRekognition (2.15.0):
-    - AWSCore (= 2.15.0)
-  - AWSTextract (2.15.0):
-    - AWSCore (= 2.15.0)
-  - AWSTranscribeStreaming (2.15.0):
-    - AWSCore (= 2.15.0)
-  - AWSTranslate (2.15.0):
-    - AWSCore (= 2.15.0)
+  - AWSPolly (2.15.1):
+    - AWSCore (= 2.15.1)
+  - AWSRekognition (2.15.1):
+    - AWSCore (= 2.15.1)
+  - AWSTextract (2.15.1):
+    - AWSCore (= 2.15.1)
+  - AWSTranscribeStreaming (2.15.1):
+    - AWSCore (= 2.15.1)
+  - AWSTranslate (2.15.1):
+    - AWSCore (= 2.15.1)
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
@@ -97,18 +97,18 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Amplify: e07bbe2b0bbeeec2b36470a842e59c98d0b7effa
   AmplifyTestCommon: 92e017076ac0437c251f7cd3c401563cab00c1ae
-  AWSAuthCore: 284f1bc07187fad68ba52a0af088fe84f7af538e
-  AWSCognitoIdentityProvider: 451b1a39c5c73afa9fc2bf8d29cb0892e9b3b34c
+  AWSAuthCore: d98801d505ea332fd1ec28fbaf3377e0ce02100f
+  AWSCognitoIdentityProvider: 5172f21b3530adbb1549501cd26e126bb211b85c
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSComprehend: 364481960afebe3e458cd512be435c6d7f48693c
-  AWSCore: b732e43f2afaef25c3a7dd9408b8c594213397bd
-  AWSMobileClient: 633ec8c81dadec097e1fdb62e372e0af9b6dd706
+  AWSComprehend: 61ae307a12b4aefa3592651e5991423fdff08831
+  AWSCore: 7dec5eefb9b95739adec68dcb3dba2a6770376a6
+  AWSMobileClient: 23aa8e4a787553742861ea1e3272420a9aaf4938
   AWSPluginsCore: 530a2a531c8cb7f9de8423689746f67108d2ceaa
-  AWSPolly: 53dab1558b38cf21634a2fa37b6e15b7b45cce1b
-  AWSRekognition: 1cc92b959b5a1c3e5a6da0b19bba034c07a4f87f
-  AWSTextract: bcc5488b21660cfc3632812a70e5f3be500f96aa
-  AWSTranscribeStreaming: fb7ebae52697b22446c5f3d53ae69cc0f8645675
-  AWSTranslate: b342d8f7f0005805423bb60b83619376ad011350
+  AWSPolly: 6bb6f94b494d4f0ea68bbecba8e22e04e43bcbc6
+  AWSRekognition: d13e5c4ab7f4c9c2234ee73dc3bade67578691a1
+  AWSTextract: e6cbcffe68b56763b30cba9225b576847ca03bb2
+  AWSTranscribeStreaming: 62010cf50d040e99b90eb40a6cf9a1dc9207588d
+  AWSTranslate: dbf5bbb46cb39334c477a599da52f56c12eef553
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - AWSAuthCore (2.15.0):
-    - AWSCore (= 2.15.0)
-  - AWSCognitoIdentityProvider (2.15.0):
+  - AWSAuthCore (2.15.1):
+    - AWSCore (= 2.15.1)
+  - AWSCognitoIdentityProvider (2.15.1):
     - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.15.0)
+    - AWSCore (= 2.15.1)
   - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.15.0)
-  - AWSMobileClient (2.15.0):
-    - AWSAuthCore (= 2.15.0)
-    - AWSCognitoIdentityProvider (= 2.15.0)
+  - AWSCore (2.15.1)
+  - AWSMobileClient (2.15.1):
+    - AWSAuthCore (= 2.15.1)
+    - AWSCognitoIdentityProvider (= 2.15.1)
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
@@ -49,11 +49,11 @@ CHECKOUT OPTIONS:
     :tag: 1.2.0
 
 SPEC CHECKSUMS:
-  AWSAuthCore: 284f1bc07187fad68ba52a0af088fe84f7af538e
-  AWSCognitoIdentityProvider: 451b1a39c5c73afa9fc2bf8d29cb0892e9b3b34c
+  AWSAuthCore: d98801d505ea332fd1ec28fbaf3377e0ce02100f
+  AWSCognitoIdentityProvider: 5172f21b3530adbb1549501cd26e126bb211b85c
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: b732e43f2afaef25c3a7dd9408b8c594213397bd
-  AWSMobileClient: 633ec8c81dadec097e1fdb62e372e0af9b6dd706
+  AWSCore: 7dec5eefb9b95739adec68dcb3dba2a6770376a6
+  AWSMobileClient: 23aa8e4a787553742861ea1e3272420a9aaf4938
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Most Podfile.lock's were updated to 2.15.1 from 2.15.0 except for Predictions from 2.13

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
