### PR TITLE
feat(api): PaginatedResult for ModelBased list query

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		214F49CE24898E8500DA616C /* Article+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49CC24898E8500DA616C /* Article+Schema.swift */; };
 		21558E3E237BB4BF0032A5BB /* GraphQLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21558E3D237BB4BF0032A5BB /* GraphQLRequest.swift */; };
 		21558E40237CB8640032A5BB /* GraphQLError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21558E3F237CB8640032A5BB /* GraphQLError.swift */; };
+		215E8C8124E4BDE900631D0C /* PaginatedResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215E8C8024E4BDE900631D0C /* PaginatedResult.swift */; };
 		216879FE23636A0A004A056E /* RepeatingTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216879FD23636A0A004A056E /* RepeatingTimer.swift */; };
 		21687A3E236371C4004A056E /* AnalyticsCategory+HubPayloadEventName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21687A3D236371C4004A056E /* AnalyticsCategory+HubPayloadEventName.swift */; };
 		21687A41236371E1004A056E /* AnalyticsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21687A40236371E1004A056E /* AnalyticsError.swift */; };
@@ -353,13 +354,13 @@
 		B9FAA180238FBB5D009414B4 /* Model+Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FAA17F238FBB5D009414B4 /* Model+Array.swift */; };
 		B9FB05F82383740D00DE1FD4 /* DataStoreStatement.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FB05F72383740D00DE1FD4 /* DataStoreStatement.swift */; };
 		D83C5160248964780091548E /* ModelGraphQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83C515F248964780091548E /* ModelGraphQLTests.swift */; };
+		D8DD7A1D24A1CCCD001C49FD /* QuerySortInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DD7A1C24A1CCCD001C49FD /* QuerySortInput.swift */; };
 		FA00F68824DA37EE003E8A71 /* AuthCategoryBehavior+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA00F68724DA37EE003E8A71 /* AuthCategoryBehavior+Combine.swift */; };
 		FA00F68A24DA3A43003E8A71 /* AuthCategoryDeviceBehavior+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA00F68924DA3A43003E8A71 /* AuthCategoryDeviceBehavior+Combine.swift */; };
 		FA00F68C24DA3A8F003E8A71 /* AuthCategoryUserBehavior+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA00F68B24DA3A8F003E8A71 /* AuthCategoryUserBehavior+Combine.swift */; };
 		FA00F68E24DA3DFF003E8A71 /* HubCategoryBehavior+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA00F68D24DA3DFE003E8A71 /* HubCategoryBehavior+Combine.swift */; };
 		FA00F69024DA3F95003E8A71 /* HubCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA00F68F24DA3F95003E8A71 /* HubCombineTests.swift */; };
 		FA00F69224DA4087003E8A71 /* PredictionsCategoryBehavior+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA00F69124DA4087003E8A71 /* PredictionsCategoryBehavior+Combine.swift */; };
-		D8DD7A1D24A1CCCD001C49FD /* QuerySortInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DD7A1C24A1CCCD001C49FD /* QuerySortInput.swift */; };
 		FA0173352375F8A5005DDDFC /* LoggingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0173342375F8A5005DDDFC /* LoggingError.swift */; };
 		FA0173372375FAA5005DDDFC /* HubError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0173362375FAA5005DDDFC /* HubError.swift */; };
 		FA05B83424CE265E0026180B /* StorageCategory+ClientBehavior+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA05B83324CE265D0026180B /* StorageCategory+ClientBehavior+Combine.swift */; };
