### PR TITLE
feat(auth): Add metadata options for passing clientMetadata to APIs

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/project.pbxproj
@@ -9,9 +9,12 @@
 /* Begin PBXBuildFile section */
 		17CD56B119F2F31BD4D27C0A /* Pods_AWSCognitoAuthPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58D3E33555611987B753EF2D /* Pods_AWSCognitoAuthPlugin.framework */; };
 		21621E0C24DE1EFE00497A24 /* AWSAuthResendSignUpCodeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21621E0B24DE1EFE00497A24 /* AWSAuthResendSignUpCodeOptions.swift */; };
-		21621E0E24DE1FC300497A24 /* AWSResendAttributeConfirmationCodeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21621E0D24DE1FC300497A24 /* AWSResendAttributeConfirmationCodeOptions.swift */; };
+		21621E0E24DE1FC300497A24 /* AWSAttributeResendConfirmationCodeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21621E0D24DE1FC300497A24 /* AWSAttributeResendConfirmationCodeOptions.swift */; };
 		21621E1024DE2D5600497A24 /* AWSUpdateUserAttributesOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21621E0F24DE2D5600497A24 /* AWSUpdateUserAttributesOptions.swift */; };
 		21621E1224DE2D6100497A24 /* AWSUpdateUserAttributeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21621E1124DE2D6100497A24 /* AWSUpdateUserAttributeOptions.swift */; };
+		21C2B50F24E1FA3800371597 /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21C2B50E24E1FA3800371597 /* amplifyconfiguration.json */; };
+		21C2B51224E3381200371597 /* AuthUserAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C2B51124E3381200371597 /* AuthUserAttributesTests.swift */; };
+		21C2B51424E35C1000371597 /* credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = 21C2B51324E35C1000371597 /* credentials.json */; };
 		3AB72AEC1B90671D652C3F96 /* Pods_HostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 234C2AFA9205B1766FB8E090 /* Pods_HostApp.framework */; };
 		8337B0CA31C0E650D640B82C /* Pods_HostApp_AWSCognitoAuthPluginIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 242DDB230CE2BA243E395217 /* Pods_HostApp_AWSCognitoAuthPluginIntegrationTests.framework */; };
 		B40F165D24784AE300CDB920 /* AWSCognitoAuthPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B43DC7452410572400D40275 /* AWSCognitoAuthPlugin.framework */; };
@@ -117,7 +120,6 @@
 		B4F3EA4F243A782700F23296 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3EA4C243A782700F23296 /* ViewController.swift */; };
 		B4F3EA50243A782700F23296 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3EA4D243A782700F23296 /* AppDelegate.swift */; };
 		B4F3EA51243A782700F23296 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3EA4E243A782700F23296 /* SceneDelegate.swift */; };
-		D8D4514C24C7AF2600EE2086 /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = D8D4514B24C7AF2500EE2086 /* amplifyconfiguration.json */; };
 		FA6B0EA8249443C90062AA59 /* AWSCognitoAuthPluginConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B0EA7249443C90062AA59 /* AWSCognitoAuthPluginConfigTests.swift */; };
 		FECB988C412E46FD5961894A /* Pods_AWSCognitoAuthPlugin_AWSCognitoAuthPluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1674B6AE81501F6E278CE00B /* Pods_AWSCognitoAuthPlugin_AWSCognitoAuthPluginTests.framework */; };
 /* End PBXBuildFile section */
@@ -152,9 +154,12 @@
 		1674B6AE81501F6E278CE00B /* Pods_AWSCognitoAuthPlugin_AWSCognitoAuthPluginTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSCognitoAuthPlugin_AWSCognitoAuthPluginTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1E372E3DB1CE31F318AE8281 /* Pods-HostApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp.debug.xcconfig"; path = "Target Support Files/Pods-HostApp/Pods-HostApp.debug.xcconfig"; sourceTree = "<group>"; };
 		21621E0B24DE1EFE00497A24 /* AWSAuthResendSignUpCodeOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAuthResendSignUpCodeOptions.swift; sourceTree = "<group>"; };
-		21621E0D24DE1FC300497A24 /* AWSResendAttributeConfirmationCodeOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSResendAttributeConfirmationCodeOptions.swift; sourceTree = "<group>"; };
+		21621E0D24DE1FC300497A24 /* AWSAttributeResendConfirmationCodeOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAttributeResendConfirmationCodeOptions.swift; sourceTree = "<group>"; };
 		21621E0F24DE2D5600497A24 /* AWSUpdateUserAttributesOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSUpdateUserAttributesOptions.swift; sourceTree = "<group>"; };
 		21621E1124DE2D6100497A24 /* AWSUpdateUserAttributeOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSUpdateUserAttributeOptions.swift; sourceTree = "<group>"; };
+		21C2B50E24E1FA3800371597 /* amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = amplifyconfiguration.json; sourceTree = "<group>"; };
+		21C2B51124E3381200371597 /* AuthUserAttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthUserAttributesTests.swift; sourceTree = "<group>"; };
+		21C2B51324E35C1000371597 /* credentials.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = credentials.json; sourceTree = "<group>"; };
 		234C2AFA9205B1766FB8E090 /* Pods_HostApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		242DDB230CE2BA243E395217 /* Pods_HostApp_AWSCognitoAuthPluginIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSCognitoAuthPluginIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		351EEBA51873352B4E797CE0 /* Pods-HostApp-AWSAuthPluginIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAuthPluginIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAuthPluginIntegrationTests/Pods-HostApp-AWSAuthPluginIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -285,7 +290,6 @@
 		B4F3EA4E243A782700F23296 /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		C49A4C812B0F973F5536DCC8 /* Pods-AWSAuthPlugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAuthPlugin.release.xcconfig"; path = "Target Support Files/Pods-AWSAuthPlugin/Pods-AWSAuthPlugin.release.xcconfig"; sourceTree = "<group>"; };
 		C5E50D8021B9740CB511898D /* Pods-AWSAuthPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAuthPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSAuthPlugin/Pods-AWSAuthPlugin.debug.xcconfig"; sourceTree = "<group>"; };
-		D8D4514B24C7AF2500EE2086 /* amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = amplifyconfiguration.json; sourceTree = "<group>"; };
 		E9289652B314AA0AA1F31BC8 /* Pods-HostApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp.release.xcconfig"; path = "Target Support Files/Pods-HostApp/Pods-HostApp.release.xcconfig"; sourceTree = "<group>"; };
 		FA6B0EA7249443C90062AA59 /* AWSCognitoAuthPluginConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSCognitoAuthPluginConfigTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -328,18 +332,27 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		21C2B51024E337B700371597 /* AuthUserAttributesTests */ = {
+			isa = PBXGroup;
+			children = (
+				21C2B51124E3381200371597 /* AuthUserAttributesTests.swift */,
+			);
+			path = AuthUserAttributesTests;
+			sourceTree = "<group>";
+		};
 		B40F166324784B3400CDB920 /* AWSCognitoAuthPluginIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
-				B40F166824784B3400CDB920 /* README.md */,
-				B40F167724784B3400CDB920 /* AWSAuthBaseTest.swift */,
 				B40F167824784B3400CDB920 /* AuthDeviceTests */,
 				B40F167424784B3400CDB920 /* AuthSessionTests */,
 				B40F167224784B3400CDB920 /* AuthSignInTests */,
 				B44373A2247C8A0C00DEF43C /* AuthSignOutTests */,
 				B40F166E24784B3400CDB920 /* AuthSignUpTests */,
