### PR TITLE
chore: Remove stray 'Unreleased' section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,6 @@
 - **predictions**: TABLE, CELL & KEY_VALUE_SET blocks are not properly processed (#660)
 - **api**: cognito user pool intercept with accessToken (#690)
 
-## Unreleased
-
-### Bug Fixes
-
-- **Predictions**: Add rowIndex and columnIndex to Cell struct ([#704](https://github.com/aws-amplify/amplify-ios/pull/704))
-
 ## 1.0.6 (2020-08-03)
 
 ### Bug Fixes


### PR DESCRIPTION
Removed stray 'Unreleased' section from CHANGELOG, since CHANGELOG is automatically generated during our release CI/CD step.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
