### PR TITLE
refactor(core): Add support for useragent to add platform info

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -9,15 +9,16 @@ import Foundation
 import AWSCore
 
 public class AmplifyAWSServiceConfiguration: AWSServiceConfiguration {
+    private static let version = "1.1.0"
+
     override public class func baseUserAgent() -> String! {
         //TODO: Retrieve this version from a centralized location:
         //https://github.com/aws-amplify/amplify-ios/issues/276
-        let version = "1.1.0"
-        let sdkName = "amplify-iOS"
+        let platformInfo = AmplifyAWSServiceConfiguration.platformInformation()
         let systemName = UIDevice.current.systemName.replacingOccurrences(of: " ", with: "-")
         let systemVersion = UIDevice.current.systemVersion
         let localeIdentifier = Locale.current.identifier
-        return "\(sdkName)/\(version) \(systemName)/\(systemVersion) \(localeIdentifier)"
+        return "\(platformInfo) \(systemName)/\(systemVersion) \(localeIdentifier)"
     }
 
     override public var userAgent: String {
@@ -39,5 +40,30 @@ public class AmplifyAWSServiceConfiguration: AWSServiceConfiguration {
 
     public init(region regionType: AWSRegionType) {
         super.init(region: regionType, credentialsProvider: nil)
+    }
+}
+
+extension AmplifyAWSServiceConfiguration {
+
+    static var platformMapping: [Platform: String] = [:]
+
+    public static func addPlatform(_ platform: Platform, version: String) {
+        guard platform != .iOS else {
+            return
+        }
+        platformMapping[platform] = version
+    }
+
+    public enum Platform: String {
+
+        case iOS = "amplify-iOS"
+
+        case flutter = "amplify-flutter"
+    }
+
+    static func platformInformation() -> String {
+        var mapping = platformMapping
+        mapping[.iOS] = version
+        return mapping.map {"\($0.rawValue)/\($1)"}.joined(separator: " ")
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -57,7 +57,7 @@ extension AmplifyAWSServiceConfiguration {
 
     static func platformInformation() -> String {
         let sdkName = "amplify-iOS"
-        let additionalPlatform = platformMapping.map {" \($0.rawValue)/\($1)"}.joined()
-        return "\(sdkName)/\(version)\(additionalPlatform)"
+        let additionalPlatform = platformMapping.map {"\($0.rawValue)/\($1) "}.joined()
+        return "\(additionalPlatform)\(sdkName)/\(version)"
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -48,22 +48,16 @@ extension AmplifyAWSServiceConfiguration {
     static var platformMapping: [Platform: String] = [:]
 
     public static func addUserAgentPlatform(_ platform: Platform, version: String) {
-        guard platform != .ios else {
-            return
-        }
         platformMapping[platform] = version
     }
 
     public enum Platform: String {
-
-        case ios = "amplify-iOS"
-
         case flutter = "amplify-flutter"
     }
 
     static func platformInformation() -> String {
-        var mapping = platformMapping
-        mapping[.ios] = version
-        return mapping.map {"\($0.rawValue)/\($1)"}.joined(separator: " ")
+        let sdkName = "amplify-iOS"
+        let additionalPlatform = platformMapping.map {" \($0.rawValue)/\($1)"}.joined()
+        return "\(sdkName)/\(version)\(additionalPlatform)"
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -47,8 +47,8 @@ extension AmplifyAWSServiceConfiguration {
 
     static var platformMapping: [Platform: String] = [:]
 
-    public static func addPlatform(_ platform: Platform, version: String) {
-        guard platform != .iOS else {
+    public static func addUserAgentPlatform(_ platform: Platform, version: String) {
+        guard platform != .ios else {
             return
         }
         platformMapping[platform] = version
@@ -56,14 +56,14 @@ extension AmplifyAWSServiceConfiguration {
 
     public enum Platform: String {
 
-        case iOS = "amplify-iOS"
+        case ios = "amplify-iOS"
 
         case flutter = "amplify-flutter"
     }
 
     static func platformInformation() -> String {
         var mapping = platformMapping
-        mapping[.iOS] = version
+        mapping[.ios] = version
         return mapping.map {"\($0.rawValue)/\($1)"}.joined(separator: " ")
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -56,8 +56,8 @@ extension AmplifyAWSServiceConfiguration {
     }
 
     static func platformInformation() -> String {
-        let sdkName = "amplify-iOS"
-        let additionalPlatform = platformMapping.map {"\($0.rawValue)/\($1) "}.joined()
-        return "\(additionalPlatform)\(sdkName)/\(version)"
+        var platformTokens = platformMapping.map { "\($0.rawValue)/\($1)" }
+        platformTokens.append("amplify-iOS/\(version)")
+        return platformTokens.joined(separator: " ")
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
@@ -10,11 +10,11 @@ import XCTest
 
 class AmplifyAWSServiceConfigurationTests: XCTestCase {
     let credentialProvider = AWSAuthService().getCredentialsProvider()
-
+    
     override func tearDown() {
         AmplifyAWSServiceConfiguration.platformMapping = [:]
     }
-
+    
     /// Test initiating AmplifyAWSServiceConfiguration
     ///
     /// - Given: Amplify library
@@ -28,10 +28,9 @@ class AmplifyAWSServiceConfigurationTests: XCTestCase {
         let currentSystemVersion = UIDevice.current.systemVersion
         let expectedLocale = Locale.current.identifier
         let expectedSystem = "\(currentSystemName)/\(currentSystemVersion)"
-
-        let configuration = AmplifyAWSServiceConfiguration(region: .USEast1,
-                                                           credentialsProvider: credentialProvider)
-
+        
+        let configuration = AmplifyAWSServiceConfiguration(region: .USEast1, credentialsProvider: credentialProvider)
+        
         XCTAssertNotNil(configuration.userAgent)
         let userAgentParts = configuration.userAgent.components(separatedBy: " ")
         XCTAssertEqual(3, userAgentParts.count)
@@ -39,7 +38,7 @@ class AmplifyAWSServiceConfigurationTests: XCTestCase {
         XCTAssertEqual(expectedSystem, userAgentParts[1])
         XCTAssertEqual(expectedLocale, userAgentParts[2])
     }
-
+    
     /// Test adding a new platform to AmplifyAWSServiceConfiguration
     ///
     /// - Given: Amplify library
@@ -49,14 +48,14 @@ class AmplifyAWSServiceConfigurationTests: XCTestCase {
     ///    - AmplifyAWSServiceConfiguration should be configured properly with the new platform added.
     ///
     func testAddNewPlatform() {
-        AmplifyAWSServiceConfiguration.addPlatform(.flutter, version: "1.1")
+        AmplifyAWSServiceConfiguration.addUserAgentPlatform(.flutter, version: "1.1")
         let currentSystemName = UIDevice.current.systemName.replacingOccurrences(of: " ", with: "-")
         let currentSystemVersion = UIDevice.current.systemVersion
         let expectedLocale = Locale.current.identifier
         let expectedSystem = "\(currentSystemName)/\(currentSystemVersion)"
-
+        
         let configuration = AmplifyAWSServiceConfiguration()
-
+        
         XCTAssertNotNil(configuration.userAgent)
         let userAgentParts = configuration.userAgent.components(separatedBy: " ")
         XCTAssertEqual(4, userAgentParts.count)
@@ -64,7 +63,7 @@ class AmplifyAWSServiceConfigurationTests: XCTestCase {
         XCTAssertEqual(expectedSystem, userAgentParts[2])
         XCTAssertEqual(expectedLocale, userAgentParts[3])
     }
-
+    
     /// Test overriding iOS platform in AmplifyAWSServiceConfiguration
     ///
     /// - Given: Amplify library
@@ -74,7 +73,7 @@ class AmplifyAWSServiceConfigurationTests: XCTestCase {
     ///    - AmplifyAWSServiceConfiguration should not take the override for iOS
     ///
     func testOverrideiOSPlatform() {
-        AmplifyAWSServiceConfiguration.addPlatform(.iOS, version: "0.33") // Uses an old version number
+        AmplifyAWSServiceConfiguration.addUserAgentPlatform(.ios, version: "0.33") // Uses an old version number
         let configuration = AmplifyAWSServiceConfiguration()
         XCTAssertNotNil(configuration.userAgent)
         let userAgentParts = configuration.userAgent.components(separatedBy: " ")

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
@@ -10,11 +10,11 @@ import XCTest
 
 class AmplifyAWSServiceConfigurationTests: XCTestCase {
     let credentialProvider = AWSAuthService().getCredentialsProvider()
-    
+
     override func tearDown() {
         AmplifyAWSServiceConfiguration.platformMapping = [:]
     }
-    
+
     /// Test initiating AmplifyAWSServiceConfiguration
     ///
     /// - Given: Amplify library
@@ -28,9 +28,9 @@ class AmplifyAWSServiceConfigurationTests: XCTestCase {
         let currentSystemVersion = UIDevice.current.systemVersion
         let expectedLocale = Locale.current.identifier
         let expectedSystem = "\(currentSystemName)/\(currentSystemVersion)"
-        
+
         let configuration = AmplifyAWSServiceConfiguration(region: .USEast1, credentialsProvider: credentialProvider)
-        
+
         XCTAssertNotNil(configuration.userAgent)
         let userAgentParts = configuration.userAgent.components(separatedBy: " ")
         XCTAssertEqual(3, userAgentParts.count)
@@ -38,7 +38,7 @@ class AmplifyAWSServiceConfigurationTests: XCTestCase {
         XCTAssertEqual(expectedSystem, userAgentParts[1])
         XCTAssertEqual(expectedLocale, userAgentParts[2])
     }
-    
+
     /// Test adding a new platform to AmplifyAWSServiceConfiguration
     ///
     /// - Given: Amplify library
@@ -53,31 +53,15 @@ class AmplifyAWSServiceConfigurationTests: XCTestCase {
         let currentSystemVersion = UIDevice.current.systemVersion
         let expectedLocale = Locale.current.identifier
         let expectedSystem = "\(currentSystemName)/\(currentSystemVersion)"
-        
+
         let configuration = AmplifyAWSServiceConfiguration()
-        
+
         XCTAssertNotNil(configuration.userAgent)
         let userAgentParts = configuration.userAgent.components(separatedBy: " ")
         XCTAssertEqual(4, userAgentParts.count)
         XCTAssert(configuration.userAgent.contains(AmplifyAWSServiceConfiguration.Platform.flutter.rawValue))
+        XCTAssert(userAgentParts[0].starts(with: "amplify-iOS/"))
         XCTAssertEqual(expectedSystem, userAgentParts[2])
         XCTAssertEqual(expectedLocale, userAgentParts[3])
-    }
-    
-    /// Test overriding iOS platform in AmplifyAWSServiceConfiguration
-    ///
-    /// - Given: Amplify library
-    /// - When:
-    ///    - I override iOS platform with a new version
-    /// - Then:
-    ///    - AmplifyAWSServiceConfiguration should not take the override for iOS
-    ///
-    func testOverrideiOSPlatform() {
-        AmplifyAWSServiceConfiguration.addUserAgentPlatform(.ios, version: "0.33") // Uses an old version number
-        let configuration = AmplifyAWSServiceConfiguration()
-        XCTAssertNotNil(configuration.userAgent)
-        let userAgentParts = configuration.userAgent.components(separatedBy: " ")
-        XCTAssertEqual(3, userAgentParts.count)
-        XCTAssertFalse(configuration.userAgent.contains("0.33"))
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
@@ -59,8 +59,8 @@ class AmplifyAWSServiceConfigurationTests: XCTestCase {
         XCTAssertNotNil(configuration.userAgent)
         let userAgentParts = configuration.userAgent.components(separatedBy: " ")
         XCTAssertEqual(4, userAgentParts.count)
-        XCTAssert(configuration.userAgent.contains(AmplifyAWSServiceConfiguration.Platform.flutter.rawValue))
-        XCTAssert(userAgentParts[0].starts(with: "amplify-iOS/"))
+        XCTAssert(userAgentParts[0].starts(with: AmplifyAWSServiceConfiguration.Platform.flutter.rawValue))
+        XCTAssert(userAgentParts[1].starts(with: "amplify-iOS/"))
         XCTAssertEqual(expectedSystem, userAgentParts[2])
         XCTAssertEqual(expectedLocale, userAgentParts[3])
     }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
@@ -10,6 +10,19 @@ import XCTest
 
 class AmplifyAWSServiceConfigurationTests: XCTestCase {
     let credentialProvider = AWSAuthService().getCredentialsProvider()
+
+    override func tearDown() {
+        AmplifyAWSServiceConfiguration.platformMapping = [:]
+    }
+
+    /// Test initiating AmplifyAWSServiceConfiguration
+    ///
+    /// - Given: Amplify library
+    /// - When:
+    ///    - I call AmplifyAWSServiceConfiguration with credential provider
+    /// - Then:
+    ///    - AmplifyAWSServiceConfiguration should be configured properly
+    ///
     func testInstantiation() {
         let currentSystemName = UIDevice.current.systemName.replacingOccurrences(of: " ", with: "-")
         let currentSystemVersion = UIDevice.current.systemVersion
@@ -25,5 +38,47 @@ class AmplifyAWSServiceConfigurationTests: XCTestCase {
         XCTAssert(userAgentParts[0].starts(with: "amplify-iOS/"))
         XCTAssertEqual(expectedSystem, userAgentParts[1])
         XCTAssertEqual(expectedLocale, userAgentParts[2])
+    }
+
+    /// Test adding a new platform to AmplifyAWSServiceConfiguration
+    ///
+    /// - Given: Amplify library
+    /// - When:
+    ///    - I add a new platform to the AmplifyAWSServiceConfiguration
+    /// - Then:
+    ///    - AmplifyAWSServiceConfiguration should be configured properly with the new platform added.
+    ///
+    func testAddNewPlatform() {
+        AmplifyAWSServiceConfiguration.addPlatform(.flutter, version: "1.1")
+        let currentSystemName = UIDevice.current.systemName.replacingOccurrences(of: " ", with: "-")
+        let currentSystemVersion = UIDevice.current.systemVersion
+        let expectedLocale = Locale.current.identifier
+        let expectedSystem = "\(currentSystemName)/\(currentSystemVersion)"
+
+        let configuration = AmplifyAWSServiceConfiguration()
+
+        XCTAssertNotNil(configuration.userAgent)
+        let userAgentParts = configuration.userAgent.components(separatedBy: " ")
+        XCTAssertEqual(4, userAgentParts.count)
+        XCTAssert(configuration.userAgent.contains(AmplifyAWSServiceConfiguration.Platform.flutter.rawValue))
+        XCTAssertEqual(expectedSystem, userAgentParts[2])
+        XCTAssertEqual(expectedLocale, userAgentParts[3])
+    }
+
+    /// Test overriding iOS platform in AmplifyAWSServiceConfiguration
+    ///
+    /// - Given: Amplify library
+    /// - When:
+    ///    - I override iOS platform with a new version
+    /// - Then:
+    ///    - AmplifyAWSServiceConfiguration should not take the override for iOS
+    ///
+    func testOverrideiOSPlatform() {
+        AmplifyAWSServiceConfiguration.addPlatform(.iOS, version: "0.33") // Uses an old version number
+        let configuration = AmplifyAWSServiceConfiguration()
+        XCTAssertNotNil(configuration.userAgent)
+        let userAgentParts = configuration.userAgent.components(separatedBy: " ")
+        XCTAssertEqual(3, userAgentParts.count)
+        XCTAssertFalse(configuration.userAgent.contains("0.33"))
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
@@ -53,13 +53,13 @@ class AmplifyAWSServiceConfigurationTests: XCTestCase {
         let currentSystemVersion = UIDevice.current.systemVersion
         let expectedLocale = Locale.current.identifier
         let expectedSystem = "\(currentSystemName)/\(currentSystemVersion)"
-
+        let expectedPlatform = "\(AmplifyAWSServiceConfiguration.Platform.flutter.rawValue)/1.1"
         let configuration = AmplifyAWSServiceConfiguration()
 
         XCTAssertNotNil(configuration.userAgent)
         let userAgentParts = configuration.userAgent.components(separatedBy: " ")
         XCTAssertEqual(4, userAgentParts.count)
-        XCTAssert(userAgentParts[0].starts(with: AmplifyAWSServiceConfiguration.Platform.flutter.rawValue))
+        XCTAssertEqual(expectedPlatform, userAgentParts[0])
         XCTAssert(userAgentParts[1].starts(with: "amplify-iOS/"))
         XCTAssertEqual(expectedSystem, userAgentParts[2])
         XCTAssertEqual(expectedLocale, userAgentParts[3])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added ability to add platform information to the user agent. The user agent can now add in the following format:
```
<Platform-2-Name/Platform-2-Version> <Platform-1-Name/Platform-1-Version> amplify-iOS/xx.yy iOS/13.6 en_US
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
