### PR TITLE
refactor(datastore): Remove the dependency of model type from datastore sync engine

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreStatement.swift
+++ b/Amplify/Categories/DataStore/DataStoreStatement.swift
@@ -15,8 +15,8 @@ public protocol DataStoreStatement {
     /// The type of the variables container related to a concrete statement implementation
     associatedtype Variables
 
-    /// The type of the `Model` associated with a particular statement
-    var modelType: Model.Type { get }
+    /// The schema of the model associated with a particular statement
+    var schema: ModelSchema { get }
 
     /// The actual string content of the statement (e.g. a SQL query or a GraphQL document)
     var stringValue: String { get }

--- a/Amplify/Categories/DataStore/Model/Internal/Model+Subscript.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Model+Subscript.swift
@@ -15,6 +15,13 @@ extension Model {
     /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
     ///   by host applications. The behavior of this may change without warning.
     public subscript(_ key: String) -> Any?? {
+        
+        if self is JsonModel {
+            let value = (self as! JsonModel).internal_value(for: key)
+            return value
+        }
+           
+        
         let mirror = Mirror(reflecting: self)
         let firstChild = mirror.children.first { $0.label == key }
         guard let property = firstChild else {

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry+Syncable.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry+Syncable.swift
@@ -11,7 +11,7 @@ public extension ModelRegistry {
     ///   by host applications. The behavior of this may change without warning.
     static var hasSyncableModels: Bool {
         if #available(iOS 13.0, *) {
-            return models.contains { !$0.schema.isSystem }
+            return modelSchemas.contains { !$0.isSystem }
         } else {
             return false
         }

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
@@ -47,15 +47,15 @@ public struct ModelRegistry {
         }
     }
 
-    public static func register(modelName: ModelName,
+    public static func register(modelType: Model.Type,
                                 modelSchema: ModelSchema,
-                                modelType: Model.Type,
                                 jsonDecoder: @escaping (String, JSONDecoder?) throws -> Model) {
         concurrencyQueue.sync {
             let modelDecoder: ModelDecoder = { jsonString, decoder in
                 return try jsonDecoder(jsonString, decoder)
             }
 
+            let modelName = modelSchema.name
             modelSchemaMapping[modelName] = modelSchema
             modelTypes[modelName] = modelType
             modelDecoders[modelName] = modelDecoder

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -23,8 +23,8 @@ public enum ModelFieldType {
     case `enum`(type: EnumPersistable.Type)
     case embedded(type: Codable.Type)
     case embeddedCollection(of: Codable.Type)
-    case model(type: Model.Type)
-    case collection(of: Model.Type)
+    case model(name: ModelName)
+    case collection(of: ModelName)
 
     public var isArray: Bool {
         switch self {
@@ -72,7 +72,7 @@ public enum ModelFieldType {
             return .enum(type: enumType)
         }
         if let modelType = type as? Model.Type {
-            return .model(type: modelType)
+            return .model(name: modelType.modelName)
         }
         if let embeddedType = type as? Codable.Type {
             return .embedded(type: embeddedType)
@@ -182,8 +182,8 @@ public enum ModelFieldDefinition {
                                associatedWith associatedKey: CodingKey) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
-                      ofType: .collection(of: type),
-                      association: .hasMany(associatedWith: associatedKey))
+                      ofType: .collection(of: type.modelName),
+                      association: .hasMany(associatedWith: associatedKey.stringValue))
     }
 
     public static func hasOne(_ key: CodingKey,
@@ -192,8 +192,8 @@ public enum ModelFieldDefinition {
                               associatedWith associatedKey: CodingKey) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
-                      ofType: .model(type: type),
-                      association: .hasOne(associatedWith: associatedKey))
+                      ofType: .model(name: type.modelName),
+                      association: .hasOne(associatedWith: associatedKey.stringValue))
     }
 
     public static func belongsTo(_ key: CodingKey,
@@ -203,8 +203,8 @@ public enum ModelFieldDefinition {
                                  targetName: String? = nil) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
-                      ofType: .model(type: type),
-                      association: .belongsTo(associatedWith: associatedKey, targetName: targetName))
+                      ofType: .model(name: type.modelName),
+                      association: .belongsTo(associatedWith: associatedKey?.stringValue, targetName: targetName))
     }
 
     public var modelField: ModelField {

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
@@ -38,7 +38,7 @@ public struct ModelField {
         return name == "id"
     }
 
-    init(name: String,
+    public init(name: String,
          type: ModelFieldType,
          isRequired: Bool = false,
          isArray: Bool = false,
@@ -54,6 +54,10 @@ public struct ModelField {
         self.authRules = authRules
     }
 }
+
+/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+///   by host applications. The behavior of this may change without warning.
+public typealias ModelName = String
 
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
@@ -78,7 +82,7 @@ public struct ModelSchema {
         return primaryKey.value
     }
 
-    init(name: String,
+    public init(name: String,
          pluralName: String? = nil,
          authRules: AuthRules = [],
          attributes: [ModelAttribute] = [],

--- a/Amplify/Categories/DataStore/Model/Model+ModelName.swift
+++ b/Amplify/Categories/DataStore/Model/Model+ModelName.swift
@@ -14,4 +14,5 @@ extension Model {
     public var modelName: String {
         return type(of: self).modelName
     }
+
 }

--- a/Amplify/Categories/DataStore/Model/Model.swift
+++ b/Amplify/Categories/DataStore/Model/Model.swift
@@ -28,5 +28,18 @@ public protocol Model: Codable {
 
     /// The Model identifier (aka primary key)
     var id: Identifier { get }
+    
+}
 
+public protocol JsonModel: Model {
+    
+    /// Return the value for key
+    func internal_value(for key: String) -> Any?
+}
+
+extension JsonModel {
+    
+    public func internal_value(for key: String) -> Any? {
+        return nil
+    }
 }

--- a/Amplify/Categories/DataStore/Subscribe/MutationEvent.swift
+++ b/Amplify/Categories/DataStore/Subscribe/MutationEvent.swift
@@ -39,13 +39,13 @@ public struct MutationEvent: Model {
     }
 
     public init<M: Model>(model: M,
+                          modelName: String? = nil,
                           mutationType: MutationType,
                           version: Int? = nil,
                           graphQLFilterJSON: String? = nil) throws {
-        let modelType = type(of: model)
         let json = try model.toJSON()
         self.init(modelId: model.id,
-                  modelName: modelType.schema.name,
+                  modelName: modelName ?? type(of: model).schema.name,
                   json: json,
                   mutationType: mutationType,
                   version: version,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
@@ -35,8 +35,8 @@ public struct AuthRuleDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
-                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
-        let authRules = modelType.schema.authRules
+                         schema: ModelSchema) -> SingleDirectiveGraphQLDocument {
+        let authRules = schema.authRules
         guard !authRules.isEmpty else {
             return document
         }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
@@ -23,7 +23,7 @@ public struct ConflictResolutionDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
-                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+                         schema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
 
         if let version = version,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/DirectiveNameDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/DirectiveNameDecorator.swift
@@ -36,18 +36,18 @@ public struct DirectiveNameDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
-                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+                         schema: ModelSchema) -> SingleDirectiveGraphQLDocument {
 
         if let queryType = queryType {
-            return document.copy(name: modelType.schema.graphQLName(queryType: queryType))
+            return document.copy(name: schema.graphQLName(queryType: queryType))
         }
 
         if let mutationType = mutationType {
-            return document.copy(name: modelType.schema.graphQLName(mutationType: mutationType))
+            return document.copy(name: schema.graphQLName(mutationType: mutationType))
         }
 
         if let subscriptionType = subscriptionType {
-            return document.copy(name: modelType.schema.graphQLName(subscriptionType: subscriptionType))
+            return document.copy(name: schema.graphQLName(subscriptionType: subscriptionType))
         }
 
         return document

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/FilterDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/FilterDecorator.swift
@@ -19,9 +19,9 @@ public struct FilterDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
-                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+                         schema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
-        let modelName = modelType.schema.name
+        let modelName = schema.name
         if case .mutation = document.operationType {
             inputs["condition"] = GraphQLDocumentInput(type: "Model\(modelName)ConditionInput",
                 value: .object(filter))

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelBasedGraphQLDocumentDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelBasedGraphQLDocumentDecorator.swift
@@ -9,5 +9,5 @@ import Foundation
 import Amplify
 
 public protocol ModelBasedGraphQLDocumentDecorator {
-    func decorate(_ document: SingleDirectiveGraphQLDocument, modelType: Model.Type) -> SingleDirectiveGraphQLDocument
+    func decorate(_ document: SingleDirectiveGraphQLDocument, schema: ModelSchema) -> SingleDirectiveGraphQLDocument
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelDecorator.swift
@@ -20,12 +20,12 @@ public struct ModelDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
-                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+                         schema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
         var graphQLInput = model.graphQLInput
 
-        if !modelType.schema.authRules.isEmpty {
-            modelType.schema.authRules.forEach { authRule in
+        if !schema.authRules.isEmpty {
+            schema.authRules.forEach { authRule in
                 if authRule.allow == .owner {
                     let ownerField = authRule.getOwnerFieldOrDefault()
                     graphQLInput = graphQLInput.filter { (field, value) -> Bool in

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelIdDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelIdDecorator.swift
@@ -18,7 +18,7 @@ public struct ModelIdDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
-                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+                         schema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
 
         if case .mutation = document.operationType {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/PaginationDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/PaginationDecorator.swift
@@ -20,7 +20,7 @@ public struct PaginationDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
-                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+                         schema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
 
         if let limit = limit {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLMutation.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLMutation.swift
@@ -21,8 +21,8 @@ public struct GraphQLMutation: SingleDirectiveGraphQLDocument {
         self.selectionSet = selectionSet
     }
 
-    public init(modelType: Model.Type) {
-        self.selectionSet = SelectionSet(fields: modelType.schema.graphQLFields)
+    public init(graphQLFields: [ModelField]) {
+        self.selectionSet = SelectionSet(fields: graphQLFields)
     }
 
     public var name: String = ""

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLQuery.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLQuery.swift
@@ -21,8 +21,8 @@ public struct GraphQLQuery: SingleDirectiveGraphQLDocument {
         self.selectionSet = selectionSet
     }
 
-    public init(modelType: Model.Type) {
-        self.selectionSet = SelectionSet(fields: modelType.schema.graphQLFields)
+    public init(graphQLFields: [ModelField]) {
+        self.selectionSet = SelectionSet(fields: graphQLFields)
     }
 
     public var name: String = ""

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLSubscription.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLSubscription.swift
@@ -21,8 +21,8 @@ public struct GraphQLSubscription: SingleDirectiveGraphQLDocument {
         self.selectionSet = selectionSet
     }
 
-    public init(modelType: Model.Type) {
-        self.selectionSet = SelectionSet(fields: modelType.schema.graphQLFields)
+    public init(graphQLFields: [ModelField]) {
+        self.selectionSet = SelectionSet(fields: graphQLFields)
     }
 
     public var operationType: GraphQLOperationType = .subscription

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/ModelBasedGraphQLDocumentBuilder.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/ModelBasedGraphQLDocumentBuilder.swift
@@ -13,25 +13,25 @@ import Amplify
 public struct ModelBasedGraphQLDocumentBuilder {
     private var decorators = [ModelBasedGraphQLDocumentDecorator]()
     private var document: SingleDirectiveGraphQLDocument
-    private let modelType: Model.Type
+    private let schema: ModelSchema
 
     public init(modelName: String, operationType: GraphQLOperationType) {
-        guard let modelType = ModelRegistry.modelType(from: modelName) else {
+        guard let modelSchema = ModelRegistry.modelSchema(from: modelName)  else {
             preconditionFailure("Missing ModelType in ModelRegistry for model name: \(modelName)")
         }
 
-        self.init(modelType: modelType, operationType: operationType)
+        self.init(schema: modelSchema, operationType: operationType)
     }
 
-    public init(modelType: Model.Type, operationType: GraphQLOperationType) {
-        self.modelType = modelType
+    public init(schema: ModelSchema, operationType: GraphQLOperationType) {
+        self.schema = schema
         switch operationType {
         case .query:
-            self.document = GraphQLQuery(modelType: modelType)
+            self.document = GraphQLQuery(graphQLFields: schema.graphQLFields)
         case .mutation:
-            self.document = GraphQLMutation(modelType: modelType)
+            self.document = GraphQLMutation(graphQLFields: schema.graphQLFields)
         case .subscription:
-            self.document = GraphQLSubscription(modelType: modelType)
+            self.document = GraphQLSubscription(graphQLFields: schema.graphQLFields)
         }
     }
 
@@ -42,7 +42,7 @@ public struct ModelBasedGraphQLDocumentBuilder {
     public mutating func build() -> SingleDirectiveGraphQLDocument {
 
         let decoratedDocument = decorators.reduce(document) { doc, decorator in
-            decorator.decorate(doc, modelType: self.modelType)
+            decorator.decorate(doc, schema: self.schema)
         }
 
         return decoratedDocument

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
@@ -130,7 +130,7 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
                                           type: GraphQLMutationType) -> GraphQLRequest<M> {
         let modelType = ModelRegistry.modelType(from: model.modelName) ?? Swift.type(of: model)
 
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .mutation)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: modelType.modelName, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: type))
 
         switch type {
@@ -157,7 +157,7 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
 
     public static func get<M: Model>(_ modelType: M.Type,
                                      byId id: String) -> GraphQLRequest<M?> {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: modelType.modelName, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
         documentBuilder.add(decorator: ModelIdDecorator(id: id))
         let document = documentBuilder.build()
@@ -170,7 +170,7 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
 
     public static func list<M: Model>(_ modelType: M.Type,
                                       where predicate: QueryPredicate? = nil) -> GraphQLRequest<[M]> {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: modelType.modelName, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
 
         if let predicate = predicate {
@@ -188,7 +188,7 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
 
     public static func subscription<M: Model>(of modelType: M.Type,
                                               type: GraphQLSubscriptionType) -> GraphQLRequest<M> {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: modelType.modelName, operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: type))
         let document = documentBuilder.build()
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
@@ -42,7 +42,8 @@ extension SelectionSet {
                 self.addChild(settingParentOf: child)
             } else if field.isAssociationOwner, let associatedModel = field.associatedModel {
                 let child = SelectionSet(value: .init(name: field.name, fieldType: .model))
-                child.withModelFields(associatedModel.schema.graphQLFields)
+                let schema = ModelRegistry.modelSchema(from: associatedModel)!
+                child.withModelFields(schema.graphQLFields)
                 self.addChild(settingParentOf: child)
             } else {
                 self.addChild(settingParentOf: .init(value: .init(name: field.graphQLName, fieldType: .value)))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -13,12 +13,12 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     public func save<M: Model>(_ model: M,
                                where condition: QueryPredicate? = nil,
                                completion: @escaping DataStoreCallback<M>) {
-        save(model, schema: model.schema, where: condition, completion: completion)
+        save(model, modelSchema: model.schema, where: condition, completion: completion)
 
     }
 
     public func save<M: Model>(_ model: M,
-                               schema: ModelSchema,
+                               modelSchema: ModelSchema,
                                where condition: QueryPredicate? = nil,
                                completion: @escaping DataStoreCallback<M>) {
         log.verbose("Saving: \(model) with condition: \(String(describing: condition))")
@@ -32,7 +32,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                 throw DataStoreError.configuration("Unable to get storage adapter",
                                                    "")
             }
-            modelExists = try engine.storageAdapter.exists(schema, withId: model.id, predicate: nil)
+            modelExists = try engine.storageAdapter.exists(modelSchema, withId: model.id, predicate: nil)
         } catch {
             if let dataStoreError = error as? DataStoreError {
                 completion(.failure(dataStoreError))
@@ -60,7 +60,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
         }
 
         storageEngine.save(model,
-                           schema: schema,
+                           modelSchema: modelSchema,
                            where: condition,
                            completion: publishingCompletion)
     }
@@ -89,17 +89,17 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                 where predicate: QueryPredicate? = nil,
                                 paginate paginationInput: QueryPaginationInput? = nil,
                                 completion: DataStoreCallback<[M]>) {
-        query(modelType, schema: modelType.schema, where: predicate, paginate: paginationInput, completion: completion)
+        query(modelType, modelSchema: modelType.schema, where: predicate, paginate: paginationInput, completion: completion)
     }
 
     public func query<M: Model>(_ modelType: M.Type,
-                                schema: ModelSchema,
+                                modelSchema: ModelSchema,
                                 where predicate: QueryPredicate? = nil,
                                 paginate paginationInput: QueryPaginationInput? = nil,
                                 completion: DataStoreCallback<[M]>) {
         reinitStorageEngineIfNeeded()
         storageEngine.query(modelType,
-                            schema: schema,
+                            modelSchema: modelSchema,
                             predicate: predicate,
                             paginationInput: paginationInput,
                             completion: completion)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -13,6 +13,14 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     public func save<M: Model>(_ model: M,
                                where condition: QueryPredicate? = nil,
                                completion: @escaping DataStoreCallback<M>) {
+        save(model, schema: model.schema, where: condition, completion: completion)
+
+    }
+
+    public func save<M: Model>(_ model: M,
+                               schema: ModelSchema,
+                               where condition: QueryPredicate? = nil,
+                               completion: @escaping DataStoreCallback<M>) {
         log.verbose("Saving: \(model) with condition: \(String(describing: condition))")
         reinitStorageEngineIfNeeded()
 
@@ -24,7 +32,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                 throw DataStoreError.configuration("Unable to get storage adapter",
                                                    "")
             }
-            modelExists = try engine.storageAdapter.exists(M.schema, withId: model.id, predicate: nil)
+            modelExists = try engine.storageAdapter.exists(schema, withId: model.id, predicate: nil)
         } catch {
             if let dataStoreError = error as? DataStoreError {
                 completion(.failure(dataStoreError))
@@ -52,9 +60,9 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
         }
 
         storageEngine.save(model,
-                           condition: condition,
+                           schema: schema,
+                           where: condition,
                            completion: publishingCompletion)
-
     }
 
     public func query<M: Model>(_ modelType: M.Type,
@@ -81,8 +89,17 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                 where predicate: QueryPredicate? = nil,
                                 paginate paginationInput: QueryPaginationInput? = nil,
                                 completion: DataStoreCallback<[M]>) {
+        query(modelType, schema: modelType.schema, where: predicate, paginate: paginationInput, completion: completion)
+    }
+
+    public func query<M: Model>(_ modelType: M.Type,
+                                schema: ModelSchema,
+                                where predicate: QueryPredicate? = nil,
+                                paginate paginationInput: QueryPaginationInput? = nil,
+                                completion: DataStoreCallback<[M]>) {
         reinitStorageEngineIfNeeded()
         storageEngine.query(modelType,
+                            schema: schema,
                             predicate: predicate,
                             paginationInput: paginationInput,
                             completion: completion)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -24,7 +24,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                 throw DataStoreError.configuration("Unable to get storage adapter",
                                                    "")
             }
-            modelExists = try engine.storageAdapter.exists(M.self, withId: model.id, predicate: nil)
+            modelExists = try engine.storageAdapter.exists(M.schema, withId: model.id, predicate: nil)
         } catch {
             if let dataStoreError = error as? DataStoreError {
                 completion(.failure(dataStoreError))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -85,7 +85,7 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
 
         try resolveStorageEngine(dataStoreConfiguration: dataStoreConfiguration)
 
-        try storageEngine.setUp(models: ModelRegistry.models)
+        try storageEngine.setUp(schemas: ModelRegistry.modelSchemas)
 
         let filter = HubFilters.forEventName(HubPayload.EventName.Amplify.configured)
         var token: UnsubscribeToken?
@@ -106,7 +106,7 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
                 self.dataStorePublisher = DataStorePublisher()
             }
             try resolveStorageEngine(dataStoreConfiguration: dataStoreConfiguration)
-            try storageEngine.setUp(models: ModelRegistry.models)
+            try storageEngine.setUp(schemas: ModelRegistry.modelSchemas)
             storageEngine.startSync()
         } catch {
             log.error(error: error)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
@@ -8,7 +8,12 @@
 import Amplify
 
 protocol ModelStorageBehavior {
-    func setUp(models: [Model.Type]) throws
+    func setUp(schemas: [ModelSchema]) throws
+
+    func save<M: Model>(_ model: M,
+                        schema: ModelSchema,
+                        where condition: QueryPredicate?,
+                        completion: @escaping DataStoreCallback<M>)
 
     func save<M: Model>(_ model: M,
                         condition: QueryPredicate?,
@@ -23,6 +28,12 @@ protocol ModelStorageBehavior {
                           completion: @escaping DataStoreCallback<[M]>)
 
     func query<M: Model>(_ modelType: M.Type,
+                         predicate: QueryPredicate?,
+                         paginationInput: QueryPaginationInput?,
+                         completion: DataStoreCallback<[M]>)
+
+    func query<M: Model>(_ modelType: M.Type,
+                         schema: ModelSchema,
                          predicate: QueryPredicate?,
                          paginationInput: QueryPaginationInput?,
                          completion: DataStoreCallback<[M]>)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
@@ -11,7 +11,7 @@ protocol ModelStorageBehavior {
     func setUp(schemas: [ModelSchema]) throws
 
     func save<M: Model>(_ model: M,
-                        schema: ModelSchema,
+                        modelSchema: ModelSchema,
                         where condition: QueryPredicate?,
                         completion: @escaping DataStoreCallback<M>)
 
@@ -33,7 +33,7 @@ protocol ModelStorageBehavior {
                          completion: DataStoreCallback<[M]>)
 
     func query<M: Model>(_ modelType: M.Type,
-                         schema: ModelSchema,
+                         modelSchema: ModelSchema,
                          predicate: QueryPredicate?,
                          paginationInput: QueryPaginationInput?,
                          completion: DataStoreCallback<[M]>)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
@@ -15,10 +15,10 @@ typealias SQLPredicate = (String, [Binding?])
 /// It walks all nodes of a predicate tree and output the appropriate SQL statement.
 ///
 /// - Parameters:
-///   - modelType: the metatype of the `Model`
+///   - schema: the schema of the model
 ///   - predicate: the query predicate
 /// - Returns: a tuple containing the SQL string and the associated values
-private func translateQueryPredicate(from modelType: Model.Type,
+private func translateQueryPredicate(from schema: ModelSchema,
                                      predicate: QueryPredicate,
                                      namespace: Substring? = nil) -> SQLPredicate {
     var sql: [String] = []
@@ -65,14 +65,14 @@ private func translateQueryPredicate(from modelType: Model.Type,
 /// compose `insert`, `update`, `delete` and `select` statements with conditions.
 struct ConditionStatement: SQLStatement {
 
-    let modelType: Model.Type
+    let schema: ModelSchema
     let stringValue: String
     let variables: [Binding?]
 
-    init(modelType: Model.Type, predicate: QueryPredicate, namespace: Substring? = nil) {
-        self.modelType = modelType
+   init(schema: ModelSchema, predicate: QueryPredicate, namespace: Substring? = nil) {
+           self.schema = schema
 
-        let (sql, variables) = translateQueryPredicate(from: modelType,
+        let (sql, variables) = translateQueryPredicate(from: schema,
                                                        predicate: predicate,
                                                        namespace: namespace)
         self.stringValue = sql

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
@@ -12,14 +12,13 @@ import Foundation
 /// associated with the passed `Model.Type`.
 struct CreateTableStatement: SQLStatement {
 
-    let modelType: Model.Type
+    let schema: ModelSchema
 
-    init(modelType: Model.Type) {
-        self.modelType = modelType
+    init(schema: ModelSchema) {
+        self.schema = schema
     }
 
     var stringValue: String {
-        let schema = modelType.schema
         let name = schema.name
         var statement = "create table if not exists \(name) (\n"
 
@@ -52,8 +51,10 @@ struct CreateTableStatement: SQLStatement {
         for (index, foreignKey) in foreignKeys.enumerated() {
             statement += "  foreign key(\"\(foreignKey.sqlName)\") "
             let associatedModel = foreignKey.requiredAssociatedModel
-            let associatedId = associatedModel.schema.primaryKey
-            let associatedModelName = associatedModel.schema.name
+            // TODO: Handle the force unwrapping
+            let schema = ModelRegistry.modelSchema(from: associatedModel)!
+            let associatedId = schema.primaryKey
+            let associatedModelName = schema.name
             statement += "references \(associatedModelName)(\"\(associatedId.sqlName)\")\n"
             statement += "    on delete cascade"
             let isNotLastKey = index < foreignKeys.endIndex - 1

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Delete.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Delete.swift
@@ -12,16 +12,16 @@ import SQLite
 /// Represents a `delete` SQL statement that is optionally composed by a `ConditionStatement`.
 struct DeleteStatement: SQLStatement {
 
-    let modelType: Model.Type
+    let schema: ModelSchema
     let conditionStatement: ConditionStatement?
     let namespace = "root"
 
-    init(modelType: Model.Type, predicate: QueryPredicate? = nil) {
-        self.modelType = modelType
+    init(schema: ModelSchema, predicate: QueryPredicate? = nil) {
+        self.schema = schema
 
         var conditionStatement: ConditionStatement?
         if let predicate = predicate {
-            let statement = ConditionStatement(modelType: modelType,
+            let statement = ConditionStatement(schema: schema,
                                                predicate: predicate,
                                                namespace: namespace[...])
             conditionStatement = statement
@@ -30,15 +30,14 @@ struct DeleteStatement: SQLStatement {
     }
 
     init(modelType: Model.Type, withId id: Model.Identifier) {
-        self.init(modelType: modelType, predicate: field("id") == id)
+        self.init(schema: modelType.schema, predicate: field("id") == id)
     }
 
     init(model: Model) {
-        self.init(modelType: type(of: model))
+        self.init(schema: model.schema)
     }
 
     var stringValue: String {
-        let schema = modelType.schema
         let sql = """
         delete from \(schema.name) as \(namespace)
         """

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
@@ -12,16 +12,15 @@ import SQLite
 /// Represents a `insert` SQL statement associated with a `Model` instance.
 struct InsertStatement: SQLStatement {
 
-    let modelType: Model.Type
+    let schema: ModelSchema
     let variables: [Binding?]
 
-    init(model: Model) {
-        self.modelType = type(of: model)
-        self.variables = model.sqlValues(for: modelType.schema.columns)
-    }
+    init(model: Model, schema: ModelSchema) {
+         self.schema = schema
+         self.variables = model.sqlValues(for: schema.columns, schema: schema)
+     }
 
     var stringValue: String {
-        let schema = modelType.schema
         let fields = schema.columns
         let columns = fields.map { $0.columnName() }
         var statement = "insert into \(schema.name) "

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Update.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Update.swift
@@ -12,18 +12,18 @@ import SQLite
 /// Represents a `update` SQL statement.
 struct UpdateStatement: SQLStatement {
 
-    let modelType: Model.Type
+    let schema: ModelSchema
     let conditionStatement: ConditionStatement?
 
     private let model: Model
 
     init(model: Model, condition: QueryPredicate? = nil) {
-        self.modelType = type(of: model)
+        self.schema = model.schema
         self.model = model
 
         var conditionStatement: ConditionStatement?
         if let condition = condition {
-            let statement = ConditionStatement(modelType: modelType,
+            let statement = ConditionStatement(schema: schema,
                                                predicate: condition)
             conditionStatement = statement
         }
@@ -32,7 +32,6 @@ struct UpdateStatement: SQLStatement {
     }
 
     var stringValue: String {
-        let schema = modelType.schema
         let columns = updateColumns.map { $0.columnName() }
 
         let columnsStatement = columns.map { column in
@@ -57,7 +56,7 @@ struct UpdateStatement: SQLStatement {
     }
 
     var variables: [Binding?] {
-        var bindings = model.sqlValues(for: updateColumns)
+        var bindings = model.sqlValues(for: updateColumns, schema: schema)
         bindings.append(model.id)
         if let conditionStatement = conditionStatement {
             bindings.append(contentsOf: conditionStatement.variables)
@@ -66,6 +65,6 @@ struct UpdateStatement: SQLStatement {
     }
 
     private var updateColumns: [ModelField] {
-        modelType.schema.columns.filter { !$0.isPrimaryKey }
+        schema.columns.filter { !$0.isPrimaryKey }
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
@@ -17,7 +17,7 @@ extension SQLiteStorageEngineAdapter {
                 throw error
             }
 
-            let shouldUpdate = try exists(modelType, withId: untypedModel.id)
+            let shouldUpdate = try exists(modelType.schema, withId: untypedModel.id)
 
             // TODO serialize result and create a new instance of the model
             // (some columns might be auto-generated after DB insert/update)
@@ -25,7 +25,7 @@ extension SQLiteStorageEngineAdapter {
                 let statement = UpdateStatement(model: untypedModel)
                 _ = try connection.prepare(statement.stringValue).run(statement.variables)
             } else {
-                let statement = InsertStatement(model: untypedModel)
+                let statement = InsertStatement(model: untypedModel, schema: untypedModel.schema)
                 _ = try connection.prepare(statement.stringValue).run(statement.variables)
             }
 
@@ -39,7 +39,7 @@ extension SQLiteStorageEngineAdapter {
                predicate: QueryPredicate? = nil,
                completion: DataStoreCallback<[Model]>) {
         do {
-            let statement = SelectStatement(from: modelType, predicate: predicate)
+            let statement = SelectStatement(from: modelType.schema, predicate: predicate)
             let rows = try connection.prepare(statement.stringValue).run(statement.variables)
             let result: [Model] = try rows.convert(toUntypedModel: modelType, using: statement)
             completion(.success(result))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -170,6 +170,7 @@ final class StorageEngine: StorageEngineBehavior {
             if #available(iOS 13.0, *) {
                 self.log.verbose("\(#function) syncing mutation for \(savedModel)")
                 self.syncMutation(of: savedModel,
+                                  schema: schema,
                                   mutationType: mutationType,
                                   predicate: condition,
                                   syncEngine: syncEngine,
@@ -471,6 +472,7 @@ final class StorageEngine: StorageEngineBehavior {
 
     @available(iOS 13.0, *)
     private func syncMutation<M: Model>(of savedModel: M,
+                                        schema: ModelSchema? = nil,
                                         mutationType: MutationEvent.MutationType,
                                         predicate: QueryPredicate? = nil,
                                         syncEngine: RemoteSyncEngineBehavior,
@@ -483,6 +485,7 @@ final class StorageEngine: StorageEngineBehavior {
             }
 
             mutationEvent = try MutationEvent(model: savedModel,
+                                              modelName: schema?.name,
                                               mutationType: mutationType,
                                               graphQLFilterJSON: graphQLFilterJSON)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -38,7 +38,7 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
 
     // MARK: - Synchronous APIs
 
-    func exists(_ modelType: Model.Type,
+    func exists(_ schema: ModelSchema,
                 withId id: Model.Identifier,
                 predicate: QueryPredicate?) throws -> Bool
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
@@ -77,7 +77,7 @@ final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
         let syncableModels = ModelRegistry.models.filter { $0.schema.isSyncable }
         let sortedModels = syncableModels.sortByDependencyOrder()
         for model in sortedModels {
-            enqueueSyncOperation(for: model)
+          //  enqueueSyncOperation(for: model)
         }
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
@@ -113,7 +113,9 @@ class SyncMutationToCloudOperation: Operation {
                                                                             version: mutationEvent.version)
             case .create:
                 let model = try mutationEvent.decodeModel()
-                request = GraphQLRequest<MutationSyncResult>.createMutation(of: model, version: mutationEvent.version)
+                request = GraphQLRequest<MutationSyncResult>.createMutation(of: model,
+                                                                            modelName: mutationEvent.modelName,
+                                                                            version: mutationEvent.version)
             }
         } catch {
             let apiError = APIError.unknown("Couldn't decode model", "", error)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -70,7 +70,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         let outgoingMutationQueue = outgoingMutationQueue ??
             OutgoingMutationQueue(storageAdapter: storageAdapter, dataStoreConfiguration: dataStoreConfiguration)
         let reconciliationQueueFactory = reconciliationQueueFactory ??
-            AWSIncomingEventReconciliationQueue.init(modelTypes:api:storageAdapter:auth:modelReconciliationQueueFactory:)
+            AWSIncomingEventReconciliationQueue.init(schemas:api:storageAdapter:auth:modelReconciliationQueueFactory:)
         let initialSyncOrchestratorFactory = initialSyncOrchestratorFactory ??
             AWSInitialSyncOrchestrator.init(dataStoreConfiguration:api:reconciliationQueue:storageAdapter:)
         let resolver = RemoteSyncEngine.Resolver.resolve(currentState:action:)
@@ -240,8 +240,8 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     private func initializeSubscriptions(api: APICategoryGraphQLBehavior,
                                          storageAdapter: StorageEngineAdapter) {
         log.debug(#function)
-        let syncableModelTypes = ModelRegistry.models.filter { $0.schema.isSyncable }
-        reconciliationQueue = reconciliationQueueFactory(syncableModelTypes, api, storageAdapter, auth, nil)
+        let syncableModelSchemas = ModelRegistry.modelSchemas.filter { $0.isSyncable }
+        reconciliationQueue = reconciliationQueueFactory(syncableModelSchemas, api, storageAdapter, auth, nil)
         reconciliationQueueSink = reconciliationQueue?.publisher.sink(
             receiveCompletion: onReceiveCompletion(receiveCompletion:),
             receiveValue: onReceive(receiveValue:))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -13,7 +13,7 @@ import Foundation
 //Used for testing:
 @available(iOS 13.0, *)
 typealias IncomingEventReconciliationQueueFactory =
-    ([Model.Type],
+    ([ModelSchema],
     APICategoryGraphQLBehavior,
     StorageEngineAdapter,
     AuthCategoryBehavior?,
@@ -23,8 +23,8 @@ typealias IncomingEventReconciliationQueueFactory =
 @available(iOS 13.0, *)
 final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue {
 
-    static let factory: IncomingEventReconciliationQueueFactory = { modelTypes, api, storageAdapter, auth, _ in
-        AWSIncomingEventReconciliationQueue(modelTypes: modelTypes,
+    static let factory: IncomingEventReconciliationQueueFactory = { modelSchemas, api, storageAdapter, auth, _ in
+        AWSIncomingEventReconciliationQueue(schemas: modelSchemas,
                                             api: api,
                                             storageAdapter: storageAdapter,
                                             auth: auth,
@@ -42,7 +42,7 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
     private var reconciliationQueueConnectionStatus: [String: Bool]
     private var modelReconciliationQueueFactory: ModelReconciliationQueueFactory
 
-    init(modelTypes: [Model.Type],
+    init(schemas: [ModelSchema],
          api: APICategoryGraphQLBehavior,
          storageAdapter: StorageEngineAdapter,
          auth: AuthCategoryBehavior? = nil,
@@ -52,14 +52,14 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
         self.reconciliationQueues = [:]
         self.reconciliationQueueConnectionStatus = [:]
         self.modelReconciliationQueueFactory = modelReconciliationQueueFactory ??
-            AWSModelReconciliationQueue.init(modelType:storageAdapter:api:auth:incomingSubscriptionEvents:)
+            AWSModelReconciliationQueue.init(schema:storageAdapter:api:auth:incomingSubscriptionEvents:)
         //TODO: Add target for SyncEngine system to help prevent thread explosion and increase performance
         // https://github.com/aws-amplify/amplify-ios/issues/399
         self.connectionStatusSerialQueue
             = DispatchQueue(label: "com.amazonaws.DataStore.AWSIncomingEventReconciliationQueue")
-        for modelType in modelTypes {
-            let modelName = modelType.modelName
-            let queue = self.modelReconciliationQueueFactory(modelType, storageAdapter, api, auth, nil)
+        for schema in schemas {
+            let modelName = schema.name
+            let queue = self.modelReconciliationQueueFactory(schema, storageAdapter, api, auth, nil)
             guard reconciliationQueues[modelName] == nil else {
                 Amplify.DataStore.log
                     .warn("Duplicate model name found: \(modelName), not subscribing")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -22,9 +22,9 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
         return subscriptionEventSubject.eraseToAnyPublisher()
     }
 
-    init(modelType: Model.Type, api: APICategoryGraphQLBehavior, auth: AuthCategoryBehavior?) {
+    init(schema: ModelSchema, api: APICategoryGraphQLBehavior, auth: AuthCategoryBehavior?) {
         self.subscriptionEventSubject = PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>()
-        self.asyncEvents = IncomingAsyncSubscriptionEventPublisher(modelType: modelType,
+        self.asyncEvents = IncomingAsyncSubscriptionEventPublisher(schema: schema,
                                                                    api: api,
                                                                    auth: auth)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -41,13 +41,13 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
 
     private let incomingSubscriptionEvents: PassthroughSubject<Event, DataStoreError>
 
-    init(modelType: Model.Type, api: APICategoryGraphQLBehavior, auth: AuthCategoryBehavior?) {
+    init(schema: ModelSchema, api: APICategoryGraphQLBehavior, auth: AuthCategoryBehavior?) {
         self.onCreateConnected = false
         self.onUpdateConnected = false
         self.onDeleteConnected = false
         self.connectionStatusQueue = OperationQueue()
         connectionStatusQueue.name
-            = "com.amazonaws.Amplify.RemoteSyncEngine.\(modelType.modelName).IncomingAsyncSubscriptionEventPublisher"
+            = "com.amazonaws.Amplify.RemoteSyncEngine.\(schema.name).IncomingAsyncSubscriptionEventPublisher"
         connectionStatusQueue.maxConcurrentOperationCount = 1
         connectionStatusQueue.isSuspended = false
 
@@ -57,7 +57,7 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
         let onCreateValueListener = onCreateValueListenerHandler(event:)
         self.onCreateValueListener = onCreateValueListener
         self.onCreateOperation = IncomingAsyncSubscriptionEventPublisher.apiSubscription(
-            for: modelType,
+            for: schema,
             subscriptionType: .onCreate,
             api: api,
             auth: auth,
@@ -68,7 +68,7 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
         let onUpdateValueListener = onUpdateValueListenerHandler(event:)
         self.onUpdateValueListener = onUpdateValueListener
         self.onUpdateOperation = IncomingAsyncSubscriptionEventPublisher.apiSubscription(
-            for: modelType,
+            for: schema,
             subscriptionType: .onUpdate,
             api: api,
             auth: auth,
@@ -79,7 +79,7 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
         let onDeleteValueListener = onDeleteValueListenerHandler(event:)
         self.onDeleteValueListener = onDeleteValueListener
         self.onDeleteOperation = IncomingAsyncSubscriptionEventPublisher.apiSubscription(
-            for: modelType,
+            for: schema,
             subscriptionType: .onDelete,
             api: api,
             auth: auth,
@@ -147,7 +147,7 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
     }
 
     static func apiSubscription(
-        for modelType: Model.Type,
+        for schema: ModelSchema,
         subscriptionType: GraphQLSubscriptionType,
         api: APICategoryGraphQLBehavior,
         auth: AuthCategoryBehavior?,
@@ -156,14 +156,14 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
     ) -> GraphQLSubscriptionOperation<Payload> {
 
         let request: GraphQLRequest<Payload>
-        if let auth = auth, modelType.schema.hasAuthenticationRules, let user = auth.getCurrentUser() {
+        if let auth = auth, schema.hasAuthenticationRules, let user = auth.getCurrentUser() {
             // TODO: check model schema for identityClaim to figure out which is the ownerId field coming from
             // https://github.com/aws-amplify/amplify-ios/issues/485
-            request = GraphQLRequest<Payload>.subscription(to: modelType,
+            request = GraphQLRequest<Payload>.subscription(to: schema.name,
                                                            subscriptionType: subscriptionType,
                                                            ownerId: user.username)
         } else {
-            request = GraphQLRequest<Payload>.subscription(to: modelType, subscriptionType: subscriptionType)
+            request = GraphQLRequest<Payload>.subscription(to: schema.name, subscriptionType: subscriptionType)
         }
 
         let operation = api.subscribe(request: request,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -13,7 +13,7 @@ import Foundation
 //Used for testing:
 @available(iOS 13.0, *)
 typealias ModelReconciliationQueueFactory = (
-    Model.Type,
+    ModelSchema,
     StorageEngineAdapter,
     APICategoryGraphQLBehavior,
     AuthCategoryBehavior?,
@@ -71,32 +71,32 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
         return modelReconciliationQueueSubject.eraseToAnyPublisher()
     }
 
-    init(modelType: Model.Type,
+    init(schema: ModelSchema,
          storageAdapter: StorageEngineAdapter?,
          api: APICategoryGraphQLBehavior,
          auth: AuthCategoryBehavior?,
          incomingSubscriptionEvents: IncomingSubscriptionEventPublisher? = nil) {
 
-        self.modelName = modelType.modelName
+        self.modelName = schema.name
 
         self.storageAdapter = storageAdapter
 
         self.modelReconciliationQueueSubject = PassthroughSubject<ModelReconciliationQueueEvent, DataStoreError>()
 
         self.reconcileAndSaveQueue = OperationQueue()
-        reconcileAndSaveQueue.name = "com.amazonaws.DataStore.\(modelType).reconcile"
+        reconcileAndSaveQueue.name = "com.amazonaws.DataStore.\(schema.name).reconcile"
         reconcileAndSaveQueue.maxConcurrentOperationCount = 1
         reconcileAndSaveQueue.underlyingQueue = DispatchQueue.global()
         reconcileAndSaveQueue.isSuspended = false
 
         self.incomingSubscriptionEventQueue = OperationQueue()
-        incomingSubscriptionEventQueue.name = "com.amazonaws.DataStore.\(modelType).remoteEvent"
+        incomingSubscriptionEventQueue.name = "com.amazonaws.DataStore.\(schema.name).remoteEvent"
         incomingSubscriptionEventQueue.maxConcurrentOperationCount = 1
         incomingSubscriptionEventQueue.underlyingQueue = DispatchQueue.global()
         incomingSubscriptionEventQueue.isSuspended = true
 
         let resolvedIncomingSubscriptionEvents = incomingSubscriptionEvents ??
-            AWSIncomingSubscriptionEventPublisher(modelType: modelType, api: api, auth: auth)
+            AWSIncomingSubscriptionEventPublisher(schema: schema, api: api, auth: auth)
         self.incomingSubscriptionEvents = resolvedIncomingSubscriptionEvents
 
         self.incomingEventsSink = resolvedIncomingSubscriptionEvents

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
@@ -1,0 +1,154 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+import Foundation
+import SQLite
+
+class SQLiteStorageEngineAdapterJsonTests: XCTestCase {
+
+    var connection: Connection!
+    var storageEngine: StorageEngine!
+    var storageAdapter: SQLiteStorageEngineAdapter!
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        super.setUp()
+        sleep(2)
+        Amplify.reset()
+        Amplify.Logging.logLevel = .warn
+
+        let validAPIPluginKey = "MockAPICategoryPlugin"
+        let validAuthPluginKey = "MockAuthCategoryPlugin"
+        do {
+            connection = try Connection(.inMemory)
+            storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
+            try storageAdapter.setUp(schemas: StorageEngine.systemModelSchemas)
+
+            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
+                                                  dataStoreConfiguration: .default)
+            storageEngine = StorageEngine(storageAdapter: storageAdapter,
+                                          dataStoreConfiguration: .default,
+                                          syncEngine: syncEngine,
+                                          validAPIPluginKey: validAPIPluginKey,
+                                          validAuthPluginKey: validAuthPluginKey)
+        } catch {
+            XCTFail(String(describing: error))
+            return
+        }
+
+        let dataStorePublisher = DataStorePublisher()
+        let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestJsonModelRegistration(),
+                                                 storageEngine: storageEngine,
+                                                 dataStorePublisher: dataStorePublisher,
+                                                 validAPIPluginKey: validAPIPluginKey,
+                                                 validAuthPluginKey: validAuthPluginKey)
+
+        let dataStoreConfig = DataStoreCategoryConfiguration(plugins: [
+            "awsDataStorePlugin": true
+        ])
+        let amplifyConfig = AmplifyConfiguration(dataStore: dataStoreConfig)
+
+        do {
+
+            try Amplify.add(plugin: dataStorePlugin)
+            try Amplify.configure(amplifyConfig)
+        } catch {
+            XCTFail(String(describing: error))
+            return
+        }
+    }
+
+    /// - Given: a list a `Post` instance
+    /// - When:
+    ///   - the `save(post)` is called
+    /// - Then:
+    ///   - call `query(Post)` to check if the model was correctly inserted
+    func testInsertPost() {
+        let expectation = self.expectation(
+            description: "it should save and select a Post from the database")
+
+        // insert a post
+        let post = ["title": "title",
+                    "content": "content information"] as [String: JSONValue]
+        let model = DynamicModel(values: post)
+        storageAdapter.save(model, schema: ModelRegistry.modelSchema(from: "Post")!) { saveResult in
+            switch saveResult {
+            case .success:
+                self.storageAdapter.query(
+                    DynamicModel.self,
+                    schema: ModelRegistry.modelSchema(from: "Post")!) { queryResult in
+                        switch queryResult {
+                        case .success(let posts):
+                            XCTAssert(posts.count == 1)
+                            if let savedPost = posts.first {
+                                XCTAssert(model.id == savedPost.id)
+                            }
+                            expectation.fulfill()
+                        case .failure(let error):
+                            XCTFail(String(describing: error))
+                            expectation.fulfill()
+                        }
+                }
+            case .failure(let error):
+                XCTFail(String(describing: error))
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 5)
+    }
+
+    /// - Given: a list a `Post` instance
+    /// - When:
+    ///   - the `save(post)` is called
+    /// - Then:
+    ///   - call `query(Post, where: title == post.title)` to check
+    ///   if the model was correctly inserted using a predicate
+    func testInsertPostAndSelectByTitle() {
+        let expectation = self.expectation(
+            description: "it should save and select a Post from the database")
+
+        // insert a post
+        let post = Post(title: "title", content: "content", createdAt: .now())
+        storageAdapter.save(post) { saveResult in
+            switch saveResult {
+            case .success:
+                let predicate = Post.keys.title == post.title
+                self.storageAdapter.query(Post.self, predicate: predicate) { queryResult in
+                    switch queryResult {
+                    case .success(let posts):
+                        XCTAssertEqual(posts.count, 1)
+                        if let savedPost = posts.first {
+                            XCTAssert(post.id == savedPost.id)
+                            XCTAssert(post.title == savedPost.title)
+                            XCTAssert(post.content == savedPost.content)
+                            XCTAssertEqual(post.createdAt.iso8601String, savedPost.createdAt.iso8601String)
+                        }
+                        expectation.fulfill()
+                    case .failure(let error):
+                        XCTFail(String(describing: error))
+                        expectation.fulfill()
+                    }
+                }
+            case .failure(let error):
+                XCTFail(String(describing: error))
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 5)
+    }
+
+
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -27,7 +27,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
         storageAdapter.save(post) { saveResult in
             switch saveResult {
             case .success:
-                storageAdapter.query(Post.self) { queryResult in
+                self.storageAdapter.query(Post.self) { queryResult in
                     switch queryResult {
                     case .success(let posts):
                         XCTAssert(posts.count == 1)
@@ -68,7 +68,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             switch saveResult {
             case .success:
                 let predicate = Post.keys.title == post.title
-                storageAdapter.query(Post.self, predicate: predicate) { queryResult in
+                self.storageAdapter.query(Post.self, predicate: predicate) { queryResult in
                     switch queryResult {
                     case .success(let posts):
                         XCTAssertEqual(posts.count, 1)
@@ -126,7 +126,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             switch insertResult {
             case .success:
                 post.title = "title updated"
-                storageAdapter.save(post) { updateResult in
+                self.storageAdapter.save(post) { updateResult in
                     switch updateResult {
                     case .success:
                         checkSavedPost(id: post.id)
@@ -177,7 +177,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             case .success:
                 post.title = "title updated"
                 let condition = Post.keys.content == post.content
-                storageAdapter.save(post, condition: condition) { updateResult in
+                self.storageAdapter.save(post, condition: condition) { updateResult in
                     switch updateResult {
                     case .success:
                         checkSavedPost(id: post.id)
@@ -237,7 +237,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             case .success:
                 post.title = "title updated"
                 let condition = Post.keys.content == "content 2 does not match previous content"
-                storageAdapter.save(post, condition: condition) { updateResult in
+                self.storageAdapter.save(post, condition: condition) { updateResult in
                     switch updateResult {
                     case .success:
                         XCTFail("Update should not be successful")
@@ -274,11 +274,11 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             switch insertResult {
             case .success:
                 saveExpectation.fulfill()
-                storageAdapter.delete(Post.self, withId: post.id) {
+                self.storageAdapter.delete(Post.self, withId: post.id) {
                     switch $0 {
                     case .success:
                         deleteExpectation.fulfill()
-                        checkIfPostIsDeleted(id: post.id)
+                        self.checkIfPostIsDeleted(id: post.id)
                         queryExpectation.fulfill()
                     case .failure(let error):
                         XCTFail(error.errorDescription)
@@ -306,11 +306,11 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                 saveExpectation.fulfill()
                 let postKeys = Post.keys
                 let predicate = postKeys.createdAt.gt(dateTestStart)
-                storageAdapter.delete(Post.self, predicate: predicate) { result in
+                self.storageAdapter.delete(Post.self, predicate: predicate) { result in
                     switch result {
                     case .success:
                         deleteExpectation.fulfill()
-                        checkIfPostIsDeleted(id: post.id)
+                        self.checkIfPostIsDeleted(id: post.id)
                         queryExpectation.fulfill()
                     case .failure(let error):
                         XCTFail(error.errorDescription)
@@ -345,12 +345,12 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                     postsAdded.append(post.id)
                     if counter == maxCount - 1 {
                         saveExpectation.fulfill()
-                        storageAdapter.delete(Post.self, predicate: QueryPredicateConstant.all) { result in
+                        self.storageAdapter.delete(Post.self, predicate: QueryPredicateConstant.all) { result in
                             switch result {
                             case .success:
                                 deleteExpectation.fulfill()
                                 for postId in postsAdded {
-                                    checkIfPostIsDeleted(id: postId)
+                                    self.checkIfPostIsDeleted(id: postId)
                                 }
                                 queryExpectation.fulfill()
                             case .failure(let error):
@@ -369,7 +369,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
 
     func checkIfPostIsDeleted(id: String) {
         do {
-            let exists = try storageAdapter.exists(Post.self, withId: id)
+            let exists = try storageAdapter.exists(Post.schema, withId: id)
             XCTAssertFalse(exists, "ID \(id) should not exist")
         } catch {
             XCTFail(String(describing: error))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SortByDependencyOrderTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SortByDependencyOrderTests.swift
@@ -29,59 +29,59 @@ class SortByDependencyOrderTests: XCTestCase {
         modelList.forEach { ModelRegistry.register(modelType: $0) }
     }
 
-    /// - Given: a list of `Model` types
+    /// - Given: a list of `ModelSchema` types
     /// - When:
     ///   - the list is not in the correct order: `[Comment, Post]`
     /// - Then:
     ///   - check if `sortByDependencyOrder()` sorts the list to `[Post, Comment]`
     func testModelDependencySortOrder() {
-        let models: [Model.Type] = [Comment.self, Post.self]
+        let modelSchemas: [ModelSchema] = [Comment.schema, Post.schema]
 
-        let sorted = models.sortByDependencyOrder()
+        let sorted = modelSchemas.sortByDependencyOrder()
 
-        let sortedModelNames = sorted.map { $0.modelName }
+        let sortedModelNames = sorted.map { $0.name }
         XCTAssertEqual(sortedModelNames, ["Post", "Comment"])
     }
 
-    /// - Given: A list of `Model` types
+    /// - Given: A list of `ModelSchema` types
     /// - When:
     ///    - not all models are connected: `[Comment, MockSynced, Post]`
     /// - Then:
     ///    - the sorted list should include unconnected models at the end
     func testModelDependencySortForUnconnectedModels() {
-        let models: [Model.Type] = [Comment.self, MockSynced.self, Post.self]
+        let modelSchemas: [ModelSchema] = [Comment.schema, MockSynced.schema, Post.schema]
 
-        let sorted = models.sortByDependencyOrder()
+        let sorted = modelSchemas.sortByDependencyOrder()
 
-        let sortedModelNames = sorted.map { $0.modelName }
+        let sortedModelNames = sorted.map { $0.name }
         XCTAssertEqual(sortedModelNames, ["Post", "Comment", "MockSynced"])
     }
 
-    /// - Given: a list of Model types
+    /// - Given: a list of `ModelSchema` types
     /// - When:
     ///    - the list includes members of two diffrently-connected dependency graphs
     /// - Then:
     ///    - the sorted list should include both graphs in order
     func testMultipleConnectedModels() {
-        let models: [Model.Type] = [Comment.self, UserProfile.self, Post.self, UserAccount.self]
+        let modelSchemas: [ModelSchema] = [Comment.schema, UserProfile.schema, Post.schema, UserAccount.schema]
 
-        let sorted = models.sortByDependencyOrder()
+        let sorted = modelSchemas.sortByDependencyOrder()
 
-        let sortedModelNames = sorted.map { $0.modelName }
+        let sortedModelNames = sorted.map { $0.name }
         XCTAssertEqual(sortedModelNames, ["Post", "Comment", "UserAccount", "UserProfile"])
     }
 
-    /// - Given: a list of Model types
+    /// - Given: a list of `ModelSchema` types
     /// - When:
     ///    - the list includes a many-to-many connection
     /// - Then:
     ///    - the sorted list should include both leaf models before the join model
     func testManyToManyConnections() {
-        let models: [Model.Type] = [Author.self, BookAuthor.self, Book.self]
+        let modelSchemas: [ModelSchema] = [Author.schema, BookAuthor.schema, Book.schema]
 
-        let sorted = models.sortByDependencyOrder()
+        let sorted = modelSchemas.sortByDependencyOrder()
 
-        let sortedModelNames = sorted.map { $0.modelName }
+        let sortedModelNames = sorted.map { $0.name }
         XCTAssertEqual(sortedModelNames, ["Author", "Book", "BookAuthor"])
     }
 
@@ -95,9 +95,11 @@ class SortByDependencyOrderTests: XCTestCase {
                                   "UserAccount", "UserProfile"]
 
         for _ in 0 ..< 10 {
-            let models = modelList.shuffled()
-            let sorted = models.sortByDependencyOrder()
-            let sortedModelNames = sorted.map { $0.modelName }
+            let modelSchemas = modelList.shuffled().map { (modelType) -> ModelSchema in
+                modelType.schema
+            }
+            let sorted = modelSchemas.sortByDependencyOrder()
+            let sortedModelNames = sorted.map { $0.name }
             XCTAssertEqual(sortedModelNames, expectedModelNames)
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/DynamicModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/DynamicModel.swift
@@ -1,0 +1,65 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+
+struct DynamicModel: JsonModel {
+    
+    public let id: String
+    public let values: [String: JSONValue]
+
+    public init(id: String = UUID().uuidString, values: [String: JSONValue]) {
+        self.id = id
+        self.values = values
+    }
+
+    public init(from decoder: Decoder) throws {
+
+        print("DEncode \(decoder)")
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        values = try decoder.singleValueContainer().decode([String: JSONValue].self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        print("Encode")
+        var container = encoder.unkeyedContainer()
+        try container.encode(values)
+    }
+
+    public func internal_value(for key: String) -> Any? {
+        if key == "id" {
+            return id
+        }
+        switch values[key] {
+        case .some(.array(let deserializedValue)):
+            return deserializedValue
+        case .some(.boolean(let deserializedValue)):
+            return deserializedValue
+        case .some(.number(let deserializedValue)):
+            return deserializedValue
+        case .some(.object(let deserializedValue)):
+            return deserializedValue
+        case .some(.string(let deserializedValue)):
+            return deserializedValue
+        case .some(.null):
+            return nil
+        case .none:
+            return nil
+        }
+    }
+}
+
+extension DynamicModel {
+
+    public enum CodingKeys: String, ModelKey {
+        case id
+        case values
+    }
+
+    public static let keys = CodingKeys.self
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/SQLModelValueConverterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/SQLModelValueConverterTests.swift
@@ -55,7 +55,7 @@ class SQLModelValueConverterTests: BaseDataStoreTests {
         let example = exampleModel
 
         // convert model to SQLite Bindings
-        let bindings = example.sqlValues()
+        let bindings = example.sqlValues(schema: example.schema)
 
         // columns are ordered, so check if the values are correct and in the right index
         XCTAssertEqual(bindings.count, ExampleWithEveryType.schema.columns.count)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
@@ -65,7 +65,7 @@ extension APICategoryDependencyTests {
 
         let connection = try Connection(.inMemory)
         storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-        try storageAdapter.setUp(models: StorageEngine.systemModels)
+        try storageAdapter.setUp(schemas: StorageEngine.systemModelSchemas)
 
         let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
                                               dataStoreConfiguration: .default)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -234,7 +234,7 @@ class InitialSyncOperationTests: XCTestCase {
         apiPlugin.responders[.queryRequestListener] = responder
 
         let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
-        try storageAdapter.setUp(models: StorageEngine.systemModels + [MockSynced.self])
+        try storageAdapter.setUp(schemas: StorageEngine.systemModelSchemas + [MockSynced.schema])
 
         let syncCallbackReceived = expectation(description: "Sync callback received, sync operation is complete")
         let reconciliationQueue = MockReconciliationQueue()
@@ -328,7 +328,7 @@ class InitialSyncOperationTests: XCTestCase {
         let startDateMilliseconds = (Int(Date().timeIntervalSince1970) - 100) * 1_000
 
         let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
-        try storageAdapter.setUp(models: StorageEngine.systemModels + [MockSynced.self])
+        try storageAdapter.setUp(schemas: StorageEngine.systemModelSchemas + [MockSynced.schema])
 
         let syncMetadata = ModelSyncMetadata(id: MockSynced.modelName, lastSync: startDateMilliseconds)
         let syncMetadataSaved = expectation(description: "Sync metadata saved")
@@ -375,7 +375,7 @@ class InitialSyncOperationTests: XCTestCase {
         let startDateMilliSeconds = (Int(Date().timeIntervalSince1970) - 100) * 1_000
 
         let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
-        try storageAdapter.setUp(models: StorageEngine.systemModels + [MockSynced.self])
+        try storageAdapter.setUp(schemas: StorageEngine.systemModelSchemas + [MockSynced.schema])
 
         let syncMetadata = ModelSyncMetadata(id: MockSynced.modelName, lastSync: startDateMilliSeconds)
         let syncMetadataSaved = expectation(description: "Sync metadata saved")
@@ -420,7 +420,7 @@ class InitialSyncOperationTests: XCTestCase {
 
     func testBaseQueryWithCustomSyncPageSize() throws {
         let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
-        try storageAdapter.setUp(models: StorageEngine.systemModels + [MockSynced.self])
+        try storageAdapter.setUp(schemas: StorageEngine.systemModelSchemas + [MockSynced.schema])
 
         let apiWasQueried = expectation(description: "API was queried for a PaginatedList of AnyModel")
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { request, listener in

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
@@ -30,7 +30,7 @@ class LocalSubscriptionTests: XCTestCase {
         do {
             let connection = try Connection(.inMemory)
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-            try storageAdapter.setUp(models: StorageEngine.systemModels)
+            try storageAdapter.setUp(schemas: StorageEngine.systemModelSchemas)
 
             let outgoingMutationQueue = NoOpMutationQueue()
             let mutationDatabaseAdapter = try AWSMutationDatabaseAdapter(storageAdapter: storageAdapter)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
@@ -35,7 +35,7 @@ class AWSMutationEventIngesterTests: XCTestCase {
         do {
             let connection = try Connection(.inMemory)
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-            try storageAdapter.setUp(models: StorageEngine.systemModels)
+            try storageAdapter.setUp(schemas: StorageEngine.systemModelSchemas)
 
             let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
                                                   dataStoreConfiguration: .default)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
@@ -40,7 +40,7 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
         do {
             let connection = try Connection(.inMemory)
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-            try storageAdapter.setUp(models: StorageEngine.systemModels)
+            try storageAdapter.setUp(schemas: StorageEngine.systemModelSchemas)
 
             let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
                                                   dataStoreConfiguration: .default)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
@@ -33,7 +33,7 @@ class BaseDataStoreTests: XCTestCase {
         do {
             connection = try Connection(.inMemory)
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-            try storageAdapter.setUp(models: StorageEngine.systemModels)
+            try storageAdapter.setUp(schemas: StorageEngine.systemModelSchemas)
 
             let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
                                                   dataStoreConfiguration: .default)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
@@ -27,3 +27,61 @@ struct TestModelRegistration: AmplifyModelRegistration {
     let version: String = "1"
 
 }
+
+struct TestJsonModelRegistration: AmplifyModelRegistration {
+
+    func registerModels(registry: ModelRegistry.Type) {
+
+        // Post
+        let id = ModelFieldDefinition.id("id").modelField
+        let title = ModelField(name: "title", type: .string, isRequired: true)
+        let content = ModelField(name: "content", type: .string, isRequired: true)
+        let updatedAt = ModelField(name: "updatedAt", type: .dateTime, isRequired: false)
+        let draft = ModelField(name: "draft", type: .bool, isRequired: false)
+        let rating = ModelField(name: "rating", type: .double, isRequired: false)
+        let comments = ModelField(name: "comments",
+                                  type: .collection(of: "Comment"),
+                                  isRequired: false,
+                                  association: .hasMany(associatedWith: "Comment.keys.post"))
+        let postSchema = ModelSchema(name: "Post",
+                                     pluralName: "Posts",
+                                     fields: [id.name: id,
+                                              title.name: title,
+                                              content.name: content,
+                                              updatedAt.name: updatedAt,
+                                              draft.name: draft,
+                                              rating.name: rating,
+                                              comments.name: comments])
+
+        ModelRegistry.register(modelName: postSchema.name,
+                               modelSchema: postSchema,
+                               dynamicType: DynamicModel.self) { (_, _) -> Model in
+                                DynamicModel(id: "", values: [:])
+        }
+
+        // Comment
+
+        let commentId = ModelFieldDefinition.id().modelField
+        let commentContent = ModelField(name: "content", type: .string, isRequired: true)
+        let commentCreatedAt = ModelField(name: "createdAt", type: .dateTime, isRequired: true)
+        let belongsTo = ModelField(name: "comment.post",
+                                   type: .model(name: "Post"),
+                                   isRequired: true,
+                                   association: .belongsTo(associatedWith: nil, targetName: "commentPostId"))
+        let commentSchema = ModelSchema(name: "Comment",
+                                        pluralName: "Comments",
+                                        fields: [
+                                            commentId.name: commentId,
+                                            commentContent.name: commentContent,
+                                            commentCreatedAt.name: commentCreatedAt,
+                                            belongsTo.name: belongsTo])
+        ModelRegistry.register(modelName: commentSchema.name,
+                               modelSchema: commentSchema,
+                               dynamicType: DynamicModel.self) { (_, _) -> Model in
+                                DynamicModel(id: "", values: [:])
+        }
+    }
+
+    let version: String = "1"
+
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -72,7 +72,10 @@ class SyncEngineTestBase: XCTestCase {
         models.forEach { ModelRegistry.register(modelType: $0) }
         let connection = try Connection(.inMemory)
         storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-        try storageAdapter.setUp(models: StorageEngine.systemModels + models)
+        let modelSchemas = models.map { (modelType) -> ModelSchema in
+            modelType.schema
+        }
+        try storageAdapter.setUp(schemas: StorageEngine.systemModelSchemas + modelSchemas)
     }
 
     /// Sets up a DataStorePlugin backed by the storageAdapter created in `setUpStorageAdapter()`, and an optional

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -85,6 +85,8 @@
 		A569484A6FBAE7EC7ADF3FD4 /* Pods_AWSDataStoreCategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A1D332BE6CF885805360B3D /* Pods_AWSDataStoreCategoryPlugin.framework */; };
 		B10BF4A52A1C9840C208C8A8 /* Pods_HostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 19AFF6D00CF3AF927BA90382 /* Pods_HostApp.framework */; };
 		B40EF02824BF68C900F2264C /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40EF02724BF68C900F2264C /* ConfigurationTests.swift */; };
+		B4D9B9E224DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D9B9E124DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift */; };
+		B4D9B9E424DF90CD0049484F /* DynamicModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D9B9E324DF90CD0049484F /* DynamicModel.swift */; };
 		B912D1B824296F1E0028F05C /* QueryPaginationInput+SQLite.swift in Sources */ = {isa = PBXBuildFile; fileRef = B912D1B724296F1E0028F05C /* QueryPaginationInput+SQLite.swift */; };
 		B912D1BA242984D10028F05C /* QueryPaginationInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B912D1B9242984D10028F05C /* QueryPaginationInputTests.swift */; };
 		B9334BA22433AF3E00C9F407 /* DataStoreConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9334BA12433AF3E00C9F407 /* DataStoreConfiguration.swift */; };
@@ -296,6 +298,8 @@
 		9D42A96449A4B73735566C07 /* Pods-AWSDataStoreCategoryPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSDataStoreCategoryPlugin/Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; sourceTree = "<group>"; };
 		9F987EC33AAD7C0904A598CA /* Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B40EF02724BF68C900F2264C /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
+		B4D9B9E124DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteStorageEngineAdapterJsonTests.swift; sourceTree = "<group>"; };
+		B4D9B9E324DF90CD0049484F /* DynamicModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicModel.swift; sourceTree = "<group>"; };
 		B912D1B724296F1E0028F05C /* QueryPaginationInput+SQLite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QueryPaginationInput+SQLite.swift"; sourceTree = "<group>"; };
 		B912D1B9242984D10028F05C /* QueryPaginationInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPaginationInputTests.swift; sourceTree = "<group>"; };
 		B9334BA12433AF3E00C9F407 /* DataStoreConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreConfiguration.swift; sourceTree = "<group>"; };
@@ -643,6 +647,7 @@
 				B996FC4623FF3C7C006D0F68 /* ExampleWithEveryType.swift */,
 				B996FC4823FF3E92006D0F68 /* ExampleWithEveryType+Schema.swift */,
 				B996FC4A23FF418C006D0F68 /* SQLModelValueConverterTests.swift */,
+				B4D9B9E324DF90CD0049484F /* DynamicModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -746,15 +751,16 @@
 		FAD2BDF423957F35006EB065 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				B40EF02724BF68C900F2264C /* ConfigurationTests.swift */,
 				B9FAA13F238C600A009414B4 /* ListTests.swift */,
 				B912D1B9242984D10028F05C /* QueryPaginationInputTests.swift */,
 				2149E5F0238869CF00873955 /* QueryPredicateTests.swift */,
 				FA4FF13B239B218000056633 /* SortByDependencyOrderTests.swift */,
+				B4D9B9E124DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift */,
 				2149E5F7238869CF00873955 /* SQLiteStorageEngineAdapterTests.swift */,
 				2149E5F6238869CF00873955 /* SQLStatementTests.swift */,
 				FA3841EC23889D8F0070AD5B /* StateMachineTests.swift */,
 				2129BE4923948A97006363A1 /* StorageAdapterMutationSyncTests.swift */,
-				B40EF02724BF68C900F2264C /* ConfigurationTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1534,6 +1540,7 @@
 				6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */,
 				FA4B8E962391C609009FC10F /* XCTest+AmplifyExtensions.swift in Sources */,
 				FAE4146C239AA40600CE94C2 /* MockSQLiteStorageEngineAdapter.swift in Sources */,
+				B4D9B9E424DF90CD0049484F /* DynamicModel.swift in Sources */,
 				B912D1BA242984D10028F05C /* QueryPaginationInputTests.swift in Sources */,
 				FA8D932F239EA5C4001ED336 /* NoOpInitialSyncOrchestrator.swift in Sources */,
 				FAABC225239B1B3500740F9F /* ModelReconciliationDeleteTests.swift in Sources */,
@@ -1557,6 +1564,7 @@
 				B9FAA142238C6082009414B4 /* BaseDataStoreTests.swift in Sources */,
 				6B52DC9624478E75007F5AD3 /* MockModelReconciliatinQueue.swift in Sources */,
 				FA4A955B239AD3F4008E876E /* Foundation+TestExtensions.swift in Sources */,
+				B4D9B9E224DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift in Sources */,
 				6B64027B23E38B9900001FD7 /* MockOutgoingMutationQueue.swift in Sources */,
 				2149E600238869CF00873955 /* SQLiteStorageEngineAdapterTests.swift in Sources */,
 				21B3AD27242BB58000C7E1DA /* ProcessMutationErrorFromCloudOperationTests.swift in Sources */,

--- a/AmplifyPlugins/DataStore/Podfile.lock
+++ b/AmplifyPlugins/DataStore/Podfile.lock
@@ -45,7 +45,7 @@ PODS:
   - SQLite.swift/standard (0.12.2)
   - Starscream (3.1.1)
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.39.2)
+  - SwiftLint (0.40.0)
 
 DEPENDENCIES:
   - Amplify (from `../../`)
@@ -115,7 +115,7 @@ SPEC CHECKSUMS:
   SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
   Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
+  SwiftLint: 4154893c73a4c52d6240195507eb7a3e3c64087e
 
 PODFILE CHECKSUM: 04860e414d616b67d24ed3346a60700f427764b9
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
