### PR TITLE
refactor(datastore): Remove the dependency of model type save and query in StorageEngine

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -230,6 +230,8 @@
 		B493E69E245394E200D9E521 /* AuthSignUpStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = B493E69D245394E200D9E521 /* AuthSignUpStep.swift */; };
 		B493E6A22453A29C00D9E521 /* AuthSignInStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = B493E6A12453A29C00D9E521 /* AuthSignInStep.swift */; };
 		B493E6A42453A32C00D9E521 /* AuthSocialWebUISignInOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B493E6A32453A32C00D9E521 /* AuthSocialWebUISignInOperation.swift */; };
+		B4944D21251C06EA00BF0BFE /* JSONValueHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4944D20251C06EA00BF0BFE /* JSONValueHolder.swift */; };
+		B4944D52251C141200BF0BFE /* JSONValueHolderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4944D51251C141200BF0BFE /* JSONValueHolderTest.swift */; };
 		B49A02F92410BEBE00B42A25 /* AuthCategory+CategoryConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49A02F82410BEBD00B42A25 /* AuthCategory+CategoryConfigurable.swift */; };
 		B49A02FB2410BEDF00B42A25 /* AuthCategory+Resettable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49A02FA2410BEDF00B42A25 /* AuthCategory+Resettable.swift */; };
 		B4A19DAB24101EEB00DE2E55 /* AuthCategoryBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A19DAA24101EEB00DE2E55 /* AuthCategoryBehavior.swift */; };
@@ -986,6 +988,8 @@
 		B493E69D245394E200D9E521 /* AuthSignUpStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSignUpStep.swift; sourceTree = "<group>"; };
 		B493E6A12453A29C00D9E521 /* AuthSignInStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSignInStep.swift; sourceTree = "<group>"; };
 		B493E6A32453A32C00D9E521 /* AuthSocialWebUISignInOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSocialWebUISignInOperation.swift; sourceTree = "<group>"; };
+		B4944D20251C06EA00BF0BFE /* JSONValueHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueHolder.swift; sourceTree = "<group>"; };
+		B4944D51251C141200BF0BFE /* JSONValueHolderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueHolderTest.swift; sourceTree = "<group>"; };
 		B49A02F82410BEBD00B42A25 /* AuthCategory+CategoryConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AuthCategory+CategoryConfigurable.swift"; sourceTree = "<group>"; };
 		B49A02FA2410BEDF00B42A25 /* AuthCategory+Resettable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AuthCategory+Resettable.swift"; sourceTree = "<group>"; };
 		B4A19DAA24101EEB00DE2E55 /* AuthCategoryBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCategoryBehavior.swift; sourceTree = "<group>"; };
@@ -2029,6 +2033,14 @@
 			path = AuthPluginBehavior;
 			sourceTree = "<group>";
 		};
+		B4944D1F251C06D300BF0BFE /* JSONHelper */ = {
+			isa = PBXGroup;
+			children = (
+				B4944D20251C06EA00BF0BFE /* JSONValueHolder.swift */,
+			);
+			path = JSONHelper;
+			sourceTree = "<group>";
+		};
 		B49A02F72410BEBD00B42A25 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
@@ -2269,6 +2281,7 @@
 		B92E03A62367CE7A006CEB8D /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				B4944D1F251C06D300BF0BFE /* JSONHelper */,
 				B92E03A72367CE7A006CEB8D /* Model.swift */,
 				FA8EE778238627040097E4F1 /* Model+ModelName.swift */,
 				2129BE502395A66F006363A1 /* AmplifyModelRegistration.swift */,
@@ -3154,6 +3167,7 @@
 				B9AF547D23F37DF20059E6C4 /* TemporalOperationTests.swift */,
 				B91A87A323D64B0F0049A12F /* TemporalTests.swift */,
 				213481D7242AFA58001966DE /* Support */,
+				B4944D51251C141200BF0BFE /* JSONValueHolderTest.swift */,
 			);
 			path = DataStore;
 			sourceTree = "<group>";
@@ -4205,6 +4219,7 @@
 				95DAAB21237E63370028544F /* LanguageDetectionResult.swift in Sources */,
 				FAC2351E227A053D00424678 /* APICategory.swift in Sources */,
 				B9B50DC223D9179F0086F1E1 /* TemporalFormat+DateTime.swift in Sources */,
+				B4944D21251C06EA00BF0BFE /* JSONValueHolder.swift in Sources */,
 				FAC2351B227A053D00424678 /* APICategoryBehavior.swift in Sources */,
 				B473B540245DE93100C45C72 /* AuthConfirmSignInRequest.swift in Sources */,
 				B46884102460A85200221268 /* AuthDevice.swift in Sources */,
@@ -4514,6 +4529,7 @@
 				B9AF547E23F37DF20059E6C4 /* TemporalOperationTests.swift in Sources */,
 				FAD3937D23820D0200463F5E /* DataStoreCategoryConfigurationTests.swift in Sources */,
 				FA607FE2233D131B00DFEA24 /* AmplifyOperationHubTests.swift in Sources */,
+				B4944D52251C141200BF0BFE /* JSONValueHolderTest.swift in Sources */,
 				FAC2356A227A056600424678 /* LoggingCategoryConfigurationTests.swift in Sources */,
 				B91A87A423D64B0F0049A12F /* TemporalTests.swift in Sources */,
 				FA00F69024DA3F95003E8A71 /* HubCombineTests.swift in Sources */,

