### PR TITLE
feat(api): Adding custom 'items' deserialization for List

### DIFF
--- a/Amplify/Categories/DataStore/Model/Collection/List+Model.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+Model.swift
@@ -112,6 +112,17 @@ public class List<ModelType: Model>: Collection, Codable, ExpressibleByArrayLite
                 let field = Element.schema.field(withName: associatedField)
                 // TODO handle eager loaded associations with elements
                 self.init([], associatedId: associatedId, associatedField: field)
+            } else if case let .array(jsonArray) = list["items"] {
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = ModelDateFormatting.decodingStrategy
+                let elements = try jsonArray.map { (jsonElement) -> Element in
+                    let serializedJSON = try encoder.encode(jsonElement)
+                    return try decoder.decode(Element.self, from: serializedJSON)
+                }
+
+                self.init(elements)
             } else {
                 self.init(Elements())
             }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/AnyModelIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/AnyModelIntegrationTests.swift
@@ -84,6 +84,8 @@ class AnyModelIntegrationTests: XCTestCase {
                     XCTFail("partial: \(model), \(errors)")
                 case .transformationError(let rawResponse, let apiError):
                     XCTFail("transformationError: \(rawResponse), \(apiError)")
+                case .unknown(let errorDescription, let recoverySuggestion, _):
+                    XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
                 }
             }
             return
@@ -148,6 +150,8 @@ class AnyModelIntegrationTests: XCTestCase {
                     XCTFail("partial: \(model), \(errors)")
                 case .transformationError(let rawResponse, let apiError):
                     XCTFail("transformationError: \(rawResponse), \(apiError)")
+                case .unknown(let errorDescription, let recoverySuggestion, _):
+                    XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
                 }
             }
             return
@@ -205,6 +209,8 @@ class AnyModelIntegrationTests: XCTestCase {
                     XCTFail("partial: \(model), \(errors)")
                 case .transformationError(let rawResponse, let apiError):
                     XCTFail("transformationError: \(rawResponse), \(apiError)")
+                case .unknown(let errorDescription, let recoverySuggestion, _):
+                    XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
                 }
             }
             return

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncBasedTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncBasedTests.swift
@@ -81,6 +81,8 @@ class GraphQLSyncBasedTests: XCTestCase {
                     XCTFail("partial: \(String(describing: model)), \(errors)")
                 case .transformationError(let rawResponse, let apiError):
                     XCTFail("transformationError: \(rawResponse), \(apiError)")
+                case .unknown(let errorDescription, let recoverySuggestion, _):
+                    XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
                 }
             }
             return
@@ -137,6 +139,8 @@ class GraphQLSyncBasedTests: XCTestCase {
                     XCTFail("partial: \(String(describing: model)), \(errors)")
                 case .transformationError(let rawResponse, let apiError):
                     XCTFail("transformationError: \(rawResponse), \(apiError)")
+                case .unknown(let errorDescription, let recoverySuggestion, _):
+                    XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
                 }
             }
             return
@@ -208,6 +212,8 @@ class GraphQLSyncBasedTests: XCTestCase {
                     XCTFail("partial: \(model), \(errors)")
                 case .transformationError(let rawResponse, let apiError):
                     XCTFail("transformationError: \(rawResponse), \(apiError)")
+                case .unknown(let errorDescription, let recoverySuggestion, _):
+                    XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
                 }
             }
             return
@@ -287,6 +293,8 @@ class GraphQLSyncBasedTests: XCTestCase {
                 XCTFail("partial: \(model), \(errors)")
             case .transformationError(let rawResponse, let apiError):
                 XCTFail("transformationError: \(rawResponse), \(apiError)")
+            case .unknown(let errorDescription, let recoverySuggestion, _):
+                XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
             }
         }
 
@@ -381,6 +389,8 @@ class GraphQLSyncBasedTests: XCTestCase {
                 XCTFail("partial: \(model), \(errors)")
             case .transformationError(let rawResponse, let apiError):
                 XCTFail("transformationError: \(rawResponse), \(apiError)")
+            case .unknown(let errorDescription, let recoverySuggestion, _):
+                XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
             }
         }
 
@@ -444,6 +454,8 @@ class GraphQLSyncBasedTests: XCTestCase {
                     XCTFail("partial: \(model), \(errors)")
                 case .transformationError(let rawResponse, let apiError):
                     XCTFail("transformationError: \(rawResponse), \(apiError)")
+                case .unknown(let errorDescription, let recoverySuggestion, _):
+                    XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
                 }
             }
             return


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Models with 1-to-many connections contain a List, for example
```
public struct Post: Model {
  public var comments: List<Comment>?
```
The post contains a list of comments. When constructing a Get Query for a Post, the Model-to-GraphQLRequest builders will only generate the first depth of a selection set since comments is not a required association. If the developer wants to retrieve the comments for that particular Post, The developer can create a custom selection set for the GetQuery containing nested selection set with the comments. 
```
query getPost($id: ID!) {
          getPost(id: $id){
            id
            title
            content
            createdAt
            updatedAt
            draft
            rating
            status
            comments {
              items {
                id
                content
                createdAt
                updatedAt
                post {
                  id
                  title
                  content
                  createdAt
                  updatedAt
                  draft
                  rating
                  status
                }
              }
              nextToken
            }
          }
        }
```
Then construct a GraphQLRequest like
```
let graphQLRequest = GraphQLRequest(document: document,
                                            variables: ["id": uuid],
                                            responseType: Post?.self,
                                            decodePath: "getPost")
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