+				21C2B51024E337B700371597 /* AuthUserAttributesTests */,
 				B40F166C24784B3400CDB920 /* AuthUserTests */,
+				B40F167724784B3400CDB920 /* AWSAuthBaseTest.swift */,
 				B40F166424784B3400CDB920 /* Configuration */,
+				B40F166824784B3400CDB920 /* README.md */,
 				B40F166624784B3400CDB920 /* Resources */,
 				B40F166924784B3400CDB920 /* Support */,
 			);
@@ -349,7 +362,8 @@
 		B40F166424784B3400CDB920 /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
-				D8D4514B24C7AF2500EE2086 /* amplifyconfiguration.json */,
+				21C2B50E24E1FA3800371597 /* amplifyconfiguration.json */,
+				21C2B51324E35C1000371597 /* credentials.json */,
 			);
 			path = Configuration;
 			sourceTree = "<group>";
@@ -500,7 +514,7 @@
 				B41D0F462475A3960049D08D /* AWSAuthSignInOptions.swift */,
 				B41D0F472475A3960049D08D /* AWSAuthSignUpOptions.swift */,
 				B41D0F482475A3960049D08D /* AWSAuthWebUISignInOptions.swift */,
-				21621E0D24DE1FC300497A24 /* AWSResendAttributeConfirmationCodeOptions.swift */,
+				21621E0D24DE1FC300497A24 /* AWSAttributeResendConfirmationCodeOptions.swift */,
 				21621E1124DE2D6100497A24 /* AWSUpdateUserAttributeOptions.swift */,
 				21621E0F24DE2D5600497A24 /* AWSUpdateUserAttributesOptions.swift */,
 			);
@@ -907,8 +921,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21C2B51424E35C1000371597 /* credentials.json in Resources */,
 				B40F167C24784B3400CDB920 /* README.md in Resources */,
-				D8D4514C24C7AF2600EE2086 /* amplifyconfiguration.json in Resources */,
+				21C2B50F24E1FA3800371597 /* amplifyconfiguration.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1233,6 +1248,7 @@
 				B40F168724784B3400CDB920 /* AuthDeviceOperationTests.swift in Sources */,
 				B40F168124784B3400CDB920 /* AuthConfirmSignUpTests.swift in Sources */,
 				B40F167E24784B3400CDB920 /* AuthConfigurationHelper.swift in Sources */,
+				21C2B51224E3381200371597 /* AuthUserAttributesTests.swift in Sources */,
 				B44373A1247C869100DEF43C /* AuthSessionHelper.swift in Sources */,
 				B40F167F24784B3400CDB920 /* AuthUserTests.swift in Sources */,
 				B40F168224784B3400CDB920 /* AuthResendSignUpCodeTests.swift in Sources */,
@@ -1287,7 +1303,7 @@
 				B41D10082475AB7E0049D08D /* AWSCognitoAuthPlugin+ClientBehavior.swift in Sources */,
 				B41D0FA72475A3960049D08D /* SignInResult+Extension.swift in Sources */,
 				B41D0F922475A3960049D08D /* AuthorizationProviderBehavior.swift in Sources */,
