### PR TITLE
refactor(datastore): Removed the dependency on Model.Type from DataStoreStatement

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreStatement.swift
+++ b/Amplify/Categories/DataStore/DataStoreStatement.swift
@@ -15,8 +15,8 @@ public protocol DataStoreStatement {
     /// The type of the variables container related to a concrete statement implementation
     associatedtype Variables
 
-    /// The type of the `Model` associated with a particular statement
-    var modelType: Model.Type { get }
+    /// The model schema of the `Model` associated with a particular statement
+    var modelSchema: ModelSchema { get }
 
     /// The actual string content of the statement (e.g. a SQL query or a GraphQL document)
     var stringValue: String { get }

--- a/Amplify/Categories/DataStore/DataStoreStatement.swift
+++ b/Amplify/Categories/DataStore/DataStoreStatement.swift
@@ -15,6 +15,13 @@ public protocol DataStoreStatement {
     /// The type of the variables container related to a concrete statement implementation
     associatedtype Variables
 
+    /// The type of the `Model` associated with a particular statement
+    @available(*, deprecated, message: """
+        Use of modelType inside the DatastoreStatement is deprecated, instead make use of
+        `ModelSchema` through the `modelSchema` property.
+    """)
+    var modelType: Model.Type { get }
+
     /// The model schema of the `Model` associated with a particular statement
     var modelSchema: ModelSchema { get }
 

--- a/Amplify/Categories/DataStore/DataStoreStatement.swift
+++ b/Amplify/Categories/DataStore/DataStoreStatement.swift
@@ -17,9 +17,9 @@ public protocol DataStoreStatement {
 
     /// The type of the `Model` associated with a particular statement
     @available(*, deprecated, message: """
-        Use of modelType inside the DatastoreStatement is deprecated, instead make use of
-        `ModelSchema` through the `modelSchema` property.
+    Use of modelType inside the DatastoreStatement is deprecated, use modelSchema instead.
     """)
+
     var modelType: Model.Type { get }
 
     /// The model schema of the `Model` associated with a particular statement

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
@@ -15,10 +15,10 @@ typealias SQLPredicate = (String, [Binding?])
 /// It walks all nodes of a predicate tree and output the appropriate SQL statement.
 ///
 /// - Parameters:
-///   - modelType: the metatype of the `Model`
+///   - modelSchema: the model schema of the `Model`
 ///   - predicate: the query predicate
 /// - Returns: a tuple containing the SQL string and the associated values
-private func translateQueryPredicate(from modelType: Model.Type,
+private func translateQueryPredicate(from modelSchema: ModelSchema,
                                      predicate: QueryPredicate,
                                      namespace: Substring? = nil) -> SQLPredicate {
     var sql: [String] = []
@@ -65,14 +65,14 @@ private func translateQueryPredicate(from modelType: Model.Type,
 /// compose `insert`, `update`, `delete` and `select` statements with conditions.
 struct ConditionStatement: SQLStatement {
 
-    let modelType: Model.Type
+    let modelSchema: ModelSchema
     let stringValue: String
     let variables: [Binding?]
 
-    init(modelType: Model.Type, predicate: QueryPredicate, namespace: Substring? = nil) {
-        self.modelType = modelType
+    init(modelSchema: ModelSchema, predicate: QueryPredicate, namespace: Substring? = nil) {
+        self.modelSchema = modelSchema
 
-        let (sql, variables) = translateQueryPredicate(from: modelType,
+        let (sql, variables) = translateQueryPredicate(from: modelSchema,
                                                        predicate: predicate,
                                                        namespace: namespace)
         self.stringValue = sql

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
@@ -9,22 +9,20 @@ import Amplify
 import Foundation
 
 /// Represents a `create table` SQL statement. The table is created based on the `ModelSchema`
-/// associated with the passed `Model.Type`.
 struct CreateTableStatement: SQLStatement {
 
-    let modelType: Model.Type
+    let modelSchema: ModelSchema
 
-    init(modelType: Model.Type) {
-        self.modelType = modelType
+    init(modelSchema: ModelSchema) {
+        self.modelSchema = modelSchema
     }
 
     var stringValue: String {
-        let schema = modelType.schema
-        let name = schema.name
+        let name = modelSchema.name
         var statement = "create table if not exists \(name) (\n"
 
-        let columns = schema.columns
-        let foreignKeys = schema.foreignKeys
+        let columns = modelSchema.columns
+        let foreignKeys = modelSchema.foreignKeys
 
         for (index, column) in columns.enumerated() {
             statement += "  \"\(column.sqlName)\" \(column.sqlType.rawValue)"

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Delete.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Delete.swift
@@ -12,16 +12,16 @@ import SQLite
 /// Represents a `delete` SQL statement that is optionally composed by a `ConditionStatement`.
 struct DeleteStatement: SQLStatement {
 
-    let modelType: Model.Type
+    let modelSchema: ModelSchema
     let conditionStatement: ConditionStatement?
     let namespace = "root"
 
-    init(modelType: Model.Type, predicate: QueryPredicate? = nil) {
-        self.modelType = modelType
+    init(modelSchema: ModelSchema, predicate: QueryPredicate? = nil) {
+        self.modelSchema = modelSchema
 
         var conditionStatement: ConditionStatement?
         if let predicate = predicate {
-            let statement = ConditionStatement(modelType: modelType,
+            let statement = ConditionStatement(modelSchema: modelSchema,
                                                predicate: predicate,
                                                namespace: namespace[...])
             conditionStatement = statement
@@ -29,18 +29,17 @@ struct DeleteStatement: SQLStatement {
         self.conditionStatement = conditionStatement
     }
 
-    init(modelType: Model.Type, withId id: Model.Identifier) {
-        self.init(modelType: modelType, predicate: field("id") == id)
+    init(modelSchema: ModelSchema, withId id: Model.Identifier) {
+        self.init(modelSchema: modelSchema, predicate: field("id") == id)
     }
 
     init(model: Model) {
-        self.init(modelType: type(of: model))
+        self.init(modelSchema: model.schema)
     }
 
     var stringValue: String {
-        let schema = modelType.schema
         let sql = """
-        delete from \(schema.name) as \(namespace)
+        delete from \(modelSchema.name) as \(namespace)
         """
 
         if let conditionStatement = conditionStatement {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
@@ -11,7 +11,6 @@ import SQLite
 
 /// Represents a `insert` SQL statement associated with a `Model` instance.
 struct InsertStatement: SQLStatement {
-
     let modelSchema: ModelSchema
     let variables: [Binding?]
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
@@ -12,19 +12,18 @@ import SQLite
 /// Represents a `insert` SQL statement associated with a `Model` instance.
 struct InsertStatement: SQLStatement {
 
-    let modelType: Model.Type
+    let modelSchema: ModelSchema
     let variables: [Binding?]
 
     init(model: Model) {
-        self.modelType = type(of: model)
-        self.variables = model.sqlValues(for: modelType.schema.columns)
+        self.modelSchema = model.schema
+        self.variables = model.sqlValues(for: modelSchema.columns)
     }
 
     var stringValue: String {
-        let schema = modelType.schema
-        let fields = schema.columns
+        let fields = modelSchema.columns
         let columns = fields.map { $0.columnName() }
-        var statement = "insert into \(schema.name) "
+        var statement = "insert into \(modelSchema.name) "
         statement += "(\(columns.joined(separator: ", ")))\n"
 
         let variablePlaceholders = Array(repeating: "?", count: columns.count).joined(separator: ", ")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
@@ -14,8 +14,8 @@ struct InsertStatement: SQLStatement {
     let modelSchema: ModelSchema
     let variables: [Binding?]
 
-    init(model: Model) {
-        self.modelSchema = model.schema
+    init(model: Model, modelSchema: ModelSchema) {
+        self.modelSchema = modelSchema
         self.variables = model.sqlValues(for: modelSchema.columns)
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Update.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Update.swift
@@ -12,18 +12,18 @@ import SQLite
 /// Represents a `update` SQL statement.
 struct UpdateStatement: SQLStatement {
 
-    let modelType: Model.Type
+    let modelSchema: ModelSchema
     let conditionStatement: ConditionStatement?
 
     private let model: Model
 
     init(model: Model, condition: QueryPredicate? = nil) {
-        self.modelType = type(of: model)
+        self.modelSchema = model.schema
         self.model = model
 
         var conditionStatement: ConditionStatement?
         if let condition = condition {
-            let statement = ConditionStatement(modelType: modelType,
+            let statement = ConditionStatement(modelSchema: modelSchema,
                                                predicate: condition)
             conditionStatement = statement
         }
@@ -32,7 +32,6 @@ struct UpdateStatement: SQLStatement {
     }
 
     var stringValue: String {
-        let schema = modelType.schema
         let columns = updateColumns.map { $0.columnName() }
 
         let columnsStatement = columns.map { column in
@@ -40,10 +39,10 @@ struct UpdateStatement: SQLStatement {
         }
 
         var sql = """
-        update \(schema.name)
+        update \(modelSchema.name)
         set
         \(columnsStatement.joined(separator: ",\n"))
-        where \(schema.primaryKey.columnName()) = ?
+        where \(modelSchema.primaryKey.columnName()) = ?
         """
 
         if let conditionStatement = conditionStatement {
@@ -66,6 +65,6 @@ struct UpdateStatement: SQLStatement {
     }
 
     private var updateColumns: [ModelField] {
-        modelType.schema.columns.filter { !$0.isPrimaryKey }
+        modelSchema.columns.filter { !$0.isPrimaryKey }
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Update.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Update.swift
@@ -17,9 +17,9 @@ struct UpdateStatement: SQLStatement {
 
     private let model: Model
 
-    init(model: Model, condition: QueryPredicate? = nil) {
-        self.modelSchema = model.schema
+    init(model: Model, modelSchema: ModelSchema, condition: QueryPredicate? = nil) {
         self.model = model
+        self.modelSchema = model.schema
 
         var conditionStatement: ConditionStatement?
         if let condition = condition {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement.swift
@@ -29,7 +29,8 @@ extension SQLStatement {
     var modelType: Model.Type {
         fatalError("""
         DataStoreStatement.modelType is deprecated. SQLStatement is an internal type and there should be \
-        no references to modelType. If you encounter this error, please open a GitHub issue.
+        no references to modelType. If you encounter this error, please open a GitHub issue. \
+        https://github.com/aws-amplify/amplify-ios/issues/new/choose
         """)
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement.swift
@@ -25,9 +25,8 @@ extension SQLStatement {
 
 extension SQLStatement {
 
-    // modelType is deprecated and instead modelSchema is used
-    //
+    // `modelType` is deprecated, instead modelSchema should be used.
     var modelType: Model.Type {
-        fatalError()
+        fatalError("Use of modelType is deprecated in SQLStatement")
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement.swift
@@ -22,3 +22,12 @@ extension SQLStatement {
         return []
     }
 }
+
+extension SQLStatement {
+
+    // modelType is deprecated and instead modelSchema is used
+    //
+    var modelType: Model.Type {
+        fatalError()
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement.swift
@@ -27,6 +27,9 @@ extension SQLStatement {
 
     // `modelType` is deprecated, instead modelSchema should be used.
     var modelType: Model.Type {
-        fatalError("Use of modelType is deprecated in SQLStatement")
+        fatalError("""
+        DataStoreStatement.modelType is deprecated. SQLStatement is an internal type and there should be \
+        no references to modelType. If you encounter this error, please open a GitHub issue.
+        """)
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -110,7 +110,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
                     return
                 }
 
-                let statement = InsertStatement(model: model)
+                let statement = InsertStatement(model: model, modelSchema: modelType.schema)
                 _ = try connection.prepare(statement.stringValue).run(statement.variables)
             }
 
@@ -126,7 +126,9 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
                     }
                 }
 
-                let statement = UpdateStatement(model: model, condition: condition)
+                let statement = UpdateStatement(model: model,
+                                                modelSchema: modelType.schema,
+                                                condition: condition)
                 _ = try connection.prepare(statement.stringValue).run(statement.variables)
             }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -86,7 +86,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
 
         let createTableStatements = models
             .sortByDependencyOrder()
-            .map { CreateTableStatement(modelType: $0).stringValue }
+            .map { CreateTableStatement(modelSchema: $0.schema).stringValue }
             .joined(separator: "\n")
 
         do {
@@ -153,7 +153,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
                           predicate: QueryPredicate,
                           completion: (DataStoreResult<[M]>) -> Void) {
         do {
-            let statement = DeleteStatement(modelType: modelType, predicate: predicate)
+            let statement = DeleteStatement(modelSchema: modelType.schema, predicate: predicate)
             _ = try connection.prepare(statement.stringValue).run(statement.variables)
             completion(.success([]))
         } catch {
@@ -178,7 +178,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
                 withId id: Model.Identifier,
                 completion: DataStoreCallback<Void>) {
         do {
-            let statement = DeleteStatement(modelType: modelType, withId: id)
+            let statement = DeleteStatement(modelSchema: modelType.schema, withId: id)
             _ = try connection.prepare(statement.stringValue).run(statement.variables)
             completion(.emptyResult)
         } catch {
@@ -192,7 +192,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
                          paginationInput: QueryPaginationInput? = nil,
                          completion: DataStoreCallback<[M]>) {
         do {
-            let statement = SelectStatement(from: modelType,
+            let statement = SelectStatement(from: modelType.schema,
                                             predicate: predicate,
                                             sort: sort,
                                             paginationInput: paginationInput)
@@ -212,7 +212,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
         var sql = "select count(\(primaryKey)) from \(schema.name) where \(primaryKey) = ?"
         var variables: [Binding?] = [id]
         if let predicate = predicate {
-            let conditionStatement = ConditionStatement(modelType: modelType,
+            let conditionStatement = ConditionStatement(modelSchema: modelType.schema,
                                                         predicate: predicate)
             sql = """
             \(sql)
@@ -240,7 +240,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
     }
 
     func queryMutationSync(for models: [Model]) throws -> [MutationSync<AnyModel>] {
-        let statement = SelectStatement(from: MutationSyncMetadata.self)
+        let statement = SelectStatement(from: MutationSyncMetadata.schema)
         let primaryKey = MutationSyncMetadata.schema.primaryKey.sqlName
         // This is a temp workaround since we don't currently support the "in" operator
         // in query predicates (this avoids the 1 + n query problem). Consider adding "in" support
@@ -266,7 +266,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
 
     func queryMutationSyncMetadata(for modelId: Model.Identifier) throws -> MutationSyncMetadata? {
         let modelType = MutationSyncMetadata.self
-        let statement = SelectStatement(from: modelType, predicate: field("id").eq(modelId))
+        let statement = SelectStatement(from: modelType.schema, predicate: field("id").eq(modelId))
         let rows = try connection.prepare(statement.stringValue).run(statement.variables)
         let result = try rows.convert(to: modelType,
                                       using: statement)
@@ -274,7 +274,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
     }
 
     func queryModelSyncMetadata(for modelType: Model.Type) throws -> ModelSyncMetadata? {
-        let statement = SelectStatement(from: ModelSyncMetadata.self,
+        let statement = SelectStatement(from: ModelSyncMetadata.schema,
                                         predicate: field("id").eq(modelType.modelName))
         let rows = try connection.prepare(statement.stringValue).run(statement.variables)
         let result = try rows.convert(to: ModelSyncMetadata.self,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
@@ -22,10 +22,10 @@ extension SQLiteStorageEngineAdapter {
             // TODO serialize result and create a new instance of the model
             // (some columns might be auto-generated after DB insert/update)
             if shouldUpdate {
-                let statement = UpdateStatement(model: untypedModel)
+                let statement = UpdateStatement(model: untypedModel, modelSchema: modelType.schema)
                 _ = try connection.prepare(statement.stringValue).run(statement.variables)
             } else {
-                let statement = InsertStatement(model: untypedModel)
+                let statement = InsertStatement(model: untypedModel, modelSchema: modelType.schema)
                 _ = try connection.prepare(statement.stringValue).run(statement.variables)
             }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
@@ -39,7 +39,7 @@ extension SQLiteStorageEngineAdapter {
                predicate: QueryPredicate? = nil,
                completion: DataStoreCallback<[Model]>) {
         do {
-            let statement = SelectStatement(from: modelType, predicate: predicate)
+            let statement = SelectStatement(from: modelType.schema, predicate: predicate)
             let rows = try connection.prepare(statement.stringValue).run(statement.variables)
             let result: [Model] = try rows.convert(toUntypedModel: modelType, using: statement)
             completion(.success(result))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
@@ -41,7 +41,7 @@ class SQLStatementTests: XCTestCase {
     /// - Then:
     ///   - check if the generated SQL statement is valid
     func testCreateTableFromSimpleModel() {
-        let statement = CreateTableStatement(modelType: Post.self)
+        let statement = CreateTableStatement(modelSchema: Post.schema)
         let expectedStatement = """
         create table if not exists Post (
           "id" text primary key not null,
@@ -65,7 +65,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid:
     ///     - contains a `foreign key` referencing `Post`
     func testCreateTableFromModelWithForeignKey() {
-        let statement = CreateTableStatement(modelType: Comment.self)
+        let statement = CreateTableStatement(modelSchema: Comment.schema)
         let expectedStatement = """
         create table if not exists Comment (
           "id" text primary key not null,
@@ -88,7 +88,7 @@ class SQLStatementTests: XCTestCase {
     ///     - contains a `foreign key` referencing `UserProfile`
     ///     - the foreign key column is `unique`
     func testCreateTableFromModelWithOneToOneForeignKey() {
-        let statement = CreateTableStatement(modelType: UserProfile.self)
+        let statement = CreateTableStatement(modelSchema: UserProfile.schema)
         let expectedStatement = """
         create table if not exists UserProfile (
           "id" text primary key not null,
@@ -109,7 +109,7 @@ class SQLStatementTests: XCTestCase {
     ///     - contains a `foreign key` referencing `Author`
     ///     - contains a `foreign key` referencing `Book`
     func testCreateTableFromManyToManyAssociationModel() {
-        let statement = CreateTableStatement(modelType: BookAuthor.self)
+        let statement = CreateTableStatement(modelSchema: BookAuthor.schema)
         let expectedStatement = """
         create table if not exists BookAuthor (
           "id" text primary key not null,
@@ -249,7 +249,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the variables match the expected values
     func testDeleteStatementFromModel() {
         let id = UUID().uuidString
-        let statement = DeleteStatement(modelType: Post.self, withId: id)
+        let statement = DeleteStatement(modelSchema: Post.schema, withId: id)
 
         let expectedStatement = """
         delete from Post as root
@@ -270,7 +270,7 @@ class SQLStatementTests: XCTestCase {
     /// - Then:
     ///   - check if the generated SQL statement is valid
     func testSelectStatementFromModel() {
-        let statement = SelectStatement(from: Post.self)
+        let statement = SelectStatement(from: Post.schema)
         let expectedStatement = """
         select
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
@@ -291,7 +291,7 @@ class SQLStatementTests: XCTestCase {
     func testSelectStatementFromModelWithPredicate() {
         let post = Post.keys
         let predicate = post.draft == false && post.rating > 3
-        let statement = SelectStatement(from: Post.self, predicate: predicate)
+        let statement = SelectStatement(from: Post.schema, predicate: predicate)
         let expectedStatement = """
         select
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
@@ -316,7 +316,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if an inner join is added referencing `Post`
     func testSelectStatementFromModelWithJoin() {
-        let statement = SelectStatement(from: Comment.self)
+        let statement = SelectStatement(from: Comment.schema)
         let expectedStatement = """
         select
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
@@ -340,7 +340,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `limit` and `offset`
     func testSelectStatementWithPaginationInfo() {
-        let statement = SelectStatement(from: Post.self, predicate: nil, paginationInput: .page(2, limit: 20))
+        let statement = SelectStatement(from: Post.schema, predicate: nil, paginationInput: .page(2, limit: 20))
         let expectedStatement = """
         select
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
@@ -362,8 +362,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `order by` and `ascending`
     func testSelectStatementWithOneSort() {
-        let statement = SelectStatement(from: Post.self,
-                                        sort: .ascending(Post.keys.id))
+        let statement = SelectStatement(from: Post.schema, sort: .ascending(Post.keys.id))
         let expectedStatement = """
         select
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
@@ -383,7 +382,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `order by` and `ascending`
     func testSelectStatementWithTwoFieldsSort() {
-        let statement = SelectStatement(from: Post.self,
+        let statement = SelectStatement(from: Post.schema,
                                         sort: .by(.ascending(Post.keys.id),
                                                   .descending(Post.keys.createdAt)))
         let expectedStatement = """
@@ -405,7 +404,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `where` statement, `order by` and `ascending`
     func testSelectStatementWithPredicateAndSort() {
-        let statement = SelectStatement(from: Post.self,
+        let statement = SelectStatement(from: Post.schema,
                                         predicate: Post.keys.rating > 4,
                                         sort: .descending(Post.keys.id))
         let expectedStatement = """
@@ -430,7 +429,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `where` statement, `order by` and `ascending`
     func testSelectStatementWithSortAndPaginationInfo() {
-        let statement = SelectStatement(from: Post.self,
+        let statement = SelectStatement(from: Post.schema,
                                         sort: .descending(Post.keys.id),
                                         paginationInput: .page(0, limit: 5))
         let expectedStatement = """
@@ -455,7 +454,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `where` statement, `order by` and `ascending`
     func testSelectStatementWithPredicateAndSortAndPaginationInfo() {
-        let statement = SelectStatement(from: Post.self,
+        let statement = SelectStatement(from: Post.schema,
                                         predicate: Post.keys.rating > 4,
                                         sort: .descending(Post.keys.id),
                                         paginationInput: .page(0, limit: 5))
@@ -485,7 +484,7 @@ class SQLStatementTests: XCTestCase {
         let post = Post.keys
 
         let predicate = post.id != nil
-        let statement = ConditionStatement(modelType: Post.self, predicate: predicate)
+        let statement = ConditionStatement(modelSchema: Post.schema, predicate: predicate)
 
         XCTAssertEqual("""
           and "id" is not null
@@ -503,7 +502,7 @@ class SQLStatementTests: XCTestCase {
         let post = Post.keys
 
         let predicate = post.id != nil
-        let statement = ConditionStatement(modelType: Post.self, predicate: predicate, namespace: "root")
+        let statement = ConditionStatement(modelSchema: Post.schema, predicate: predicate, namespace: "root")
 
         XCTAssertEqual("""
           and "root"."id" is not null
@@ -521,7 +520,7 @@ class SQLStatementTests: XCTestCase {
         func assertPredicate(_ predicate: QueryPredicate,
                              matches sql: String,
                              bindings: [Binding?]? = nil) {
-            let statement = ConditionStatement(modelType: Post.self, predicate: predicate, namespace: "root")
+            let statement = ConditionStatement(modelSchema: Post.schema, predicate: predicate, namespace: "root")
             XCTAssertEqual(statement.stringValue, "  and \(sql)")
             if let bindings = bindings {
                 XCTAssertEqual(bindings.count, statement.variables.count)
@@ -570,7 +569,7 @@ class SQLStatementTests: XCTestCase {
             && post.updatedAt == nil
             && (post.content ~= "gelato" || post.title.beginsWith("ice cream"))
 
-        let statement = ConditionStatement(modelType: Post.self, predicate: predicate)
+        let statement = ConditionStatement(modelSchema: Post.schema, predicate: predicate)
 
         XCTAssertEqual("""
           and "id" is not null
@@ -610,7 +609,7 @@ class SQLStatementTests: XCTestCase {
             && post.updatedAt == nil
             && (post.content ~= "gelato" || post.title.beginsWith("ice cream"))
 
-        let statement = ConditionStatement(modelType: Post.self, predicate: predicate, namespace: "root")
+        let statement = ConditionStatement(modelSchema: Post.schema, predicate: predicate, namespace: "root")
 
         XCTAssertEqual("""
           and "root"."id" is not null

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
@@ -137,7 +137,7 @@ class SQLStatementTests: XCTestCase {
                         content: "content",
                         createdAt: .now(),
                         status: .draft)
-        let statement = InsertStatement(model: post)
+        let statement = InsertStatement(model: post, modelSchema: post.schema)
 
         let expectedStatement = """
         insert into Post ("id", "content", "createdAt", "draft", "rating", "status", "title", "updatedAt")
@@ -162,7 +162,7 @@ class SQLStatementTests: XCTestCase {
     func testInsertStatementFromModelWithForeignKey() {
         let post = Post(title: "title", content: "content", createdAt: .now())
         let comment = Comment(content: "comment", createdAt: .now(), post: post)
-        let statement = InsertStatement(model: comment)
+        let statement = InsertStatement(model: comment, modelSchema: comment.schema)
 
         let expectedStatement = """
         insert into Comment ("id", "content", "createdAt", "commentPostId")
@@ -185,7 +185,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the variables match the expected values
     func testUpdateStatementFromModel() {
         let post = Post(title: "title", content: "content", createdAt: .now())
-        let statement = UpdateStatement(model: post)
+        let statement = UpdateStatement(model: post, modelSchema: post.schema)
 
         let expectedStatement = """
         update Post
@@ -216,7 +216,7 @@ class SQLStatementTests: XCTestCase {
     func testUpdateStatementFromModelWithCondition() {
         let post = Post(title: "title", content: "content", createdAt: .now())
         let condition = Post.keys.content == "content2"
-        let statement = UpdateStatement(model: post, condition: condition)
+        let statement = UpdateStatement(model: post, modelSchema: post.schema, condition: condition)
 
         let expectedStatement = """
         update Post

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSDataStoreCategoryPlugin.xcscheme
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSDataStoreCategoryPlugin.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
*Description of changes:*

DatastoreStatement that communicate with the underlying storage doesnot need a dependency on Model.Type. This PR is part of the larger work on removing the dependency on the static properties of Model.Type from Datastore.

Instead of Model.Type DatastoreStatement will be using ModelSchema. The `Model.Type` property in `DatastoreStatement` is not used anywhere externally before this change. So make this change should not affect any public apis.

*Current usage of DatastoreStatement:*

`DatastoreStatement` protocol is currently only used as a parent protocol of [`SQLStatement`](https://github.com/aws-amplify/amplify-ios/blob/d88447789d26f042e26f70565a9283dc143a8b22/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement.swift#L15). And `SQLStatement` is adopted by internal structs - `ConditionStatement`, `CreateTableStatement`, `DeleteStatement`, `InsertStatement`, `SelectStatement`and `UpdateStatement`. None of these struct's object uses `Model.Type` where the object is used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