@@ -752,6 +753,7 @@
 		214F49CC24898E8500DA616C /* Article+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Article+Schema.swift"; sourceTree = "<group>"; };
 		21558E3D237BB4BF0032A5BB /* GraphQLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRequest.swift; sourceTree = "<group>"; };
 		21558E3F237CB8640032A5BB /* GraphQLError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLError.swift; sourceTree = "<group>"; };
+		215E8C8024E4BDE900631D0C /* PaginatedResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedResult.swift; sourceTree = "<group>"; };
 		215F4BCAAB89FA54AA121BDE /* Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin.release.xcconfig"; path = "Target Support Files/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin.release.xcconfig"; sourceTree = "<group>"; };
 		216879FD23636A0A004A056E /* RepeatingTimer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepeatingTimer.swift; sourceTree = "<group>"; };
 		21687A3D236371C4004A056E /* AnalyticsCategory+HubPayloadEventName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AnalyticsCategory+HubPayloadEventName.swift"; sourceTree = "<group>"; };
@@ -1532,6 +1534,7 @@
 				2129BE1A2394806B006363A1 /* QueryPredicate+GraphQL.swift */,
 				212CE6FB23E9E523007D8E71 /* SelectionSet.swift */,
 				21A3FDBE2465FA1500E76120 /* AuthRule+Extension.swift */,
+				215E8C8024E4BDE900631D0C /* PaginatedResult.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -4079,6 +4082,7 @@
 				212CE70E23E9E991007D8E71 /* PaginationDecorator.swift in Sources */,
 				21AD424B249BF0DA0016FE95 /* AnyModel.swift in Sources */,
 				21420A9C237222A900FA140C /* AWSAuthService.swift in Sources */,
+				215E8C8124E4BDE900631D0C /* PaginatedResult.swift in Sources */,
 				B4EBEB66246204E400D06375 /* AuthCognitoTokensProvider.swift in Sources */,
 				21AD424D249BF0E50016FE95 /* AnyModel+Schema.swift in Sources */,
 				2129BE4F23949F1B006363A1 /* MutationSyncMetadata+Schema.swift in Sources */,

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		217856A423810B9400A30D19 /* AWSAPICategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B478F5FB2374DBF400C4F92B /* AWSAPICategoryPlugin.framework */; };
 		217856B72381F19400A30D19 /* AWSAPICategoryPluginEndpointType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217856B62381F19300A30D19 /* AWSAPICategoryPluginEndpointType.swift */; };
 		217856C22383339D00A30D19 /* GraphQLModelBasedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217856C12383339D00A30D19 /* GraphQLModelBasedTests.swift */; };
+		2189385B24E59C4700DE5314 /* GraphQLResponseDecoder+PaginatedResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2189385A24E59C4700DE5314 /* GraphQLResponseDecoder+PaginatedResult.swift */; };
 		219A888F23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219A888E23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.swift */; };
 		219A889123ECF8A500BBC5F2 /* AWSAPICategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B478F5FB2374DBF400C4F92B /* AWSAPICategoryPlugin.framework */; };
 		219A88A223EE034F00BBC5F2 /* RESTWithUserPoolIntegrationTests-amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 219A889F23EE01A700BBC5F2 /* RESTWithUserPoolIntegrationTests-amplifyconfiguration.json */; };
@@ -306,6 +307,7 @@
 		217856A323810B9400A30D19 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		217856B62381F19300A30D19 /* AWSAPICategoryPluginEndpointType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAPICategoryPluginEndpointType.swift; sourceTree = "<group>"; };
 		217856C12383339D00A30D19 /* GraphQLModelBasedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLModelBasedTests.swift; sourceTree = "<group>"; };
+		2189385A24E59C4700DE5314 /* GraphQLResponseDecoder+PaginatedResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLResponseDecoder+PaginatedResult.swift"; sourceTree = "<group>"; };
 		219A888C23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RESTWithUserPoolIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		219A888E23ECF8A400BBC5F2 /* RESTWithUserPoolIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTWithUserPoolIntegrationTests.swift; sourceTree = "<group>"; };
 		219A889023ECF8A500BBC5F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -827,6 +829,7 @@
 				21D7A0CD237B54D90057D00D /* GraphQLOperationRequestUtils+Validator.swift */,
 				21D7A0CE237B54D90057D00D /* GraphQLResponseDecoder.swift */,
 				21E2E2272451E66A007D7767 /* GraphQLResponseDecoder+DecodeError.swift */,