-				21621E0E24DE1FC300497A24 /* AWSResendAttributeConfirmationCodeOptions.swift in Sources */,
+				21621E0E24DE1FC300497A24 /* AWSAttributeResendConfirmationCodeOptions.swift in Sources */,
 				B41D0F902475A3960049D08D /* AuthUserServiceAdapter.swift in Sources */,
 				B41D0FD82475A3960049D08D /* AWSMobileClientBehavior.swift in Sources */,
 				B41D0FCF2475A3960049D08D /* AuthResetPasswordRequest+Validate.swift in Sources */,

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		17CD56B119F2F31BD4D27C0A /* Pods_AWSCognitoAuthPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58D3E33555611987B753EF2D /* Pods_AWSCognitoAuthPlugin.framework */; };
+		21621E0C24DE1EFE00497A24 /* AWSAuthResendSignUpCodeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21621E0B24DE1EFE00497A24 /* AWSAuthResendSignUpCodeOptions.swift */; };
+		21621E0E24DE1FC300497A24 /* AWSResendAttributeConfirmationCodeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21621E0D24DE1FC300497A24 /* AWSResendAttributeConfirmationCodeOptions.swift */; };
+		21621E1024DE2D5600497A24 /* AWSUpdateUserAttributesOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21621E0F24DE2D5600497A24 /* AWSUpdateUserAttributesOptions.swift */; };
+		21621E1224DE2D6100497A24 /* AWSUpdateUserAttributeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21621E1124DE2D6100497A24 /* AWSUpdateUserAttributeOptions.swift */; };
 		3AB72AEC1B90671D652C3F96 /* Pods_HostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 234C2AFA9205B1766FB8E090 /* Pods_HostApp.framework */; };
 		8337B0CA31C0E650D640B82C /* Pods_HostApp_AWSCognitoAuthPluginIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 242DDB230CE2BA243E395217 /* Pods_HostApp_AWSCognitoAuthPluginIntegrationTests.framework */; };
 		B40F165D24784AE300CDB920 /* AWSCognitoAuthPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B43DC7452410572400D40275 /* AWSCognitoAuthPlugin.framework */; };
@@ -147,6 +151,10 @@
 		1218D5A8F8902BF0D88AFB50 /* Pods-HostApp-AWSCognitoAuthPluginIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSCognitoAuthPluginIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSCognitoAuthPluginIntegrationTests/Pods-HostApp-AWSCognitoAuthPluginIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		1674B6AE81501F6E278CE00B /* Pods_AWSCognitoAuthPlugin_AWSCognitoAuthPluginTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSCognitoAuthPlugin_AWSCognitoAuthPluginTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1E372E3DB1CE31F318AE8281 /* Pods-HostApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp.debug.xcconfig"; path = "Target Support Files/Pods-HostApp/Pods-HostApp.debug.xcconfig"; sourceTree = "<group>"; };
+		21621E0B24DE1EFE00497A24 /* AWSAuthResendSignUpCodeOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAuthResendSignUpCodeOptions.swift; sourceTree = "<group>"; };
+		21621E0D24DE1FC300497A24 /* AWSResendAttributeConfirmationCodeOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSResendAttributeConfirmationCodeOptions.swift; sourceTree = "<group>"; };
+		21621E0F24DE2D5600497A24 /* AWSUpdateUserAttributesOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSUpdateUserAttributesOptions.swift; sourceTree = "<group>"; };
+		21621E1124DE2D6100497A24 /* AWSUpdateUserAttributeOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSUpdateUserAttributeOptions.swift; sourceTree = "<group>"; };
 		234C2AFA9205B1766FB8E090 /* Pods_HostApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		242DDB230CE2BA243E395217 /* Pods_HostApp_AWSCognitoAuthPluginIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSCognitoAuthPluginIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		351EEBA51873352B4E797CE0 /* Pods-HostApp-AWSAuthPluginIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAuthPluginIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAuthPluginIntegrationTests/Pods-HostApp-AWSAuthPluginIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -487,10 +495,14 @@
 				B41D0F492475A3960049D08D /* AWSAuthConfirmResetPasswordOptions.swift */,
 				B41D0F432475A3960049D08D /* AWSAuthConfirmSignInOptions.swift */,
 				B41D0F442475A3960049D08D /* AWSAuthConfirmSignUpOptions.swift */,
+				21621E0B24DE1EFE00497A24 /* AWSAuthResendSignUpCodeOptions.swift */,
 				B41D0F452475A3960049D08D /* AWSAuthResetPasswordOptions.swift */,
 				B41D0F462475A3960049D08D /* AWSAuthSignInOptions.swift */,
 				B41D0F472475A3960049D08D /* AWSAuthSignUpOptions.swift */,
 				B41D0F482475A3960049D08D /* AWSAuthWebUISignInOptions.swift */,
+				21621E0D24DE1FC300497A24 /* AWSResendAttributeConfirmationCodeOptions.swift */,
+				21621E1124DE2D6100497A24 /* AWSUpdateUserAttributeOptions.swift */,
+				21621E0F24DE2D5600497A24 /* AWSUpdateUserAttributesOptions.swift */,
 			);
 			path = Options;
 			sourceTree = "<group>";
@@ -1247,6 +1259,7 @@
 				B41D0FCB2475A3960049D08D /* Tokens+Extension.swift in Sources */,
 				B41D0FBF2475A3960049D08D /* AWSAuthResetPasswordOperation.swift in Sources */,
 				B41D0FC32475A3960049D08D /* AuthPluginErrorConstants.swift in Sources */,
+				21621E0C24DE1EFE00497A24 /* AWSAuthResendSignUpCodeOptions.swift in Sources */,
 				B41D0FD02475A3960049D08D /* AuthSignUpRequest+Validate.swift in Sources */,
 				B41D0FB32475A3960049D08D /* AWSAuthAttributeResendConfirmationCodeOperation.swift in Sources */,
 				B41D0F952475A3960049D08D /* AuthenticationProviderAdapter+Password.swift in Sources */,
@@ -1274,6 +1287,7 @@
 				B41D10082475AB7E0049D08D /* AWSCognitoAuthPlugin+ClientBehavior.swift in Sources */,
 				B41D0FA72475A3960049D08D /* SignInResult+Extension.swift in Sources */,
 				B41D0F922475A3960049D08D /* AuthorizationProviderBehavior.swift in Sources */,