--- a/Amplify/Categories/DataStore/DataStoreStatement.swift
+++ b/Amplify/Categories/DataStore/DataStoreStatement.swift
@@ -19,7 +19,6 @@ public protocol DataStoreStatement {
     @available(*, deprecated, message: """
     Use of modelType inside the DatastoreStatement is deprecated, use modelSchema instead.
     """)
-
     var modelType: Model.Type { get }
 
     /// The model schema of the `Model` associated with a particular statement

--- a/Amplify/Categories/DataStore/Model/Internal/Model+Subscript.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Model+Subscript.swift
@@ -16,8 +16,8 @@ extension Model {
     ///   by host applications. The behavior of this may change without warning.
     public subscript(_ key: String) -> Any?? {
 
-        if let jsonModel = self as? JSONModel {
-            let value = jsonModel.internalValue(for: key)
+        if let jsonModel = self as? JSONValueHolder {
+            let value = jsonModel.jsonValue(for: key)
             return value
         }
 

--- a/Amplify/Categories/DataStore/Model/Internal/Model+Subscript.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Model+Subscript.swift
@@ -16,8 +16,8 @@ extension Model {
     ///   by host applications. The behavior of this may change without warning.
     public subscript(_ key: String) -> Any?? {
 
-        if let jsonModel = self as? JsonModel {
-            let value = jsonModel.internal_value(for: key)
+        if let jsonModel = self as? JSONModel {
+            let value = jsonModel.internalValue(for: key)
             return value
         }
 

--- a/Amplify/Categories/DataStore/Model/Internal/Model+Subscript.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Model+Subscript.swift
@@ -15,6 +15,12 @@ extension Model {
     /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
     ///   by host applications. The behavior of this may change without warning.
     public subscript(_ key: String) -> Any?? {
+
+        if let jsonModel = self as? JsonModel {
+            let value = jsonModel.internal_value(for: key)
+            return value
+        }
+
         let mirror = Mirror(reflecting: self)
         let firstChild = mirror.children.first { $0.label == key }
         guard let property = firstChild else {

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
@@ -35,17 +35,11 @@ public struct ModelRegistry {
     }
 
     public static func register(modelType: Model.Type) {
-        concurrencyQueue.sync {
-            let modelDecoder: ModelDecoder = { jsonString, jsonDecoder in
-                let model = try modelType.from(json: jsonString, decoder: jsonDecoder)
-                return model
-            }
-
-            modelDecoders[modelType.modelName] = modelDecoder
-
-            modelTypes[modelType.modelName] = modelType
-
-            modelSchemaMapping[modelType.modelName] = modelType.schema
+        register(modelName: modelType.modelName,
+                 modelSchema: modelType.schema,
+                 modelType: modelType) { (jsonString, jsonDecoder) -> Model in
+            let model = try modelType.from(json: jsonString, decoder: jsonDecoder)
+            return model
         }
     }
 

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
@@ -49,6 +49,21 @@ public struct ModelRegistry {
         }
     }
 
+    public static func register(modelName: ModelName,
+                                modelSchema: ModelSchema,
+                                modelType: Model.Type,
+                                jsonDecoder: @escaping (String, JSONDecoder?) throws -> Model) {
+        concurrencyQueue.sync {
+            let modelDecoder: ModelDecoder = { jsonString, decoder in
+                return try jsonDecoder(jsonString, decoder)
+            }
+
+            modelSchemaMapping[modelName] = modelSchema
+            modelTypes[modelName] = modelType
+            modelDecoders[modelName] = modelDecoder
+        }
+    }
+
     public static func modelType(from name: ModelName) -> Model.Type? {
         concurrencyQueue.sync {
             modelTypes[name]

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
@@ -38,7 +38,7 @@ public struct ModelField {
         return name == "id"
     }
 
-    init(name: String,
+    public init(name: String,
          type: ModelFieldType,
          isRequired: Bool = false,
          isArray: Bool = false,
@@ -82,7 +82,7 @@ public struct ModelSchema {
         return primaryKey.value
     }
 
-    init(name: String,
+    public init(name: String,
          pluralName: String? = nil,
          authRules: AuthRules = [],
          attributes: [ModelAttribute] = [],

--- a/Amplify/Categories/DataStore/Model/JSONHelper/JSONValueHolder.swift
+++ b/Amplify/Categories/DataStore/Model/JSONHelper/JSONValueHolder.swift
@@ -1,0 +1,37 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// A type that holds internal data in json format
+///
+/// Internally  a `JSONValueHolder` will have the data stored as a json map. Properties of the type can be retrieved
+/// using the function `jsonValue(for:)` passing in the key of the property.
+///
+/// Example:
+/// ==============================================
+///         struct DynamicModel: JSONValueHolder {
+///             let values: [String: Any]
+///
+///             public func internalValue(for key: String) -> Any? {
+///                 return values[key] 
+///             }
+///          }
+public protocol JSONValueHolder {
+
+    /// Return the value for the given key.
+    ///
+    /// If a particular key has nil as it value, this method should return .some(nil) as the value.
+    func jsonValue(for key: String) -> Any??
+}
+
+extension JSONValueHolder {
+
+    public func jsonValue(for key: String) -> Any?? {
+        return nil
+    }
+}

--- a/Amplify/Categories/DataStore/Model/Model.swift
+++ b/Amplify/Categories/DataStore/Model/Model.swift
@@ -30,3 +30,16 @@ public protocol Model: Codable {
     var id: Identifier { get }
 
 }
+
+public protocol JsonModel: Model {
+
+    /// Return the value for key
+    func internal_value(for key: String) -> Any?
+}
+
+extension JsonModel {
+
+    public func internal_value(for key: String) -> Any? {
+        return nil
+    }
+}

--- a/Amplify/Categories/DataStore/Model/Model.swift
+++ b/Amplify/Categories/DataStore/Model/Model.swift
@@ -31,15 +31,15 @@ public protocol Model: Codable {
 
 }
 
-public protocol JsonModel: Model {
+public protocol JSONModel: Model {
 
     /// Return the value for key
-    func internal_value(for key: String) -> Any?
+    func internalValue(for key: String) -> Any?
 }
 
-extension JsonModel {
+extension JSONModel {
 
-    public func internal_value(for key: String) -> Any? {
+    public func internalValue(for key: String) -> Any? {
         return nil
     }
 }

--- a/Amplify/Categories/DataStore/Model/Model.swift
+++ b/Amplify/Categories/DataStore/Model/Model.swift
@@ -28,18 +28,4 @@ public protocol Model: Codable {
 
     /// The Model identifier (aka primary key)
     var id: Identifier { get }
-
-}
-
-public protocol JSONModel: Model {
-
-    /// Return the value for key
-    func internalValue(for key: String) -> Any?
-}
-
-extension JSONModel {
-
-    public func internalValue(for key: String) -> Any? {
-        return nil
-    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
@@ -11,6 +11,11 @@ protocol ModelStorageBehavior {
     func setUp(modelSchemas: [ModelSchema]) throws
 
     func save<M: Model>(_ model: M,
+                        modelSchema: ModelSchema,
+                        where condition: QueryPredicate?,
+                        completion: @escaping DataStoreCallback<M>)
+
+    func save<M: Model>(_ model: M,
                         condition: QueryPredicate?,
                         completion: @escaping DataStoreCallback<M>)
 
@@ -23,6 +28,13 @@ protocol ModelStorageBehavior {
                           completion: @escaping DataStoreCallback<[M]>)
 
     func query<M: Model>(_ modelType: M.Type,
+                         predicate: QueryPredicate?,
+                         sort: QuerySortInput?,
+                         paginationInput: QueryPaginationInput?,
+                         completion: DataStoreCallback<[M]>)
+
+    func query<M: Model>(_ modelType: M.Type,
+                         modelSchema: ModelSchema,
                          predicate: QueryPredicate?,
                          sort: QuerySortInput?,
                          paginationInput: QueryPaginationInput?,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
@@ -57,9 +57,8 @@ extension Model {
     ///
     /// - Parameter fields: an optional subset of fields
     /// - Returns: an array of SQLite's `Binding` compatible type
-    internal func sqlValues(for fields: [ModelField]? = nil) -> [Binding?] {
-        let modelType = type(of: self)
-        let modelFields = fields ?? modelType.schema.sortedFields
+    internal func sqlValues(for fields: [ModelField]? = nil, modelSchema: ModelSchema) -> [Binding?] {
+        let modelFields = fields ?? modelSchema.sortedFields
         let values: [Binding?] = modelFields.map { field in
 
             // self[field.name] subscript accessor returns an Any??, we need to do a few things:
@@ -101,7 +100,7 @@ extension Model {
                 return binding
             } catch {
                 logger.warn("""
-                Error converting \(modelType.modelName).\(field.name) to the proper SQLite Binding.
+                    Error converting \(modelSchema.name).\(field.name) to the proper SQLite Binding.
                 Root cause is: \(String(describing: error))
                 """)
                 return nil

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
@@ -100,7 +100,7 @@ extension Model {
                 return binding
             } catch {
                 logger.warn("""
-                    Error converting \(modelSchema.name).\(field.name) to the proper SQLite Binding.
+                Error converting \(modelSchema.name).\(field.name) to the proper SQLite Binding.
                 Root cause is: \(String(describing: error))
                 """)
                 return nil

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
@@ -149,7 +149,7 @@ extension Array where Element == Model.Type {
                             """)
                         }
                         return modelType
-                }
+                    }
                 associatedModels.forEach(walkAssociatedModels(of:))
 
                 let key = modelType.schema.name
@@ -177,7 +177,7 @@ extension Array where Element == ModelSchema {
                     .filter { $0.isForeignKey }
                     .map { (schema) -> ModelSchema in
                         guard let associatedSchema = ModelRegistry.modelSchema(from: schema.requiredAssociatedModel)
-                            else {
+                        else {
                             preconditionFailure("""
                             Could not retrieve schema for the model \(schema.requiredAssociatedModel), verify that
                             datastore is initialized.

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
@@ -16,7 +16,7 @@ struct InsertStatement: SQLStatement {
 
     init(model: Model, modelSchema: ModelSchema) {
         self.modelSchema = modelSchema
-        self.variables = model.sqlValues(for: modelSchema.columns)
+        self.variables = model.sqlValues(for: modelSchema.columns, modelSchema: modelSchema)
     }
 
     var stringValue: String {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Update.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Update.swift
@@ -19,7 +19,7 @@ struct UpdateStatement: SQLStatement {
 
     init(model: Model, modelSchema: ModelSchema, condition: QueryPredicate? = nil) {
         self.model = model
-        self.modelSchema = model.schema
+        self.modelSchema = modelSchema
 
         var conditionStatement: ConditionStatement?
         if let condition = condition {
@@ -56,7 +56,7 @@ struct UpdateStatement: SQLStatement {
     }
 
     var variables: [Binding?] {
-        var bindings = model.sqlValues(for: updateColumns)
+        var bindings = model.sqlValues(for: updateColumns, modelSchema: modelSchema)
         bindings.append(model.id)
         if let conditionStatement = conditionStatement {
             bindings.append(contentsOf: conditionStatement.variables)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
@@ -22,7 +22,7 @@ extension SQLiteStorageEngineAdapter {
             // TODO serialize result and create a new instance of the model
             // (some columns might be auto-generated after DB insert/update)
             if shouldUpdate {
-                let statement = UpdateStatement(model: untypedModel, modelSchema: modelType.schema)
+                let statement = UpdateStatement(model: untypedModel, modelSchema: untypedModel.schema)
                 _ = try connection.prepare(statement.stringValue).run(statement.variables)
             } else {
                 let statement = InsertStatement(model: untypedModel, modelSchema: untypedModel.schema)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
@@ -25,7 +25,7 @@ extension SQLiteStorageEngineAdapter {
                 let statement = UpdateStatement(model: untypedModel, modelSchema: modelType.schema)
                 _ = try connection.prepare(statement.stringValue).run(statement.variables)
             } else {
-                let statement = InsertStatement(model: untypedModel, modelSchema: modelType.schema)
+                let statement = InsertStatement(model: untypedModel, modelSchema: untypedModel.schema)
                 _ = try connection.prepare(statement.stringValue).run(statement.variables)
             }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -31,6 +31,7 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
                completion: DataStoreCallback<[Model]>)
 
     func query<M: Model>(_ modelType: M.Type,
+                         modelSchema: ModelSchema,
                          predicate: QueryPredicate?,
                          sort: QuerySortInput?,
                          paginationInput: QueryPaginationInput?,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
@@ -1,0 +1,110 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+import Foundation
+import SQLite
+
+class SQLiteStorageEngineAdapterJsonTests: XCTestCase {
+
+    var connection: Connection!
+    var storageEngine: StorageEngine!
+    var storageAdapter: SQLiteStorageEngineAdapter!
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        super.setUp()
+        sleep(2)
+        Amplify.reset()
+        Amplify.Logging.logLevel = .warn
+
+        let validAPIPluginKey = "MockAPICategoryPlugin"
+        let validAuthPluginKey = "MockAuthCategoryPlugin"
+        do {
+            connection = try Connection(.inMemory)
+            storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
+            try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
+
+            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
+                                                  dataStoreConfiguration: .default)
+            storageEngine = StorageEngine(storageAdapter: storageAdapter,
+                                          dataStoreConfiguration: .default,
+                                          syncEngine: syncEngine,
+                                          validAPIPluginKey: validAPIPluginKey,
+                                          validAuthPluginKey: validAuthPluginKey)
+        } catch {
+            XCTFail(String(describing: error))
+            return
+        }
+
+        let dataStorePublisher = DataStorePublisher()
+        let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestJsonModelRegistration(),
+                                                 storageEngine: storageEngine,
+                                                 dataStorePublisher: dataStorePublisher,
+                                                 validAPIPluginKey: validAPIPluginKey,
+                                                 validAuthPluginKey: validAuthPluginKey)
+
+        let dataStoreConfig = DataStoreCategoryConfiguration(plugins: [
+            "awsDataStorePlugin": true
+        ])
+        let amplifyConfig = AmplifyConfiguration(dataStore: dataStoreConfig)
+
+        do {
+
+            try Amplify.add(plugin: dataStorePlugin)
+            try Amplify.configure(amplifyConfig)
+        } catch {
+            XCTFail(String(describing: error))
+            return
+        }
+    }
+
+    /// - Given: a list a `Post` instance
+    /// - When:
+    ///   - the `save(post)` is called
+    /// - Then:
+    ///   - call `query(Post)` to check if the model was correctly inserted
+    func testInsertPost() {
+        let expectation = self.expectation(
+            description: "it should save and select a Post from the database")
+
+        // insert a post
+        let post = ["title": "title",
+                    "content": "content information"] as [String: JSONValue]
+        let model = DynamicModel(values: post)
+        storageAdapter.save(model, modelSchema: ModelRegistry.modelSchema(from: "Post")!) { saveResult in
+            switch saveResult {
+            case .success:
+                self.storageAdapter.query(
+                    DynamicModel.self,
+                    modelSchema: ModelRegistry.modelSchema(from: "Post")!) { queryResult in
+                        switch queryResult {
+                        case .success(let posts):
+                            XCTAssert(posts.count == 1)
+                            if let savedPost = posts.first {
+                                XCTAssert(model.id == savedPost.id)
+                            }
+                            expectation.fulfill()
+                        case .failure(let error):
+                            XCTFail(String(describing: error))
+                            expectation.fulfill()
+                        }
+                }
+            case .failure(let error):
+                XCTFail(String(describing: error))
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: 5)
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -27,7 +27,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
         storageAdapter.save(post) { saveResult in
             switch saveResult {
             case .success:
-                storageAdapter.query(Post.self) { queryResult in
+                self.storageAdapter.query(Post.self) { queryResult in
                     switch queryResult {
                     case .success(let posts):
                         XCTAssert(posts.count == 1)
@@ -68,7 +68,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             switch saveResult {
             case .success:
                 let predicate = Post.keys.title == post.title
-                storageAdapter.query(Post.self, predicate: predicate) { queryResult in
+                self.storageAdapter.query(Post.self, predicate: predicate) { queryResult in
                     switch queryResult {
                     case .success(let posts):
                         XCTAssertEqual(posts.count, 1)
@@ -126,7 +126,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             switch insertResult {
             case .success:
                 post.title = "title updated"
-                storageAdapter.save(post) { updateResult in
+                self.storageAdapter.save(post) { updateResult in
                     switch updateResult {
                     case .success:
                         checkSavedPost(id: post.id)
@@ -177,7 +177,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             case .success:
                 post.title = "title updated"
                 let condition = Post.keys.content == post.content
-                storageAdapter.save(post, condition: condition) { updateResult in
+                self.storageAdapter.save(post, condition: condition) { updateResult in
                     switch updateResult {
                     case .success:
                         checkSavedPost(id: post.id)
@@ -237,7 +237,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             case .success:
                 post.title = "title updated"
                 let condition = Post.keys.content == "content 2 does not match previous content"
-                storageAdapter.save(post, condition: condition) { updateResult in
+                self.storageAdapter.save(post, condition: condition) { updateResult in
                     switch updateResult {
                     case .success:
                         XCTFail("Update should not be successful")
@@ -274,11 +274,11 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             switch insertResult {
             case .success:
                 saveExpectation.fulfill()
-                storageAdapter.delete(Post.self, withId: post.id) {
+                self.storageAdapter.delete(Post.self, withId: post.id) {
                     switch $0 {
                     case .success:
                         deleteExpectation.fulfill()
-                        checkIfPostIsDeleted(id: post.id)
+                        self.checkIfPostIsDeleted(id: post.id)
                         queryExpectation.fulfill()
                     case .failure(let error):
                         XCTFail(error.errorDescription)
@@ -306,11 +306,11 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                 saveExpectation.fulfill()
                 let postKeys = Post.keys
                 let predicate = postKeys.createdAt.gt(dateTestStart)
-                storageAdapter.delete(Post.self, predicate: predicate) { result in
+                self.storageAdapter.delete(Post.self, predicate: predicate) { result in
                     switch result {
                     case .success:
                         deleteExpectation.fulfill()
-                        checkIfPostIsDeleted(id: post.id)
+                        self.checkIfPostIsDeleted(id: post.id)
                         queryExpectation.fulfill()
                     case .failure(let error):
                         XCTFail(error.errorDescription)
@@ -345,12 +345,12 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                     postsAdded.append(post.id)
                     if counter == maxCount - 1 {
                         saveExpectation.fulfill()
-                        storageAdapter.delete(Post.self, predicate: QueryPredicateConstant.all) { result in
+                        self.storageAdapter.delete(Post.self, predicate: QueryPredicateConstant.all) { result in
                             switch result {
                             case .success:
                                 deleteExpectation.fulfill()
                                 for postId in postsAdded {
-                                    checkIfPostIsDeleted(id: postId)
+                                    self.checkIfPostIsDeleted(id: postId)
                                 }
                                 queryExpectation.fulfill()
                             case .failure(let error):

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SortByDependencyOrderTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SortByDependencyOrderTests.swift
@@ -29,59 +29,59 @@ class SortByDependencyOrderTests: XCTestCase {
         modelList.forEach { ModelRegistry.register(modelType: $0) }
     }
 
-    /// - Given: a list of `Model` types
+    /// - Given: a list of `ModelSchema` types
     /// - When:
     ///   - the list is not in the correct order: `[Comment, Post]`
     /// - Then:
     ///   - check if `sortByDependencyOrder()` sorts the list to `[Post, Comment]`
     func testModelDependencySortOrder() {
-        let models: [Model.Type] = [Comment.self, Post.self]
+        let modelSchemas: [ModelSchema] = [Comment.schema, Post.schema]
 
-        let sorted = models.sortByDependencyOrder()
+        let sorted = modelSchemas.sortByDependencyOrder()
 
-        let sortedModelNames = sorted.map { $0.modelName }
+        let sortedModelNames = sorted.map { $0.name }
         XCTAssertEqual(sortedModelNames, ["Post", "Comment"])
     }
 
-    /// - Given: A list of `Model` types
+    /// - Given: A list of `ModelSchema` types
     /// - When:
     ///    - not all models are connected: `[Comment, MockSynced, Post]`
     /// - Then:
     ///    - the sorted list should include unconnected models at the end
     func testModelDependencySortForUnconnectedModels() {
-        let models: [Model.Type] = [Comment.self, MockSynced.self, Post.self]
+        let modelSchemas: [ModelSchema] = [Comment.schema, MockSynced.schema, Post.schema]
 
-        let sorted = models.sortByDependencyOrder()
+        let sorted = modelSchemas.sortByDependencyOrder()
 
-        let sortedModelNames = sorted.map { $0.modelName }
+        let sortedModelNames = sorted.map { $0.name }
         XCTAssertEqual(sortedModelNames, ["Post", "Comment", "MockSynced"])
     }
 
-    /// - Given: a list of Model types
+    /// - Given: a list of `ModelSchema` types
     /// - When:
     ///    - the list includes members of two diffrently-connected dependency graphs
     /// - Then:
     ///    - the sorted list should include both graphs in order
     func testMultipleConnectedModels() {
-        let models: [Model.Type] = [Comment.self, UserProfile.self, Post.self, UserAccount.self]
+        let modelSchemas: [ModelSchema] = [Comment.schema, UserProfile.schema, Post.schema, UserAccount.schema]
 
-        let sorted = models.sortByDependencyOrder()
+        let sorted = modelSchemas.sortByDependencyOrder()
 
-        let sortedModelNames = sorted.map { $0.modelName }
+        let sortedModelNames = sorted.map { $0.name }
         XCTAssertEqual(sortedModelNames, ["Post", "Comment", "UserAccount", "UserProfile"])
     }
 
-    /// - Given: a list of Model types
+    /// - Given: a list of `ModelSchema` types
     /// - When:
     ///    - the list includes a many-to-many connection
     /// - Then:
     ///    - the sorted list should include both leaf models before the join model
     func testManyToManyConnections() {
-        let models: [Model.Type] = [Author.self, BookAuthor.self, Book.self]
+        let modelSchemas: [ModelSchema] = [Author.schema, BookAuthor.schema, Book.schema]
 
-        let sorted = models.sortByDependencyOrder()
+        let sorted = modelSchemas.sortByDependencyOrder()
 
-        let sortedModelNames = sorted.map { $0.modelName }
+        let sortedModelNames = sorted.map { $0.name }
         XCTAssertEqual(sortedModelNames, ["Author", "Book", "BookAuthor"])
     }
 
@@ -95,9 +95,11 @@ class SortByDependencyOrderTests: XCTestCase {
                                   "UserAccount", "UserProfile"]
 
         for _ in 0 ..< 10 {
-            let models = modelList.shuffled()
-            let sorted = models.sortByDependencyOrder()
-            let sortedModelNames = sorted.map { $0.modelName }
+            let modelSchemas = modelList.shuffled().map { (modelType) -> ModelSchema in
+                modelType.schema
+            }
+            let sorted = modelSchemas.sortByDependencyOrder()
+            let sortedModelNames = sorted.map { $0.name }
             XCTAssertEqual(sortedModelNames, expectedModelNames)
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/DynamicModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/DynamicModel.swift
@@ -1,0 +1,65 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+
+struct DynamicModel: JsonModel {
+
+    public let id: String
+    public let values: [String: JSONValue]
+
+    public init(id: String = UUID().uuidString, values: [String: JSONValue]) {
+        self.id = id
+        self.values = values
+    }
+
+    public init(from decoder: Decoder) throws {
+
+        print("DEncode \(decoder)")
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        values = try decoder.singleValueContainer().decode([String: JSONValue].self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        print("Encode")
+        var container = encoder.unkeyedContainer()
+        try container.encode(values)
+    }
+
+    public func internal_value(for key: String) -> Any? {
+        if key == "id" {
+            return id
+        }
+        switch values[key] {
+        case .some(.array(let deserializedValue)):
+            return deserializedValue
+        case .some(.boolean(let deserializedValue)):
+            return deserializedValue
+        case .some(.number(let deserializedValue)):
+            return deserializedValue
+        case .some(.object(let deserializedValue)):
+            return deserializedValue
+        case .some(.string(let deserializedValue)):
+            return deserializedValue
+        case .some(.null):
+            return nil
+        case .none:
+            return nil
+        }
+    }
+}
+
+extension DynamicModel {
+
+    public enum CodingKeys: String, ModelKey {
+        case id
+        case values
+    }
+
+    public static let keys = CodingKeys.self
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/DynamicModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/DynamicModel.swift
@@ -7,7 +7,7 @@
 
 import Amplify
 
-struct DynamicModel: JsonModel {
+struct DynamicModel: JSONModel {
 
     public let id: String
     public let values: [String: JSONValue]
@@ -31,7 +31,7 @@ struct DynamicModel: JsonModel {
         try container.encode(values)
     }
 
-    public func internal_value(for key: String) -> Any? {
+    public func internalValue(for key: String) -> Any? {
         if key == "id" {
             return id
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/DynamicModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/DynamicModel.swift
@@ -7,7 +7,7 @@
 
 import Amplify
 
-struct DynamicModel: JSONModel {
+struct DynamicModel: Model, JSONValueHolder {
 
     public let id: String
     public let values: [String: JSONValue]
@@ -31,7 +31,7 @@ struct DynamicModel: JSONModel {
         try container.encode(values)
     }
 
-    public func internalValue(for key: String) -> Any? {
+    public func jsonValue(for key: String) -> Any?? {
         if key == "id" {
             return id
         }
@@ -47,7 +47,7 @@ struct DynamicModel: JSONModel {
         case .some(.string(let deserializedValue)):
             return deserializedValue
         case .some(.null):
-            return nil
+            return .some(nil)
         case .none:
             return nil
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/SQLModelValueConverterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/SQLModelValueConverterTests.swift
@@ -55,7 +55,7 @@ class SQLModelValueConverterTests: BaseDataStoreTests {
         let example = exampleModel
 
         // convert model to SQLite Bindings
-        let bindings = example.sqlValues()
+        let bindings = example.sqlValues(modelSchema: example.schema)
 
         // columns are ordered, so check if the values are correct and in the right index
         XCTAssertEqual(bindings.count, ExampleWithEveryType.schema.columns.count)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
@@ -27,3 +27,61 @@ struct TestModelRegistration: AmplifyModelRegistration {
     let version: String = "1"
 
 }
+
+struct TestJsonModelRegistration: AmplifyModelRegistration {
+
+    func registerModels(registry: ModelRegistry.Type) {
+
+        // Post
+        let id = ModelFieldDefinition.id("id").modelField
+        let title = ModelField(name: "title", type: .string, isRequired: true)
+        let content = ModelField(name: "content", type: .string, isRequired: true)
+        let updatedAt = ModelField(name: "updatedAt", type: .dateTime, isRequired: false)
+        let draft = ModelField(name: "draft", type: .bool, isRequired: false)
+        let rating = ModelField(name: "rating", type: .double, isRequired: false)
+        let comments = ModelField(name: "comments",
+                                  type: .collection(of: "Comment"),
+                                  isRequired: false,
+                                  association: .hasMany(associatedWith: "Comment.keys.post"))
+        let postSchema = ModelSchema(name: "Post",
+                                     pluralName: "Posts",
+                                     fields: [id.name: id,
+                                              title.name: title,
+                                              content.name: content,
+                                              updatedAt.name: updatedAt,
+                                              draft.name: draft,
+                                              rating.name: rating,
+                                              comments.name: comments])
+
+        ModelRegistry.register(modelName: postSchema.name,
+                               modelSchema: postSchema,
+                               modelType: DynamicModel.self) { (_, _) -> Model in
+                                DynamicModel(id: "", values: [:])
+        }
+
+        // Comment
+
+        let commentId = ModelFieldDefinition.id().modelField
+        let commentContent = ModelField(name: "content", type: .string, isRequired: true)
+        let commentCreatedAt = ModelField(name: "createdAt", type: .dateTime, isRequired: true)
+        let belongsTo = ModelField(name: "comment.post",
+                                   type: .model(name: "Post"),
+                                   isRequired: true,
+                                   association: .belongsTo(associatedWith: nil, targetName: "commentPostId"))
+        let commentSchema = ModelSchema(name: "Comment",
+                                        pluralName: "Comments",
+                                        fields: [
+                                            commentId.name: commentId,
+                                            commentContent.name: commentContent,
+                                            commentCreatedAt.name: commentCreatedAt,
+                                            belongsTo.name: belongsTo])
+        ModelRegistry.register(modelName: commentSchema.name,
+                               modelSchema: commentSchema,
+                               modelType: DynamicModel.self) { (_, _) -> Model in
+                                DynamicModel(id: "", values: [:])
+        }
+    }
+
+    let version: String = "1"
+
+}

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -85,6 +85,8 @@
 		A569484A6FBAE7EC7ADF3FD4 /* Pods_AWSDataStoreCategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A1D332BE6CF885805360B3D /* Pods_AWSDataStoreCategoryPlugin.framework */; };
 		B10BF4A52A1C9840C208C8A8 /* Pods_HostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 19AFF6D00CF3AF927BA90382 /* Pods_HostApp.framework */; };
 		B40EF02824BF68C900F2264C /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40EF02724BF68C900F2264C /* ConfigurationTests.swift */; };
+		B4D9B9E224DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D9B9E124DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift */; };
+		B4D9B9E424DF90CD0049484F /* DynamicModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D9B9E324DF90CD0049484F /* DynamicModel.swift */; };
 		B912D1B824296F1E0028F05C /* QueryPaginationInput+SQLite.swift in Sources */ = {isa = PBXBuildFile; fileRef = B912D1B724296F1E0028F05C /* QueryPaginationInput+SQLite.swift */; };
 		B912D1BA242984D10028F05C /* QueryPaginationInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B912D1B9242984D10028F05C /* QueryPaginationInputTests.swift */; };
 		B9334BA22433AF3E00C9F407 /* DataStoreConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9334BA12433AF3E00C9F407 /* DataStoreConfiguration.swift */; };
@@ -302,6 +304,8 @@
 		9D42A96449A4B73735566C07 /* Pods-AWSDataStoreCategoryPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSDataStoreCategoryPlugin/Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; sourceTree = "<group>"; };
 		9F987EC33AAD7C0904A598CA /* Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B40EF02724BF68C900F2264C /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
+		B4D9B9E124DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteStorageEngineAdapterJsonTests.swift; sourceTree = "<group>"; };
+		B4D9B9E324DF90CD0049484F /* DynamicModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicModel.swift; sourceTree = "<group>"; };
 		B912D1B724296F1E0028F05C /* QueryPaginationInput+SQLite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QueryPaginationInput+SQLite.swift"; sourceTree = "<group>"; };
 		B912D1B9242984D10028F05C /* QueryPaginationInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPaginationInputTests.swift; sourceTree = "<group>"; };
 		B9334BA12433AF3E00C9F407 /* DataStoreConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreConfiguration.swift; sourceTree = "<group>"; };
@@ -658,6 +662,7 @@
 				B996FC4623FF3C7C006D0F68 /* ExampleWithEveryType.swift */,
 				B996FC4823FF3E92006D0F68 /* ExampleWithEveryType+Schema.swift */,
 				B996FC4A23FF418C006D0F68 /* SQLModelValueConverterTests.swift */,
+				B4D9B9E324DF90CD0049484F /* DynamicModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -771,15 +776,16 @@
 		FAD2BDF423957F35006EB065 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				B40EF02724BF68C900F2264C /* ConfigurationTests.swift */,
 				B9FAA13F238C600A009414B4 /* ListTests.swift */,
 				B912D1B9242984D10028F05C /* QueryPaginationInputTests.swift */,
 				2149E5F0238869CF00873955 /* QueryPredicateTests.swift */,
 				FA4FF13B239B218000056633 /* SortByDependencyOrderTests.swift */,
+				B4D9B9E124DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift */,
 				2149E5F7238869CF00873955 /* SQLiteStorageEngineAdapterTests.swift */,
 				2149E5F6238869CF00873955 /* SQLStatementTests.swift */,
 				FA3841EC23889D8F0070AD5B /* StateMachineTests.swift */,
 				2129BE4923948A97006363A1 /* StorageAdapterMutationSyncTests.swift */,
-				B40EF02724BF68C900F2264C /* ConfigurationTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1564,6 +1570,7 @@
 				6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */,
 				FA4B8E962391C609009FC10F /* XCTest+AmplifyExtensions.swift in Sources */,
 				FAE4146C239AA40600CE94C2 /* MockSQLiteStorageEngineAdapter.swift in Sources */,
+				B4D9B9E424DF90CD0049484F /* DynamicModel.swift in Sources */,
 				B912D1BA242984D10028F05C /* QueryPaginationInputTests.swift in Sources */,
 				FA8D932F239EA5C4001ED336 /* NoOpInitialSyncOrchestrator.swift in Sources */,
 				FAABC225239B1B3500740F9F /* ModelReconciliationDeleteTests.swift in Sources */,
@@ -1587,6 +1594,7 @@
 				B9FAA142238C6082009414B4 /* BaseDataStoreTests.swift in Sources */,
 				6B52DC9624478E75007F5AD3 /* MockModelReconciliatinQueue.swift in Sources */,
 				FA4A955B239AD3F4008E876E /* Foundation+TestExtensions.swift in Sources */,
+				B4D9B9E224DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift in Sources */,
 				6B64027B23E38B9900001FD7 /* MockOutgoingMutationQueue.swift in Sources */,
 				2149E600238869CF00873955 /* SQLiteStorageEngineAdapterTests.swift in Sources */,
 				21B3AD27242BB58000C7E1DA /* ProcessMutationErrorFromCloudOperationTests.swift in Sources */,

--- a/AmplifyPlugins/DataStore/Podfile.lock
+++ b/AmplifyPlugins/DataStore/Podfile.lock
@@ -45,7 +45,7 @@ PODS:
   - SQLite.swift/standard (0.12.2)
   - Starscream (3.1.1)
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.40.2)
+  - SwiftLint (0.40.3)
 
 DEPENDENCIES:
   - Amplify (from `../../`)
@@ -115,7 +115,7 @@ SPEC CHECKSUMS:
   SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
   Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: 1216c910d27c2633ade33b4f071bb6b930982e62
+  SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
 
 PODFILE CHECKSUM: 04860e414d616b67d24ed3346a60700f427764b9
 

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -49,7 +49,7 @@ class MockAPICategoryPlugin: MessageReporter, APICategoryPlugin {
                                                  responseType: request.responseType,
                                                  options: options)
         let operation = MockGraphQLOperation(request: request, responseType: request.responseType)
-        
+
         return operation
     }
 

--- a/AmplifyTests/CategoryTests/DataStore/JSONValueHolderTest.swift
+++ b/AmplifyTests/CategoryTests/DataStore/JSONValueHolderTest.swift
@@ -1,0 +1,65 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import Amplify
+
+class JSONValueHolderTest: XCTestCase {
+
+    var jsonValueHodler = DynamicModel(values: ["id": 123,
+                                                "name": nil,
+                                                "comment": "here is a comment"])
+
+    func testJsonDoubleValue() {
+        guard let id = jsonValueHodler.jsonValue(for: "id") as? Double else {
+            XCTFail("Should cast to Double")
+            return
+        }
+        XCTAssertEqual(id, 123, "Returned value should match")
+    }
+
+    func testJsonStringValue() {
+        guard let comment = jsonValueHodler.jsonValue(for: "comment") as? String else {
+            XCTFail("Should cast to String")
+            return
+        }
+        XCTAssertEqual(comment, "here is a comment", "Returned value should match")
+    }
+
+    func testNilJsonValue() {
+        let name = jsonValueHodler.jsonValue(for: "name")
+        guard case .some(let value) = name else {
+            XCTFail("Should cast to an Optional value")
+            return
+        }
+        XCTAssertNil(value, "Returned value should be nil")
+    }
+}
+
+struct DynamicModel: JSONValueHolder {
+
+    let values: [String: JSONValue]
+
+    func jsonValue(for key: String) -> Any?? {
+        switch values[key] {
+        case .some(.array(let deserializedValue)):
+            return deserializedValue
+        case .some(.boolean(let deserializedValue)):
+            return deserializedValue
+        case .some(.number(let deserializedValue)):
+            return deserializedValue
+        case .some(.object(let deserializedValue)):
+            return deserializedValue
+        case .some(.string(let deserializedValue)):
+            return deserializedValue
+        case .some(.null):
+            return .some(nil)
+        case .none:
+            return nil
+        }
+    }
+}

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.40.2)
+  - SwiftLint (0.40.3)
 
 DEPENDENCIES:
   - AWSMobileClient (~> 2.15.0)
@@ -57,7 +57,7 @@ SPEC CHECKSUMS:
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: 1216c910d27c2633ade33b4f071bb6b930982e62
+  SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
 
 PODFILE CHECKSUM: a2acde35ab1bc6b80b362106cfda70905a6a840f
 


### PR DESCRIPTION
*Description of changes:*

Removes the dependency on model type in the StorageEngine apis `save` and `query`. Added a new protocol called `JSONValueHolder`, the concrete implementation of this protocol will holds the internal data in a json format. `JSONValueHolder.jsonValue(for:)` can be used to get the value for a particular key inside the json map. 

For example developer can create the following struct using the `JSONValueHolder`.

```swift

struct DynamicModel: JSONValueHolder {

    let values: [String: JSONValue]

    func jsonValue(for key: String) -> Any?? {
        switch values[key] {
        case .some(.array(let deserializedValue)):
            return deserializedValue
        case .some(.boolean(let deserializedValue)):
            return deserializedValue
        case .some(.number(let deserializedValue)):
            return deserializedValue
        case .some(.object(let deserializedValue)):
            return deserializedValue
        case .some(.string(let deserializedValue)):
            return deserializedValue
        case .some(.null):
            return .some(nil)
        case .none:
            return nil
        }
    }
}


```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
