### PR TITLE
refactor(datastore): Removed dependency of Model.Type in setup

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
@@ -26,6 +26,12 @@ public struct ModelRegistry {
         }
     }
 
+    public static var modelSchemas: [ModelSchema] {
+        concurrencyQueue.sync {
+            Array(modelTypes.values.map { $0.schema })
+        }
+    }
+
     public static func register(modelType: Model.Type) {
         concurrencyQueue.sync {
             let modelDecoder: ModelDecoder = { jsonString, jsonDecoder in
@@ -42,6 +48,12 @@ public struct ModelRegistry {
     public static func modelType(from name: String) -> Model.Type? {
         concurrencyQueue.sync {
             modelTypes[name]
+        }
+    }
+
+    public static func modelSchema(from modelType: Model.Type) -> ModelSchema? {
+        concurrencyQueue.sync {
+            modelType.schema
         }
     }
 

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
@@ -61,6 +61,10 @@ public typealias ModelFields = [String: ModelField]
 
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
+public typealias ModelName = String
+
+/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+///   by host applications. The behavior of this may change without warning.
 public struct ModelSchema {
 
     public let name: String

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -78,14 +78,14 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
 
     /// By the time this method gets called, DataStore will already have invoked
     /// `AmplifyModelRegistration.registerModels`, so we can inspect those models to derive isSyncEnabled, and pass
-    /// them to `StorageEngine.setUp(models:)`
+    /// them to `StorageEngine.setUp(modelSchemas:)`
     public func configure(using amplifyConfiguration: Any?) throws {
         modelRegistration.registerModels(registry: ModelRegistry.self)
         resolveSyncEnabled()
 
         try resolveStorageEngine(dataStoreConfiguration: dataStoreConfiguration)
 
-        try storageEngine.setUp(models: ModelRegistry.models)
+        try storageEngine.setUp(modelSchemas: ModelRegistry.modelSchemas)
 
         let filter = HubFilters.forEventName(HubPayload.EventName.Amplify.configured)
         var token: UnsubscribeToken?
@@ -106,7 +106,7 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
                 self.dataStorePublisher = DataStorePublisher()
             }
             try resolveStorageEngine(dataStoreConfiguration: dataStoreConfiguration)
-            try storageEngine.setUp(models: ModelRegistry.models)
+            try storageEngine.setUp(modelSchemas: ModelRegistry.modelSchemas)
             storageEngine.startSync()
         } catch {
             log.error(error: error)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
@@ -8,7 +8,7 @@
 import Amplify
 
 protocol ModelStorageBehavior {
-    func setUp(models: [Model.Type]) throws
+    func setUp(modelSchemas: [ModelSchema]) throws
 
     func save<M: Model>(_ model: M,
                         condition: QueryPredicate?,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
@@ -157,3 +157,29 @@ extension Array where Element == Model.Type {
     }
 
 }
+
+extension Array where Element == ModelSchema {
+
+    func sortByDependencyOrder() -> Self {
+        var sortedKeys: [String] = []
+        var sortMap: [String: ModelSchema] = [:]
+
+        func walkAssociatedModels(of schema: ModelSchema) {
+            if !sortedKeys.contains(schema.name) {
+                let associatedModels = schema.sortedFields
+                    .filter { $0.isForeignKey }
+                    .map { ModelRegistry.modelSchema(from: $0.requiredAssociatedModel )! }
+                associatedModels.forEach(walkAssociatedModels(of:))
+
+                let key = schema.name
+                sortedKeys.append(key)
+                sortMap[key] = schema
+            }
+        }
+
+        let sortedStartList = sorted { $0.name < $1.name }
+        sortedStartList.forEach(walkAssociatedModels(of:))
+        return sortedKeys.map { sortMap[$0]! }
+    }
+
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -81,12 +81,12 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
         return documentsPath.appendingPathComponent("\(databaseName).db")
     }
 
-    func setUp(models: [Model.Type]) throws {
-        log.debug("Setting up \(models.count) models")
+    func setUp(modelSchemas: [ModelSchema]) throws {
+        log.debug("Setting up \(modelSchemas.count) models")
 
-        let createTableStatements = models
+        let createTableStatements = modelSchemas
             .sortByDependencyOrder()
-            .map { CreateTableStatement(modelSchema: $0.schema).stringValue }
+            .map { CreateTableStatement(modelSchema: $0).stringValue }
             .joined(separator: "\n")
 
         do {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -54,11 +54,11 @@ final class StorageEngine: StorageEngineBehavior {
         return storageEnginePublisher.eraseToAnyPublisher()
     }
 
-    static var systemModels: [Model.Type] {
+    static var systemModelSchemas: [ModelSchema] {
         return [
-            ModelSyncMetadata.self,
-            MutationEvent.self,
-            MutationSyncMetadata.self
+            ModelSyncMetadata.schema,
+            MutationEvent.schema,
+            MutationSyncMetadata.schema
         ]
     }
 
@@ -88,7 +88,7 @@ final class StorageEngine: StorageEngineBehavior {
 
         let storageAdapter = try SQLiteStorageEngineAdapter(version: modelRegistryVersion, databaseName: databaseName)
 
-        try storageAdapter.setUp(models: StorageEngine.systemModels)
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
         if #available(iOS 13.0, *) {
             let syncEngine = isSyncEnabled ? try? RemoteSyncEngine(storageAdapter: storageAdapter,
                                                                    dataStoreConfiguration: dataStoreConfiguration) : nil
@@ -126,8 +126,8 @@ final class StorageEngine: StorageEngineBehavior {
         }
     }
 
-    func setUp(models: [Model.Type]) throws {
-        try storageAdapter.setUp(models: models)
+    func setUp(modelSchemas: [ModelSchema]) throws {
+        try storageAdapter.setUp(modelSchemas: modelSchemas)
     }
 
     func save<M: Model>(_ model: M, condition: QueryPredicate? = nil, completion: @escaping DataStoreCallback<M>) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
@@ -65,7 +65,7 @@ extension APICategoryDependencyTests {
 
         let connection = try Connection(.inMemory)
         storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-        try storageAdapter.setUp(models: StorageEngine.systemModels)
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
 
         let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
                                               dataStoreConfiguration: .default)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -234,7 +234,7 @@ class InitialSyncOperationTests: XCTestCase {
         apiPlugin.responders[.queryRequestListener] = responder
 
         let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
-        try storageAdapter.setUp(models: StorageEngine.systemModels + [MockSynced.self])
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas + [MockSynced.schema])
 
         let syncCallbackReceived = expectation(description: "Sync callback received, sync operation is complete")
         let reconciliationQueue = MockReconciliationQueue()
@@ -328,7 +328,7 @@ class InitialSyncOperationTests: XCTestCase {
         let startDateMilliseconds = (Int(Date().timeIntervalSince1970) - 100) * 1_000
 
         let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
-        try storageAdapter.setUp(models: StorageEngine.systemModels + [MockSynced.self])
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas + [MockSynced.schema])
 
         let syncMetadata = ModelSyncMetadata(id: MockSynced.modelName, lastSync: startDateMilliseconds)
         let syncMetadataSaved = expectation(description: "Sync metadata saved")
@@ -375,7 +375,7 @@ class InitialSyncOperationTests: XCTestCase {
         let startDateMilliSeconds = (Int(Date().timeIntervalSince1970) - 100) * 1_000
 
         let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
-        try storageAdapter.setUp(models: StorageEngine.systemModels + [MockSynced.self])
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas + [MockSynced.schema])
 
         let syncMetadata = ModelSyncMetadata(id: MockSynced.modelName, lastSync: startDateMilliSeconds)
         let syncMetadataSaved = expectation(description: "Sync metadata saved")
@@ -420,7 +420,7 @@ class InitialSyncOperationTests: XCTestCase {
 
     func testBaseQueryWithCustomSyncPageSize() throws {
         let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
-        try storageAdapter.setUp(models: StorageEngine.systemModels + [MockSynced.self])
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas + [MockSynced.schema])
 
         let apiWasQueried = expectation(description: "API was queried for a PaginatedList of AnyModel")
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { request, listener in

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
@@ -30,7 +30,7 @@ class LocalSubscriptionTests: XCTestCase {
         do {
             let connection = try Connection(.inMemory)
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-            try storageAdapter.setUp(models: StorageEngine.systemModels)
+            try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
 
             let outgoingMutationQueue = NoOpMutationQueue()
             let mutationDatabaseAdapter = try AWSMutationDatabaseAdapter(storageAdapter: storageAdapter)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
@@ -35,7 +35,7 @@ class AWSMutationEventIngesterTests: XCTestCase {
         do {
             let connection = try Connection(.inMemory)
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-            try storageAdapter.setUp(models: StorageEngine.systemModels)
+            try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
 
             let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
                                                   dataStoreConfiguration: .default)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
@@ -40,7 +40,7 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
         do {
             let connection = try Connection(.inMemory)
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-            try storageAdapter.setUp(models: StorageEngine.systemModels)
+            try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
 
             let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
                                                   dataStoreConfiguration: .default)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -32,7 +32,7 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
         self.shouldReturnErrorOnDeleteMutation = false
     }
 
-    func setUp(models: [Model.Type]) throws {
+    func setUp(modelSchemas: [ModelSchema]) throws {
         XCTFail("Not expected to execute")
     }
 
@@ -183,7 +183,7 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
     func startSync() {
     }
 
-    func setUp(models: [Model.Type]) throws {
+    func setUp(modelSchemas: [ModelSchema]) throws {
     }
 
     func save<M: Model>(_ model: M, condition: QueryPredicate?, completion: @escaping DataStoreCallback<M>) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
@@ -33,7 +33,7 @@ class BaseDataStoreTests: XCTestCase {
         do {
             connection = try Connection(.inMemory)
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-            try storageAdapter.setUp(models: StorageEngine.systemModels)
+            try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
 
             let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
                                                   dataStoreConfiguration: .default)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -72,7 +72,7 @@ class SyncEngineTestBase: XCTestCase {
         models.forEach { ModelRegistry.register(modelType: $0) }
         let connection = try Connection(.inMemory)
         storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-        try storageAdapter.setUp(models: StorageEngine.systemModels + models)
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas + models.map { $0.schema })
     }
 
     /// Sets up a DataStorePlugin backed by the storageAdapter created in `setUpStorageAdapter()`, and an optional

--- a/AmplifyPlugins/DataStore/Podfile.lock
+++ b/AmplifyPlugins/DataStore/Podfile.lock
@@ -22,18 +22,18 @@ PODS:
     - AWSPluginsCore (= 1.1.2)
   - AppSyncRealTimeClient (1.4.1):
     - Starscream (~> 3.1.0)
-  - AWSAuthCore (2.15.3):
-    - AWSCore (= 2.15.3)
-  - AWSCognitoIdentityProvider (2.15.3):
-    - AWSCognitoIdentityProviderASF (= 1.0.2)
-    - AWSCore (= 2.15.3)
-  - AWSCognitoIdentityProviderASF (1.0.2)
-  - AWSCore (2.15.3)
-  - AWSMobileClient (2.15.3):
-    - AWSAuthCore (= 2.15.3)
-    - AWSCognitoIdentityProvider (= 2.15.3)
-  - AWSPluginsCore (1.1.2):
-    - Amplify (= 1.1.2)
+  - AWSAuthCore (2.15.2):
+    - AWSCore (= 2.15.2)
+  - AWSCognitoIdentityProvider (2.15.2):
+    - AWSCognitoIdentityProviderASF (= 1.0.1)
+    - AWSCore (= 2.15.2)
+  - AWSCognitoIdentityProviderASF (1.0.1)
+  - AWSCore (2.15.2)
+  - AWSMobileClient (2.15.2):
+    - AWSAuthCore (= 2.15.2)
+    - AWSCognitoIdentityProvider (= 2.15.2)
+  - AWSPluginsCore (1.1.1):
+    - Amplify (= 1.1.1)
     - AWSCore (~> 2.15.0)
     - AWSMobileClient (~> 2.15.0)
   - CwlCatchException (1.0.2)
@@ -99,16 +99,16 @@ CHECKOUT OPTIONS:
     :tag: 1.2.0
 
 SPEC CHECKSUMS:
-  Amplify: cdb7a7c8b8d4fbd7815e4b25812207516d83416b
-  AmplifyPlugins: 6ee36c02d09f7e848c6b9c6a936328da357761ac
-  AmplifyTestCommon: f1200fd777aba42fc92d63a671cbd5c66edd751a
-  AppSyncRealTimeClient: 879b9fa3ce3f335450ca06e0def279fa90af9e76
-  AWSAuthCore: 598e8eb56e12799877414d10b04598de12a15992
-  AWSCognitoIdentityProvider: 4a721292eda37a8c3ef451e8fec28abe14aff18e
-  AWSCognitoIdentityProviderASF: 0fb6ea671c05a63276e320726f680cd880522442
-  AWSCore: 5a8f9d7461dbe5ea6a5473c41cf113b687e19136
-  AWSMobileClient: 5c29678413764ee3bcd528421331deb0a35b72fb
-  AWSPluginsCore: fce4a87408b6eba8f060af873c95a0347fbb4f98
+  Amplify: e23b610dde2539d67ec29843c7f01010b44b98ba
+  AmplifyPlugins: 9e1e1bff2a8b1676307101ca7d768a7be49c0456
+  AmplifyTestCommon: 6c85e20d4d2a7304b4ba0f97868e5a89ff1204d9
+  AppSyncRealTimeClient: 1e14f5584218e63b00fffbc093ad1934701a4b68
+  AWSAuthCore: e6efd4a6497e518793da9e871eaeb4b940f2f182
+  AWSCognitoIdentityProvider: 094934098017284051bddd4441a914c63d4fff69
+  AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
+  AWSCore: 81cfee0ac51488a60930d5dfb18d3ae48cf5e1a8
+  AWSMobileClient: 9c0d7723c635c8cf4cad7e74bbf378963db5d975
+  AWSPluginsCore: 4e98e284fff7763470ef94f7538449f20d891f70
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825

--- a/AmplifyPlugins/DataStore/Podfile.lock
+++ b/AmplifyPlugins/DataStore/Podfile.lock
@@ -22,18 +22,18 @@ PODS:
     - AWSPluginsCore (= 1.1.2)
   - AppSyncRealTimeClient (1.4.1):
     - Starscream (~> 3.1.0)
-  - AWSAuthCore (2.15.2):
-    - AWSCore (= 2.15.2)
-  - AWSCognitoIdentityProvider (2.15.2):
-    - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.15.2)
-  - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.15.2)
-  - AWSMobileClient (2.15.2):
-    - AWSAuthCore (= 2.15.2)
-    - AWSCognitoIdentityProvider (= 2.15.2)
-  - AWSPluginsCore (1.1.1):
-    - Amplify (= 1.1.1)
+  - AWSAuthCore (2.15.3):
+    - AWSCore (= 2.15.3)
+  - AWSCognitoIdentityProvider (2.15.3):
+    - AWSCognitoIdentityProviderASF (= 1.0.2)
+    - AWSCore (= 2.15.3)
+  - AWSCognitoIdentityProviderASF (1.0.2)
+  - AWSCore (2.15.3)
+  - AWSMobileClient (2.15.3):
+    - AWSAuthCore (= 2.15.3)
+    - AWSCognitoIdentityProvider (= 2.15.3)
+  - AWSPluginsCore (1.1.2):
+    - Amplify (= 1.1.2)
     - AWSCore (~> 2.15.0)
     - AWSMobileClient (~> 2.15.0)
   - CwlCatchException (1.0.2)
@@ -99,16 +99,16 @@ CHECKOUT OPTIONS:
     :tag: 1.2.0
 
 SPEC CHECKSUMS:
-  Amplify: e23b610dde2539d67ec29843c7f01010b44b98ba
-  AmplifyPlugins: 9e1e1bff2a8b1676307101ca7d768a7be49c0456
-  AmplifyTestCommon: 6c85e20d4d2a7304b4ba0f97868e5a89ff1204d9
-  AppSyncRealTimeClient: 1e14f5584218e63b00fffbc093ad1934701a4b68
-  AWSAuthCore: e6efd4a6497e518793da9e871eaeb4b940f2f182
-  AWSCognitoIdentityProvider: 094934098017284051bddd4441a914c63d4fff69
-  AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: 81cfee0ac51488a60930d5dfb18d3ae48cf5e1a8
-  AWSMobileClient: 9c0d7723c635c8cf4cad7e74bbf378963db5d975
-  AWSPluginsCore: 4e98e284fff7763470ef94f7538449f20d891f70
+  Amplify: cdb7a7c8b8d4fbd7815e4b25812207516d83416b
+  AmplifyPlugins: 6ee36c02d09f7e848c6b9c6a936328da357761ac
+  AmplifyTestCommon: f1200fd777aba42fc92d63a671cbd5c66edd751a
+  AppSyncRealTimeClient: 879b9fa3ce3f335450ca06e0def279fa90af9e76
+  AWSAuthCore: 598e8eb56e12799877414d10b04598de12a15992
+  AWSCognitoIdentityProvider: 4a721292eda37a8c3ef451e8fec28abe14aff18e
+  AWSCognitoIdentityProviderASF: 0fb6ea671c05a63276e320726f680cd880522442
+  AWSCore: 5a8f9d7461dbe5ea6a5473c41cf113b687e19136
+  AWSMobileClient: 5c29678413764ee3bcd528421331deb0a35b72fb
+  AWSPluginsCore: fce4a87408b6eba8f060af873c95a0347fbb4f98
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825


### PR DESCRIPTION
*Description of changes:* 

During configuration of datastore storage we pass a list of Model.Type to setup the storage. This is not required and can be replaced with a list of ModelSchema. This PR is part of the larger work on removing the dependency on the static properties of Model.Type from Datastore.

*Previous PRs:*
Removed the dependency on Model.Type from DataStoreStatement - https://github.com/aws-amplify/amplify-ios/pull/718

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
