### PR TITLE
refactor(datastore): Changed StorageEngineAdapter.exists api to accept ModelSchema instead of Model.Type

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -24,7 +24,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                 throw DataStoreError.configuration("Unable to get storage adapter",
                                                    "")
             }
-            modelExists = try engine.storageAdapter.exists(M.self, withId: model.id, predicate: nil)
+            modelExists = try engine.storageAdapter.exists(M.schema, withId: model.id, predicate: nil)
         } catch {
             if let dataStoreError = error as? DataStoreError {
                 completion(.failure(dataStoreError))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
@@ -17,7 +17,7 @@ extension SQLiteStorageEngineAdapter {
                 throw error
             }
 
-            let shouldUpdate = try exists(modelType, withId: untypedModel.id)
+            let shouldUpdate = try exists(modelType.schema, withId: untypedModel.id)
 
             // TODO serialize result and create a new instance of the model
             // (some columns might be auto-generated after DB insert/update)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -135,7 +135,7 @@ final class StorageEngine: StorageEngineBehavior {
         // mutation type
         let modelExists: Bool
         do {
-            modelExists = try storageAdapter.exists(M.self, withId: model.id, predicate: nil)
+            modelExists = try storageAdapter.exists(M.schema, withId: model.id, predicate: nil)
         } catch {
             let dataStoreError = DataStoreError.invalidOperation(causedBy: error)
             completion(.failure(dataStoreError))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -38,7 +38,7 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
 
     // MARK: - Synchronous APIs
 
-    func exists(_ modelType: Model.Type,
+    func exists(_ modelSchema: ModelSchema,
                 withId id: Model.Identifier,
                 predicate: QueryPredicate?) throws -> Bool
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -369,7 +369,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
 
     func checkIfPostIsDeleted(id: String) {
         do {
-            let exists = try storageAdapter.exists(Post.self, withId: id)
+            let exists = try storageAdapter.exists(Post.schema, withId: id)
             XCTAssertFalse(exists, "ID \(id) should not exist")
         } catch {
             XCTFail(String(describing: error))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -99,7 +99,7 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
         return []
     }
 
-    func exists(_ modelType: Model.Type, withId id: Model.Identifier, predicate: QueryPredicate?) throws -> Bool {
+    func exists(_ modelSchema: ModelSchema, withId id: Model.Identifier, predicate: QueryPredicate?) throws -> Bool {
         XCTFail("Not expected to execute")
         return true
     }


### PR DESCRIPTION
*Description of changes:* 

Changed `StorageEngineAdapter.exists` api to accept ModelSchema instead of Model.Type. This PR is part of the larger work on removing the dependency on the static properties of Model.Type from Datastore.

Previous PRs:
Removed dependency of Model.Type in setup (#734)
Removed the dependency on Model.Type from DataStoreStatement - #718

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