+				2189385A24E59C4700DE5314 /* GraphQLResponseDecoder+PaginatedResult.swift */,
 				21409C5F2384DF17000A53C9 /* RESTOperationRequest+RESTRequest.swift */,
 				21D7A0C7237B54D90057D00D /* RESTOperationRequest+Validate.swift */,
 				21D7A0C8237B54D90057D00D /* RESTOperationRequestUtils.swift */,
@@ -2177,6 +2180,7 @@
 				21D7A0DF237B54D90057D00D /* AWSGraphQLOperation.swift in Sources */,
 				6B33897223AAD94800561E5B /* AWSAPIPlugin+Reachability.swift in Sources */,
 				FA8EE785238632620097E4F1 /* AWSAPIPlugin+Log.swift in Sources */,
+				2189385B24E59C4700DE5314 /* GraphQLResponseDecoder+PaginatedResult.swift in Sources */,
 				21D7A10F237B54D90057D00D /* RESTOperationRequestUtils+Validator.swift in Sources */,
 				21D7A111237B54D90057D00D /* APIError+DecodingError.swift in Sources */,
 				21D5286724169E74005186BA /* IAMAuthInterceptor.swift in Sources */,

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLOperation+APIOperation.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLOperation+APIOperation.swift
@@ -64,7 +64,9 @@ extension AWSGraphQLOperation: APIOperation {
             let graphQLResponse = try GraphQLResponseDecoder.decode(graphQLServiceResponse: graphQLServiceResponse,
                                                                     responseType: request.responseType,
                                                                     decodePath: request.decodePath,
-                                                                    rawGraphQLResponse: graphQLResponseData)
+                                                                    rawGraphQLResponse: graphQLResponseData,
+                                                                    document: request.document,
+                                                                    variables: request.variables)
 
             dispatch(result: .success(graphQLResponse))
             finish()

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/GraphQLResponseDecoder+PaginatedResult.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/GraphQLResponseDecoder+PaginatedResult.swift
@@ -1,0 +1,43 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Amplify
+import AWSPluginsCore
+
+extension GraphQLResponseDecoder {
+
+    static func decodeToPaginatedResult<R: Decodable>(responseData: R,
+                                                      responseType: R.Type,
+                                                      graphQLData: JSONValue,
+                                                      document: String? = nil,
+                                                      variables: [String: Any]? = nil) throws -> R {
+        if responseData is PaginatedResultDecodable, let document = document {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = ModelDateFormatting.decodingStrategy
+            let paginatedResultData: PaginatedResultData
+            if let variables = variables {
+                let variablesData = try JSONSerialization.data(withJSONObject: variables)
+                let variablesJSON = try decoder.decode([String: JSONValue].self, from: variablesData)
+                paginatedResultData = PaginatedResultData(document: document,
+                                                          variables: variablesJSON,
+                                                          graphQLData: graphQLData)
+            } else {
+                paginatedResultData = PaginatedResultData(document: document,
+                                                          graphQLData: graphQLData)
+            }
+
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
+            let encodedData =  try encoder.encode(paginatedResultData)
+            let response = try decoder.decode(responseType, from: encodedData)
+            return response
+        }
+
+        return responseData
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
@@ -20,16 +20,34 @@ protocol ModelGraphQLRequestFactory {
 
     /// Creates a `GraphQLRequest` that represents a query that expects multiple values as a result.
     /// The request will be created with the correct document based on the `ModelSchema` and
-    /// variables based on the the predicate.
+    /// variables based on the predicate.
     ///
     /// - Parameters:
     ///   - modelType: the metatype of the model
     ///   - predicate: an optional predicate containing the criteria for the query
+    ///   - limit: limit the number of results to be returned
     /// - Returns: a valid `GraphQLRequest` instance
     ///
     /// - seealso: `GraphQLQuery`, `GraphQLQueryType.list`
     static func list<M: Model>(_ modelType: M.Type,
-                               where predicate: QueryPredicate?) -> GraphQLRequest<List<M>>
+                               where predicate: QueryPredicate?,
+                               limit: Int?) -> GraphQLRequest<List<M>>
+
+    /// Creates a `GraphQLRequest` that represents a query that expects multiple values as a result.
+    /// The request will be created with the correct document based on the `ModelSchema` and
+    /// variables based on the the predicate and limit. Use this to get a `PaginatedResult` which
+    /// can be used to retrieve the another `GraphQLRequest` for the subsequential page of results.
+    ///
+    /// - Parameters:
+    ///   - modelType: the metatype of the model
+    ///   - predicate: an optional predicate containing the criteria for the query
+    ///   - limit: limit the number of results to be returned
+    /// - Returns: a valid `GraphQLRequest` instance with `PaginatedResult`
+    ///
+    /// - seealso: `GraphQLQuery`, `GraphQLQueryType.list`
+    static func paginatedList<M: Model>(_ modelType: M.Type,
+                                        where predicate: QueryPredicate?,
+                                        limit: Int?) -> GraphQLRequest<PaginatedResult<M>>
 
     /// Creates a `GraphQLRequest` that represents a query that expects a single value as a result.
     /// The request will be created with the correct correct document based on the `ModelSchema` and
@@ -167,7 +185,8 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
     }
 
     public static func list<M: Model>(_ modelType: M.Type,
-                                      where predicate: QueryPredicate? = nil) -> GraphQLRequest<List<M>> {
+                                      where predicate: QueryPredicate? = nil,
+                                      limit: Int? = nil) -> GraphQLRequest<List<M>> {
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
 
@@ -175,12 +194,31 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
             documentBuilder.add(decorator: FilterDecorator(filter: predicate.graphQLFilter))
         }
 
-        documentBuilder.add(decorator: PaginationDecorator())
+        documentBuilder.add(decorator: PaginationDecorator(limit: limit))
         let document = documentBuilder.build()
 
         return GraphQLRequest<List<M>>(document: document.stringValue,
                                        variables: document.variables,
                                        responseType: List<M>.self)
+    }
+
+    public static func paginatedList<M: Model>(_ modelType: M.Type,
+                                               where predicate: QueryPredicate? = nil,
+                                               limit: Int? = 1_000) -> GraphQLRequest<PaginatedResult<M>> {
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .query)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
+
+        if let predicate = predicate {
+            documentBuilder.add(decorator: FilterDecorator(filter: predicate.graphQLFilter))
+        }
+
+        documentBuilder.add(decorator: PaginationDecorator(limit: limit))
+        let document = documentBuilder.build()
+
+        return GraphQLRequest<PaginatedResult<M>>(document: document.stringValue,
+                                                variables: document.variables,
+                                                responseType: PaginatedResult<M>.self,
+                                                decodePath: document.name)
     }
 
     public static func subscription<M: Model>(of modelType: M.Type,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/PaginatedResult.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/PaginatedResult.swift
@@ -1,0 +1,132 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Foundation
+
+public protocol PaginatedResultDecodable { }
+
+public class PaginatedResult<ModelType: Model>: Decodable, PaginatedResultDecodable {
+    private let items: [ModelType]
+    private let nextToken: String?
+    private let document: String?
+    private let variables: [String: JSONValue]?
+
+    init(_ items: [ModelType],
+                nextToken: String? = nil,
+                document: String? = nil,
+                variables: [String: JSONValue]? = nil) {
+        self.items = items
+        self.nextToken = nextToken
+        self.document = document
+        self.variables = variables
+    }
+
+    /// Retrieve the list of items for this page
+    public func getItems() -> [ModelType] {
+        return items
+    }
+
+    /// Check if there is another page of results
+    public func hasNextResult() -> Bool {
+        return nextToken != nil
+    }
+
+    /// Retrieve the GraphQLRequest to perform querying the next page of results
+    public func getRequestForNextResult() -> GraphQLRequest<PaginatedResult<ModelType>> {
+        guard let nextToken = nextToken, let document = document else {
+            fatalError("getRequestForNextResult called for missing nextToken")
+        }
+
+        if var variables = variables {
+            variables.updateValue(.string(nextToken), forKey: "nextToken")
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
+            if let variablesData = try? encoder.encode(variables),
+                let variablesJSON = try? JSONSerialization.jsonObject(with: variablesData) as? [String: Any] {
+                return GraphQLRequest<PaginatedResult<ModelType>>(document: document,
+                                                                  variables: variablesJSON,
+                                                                  responseType: PaginatedResult<ModelType>.self)
+            }
+        }
+        return GraphQLRequest<PaginatedResult<ModelType>>(document: document,
+                                                          variables: ["nextToken": nextToken],
+                                                          responseType: PaginatedResult<ModelType>.self)
+
+    }
+
+    required convenience public init(from decoder: Decoder) throws {
+        let json = try JSONValue(from: decoder)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
+
+        if let paginatedResultData = try? PaginatedResultData.init(from: decoder) {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = ModelDateFormatting.decodingStrategy
+            let elements = try paginatedResultData.getItems().map { (jsonElement) -> ModelType in
+                let serializedJSON = try encoder.encode(jsonElement)
+                return try decoder.decode(ModelType.self, from: serializedJSON)
+            }
+
+            self.init(elements,
+                      nextToken: paginatedResultData.getNextToken(),
+                      document: paginatedResultData.document,
+                      variables: paginatedResultData.variables)
+            return
+        }
+
+        guard case let .object(jsonObject) = json,
+            case let .array(jsonArray) = jsonObject["items"] else {
+            self.init([ModelType]())
+            return
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = ModelDateFormatting.decodingStrategy
+        let elements = try jsonArray.map { (jsonElement) -> ModelType in
+            let serializedJSON = try encoder.encode(jsonElement)
+            return try decoder.decode(ModelType.self, from: serializedJSON)
+        }
+
+        self.init(elements)
+    }
+}
+
+/// `PaginatedResultData` is used internally to store GraphQL request related information, alongside the GraphQL
+/// response's decodable payload. This is used alongside APIPlugin's deserialization logic by generating a
+/// `PaginatedResult` to be deserialized into the final `PaginatedResult` response to the caller.
+///
+/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+///   by host applications. The behavior of this may change without warning.
+public struct PaginatedResultData: Codable {
+    let document: String
+    let variables: [String: JSONValue]?
+    private let graphQLData: JSONValue
+
+    public init(document: String, variables: [String: JSONValue]? = nil, graphQLData: JSONValue) {
+        self.document = document
+        self.variables = variables
+        self.graphQLData = graphQLData
+    }
+
+    public func getNextToken() -> String? {
+        if case let .string(nextToken) = graphQLData["nextToken"] {
+            return nextToken
+        }
+
+        return nil
+    }
+
+    public func getItems() -> [JSONValue] {
+        if case let .array(jsonArray) = graphQLData["items"] {
+            return jsonArray
+        }
+
+        return []
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The Model-to-GraphQLRequest builders provides a `.list` query that returns a Collection. This is missing a mechanism for handling pagination from the AppSync API. By providing the `PaginatedResult` return type, the developer can use this to get the next request and perform the next API call to get the next page of results.
- The `PaginatedResult` class is introduced in AWSPluginsCore, with three methods on it: getItems, hasNextResult, and getRequestForNextRequest. Same as [Android docs](https://docs.amplify.aws/lib/graphqlapi/query-data/q/platform/android#list-multiple-pages-of-items)
- The `limit` parameter is added to the static builder for `.list`.

*Customer impact*
So far, customers currently using `.list` to create their GraphQLRequest will receive the first 1000 items (less if they applied a filter, since the filter is applied post-dynamodb-query). This introduces a new static builder `.paginatedList` which returns a `PaginatedResult`. We could also deprecate by removing the old `.list` and to keep the name the same as `list` and will require developers to update how they handle the response 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
