### PR TITLE
feat(api): default decodePath behavior

### DIFF
--- a/Amplify/Categories/DataStore/Model/Collection/List+Model.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+Model.swift
@@ -112,6 +112,17 @@ public class List<ModelType: Model>: Collection, Codable, ExpressibleByArrayLite
                 let field = Element.schema.field(withName: associatedField)
                 // TODO handle eager loaded associations with elements
                 self.init([], associatedId: associatedId, associatedField: field)
+            } else if case let .array(jsonArray) = list["items"] {
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = ModelDateFormatting.decodingStrategy
+                let elements = try jsonArray.map { (jsonElement) -> Element in
+                    let serializedJSON = try encoder.encode(jsonElement)
+                    return try decoder.decode(Element.self, from: serializedJSON)
+                }
+
+                self.init(elements)
             } else {
                 self.init(Elements())
             }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/GraphQLResponseDecoder.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/GraphQLResponseDecoder.swift
@@ -33,9 +33,9 @@ struct GraphQLResponseDecoder {
         case (.some(let data), .none):
             do {
                 let jsonValue = JSONValue.object(data)
-                let responseData = try decode(graphQLData: jsonValue,
-                                              into: responseType,
-                                              at: decodePath)
+                let graphQLData = try getModelJSONValue(from: jsonValue, at: decodePath)
+                let responseData = try decode(graphQLData: graphQLData,
+                                              into: responseType)
                 return GraphQLResponse<R>.success(responseData)
             } catch let decodingError as DecodingError {
                 let error = APIError(error: decodingError)
@@ -60,9 +60,9 @@ struct GraphQLResponseDecoder {
                 }
 
                 let jsonValue = JSONValue.object(data)
-                let responseData = try decode(graphQLData: jsonValue,
-                                              into: responseType,
-                                              at: decodePath)
+                let graphQLData = try getModelJSONValue(from: jsonValue, at: decodePath)
+                let responseData = try decode(graphQLData: graphQLData,
+                                              into: responseType)
                 let responseErrors = try decodeErrors(graphQLErrors: errors)
                 return GraphQLResponse<R>.failure(.partial(responseData, responseErrors))
             } catch let decodingError as DecodingError {
@@ -139,25 +139,21 @@ struct GraphQLResponseDecoder {
     }
 
     private static func decode<R: Decodable>(graphQLData: JSONValue,
-                                             into responseType: R.Type,
-                                             at decodePath: String?) throws -> R {
+                                             into responseType: R.Type) throws -> R {
 
         let isAnyModel = responseType == AnyModel.self
 
         let serializedJSON = isAnyModel ?
-            try serializeAnyModel(from: graphQLData, at: decodePath) :
-            try serialize(graphQLData: graphQLData, at: decodePath)
+            try serializeAnyModel(from: graphQLData) :
+            try serialize(graphQLData: graphQLData)
 
         if responseType == String.self {
-
             guard let responseString = String(data: serializedJSON, encoding: .utf8) else {
                 throw APIError.operationError("could not get string from data", "", nil)
             }
-
             guard let response = responseString as? R else {
                 throw APIError.operationError("Not of type \(String(describing: R.self))", "", nil)
             }
-
             return response
         }
 
@@ -166,33 +162,34 @@ struct GraphQLResponseDecoder {
         return try decoder.decode(responseType, from: serializedJSON)
     }
 
-    private static func serialize(graphQLData: JSONValue,
-                                  at decodePath: String?) throws -> Data {
-        let modelJSON = try getModelJSONValue(from: graphQLData, at: decodePath)
+    private static func serialize(graphQLData: JSONValue) throws -> Data {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
-        return try encoder.encode(modelJSON)
+        return try encoder.encode(graphQLData)
     }
 
-    private static func serializeAnyModel(from graphQLData: JSONValue,
-                                          at decodePath: String?) throws -> Data {
-        let modelJSON = try getModelJSONValue(from: graphQLData, at: decodePath)
-        let anyModel = try AnyModel(modelJSON: modelJSON)
+    private static func serializeAnyModel(from graphQLData: JSONValue) throws -> Data {
+        let anyModel = try AnyModel(modelJSON: graphQLData)
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
         return try encoder.encode(anyModel)
     }
 
+    /// Retrieve the Model data at the given `decodePath`. If the decode path is not specified,
+    /// retrieve the first object if there is a single nested object at `graphQLData`
     private static func getModelJSONValue(from graphQLData: JSONValue,
                                           at decodePath: String?) throws -> JSONValue {
-        guard let decodePath = decodePath else {
-            return graphQLData
+        if let decodePath = decodePath {
+            guard let model = graphQLData.value(at: decodePath) else {
+                throw APIError.operationError("Could not retrieve object, given decode path: \(decodePath)", "", nil)
+            }
+            return model
+        } else if case let .object(graphQLDataObject) = graphQLData,
+                  graphQLDataObject.count == 1,
+                  let firstGraphQLDataObject = graphQLDataObject.first {
+            return firstGraphQLDataObject.value
         }
 
-        guard let model = graphQLData.value(at: decodePath) else {
-            throw APIError.operationError("Could not retrieve object, given decode path: \(decodePath)", "", nil)
-        }
-
-        return model
+        return graphQLData
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/AnyModelIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/AnyModelIntegrationTests.swift
@@ -84,6 +84,8 @@ class AnyModelIntegrationTests: XCTestCase {
                     XCTFail("partial: \(model), \(errors)")
                 case .transformationError(let rawResponse, let apiError):
                     XCTFail("transformationError: \(rawResponse), \(apiError)")
+                case .unknown(let errorDescription, let recoverySuggestion, _):
+                    XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
                 }
             }
             return
@@ -148,6 +150,8 @@ class AnyModelIntegrationTests: XCTestCase {
                     XCTFail("partial: \(model), \(errors)")
                 case .transformationError(let rawResponse, let apiError):
                     XCTFail("transformationError: \(rawResponse), \(apiError)")
+                case .unknown(let errorDescription, let recoverySuggestion, _):
+                    XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
                 }
             }
             return
@@ -205,6 +209,8 @@ class AnyModelIntegrationTests: XCTestCase {
                     XCTFail("partial: \(model), \(errors)")
                 case .transformationError(let rawResponse, let apiError):
                     XCTFail("transformationError: \(rawResponse), \(apiError)")
+                case .unknown(let errorDescription, let recoverySuggestion, _):
+                    XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
                 }
             }
             return

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLModelBasedTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLModelBasedTests.swift
@@ -130,8 +130,7 @@ class GraphQLModelBasedTests: XCTestCase {
         """
         let graphQLRequest = GraphQLRequest(document: document,
                                             variables: ["id": uuid],
-                                            responseType: Post?.self,
-                                            decodePath: "getPost")
+                                            responseType: Post?.self)
         _ = Amplify.API.query(request: graphQLRequest) { event in
             switch event {
             case .success(let graphQLResponse):

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncBasedTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncBasedTests.swift
@@ -81,6 +81,8 @@ class GraphQLSyncBasedTests: XCTestCase {
                     XCTFail("partial: \(String(describing: model)), \(errors)")
                 case .transformationError(let rawResponse, let apiError):
                     XCTFail("transformationError: \(rawResponse), \(apiError)")
+                case .unknown(let errorDescription, let recoverySuggestion, _):
+                    XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
                 }
             }
             return
@@ -137,6 +139,8 @@ class GraphQLSyncBasedTests: XCTestCase {
                     XCTFail("partial: \(String(describing: model)), \(errors)")
                 case .transformationError(let rawResponse, let apiError):
                     XCTFail("transformationError: \(rawResponse), \(apiError)")
+                case .unknown(let errorDescription, let recoverySuggestion, _):
+                    XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
                 }
             }
             return
@@ -208,6 +212,8 @@ class GraphQLSyncBasedTests: XCTestCase {
                     XCTFail("partial: \(model), \(errors)")
                 case .transformationError(let rawResponse, let apiError):
                     XCTFail("transformationError: \(rawResponse), \(apiError)")
+                case .unknown(let errorDescription, let recoverySuggestion, _):
+                    XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
                 }
             }
             return
@@ -287,6 +293,8 @@ class GraphQLSyncBasedTests: XCTestCase {
                 XCTFail("partial: \(model), \(errors)")
             case .transformationError(let rawResponse, let apiError):
                 XCTFail("transformationError: \(rawResponse), \(apiError)")
+            case .unknown(let errorDescription, let recoverySuggestion, _):
+                XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
             }
         }
 
@@ -381,6 +389,8 @@ class GraphQLSyncBasedTests: XCTestCase {
                 XCTFail("partial: \(model), \(errors)")
             case .transformationError(let rawResponse, let apiError):
                 XCTFail("transformationError: \(rawResponse), \(apiError)")
+            case .unknown(let errorDescription, let recoverySuggestion, _):
+                XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
             }
         }
 
@@ -444,6 +454,8 @@ class GraphQLSyncBasedTests: XCTestCase {
                     XCTFail("partial: \(model), \(errors)")
                 case .transformationError(let rawResponse, let apiError):
                     XCTFail("transformationError: \(rawResponse), \(apiError)")
+                case .unknown(let errorDescription, let recoverySuggestion, _):
+                    XCTFail("UnknownError: \(errorDescription), \(recoverySuggestion)")
                 }
             }
             return

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLMutateCombineTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLMutateCombineTests.swift
@@ -16,7 +16,7 @@ class GraphQLMutateCombineTests: OperationTestBase {
     let testDocument = "mutate { updateTodo { id name description }}"
 
     func testMutateSucceeds() throws {
-        let testJSONData: JSONValue = ["foo": true]
+        let testJSONData: JSONValue = true
         let sentData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
         try setUpPluginForSingleResponse(sending: sentData, for: .graphQL)
 

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLQueryCombineTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLQueryCombineTests.swift
@@ -16,7 +16,7 @@ class GraphQLQueryCombineTests: OperationTestBase {
     let testDocument = "query { getTodo { id name description }}"
 
     func testQuerySucceeds() throws {
-        let testJSONData: JSONValue = ["foo": true]
+        let testJSONData: JSONValue = true
         let sentData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
         try setUpPluginForSingleResponse(sending: sentData, for: .graphQL)
 

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLSubscribeTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLSubscribeTests.swift
@@ -63,7 +63,7 @@ class GraphQLSubscribeTests: OperationTestBase {
     /// - The value handler is invoked with a disconnection message
     /// - The completion handler is invoked with a normal termination
     func testHappyPath() throws {
-        let testJSON: JSONValue = ["foo": true]
+        let testJSON: JSONValue = true
         let testData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
         receivedCompletionFinish.shouldTrigger = true
         receivedCompletionFailure.shouldTrigger = false
@@ -172,7 +172,7 @@ class GraphQLSubscribeTests: OperationTestBase {
     }
 
     func testMultipleSuccessValues() throws {
-        let testJSON: JSONValue = ["foo": true]
+        let testJSON: JSONValue = true
         let testData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
         receivedCompletionFinish.shouldTrigger = true
         receivedCompletionFailure.shouldTrigger = false

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -58,8 +58,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
 
         return GraphQLRequest<MutationSyncResult?>(document: document.stringValue,
                                                    variables: document.variables,
-                                                   responseType: MutationSyncResult?.self,
-                                                   decodePath: document.name)
+                                                   responseType: MutationSyncResult?.self)
     }
 
     public static func createMutation(of model: Model,
@@ -89,8 +88,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
 
         return GraphQLRequest<MutationSyncResult>(document: document.stringValue,
                                                   variables: document.variables,
-                                                  responseType: MutationSyncResult.self,
-                                                  decodePath: document.name)
+                                                  responseType: MutationSyncResult.self)
     }
 
     public static func subscription(to modelType: Model.Type,
@@ -103,8 +101,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
 
         return GraphQLRequest<MutationSyncResult>(document: document.stringValue,
                                                   variables: document.variables,
-                                                  responseType: MutationSyncResult.self,
-                                                  decodePath: document.name)
+                                                  responseType: MutationSyncResult.self)
     }
 
     public static func subscription(to modelType: Model.Type,
@@ -119,8 +116,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
 
         return GraphQLRequest<MutationSyncResult>(document: document.stringValue,
                                                   variables: document.variables,
-                                                  responseType: MutationSyncResult.self,
-                                                  decodePath: document.name)
+                                                  responseType: MutationSyncResult.self)
     }
 
     public static func syncQuery(modelType: Model.Type,
@@ -140,8 +136,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
 
         return GraphQLRequest<SyncQueryResult>(document: document.stringValue,
                                                variables: document.variables,
-                                               responseType: SyncQueryResult.self,
-                                               decodePath: document.name)
+                                               responseType: SyncQueryResult.self)
     }
 
     // MARK: Private methods
@@ -163,7 +158,6 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
 
         return GraphQLRequest<MutationSyncResult>(document: document.stringValue,
                                                   variables: document.variables,
-                                                  responseType: MutationSyncResult.self,
-                                                  decodePath: document.name)
+                                                  responseType: MutationSyncResult.self)
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
@@ -29,7 +29,7 @@ protocol ModelGraphQLRequestFactory {
     ///
     /// - seealso: `GraphQLQuery`, `GraphQLQueryType.list`
     static func list<M: Model>(_ modelType: M.Type,
-                               where predicate: QueryPredicate?) -> GraphQLRequest<List<M>>
+                               where predicate: QueryPredicate?) -> GraphQLRequest<[M]>
 
     /// Creates a `GraphQLRequest` that represents a query that expects a single value as a result.
     /// The request will be created with the correct correct document based on the `ModelSchema` and
@@ -167,7 +167,7 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
     }
 
     public static func list<M: Model>(_ modelType: M.Type,
-                                      where predicate: QueryPredicate? = nil) -> GraphQLRequest<List<M>> {
+                                      where predicate: QueryPredicate? = nil) -> GraphQLRequest<[M]> {
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
 
@@ -178,9 +178,9 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
         documentBuilder.add(decorator: PaginationDecorator())
         let document = documentBuilder.build()
 
-        return GraphQLRequest<List<M>>(document: document.stringValue,
+        return GraphQLRequest<[M]>(document: document.stringValue,
                                        variables: document.variables,
-                                       responseType: List<M>.self)
+                                       responseType: [M].self)
     }
 
     public static func subscription<M: Model>(of modelType: M.Type,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
@@ -179,8 +179,9 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
         let document = documentBuilder.build()
 
         return GraphQLRequest<[M]>(document: document.stringValue,
-                                       variables: document.variables,
-                                       responseType: [M].self)
+                                   variables: document.variables,
+                                   responseType: [M].self,
+                                   decodePath: document.name + ".items")
     }
 
     public static func subscription<M: Model>(of modelType: M.Type,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
@@ -29,7 +29,7 @@ protocol ModelGraphQLRequestFactory {
     ///
     /// - seealso: `GraphQLQuery`, `GraphQLQueryType.list`
     static func list<M: Model>(_ modelType: M.Type,
-                               where predicate: QueryPredicate?) -> GraphQLRequest<[M]>
+                               where predicate: QueryPredicate?) -> GraphQLRequest<List<M>>
 
     /// Creates a `GraphQLRequest` that represents a query that expects a single value as a result.
     /// The request will be created with the correct correct document based on the `ModelSchema` and
@@ -151,8 +151,7 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
         let document = documentBuilder.build()
         return GraphQLRequest<M>(document: document.stringValue,
                                  variables: document.variables,
-                                 responseType: M.self,
-                                 decodePath: document.name)
+                                 responseType: M.self)
     }
 
     public static func get<M: Model>(_ modelType: M.Type,
@@ -164,12 +163,11 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
 
         return GraphQLRequest<M?>(document: document.stringValue,
                                   variables: document.variables,
-                                  responseType: M?.self,
-                                  decodePath: document.name)
+                                  responseType: M?.self)
     }
 
     public static func list<M: Model>(_ modelType: M.Type,
-                                      where predicate: QueryPredicate? = nil) -> GraphQLRequest<[M]> {
+                                      where predicate: QueryPredicate? = nil) -> GraphQLRequest<List<M>> {
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
 
@@ -180,10 +178,9 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
         documentBuilder.add(decorator: PaginationDecorator())
         let document = documentBuilder.build()
 
-        return GraphQLRequest<[M]>(document: document.stringValue,
-                                   variables: document.variables,
-                                   responseType: [M].self,
-                                   decodePath: document.name + ".items")
+        return GraphQLRequest<List<M>>(document: document.stringValue,
+                                       variables: document.variables,
+                                       responseType: List<M>.self)
     }
 
     public static func subscription<M: Model>(of modelType: M.Type,
@@ -194,7 +191,6 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
 
         return GraphQLRequest<M>(document: document.stringValue,
                                  variables: document.variables,
-                                 responseType: modelType,
-                                 decodePath: document.name)
+                                 responseType: modelType)
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestModelTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestModelTests.swift
@@ -99,7 +99,7 @@ class GraphQLRequestModelTests: XCTestCase {
         let request = GraphQLRequest<Post>.list(Post.self, where: predicate)
 
         XCTAssertEqual(document.stringValue, request.document)
-        XCTAssert(request.responseType == List<Post>.self)
+        XCTAssert(request.responseType == [Post].self)
         XCTAssertNotNil(request.variables)
     }
 

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestModelTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestModelTests.swift
@@ -99,7 +99,7 @@ class GraphQLRequestModelTests: XCTestCase {
         let request = GraphQLRequest<Post>.list(Post.self, where: predicate)
 
         XCTAssertEqual(document.stringValue, request.document)
-        XCTAssert(request.responseType == [Post].self)
+        XCTAssert(request.responseType == List<Post>.self)
         XCTAssertNotNil(request.variables)
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
GraphQL responses are returned in the format of
```
{ "data": { }
  "errors": [ ] }
```
A GraphQL request can specify a `decodePath` to extract a specific part of the object at `data` out from the response. In Android, the default behavior is to take the first element at the `data` object. See [comment](https://github.com/aws-amplify/docs/pull/2141#discussion_r462599129)

Before, we would always have to use the decodePath, for example

```
{
 "data": {
   "getTodo": {
      "id": 111
  }
 }
}
```

will require a decodePath = "getTodo" to get to the object `{ "id": 111}` and deserialize successfully when the Todo Model is passed as `responseType`. This PR first
- defaults to the first value of the object under "data" to automatically retrieve `{ "id": 111 }`.

*Customer impact*
- If the customer is using Model-based GraphQLRequest builders - no change, decodePath is removed from the internal implementation
- If the customer is building their own GraphQLRequest with decodePath - no change required, however if they are deserializing to a single model, which is usually the case when using GraphQLTransform provisioned API, then they can also remove `decodePath` which is in alignment with Android
- If customer is building their own GraphQLRequest without decodePath and deserialize to a single object - Change is required since now the nested object is returned so their responseType should be updated, for example
```
struct TodoResponse: Decodable {
    let getTodo: Todo
    struct Todo: Decodable {
      let id: String
    }
}
```
the response type `let responseType = TodoResponse.self` can be updated to `let responseType = Todo.self`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