+				21621E0E24DE1FC300497A24 /* AWSResendAttributeConfirmationCodeOptions.swift in Sources */,
 				B41D0F902475A3960049D08D /* AuthUserServiceAdapter.swift in Sources */,
 				B41D0FD82475A3960049D08D /* AWSMobileClientBehavior.swift in Sources */,
 				B41D0FCF2475A3960049D08D /* AuthResetPasswordRequest+Validate.swift in Sources */,
@@ -1285,6 +1299,7 @@
 				B41D0FBE2475A3960049D08D /* AWSAuthForgetDeviceOperation.swift in Sources */,
 				B41D0FB42475A3960049D08D /* AWSAuthFetchUserAttributeOperation.swift in Sources */,
 				B41D0F9E2475A3960049D08D /* AWSAuthConfirmSignUpOptions.swift in Sources */,
+				21621E1224DE2D6100497A24 /* AWSUpdateUserAttributeOptions.swift in Sources */,
 				B41D0FB22475A3960049D08D /* AWSAuthUpdateUserAttributeOperation.swift in Sources */,
 				B41D0FBA2475A3960049D08D /* AWSAuthSocialWebUISignInOperation.swift in Sources */,
 				B41D0FC42475A3960049D08D /* UserCodeDeliveryDetails+Extension.swift in Sources */,
@@ -1316,6 +1331,7 @@
 				B41D0F8A2475A3960049D08D /* AuthHubEventHandler.swift in Sources */,
 				B41D0FA22475A3960049D08D /* AWSAuthWebUISignInOptions.swift in Sources */,
 				B41D0FC62475A3960049D08D /* AWSMobileClient+Reset.swift in Sources */,
