### PR TITLE
fix(Predictions): rowIndex and columnIndex for cell

### DIFF
--- a/Amplify/Categories/Predictions/Models/Table.swift
+++ b/Amplify/Categories/Predictions/Models/Table.swift
@@ -32,6 +32,8 @@ public extension Table {
         public let polygon: Polygon
 
         public let isSelected: Bool
+        public let rowIndex: Int
+        public let columnIndex: Int
         public let rowSpan: Int
         public let columnSpan: Int
 
@@ -39,12 +41,16 @@ public extension Table {
                     boundingBox: CGRect,
                     polygon: Polygon,
                     isSelected: Bool,
+                    rowIndex: Int,
+                    columnIndex: Int,
                     rowSpan: Int,
                     columnSpan: Int) {
             self.text = text
             self.boundingBox = boundingBox
             self.polygon = polygon
             self.isSelected = isSelected
+            self.rowIndex = rowIndex
+            self.columnIndex = columnIndex
             self.rowSpan = rowSpan
             self.columnSpan = columnSpan
         }

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/IdentifyTextResultTransformers+Tables.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/IdentifyTextResultTransformers+Tables.swift
@@ -67,6 +67,8 @@ extension IdentifyTextResultTransformers {
     static func constructTableCell(_ block: AWSTextractBlock, _ blockMap: [String: AWSTextractBlock]) -> Table.Cell? {
         guard block.blockType == .cell,
             let relationships = block.relationships,
+            let rowIndex = block.rowIndex,
+            let columnIndex = block.columnIndex,
             let rowSpan = block.rowSpan,
             let columnSpan = block.columnSpan,
             let geometry = block.geometry,
@@ -115,10 +117,12 @@ extension IdentifyTextResultTransformers {
                 return nil
         }
 
-        return Table.Cell(text: words,
+        return Table.Cell(text: words.trimmingCharacters(in: .whitespacesAndNewlines),
                           boundingBox: boundingBox,
                           polygon: polygon,
                           isSelected: isSelected,
+                          rowIndex: Int(truncating: rowIndex),
+                          columnIndex: Int(truncating: columnIndex),
                           rowSpan: Int(truncating: rowSpan),
                           columnSpan: Int(truncating: columnSpan))
     }

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/IdentifyBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/IdentifyBasicIntegrationTests.swift
@@ -304,6 +304,8 @@ class IdentifyBasicIntegrationTests: AWSPredictionsPluginTestBase {
                 XCTAssertEqual(data.identifiedLines.count, 3)
                 XCTAssertFalse(data.tables.isEmpty)
                 XCTAssertEqual(data.tables.count, 1)
+                XCTAssertFalse(data.tables[0].cells.isEmpty)
+                XCTAssertEqual(data.tables[0].cells.count, 3)
                 XCTAssertEqual(data.tables[0].cells[0].rowIndex, 1)
                 XCTAssertEqual(data.tables[0].cells[0].columnIndex, 1)
                 XCTAssertEqual(data.tables[0].cells[0].text, "Upper left")

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/IdentifyBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/IdentifyBasicIntegrationTests.swift
@@ -286,9 +286,9 @@ class IdentifyBasicIntegrationTests: AWSPredictionsPluginTestBase {
 
         let completeInvoked = expectation(description: "Completed is invoked")
 
-            let operation = Amplify.Predictions.identify(type: .detectText(.table),
-                                                         image: url,
-                                                         options: PredictionsIdentifyRequest.Options()) { event in
+        let operation = Amplify.Predictions.identify(type: .detectText(.table),
+                                                     image: url,
+                                                     options: PredictionsIdentifyRequest.Options()) { event in
             switch event {
             case .success(let result):
                 guard let data = result as? IdentifyDocumentTextResult else {
@@ -304,6 +304,15 @@ class IdentifyBasicIntegrationTests: AWSPredictionsPluginTestBase {
                 XCTAssertEqual(data.identifiedLines.count, 3)
                 XCTAssertFalse(data.tables.isEmpty)
                 XCTAssertEqual(data.tables.count, 1)
+                XCTAssertEqual(data.tables[0].cells[0].rowIndex, 1)
+                XCTAssertEqual(data.tables[0].cells[0].columnIndex, 1)
+                XCTAssertEqual(data.tables[0].cells[0].text, "Upper left")
+                XCTAssertEqual(data.tables[0].cells[1].rowIndex, 2)
+                XCTAssertEqual(data.tables[0].cells[1].columnIndex, 2)
+                XCTAssertEqual(data.tables[0].cells[1].text, "Middle")
+                XCTAssertEqual(data.tables[0].cells[2].rowIndex, 3)
+                XCTAssertEqual(data.tables[0].cells[2].columnIndex, 3)
+                XCTAssertEqual(data.tables[0].cells[2].text, "Bottom right")
                 completeInvoked.fulfill()
             case .failure(let error):
                 XCTFail("Failed with \(error)")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Bug Fixes
+
+- Fixed the bug where cell struct is missing rowIndex and columnIndex
+
 ## 1.0.6 (2020-08-03)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## unreleased
+## Unreleased
 
 ### Bug Fixes
 
-- Fixed the bug where cell struct is missing rowIndex and columnIndex
+- **Predictions**: Add rowIndex and columnIndex to Cell struct([#704](https://github.com/aws-amplify/amplify-ios/pull/704)
 
 ## 1.0.6 (2020-08-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- **Predictions**: Add rowIndex and columnIndex to Cell struct([#704](https://github.com/aws-amplify/amplify-ios/pull/704)
+- **Predictions**: Add rowIndex and columnIndex to Cell struct (#704)
 
 ## 1.0.6 (2020-08-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- **Predictions**: Add rowIndex and columnIndex to Cell struct (#704)
+- **Predictions**: Add rowIndex and columnIndex to Cell struct ([#704](https://github.com/aws-amplify/amplify-ios/pull/704))
 
 ## 1.0.6 (2020-08-03)
 


### PR DESCRIPTION
*Description of changes:*

Reference for this issue: https://github.com/aws-amplify/amplify-ios/issues/694

- Added `rowIndex` and `columnIndex` for `CELL` struct.
- Updated integration test `testIdentifyTextTables`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
