### PR TITLE
chore: Remove version from .jazzy config

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,5 +1,4 @@
 module: Amplify
-module_version: 0.11.0
 author: Amazon Web Services
 github_url: https://github.com/aws-amplify/amplify-ios
 


### PR DESCRIPTION
By not specifying in the .jazzy.yaml file, Jazzy will pick up the version from
the module's Info.plist, which is updated as part of the version bump.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