+				21621E1024DE2D5600497A24 /* AWSUpdateUserAttributesOptions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthUserServiceAdapter.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthUserServiceAdapter.swift
@@ -47,7 +47,8 @@ class AuthUserServiceAdapter: AuthUserServiceBehavior {
                          completionHandler: @escaping UpdateUserAttributeCompletion) {
 
         let attribuetList = [request.userAttribute]
-        updateAttributes(attributeList: attribuetList) { result in
+        let clientMetaData = (request.options.pluginOptions as? AWSUpdateUserAttributeOptions)?.metadata ?? [:]
+        updateAttributes(attributeList: attribuetList, clientMetaData: clientMetaData) { result in
             switch result {
             case .success(let updateAttributeResultDict):
                 guard let updateResult = updateAttributeResultDict[request.userAttribute.key] else {
@@ -66,13 +67,20 @@ class AuthUserServiceAdapter: AuthUserServiceBehavior {
 
     func updateAttributes(request: AuthUpdateUserAttributesRequest,
                           completionHandler: @escaping UpdateUserAttributesCompletion) {
-        updateAttributes(attributeList: request.userAttributes, completionHandler: completionHandler)
+        let clientMetaData = (request.options.pluginOptions as? AWSUpdateUserAttributesOptions)?.metadata ?? [:]
+        updateAttributes(attributeList: request.userAttributes,
+                         clientMetaData: clientMetaData,
+                         completionHandler: completionHandler)
     }
 
     func resendAttributeConfirmationCode(request: AuthAttributeResendConfirmationCodeRequest,
                                          completionHandler: @escaping ResendAttributeConfirmationCodeCompletion) {
 
-        awsMobileClient.verifyUserAttribute(attributeName: request.attributeKey.rawValue) { result, error in
+        let clientMetaData = (request.options.pluginOptions
+                                as? AWSResendAttributeConfirmationCodeOptions)?.metadata ?? [:]
+
+        awsMobileClient.verifyUserAttribute(attributeName: request.attributeKey.rawValue,
+                                            clientMetaData: clientMetaData) { result, error in
 
             guard error == nil else {
                 if let awsMobileClientError = error as? AWSMobileClientError,
@@ -149,12 +157,14 @@ class AuthUserServiceAdapter: AuthUserServiceBehavior {
     }
 
     private func updateAttributes(attributeList: [AuthUserAttribute],
+                                  clientMetaData: [String: String],
                                   completionHandler: @escaping UpdateUserAttributesCompletion) {
 
         let attributeMap = attributeList.reduce(into: [String: String]()) {
             $0[$1.key.rawValue] = $1.value
         }
-        awsMobileClient.updateUserAttributes(attributeMap: attributeMap) { result, error in
+        awsMobileClient.updateUserAttributes(attributeMap: attributeMap,
+                                             clientMetaData: clientMetaData) { result, error in
             guard error == nil else {
                 if let awsMobileClientError = error as? AWSMobileClientError,
                     case .notSignedIn = awsMobileClientError {

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthUserServiceAdapter.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthUserServiceAdapter.swift
@@ -77,7 +77,7 @@ class AuthUserServiceAdapter: AuthUserServiceBehavior {
                                          completionHandler: @escaping ResendAttributeConfirmationCodeCompletion) {
 
         let clientMetaData = (request.options.pluginOptions
-                                as? AWSResendAttributeConfirmationCodeOptions)?.metadata ?? [:]
+                                as? AWSAttributeResendConfirmationCodeOptions)?.metadata ?? [:]
 
         awsMobileClient.verifyUserAttribute(attributeName: request.attributeKey.rawValue,
                                             clientMetaData: clientMetaData) { result, error in

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -20,12 +20,12 @@ extension AuthenticationProviderAdapter {
         // Password can be nil, but awsmobileclient need it to have a dummy value.
         let password = request.password ?? ""
 
-        // AWSMobileClient internally uses the validationData as the clientMetaData, so passing the metaData
-        // to the validationData here.
-        let validationData = (request.options.pluginOptions as? AWSAuthSignInOptions)?.metadata
+        let clientMetaData = (request.options.pluginOptions as? AWSAuthSignInOptions)?.metadata ?? [:]
+
         awsMobileClient.signIn(username: username,
                                password: password,
-                               validationData: validationData) { [weak self] result, error in
+                               validationData: nil,
+                               clientMetaData: clientMetaData) { [weak self] result, error in
                                 guard let self = self else { return }
 
                                 guard error == nil else {

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignUp.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignUp.swift
@@ -83,7 +83,9 @@ extension AuthenticationProviderAdapter {
     func resendSignUpCode(request: AuthResendSignUpCodeRequest,
                           completionHandler: @escaping (Result<AuthCodeDeliveryDetails, AuthError>) -> Void) {
 
-        awsMobileClient.resendSignUpCode(username: request.username) { result, error in
+        let clientMetaData = (request.options.pluginOptions as? AWSAuthResendSignUpCodeOptions)?.metadata ?? [:]
+
+        awsMobileClient.resendSignUpCode(username: request.username, clientMetaData: clientMetaData) { result, error in
             guard error == nil else {
                 let authError = AuthErrorHelper.toAuthError(error!)
                 completionHandler(.failure(authError))

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAttributeResendConfirmationCodeOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAttributeResendConfirmationCodeOptions.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct AWSResendAttributeConfirmationCodeOptions {
+public struct AWSAttributeResendConfirmationCodeOptions {
 
     public let metadata: [String: String]?
 

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthResendSignUpCodeOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthResendSignUpCodeOptions.swift
@@ -1,0 +1,17 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public struct AWSAuthResendSignUpCodeOptions {
+
+    public let metadata: [String: String]?
+
+    public init(metadata: [String: String]? = nil) {
+        self.metadata = metadata
+    }
+}

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSResendAttributeConfirmationCodeOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSResendAttributeConfirmationCodeOptions.swift
@@ -1,0 +1,17 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public struct AWSResendAttributeConfirmationCodeOptions {
+
+    public let metadata: [String: String]?
+
+    public init(metadata: [String: String]? = nil) {
+        self.metadata = metadata
+    }
+}

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSUpdateUserAttributeOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSUpdateUserAttributeOptions.swift
@@ -1,0 +1,17 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public struct AWSUpdateUserAttributeOptions {
+
+    public let metadata: [String: String]?
+
+    public init(metadata: [String: String]? = nil) {
+        self.metadata = metadata
+    }
+}

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSUpdateUserAttributesOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSUpdateUserAttributesOptions.swift
@@ -1,0 +1,17 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public struct AWSUpdateUserAttributesOptions {
+
+    public let metadata: [String: String]?
+
+    public init(metadata: [String: String]? = nil) {
+        self.metadata = metadata
+    }
+}

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Service/AWSMobileClient/AWSMobileClientAdapter.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Service/AWSMobileClient/AWSMobileClientAdapter.swift
@@ -61,17 +61,23 @@ class AWSMobileClientAdapter: AWSMobileClientBehavior {
                                       completionHandler: completionHandler)
     }
 
-    func resendSignUpCode(username: String, completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
-        awsMobileClient.resendSignUpCode(username: username, completionHandler: completionHandler)
+    func resendSignUpCode(username: String,
+                          clientMetaData: [String: String],
+                          completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
+        awsMobileClient.resendSignUpCode(username: username,
+                                         clientMetaData: clientMetaData,
+                                         completionHandler: completionHandler)
     }
 
     func signIn(username: String,
                 password: String,
                 validationData: [String: String]? = nil,
+                clientMetaData: [String: String] = [:],
                 completionHandler: @escaping ((SignInResult?, Error?) -> Void)) {
         awsMobileClient.signIn(username: username,
                                password: password,
                                validationData: validationData,
+                               clientMetaData: clientMetaData,
                                completionHandler: completionHandler)
     }
 
@@ -121,14 +127,18 @@ class AWSMobileClientAdapter: AWSMobileClientBehavior {
     }
 
     func verifyUserAttribute(attributeName: String,
+                             clientMetaData: [String: String] = [:],
                              completionHandler: @escaping ((UserCodeDeliveryDetails?, Error?) -> Void)) {
         awsMobileClient.verifyUserAttribute(attributeName: attributeName,
+                                            clientMetaData: clientMetaData,
                                             completionHandler: completionHandler)
     }
 
     func updateUserAttributes(attributeMap: [String: String],
+                              clientMetaData: [String: String] = [:],
                               completionHandler: @escaping (([UserCodeDeliveryDetails]?, Error?) -> Void)) {
         awsMobileClient.updateUserAttributes(attributeMap: attributeMap,
+                                             clientMetaData: clientMetaData,
                                              completionHandler: completionHandler)
     }
 

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Service/AWSMobileClient/AWSMobileClientBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Service/AWSMobileClient/AWSMobileClientBehavior.swift
@@ -26,11 +26,13 @@ protocol AWSMobileClientBehavior {
                        completionHandler: @escaping ((SignUpResult?, Error?) -> Void))
 
     func resendSignUpCode(username: String,
+                          clientMetaData: [String: String],
                           completionHandler: @escaping ((SignUpResult?, Error?) -> Void))
 
     func signIn(username: String,
                 password: String,
                 validationData: [String: String]?,
+                clientMetaData: [String: String],
                 completionHandler: @escaping ((SignInResult?, Error?) -> Void))
 
     func federatedSignIn(providerName: String, token: String,
@@ -57,9 +59,11 @@ protocol AWSMobileClientBehavior {
     func getUserSub() -> String?
 
     func verifyUserAttribute(attributeName: String,
+                             clientMetaData: [String: String],
                              completionHandler: @escaping ((UserCodeDeliveryDetails?, Error?) -> Void))
 
     func updateUserAttributes(attributeMap: [String: String],
+                              clientMetaData: [String: String],
                               completionHandler: @escaping (([UserCodeDeliveryDetails]?, Error?) -> Void))
 
     func getUserAttributes(completionHandler: @escaping (([String: String]?, Error?) -> Void))

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AWSAuthBaseTest.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AWSAuthBaseTest.swift
@@ -12,10 +12,15 @@ import AWSCognitoAuthPlugin
 class AWSAuthBaseTest: XCTestCase {
 
     let networkTimeout = TimeInterval(10)
+    var email = UUID().uuidString + "@" + UUID().uuidString + ".com"
 
-     func initializeAmplify() {
-
+    func initializeAmplify() {
         do {
+            let credentialsConfiguration = try AuthConfigurationHelper.credentialsConfiguration()
+            if let emailJSONValue = credentialsConfiguration.value(at: "email"),
+               case let .string(emailValue) = emailJSONValue {
+                email = emailValue
+            }
             let configuration = try AuthConfigurationHelper.amplifyConfiguration()
             let authPlugin = AWSCognitoAuthPlugin()
             try Amplify.add(plugin: authPlugin)

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignInTests/AuthUsernamePasswordSignInTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignInTests/AuthUsernamePasswordSignInTests.swift
@@ -59,6 +59,18 @@ class AuthUsernamePasswordSignInTests: AWSAuthBaseTest {
     }
 
     /// Test successful signIn of a valid user
+    /// Internally, Two Cognito APIs will be called, Cognito's `InitiateAuth` and `RespondToAuthChallenge` API.
+    ///
+    /// `InitiateAuth` will trigger the Pre signup, Pre authentication, and User migration lambdas. Passed in metadata
+    /// will be used as client metadata to Cognito's API, and passed to the the lambda as validationData.
+    /// See https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html for more
+    /// details.
+    ///
+    /// `RespondToAuthChallenge` will trigger the Post authentication, Pre token generation, Define auth challenge,
+    /// Create auth challenge, and Verify auth challenge lambdas. Passed in metadata will be used as client metadata to
+    /// Cognito's API, and passed to the lambda as clientMetadata.
+    /// See https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_RespondToAuthChallenge.html
+    /// for more details
     ///
     /// - Given: A user registered in Cognito user pool
     /// - When:
@@ -79,8 +91,7 @@ class AuthUsernamePasswordSignInTests: AWSAuthBaseTest {
         wait(for: [signUpExpectation], timeout: networkTimeout)
 
         let operationExpectation = expectation(description: "Operation should complete")
-        let awsAuthSignInOptions = AWSAuthSignInOptions(validationData: ["mydata": "myvalue"],
-                                                        metadata: ["mydata": "myvalue"])
+        let awsAuthSignInOptions = AWSAuthSignInOptions(metadata: ["mySignInData": "myvalue"])
         let options = AuthSignInOperation.Request.Options(pluginOptions: awsAuthSignInOptions)
         let operation = Amplify.Auth.signIn(username: username, password: password, options: options) { result in
             defer {

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthSignUpTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthSignUpTests.swift
@@ -33,7 +33,6 @@ class AuthSignUpTests: AWSAuthBaseTest {
     func testSuccessfulRegisterUser() {
         let username = "integTest\(UUID().uuidString)"
         let password = "P123@\(UUID().uuidString)"
-
         let operationExpectation = expectation(description: "Operation should complete")
         let operation = Amplify.Auth.signUp(username: username, password: password) { result in
             defer {
@@ -51,20 +50,26 @@ class AuthSignUpTests: AWSAuthBaseTest {
     }
 
     /// Test if user registration is successful.
+    /// Internally, Cognito's `SignUp` API will be called, and will trigger the Pre sign-up, Custom message, and Post
+    /// confirmation lambdas with clientMetadata from the passed in metadata.
+    /// See https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SignUp.html for more
+    /// details.
     ///
     /// - Given: A username that is not present in the system
     /// - When:
-    ///    - I invoke Amplify.Auth.signUp with the username, a random password and AWSAuthSignUpOptions
+    ///    - I invoke Amplify.Auth.signUp with the username, a random password and AWSAuthSignUpOptions containing
+    ///    validation data and metadata
     /// - Then:
     ///    - I should get a signup complete step.
+    ///    - Configured lambda triggers should have the validationData and clientMetadata.
     ///
     func testRegisterUserWithSignUpOptions() {
         let username = "integTest\(UUID().uuidString)"
         let password = "P123@\(UUID().uuidString)"
 
         let operationExpectation = expectation(description: "Operation should complete")
-        let awsAuthSignUpOptions = AWSAuthSignUpOptions(validationData: ["mydata": "myvalue"],
-                                                        metadata: ["mydata": "myvalue"])
+        let awsAuthSignUpOptions = AWSAuthSignUpOptions(validationData: ["myValidationData": "myvalue"],
+                                                        metadata: ["myClientMetadata": "myvalue"])
         let options = AuthSignUpOperation.Request.Options(pluginOptions: awsAuthSignUpOptions)
         let operation = Amplify.Auth.signUp(username: username, password: password, options: options) { result in
             defer {

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthUserAttributesTests/AuthUserAttributesTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthUserAttributesTests/AuthUserAttributesTests.swift
@@ -1,0 +1,111 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+import AWSCognitoAuthPlugin
+
+class AuthUserAttributesTests: AWSAuthBaseTest {
+
+    override func setUp() {
+        super.setUp()
+        initializeAmplify()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        Amplify.reset()
+        sleep(2)
+    }
+
+    /// Test updating the user's email attribute.
+    /// Internally, Cognito's `UpdateUserAttributes` API will be called with metadata as clientMetadata.
+    /// The configured lambda trigger will invoke the custom message lambda with the client metadata payload. See
+    /// https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UpdateUserAttributes.html
+    /// for more details.
+    ///
+    /// - Given: A confirmed user
+    /// - When:
+    ///    - I invoke Amplify.Auth.update with email attribute
+    /// - Then:
+    ///    - The request should be successful and the email specified should receive a confirmation code
+    ///
+    func testSuccessfulUpdateEmailAttribute() throws {
+        let username = "integTest\(UUID().uuidString)"
+        let password = "P123@\(UUID().uuidString)"
+
+        let signInExpectation = expectation(description: "SignIn operation should complete")
+        AuthSignInHelper.registerAndSignInUser(username: username, password: password) { didSucceed, error in
+            signInExpectation.fulfill()
+            XCTAssertTrue(didSucceed, "SignIn operation failed - \(String(describing: error))")
+        }
+        wait(for: [signInExpectation], timeout: networkTimeout)
+
+        let updateExpectation = expectation(description: "Update operation should complete")
+        let pluginOptions = AWSUpdateUserAttributeOptions(metadata: ["mydata": "myvalue"])
+        let options = AuthUpdateUserAttributeRequest.Options(pluginOptions: pluginOptions)
+        _ = Amplify.Auth.update(userAttribute: AuthUserAttribute(.email, value: email), options: options) { result in
+            switch result {
+            case .success:
+                updateExpectation.fulfill()
+            case .failure(let error):
+                XCTFail("Failed to update user attribute with \(error)")
+            }
+        }
+        wait(for: [updateExpectation], timeout: networkTimeout)
+    }
+
+    /// Test resending code for the user's updated email attribute.
+    /// Internally, Cognito's `GetUserAttributeVerificationCode` API will be called with metadata as clientMetadata.
+    /// The configured lambda trigger will invoke the custom message lambda with the client metadata payload. See
+    /// https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_GetUserAttributeVerificationCode.html
+    /// for more details.
+    ///
+    /// - Given: A confirmed user, with email added to the user's attributes (sending first confirmation code)
+    /// - When:
+    ///    - I invoke Amplify.Auth.resendConfirmationCode for email
+    /// - Then:
+    ///    - The request should be successful and the email specified should receive a second confirmation code
+    ///
+    func testSuccessfulResendConfirmationCode() throws {
+        let username = "integTest\(UUID().uuidString)"
+        let password = "P123@\(UUID().uuidString)"
+
+        let signInExpectation = expectation(description: "SignIn operation should complete")
+        AuthSignInHelper.registerAndSignInUser(username: username, password: password) { didSucceed, error in
+            signInExpectation.fulfill()
+            XCTAssertTrue(didSucceed, "SignIn operation failed - \(String(describing: error))")
+        }
+        wait(for: [signInExpectation], timeout: networkTimeout)
+
+        let updateExpectation = expectation(description: "Update operation should complete")
+        _ = Amplify.Auth.update(userAttribute: AuthUserAttribute(.email, value: email)) { result in
+            switch result {
+            case .success:
+                updateExpectation.fulfill()
+            case .failure(let error):
+                XCTFail("Failed to update user attribute with \(error)")
+            }
+        }
+        wait(for: [updateExpectation], timeout: networkTimeout)
+
+        let resendExpectation = expectation(description: "ResendConfirmationCode operation should complete")
+
+        let pluginOptions = AWSAttributeResendConfirmationCodeOptions(metadata: ["mydata": "myvalue"])
+        let options = AuthAttributeResendConfirmationCodeRequest.Options(pluginOptions: pluginOptions)
+        _ = Amplify.Auth.resendConfirmationCode(for: .email, options: options) { result in
+            switch result {
+            case .success(let deliveryDetails):
+                print("Resend code send to - \(deliveryDetails)")
+                resendExpectation.fulfill()
+            case .failure(let error):
+                print("Resend code failed with error \(error)")
+            }
+        }
+        wait(for: [resendExpectation], timeout: networkTimeout)
+    }
+}

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/README.md
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/README.md
@@ -45,32 +45,49 @@ amplify add auth
     No
  
  What attributes are required for signing up? 
-    NA
+   (Press Space to deselect Email, if selected, then press Enter with none selected)
  Specify the app's refresh token expiration period (in days): 
     30
  Do you want to specify the user attributes this app can read and write? 
     No
  Do you want to enable any of the following capabilities?
-    NA
+    (press Enter with none selected)
  Do you want to use an OAuth flow? 
     No
 ? Do you want to configure Lambda Triggers for Cognito? 
     Yes
-? Which triggers do you want to enable for Cognito 
+? Which triggers do you want to enable for Cognito
+    Custom Message
     Pre Sign-up
+    [Choose any many that you would like]
+? What functionality do you want to use for Custom Message
+    Create your own module
 ? What functionality do you want to use for Pre Sign-up 
     Create your own module
 Succesfully added the Lambda function locally
 ? Do you want to edit your custom function now? Yes
 Please edit the file in your editor: 
 
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.handler = async (event) => {
+For Pre Sign-up lambda
+```
+exports.handler = (event, context, callback) => {
     event.response.autoConfirmUser = true;
-    return event;
+    console.log(event);
+    console.log(context);
+    callback(null, event);
 };
+```
 
+For Custom Message and other lambdas
+```
+// you can simply set them to log the input so you can verify valid and correct validationData/clientMetadata
+exports.handler = (event, context, callback) => {
+    event.response.autoConfirmUser = true;
+    console.log(event);
+    console.log(context);
+    callback(null, event);
+};
+```
 ? Press enter to continue
 Successfully added resource amplifyintegtest locally
 
@@ -78,3 +95,11 @@ amplify push
 ```
 This will create a amplifyconfiguration.json file in your local, drag that into the folder path AWSCognitoAuthPluginIntegrationTests/Configuration and give `AWSCognitoAuthPluginIntegrationTests` as the target.
 
+Next create `credentials.json` and add it to the same folder path, with the following values
+```
+{
+    "email": [YOUR_EMAIL]
+}
+```
+
+The email should be a valid email you can use for testing, for example for making sure you receive a confirmation code when updating user's attributes with an email.

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/README.md
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/README.md
@@ -78,7 +78,7 @@ exports.handler = (event, context, callback) => {
 };
 ```
 
-For Custom Message and other lambdas
+For Custom Message and any other lambdas
 ```
 // you can simply set them to log the input so you can verify valid and correct validationData/clientMetadata
 exports.handler = (event, context, callback) => {

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/README.md
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/README.md
@@ -59,7 +59,7 @@ amplify add auth
 ? Which triggers do you want to enable for Cognito
     Custom Message
     Pre Sign-up
-    [Choose any many that you would like]
+    [Choose as many that you would like to manually verify later]
 ? What functionality do you want to use for Custom Message
     Create your own module
 ? What functionality do you want to use for Pre Sign-up 
@@ -103,3 +103,5 @@ Next create `credentials.json` and add it to the same folder path, with the foll
 ```
 
 The email should be a valid email you can use for testing, for example for making sure you receive a confirmation code when updating user's attributes with an email.
+
+After running tests pass that in `metadata`, you can verify the corresponding lambdas have been trigger with payloads containing this data.

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/Support/AuthConfigurationHelper.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/Support/AuthConfigurationHelper.swift
@@ -10,7 +10,27 @@ import Amplify
 class AuthConfigurationHelper {
 
     static func amplifyConfiguration(with fileName: String = "amplifyconfiguration") throws -> AmplifyConfiguration {
+        guard let configurationData = try? getConfigurationData(with: fileName) else {
+            throw AuthTestError.invalidData
+        }
+        guard let configuration = try? JSONDecoder().decode(AmplifyConfiguration.self, from: configurationData) else {
+            throw AuthTestError.parseError
+        }
+        return configuration
+    }
 
+    static func credentialsConfiguration(with fileName: String = "credentials") throws -> JSONValue {
+        guard let configurationData = try? getConfigurationData(with: fileName) else {
+            throw AuthTestError.invalidData
+        }
+
+        guard let configuration = try? JSONDecoder().decode(JSONValue.self, from: configurationData) else {
+            throw AuthTestError.parseError
+        }
+        return configuration
+    }
+
+    static func getConfigurationData(with fileName: String) throws -> Data {
         let testBundle = Bundle(for: self)
         guard let configurationFile = testBundle.url(forResource: fileName, withExtension: "json") else {
             throw AuthTestError.invalidData
@@ -18,11 +38,7 @@ class AuthConfigurationHelper {
         guard let configurationData = try? Data(contentsOf: configurationFile) else {
            throw AuthTestError.invalidData
         }
-
-        guard let configuration = try? JSONDecoder().decode(AmplifyConfiguration.self, from: configurationData) else {
-            throw AuthTestError.parseError
-        }
-        return configuration
+        return configurationData
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This exposes a few new Options structs to pass metadata into certain API calls

APIs
- ResendSignUpCode (new) → requires another set up to integ test
- ResendAttributeConfirmationCode (new)
  - test: testSuccessfulResendConfirmationCode
  - flow: resendConfirmationCode → verifyUserAttribute -> AWSMobileClientUserDetails.verifyUserAttribute → getUserAttributeVerificationCode
- UpdateUserAttribute (new) / UpdateUserAttributes (new)
  - test: testSuccessfulUpdateEmailAttribute
  - flow:  update → updateUserAttributes -> AWSMobileClientUserDetails.updateUserAttributes → update(attributes)
- Sign up
  - test: testRegisterUserWithSignUpOptions calls Cognito's Sign Up
- Sign In
  - test: testSignInWithSignInOptions
  - flow: Cognito [InitialAuth](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html) and [RespondToAuthChallenge](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_RespondToAuthChallenge.html) APIs
  -  AWSAuthSignInOptions contains validation data and metadata. metadata is passed as client metadata to AWSMobileClient, which passes it as clientMetadata to cognito API and shows up in the InitialAuth triggered lambda as validation data. It also shows up as clientMetadata for RespondToAuthChallenge trigger lambdas. So developer can pass in metadata for both. we can just remove validationData from AWSAuthSignInOptions

- TODO (tracking in separate issue: https://github.com/aws-amplify/amplify-ios/issues/709)
  - custom auth integration test - MFA client metadata
  - enabled MFA (confirmSignUp) tests

Previous work in AWSMobileClient for reference:
https://github.com/aws-amplify/aws-sdk-ios/pull/2872
https://github.com/aws-amplify/aws-sdk-ios/pull/2883
https://github.com/aws-amplify/aws-sdk-ios/pull/2883

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
