### PR TITLE
refactor(datastore): Remove dependency on Model.Type from registration

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreStatement.swift
+++ b/Amplify/Categories/DataStore/DataStoreStatement.swift
@@ -19,6 +19,7 @@ public protocol DataStoreStatement {
     @available(*, deprecated, message: """
     Use of modelType inside the DatastoreStatement is deprecated, use modelSchema instead.
     """)
+    
     var modelType: Model.Type { get }
 
     /// The model schema of the `Model` associated with a particular statement

--- a/Amplify/Categories/DataStore/DataStoreStatement.swift
+++ b/Amplify/Categories/DataStore/DataStoreStatement.swift
@@ -19,7 +19,7 @@ public protocol DataStoreStatement {
     @available(*, deprecated, message: """
     Use of modelType inside the DatastoreStatement is deprecated, use modelSchema instead.
     """)
-    
+
     var modelType: Model.Type { get }
 
     /// The model schema of the `Model` associated with a particular statement

--- a/Amplify/Categories/DataStore/DataStoreStatement.swift
+++ b/Amplify/Categories/DataStore/DataStoreStatement.swift
@@ -20,10 +20,10 @@ public protocol DataStoreStatement {
     Use of modelType inside the DatastoreStatement is deprecated, use modelSchema instead.
     """)
     var modelType: Model.Type { get }
-    
+
     /// The model schema of the `Model` associated with a particular statement
     var modelSchema: ModelSchema { get }
-    
+
     /// The actual string content of the statement (e.g. a SQL query or a GraphQL document)
     var stringValue: String { get }
 

--- a/Amplify/Categories/DataStore/DataStoreStatement.swift
+++ b/Amplify/Categories/DataStore/DataStoreStatement.swift
@@ -19,12 +19,11 @@ public protocol DataStoreStatement {
     @available(*, deprecated, message: """
     Use of modelType inside the DatastoreStatement is deprecated, use modelSchema instead.
     """)
-
     var modelType: Model.Type { get }
-
+    
     /// The model schema of the `Model` associated with a particular statement
     var modelSchema: ModelSchema { get }
-
+    
     /// The actual string content of the statement (e.g. a SQL query or a GraphQL document)
     var stringValue: String { get }
 

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
@@ -16,9 +16,11 @@ public struct ModelRegistry {
     /// ModelDecoders are used to decode untyped model data, looking up by model name
     private typealias ModelDecoder = (String, JSONDecoder?) throws -> Model
 
-    private static var modelTypes = [String: Model.Type]()
+    private static var modelTypes = [ModelName: Model.Type]()
 
-    private static var modelDecoders = [String: ModelDecoder]()
+    private static var modelDecoders = [ModelName: ModelDecoder]()
+
+    private static var modelSchemaMapping = [ModelName: ModelSchema]()
 
     public static var models: [Model.Type] {
         concurrencyQueue.sync {
@@ -28,7 +30,11 @@ public struct ModelRegistry {
 
     public static var modelSchemas: [ModelSchema] {
         concurrencyQueue.sync {
+<<<<<<< HEAD
             Array(modelTypes.values.map { $0.schema })
+=======
+            Array(modelSchemaMapping.values)
+>>>>>>> refactor(datastore): Remove dependency on Model.Type from registeration
         }
     }
 
@@ -42,22 +48,24 @@ public struct ModelRegistry {
             modelDecoders[modelType.modelName] = modelDecoder
 
             modelTypes[modelType.modelName] = modelType
+
+            modelSchemaMapping[modelType.modelName] = modelType.schema
         }
     }
 
-    public static func modelType(from name: String) -> Model.Type? {
+    public static func modelType(from name: ModelName) -> Model.Type? {
         concurrencyQueue.sync {
             modelTypes[name]
         }
     }
 
-    public static func modelSchema(from modelType: Model.Type) -> ModelSchema? {
+    public static func modelSchema(from name: ModelName) -> ModelSchema? {
         concurrencyQueue.sync {
-            modelType.schema
+            modelSchemaMapping[name]
         }
     }
 
-    public static func decode(modelName: String,
+    public static func decode(modelName: ModelName,
                               from jsonString: String,
                               jsonDecoder: JSONDecoder? = nil) throws -> Model {
         try concurrencyQueue.sync {

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
@@ -55,6 +55,13 @@ public struct ModelRegistry {
         }
     }
 
+    @available(*, deprecated, message: """
+    Retrieving model schema using Model.Type is deprecated, instead retrieve using model name.
+    """)
+    public static func modelSchema(from modelType: Model.Type) -> ModelSchema? {
+        return modelSchema(from: modelType.modelName)
+    }
+
     public static func modelSchema(from name: ModelName) -> ModelSchema? {
         concurrencyQueue.sync {
             modelSchemaMapping[name]

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
@@ -30,11 +30,7 @@ public struct ModelRegistry {
 
     public static var modelSchemas: [ModelSchema] {
         concurrencyQueue.sync {
-<<<<<<< HEAD
-            Array(modelTypes.values.map { $0.schema })
-=======
             Array(modelSchemaMapping.values)
->>>>>>> refactor(datastore): Remove dependency on Model.Type from registeration
         }
     }
 

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
@@ -87,9 +87,9 @@ import Foundation
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
 public enum ModelAssociation {
-    case hasMany(associatedWith: CodingKey?)
-    case hasOne(associatedWith: CodingKey?)
-    case belongsTo(associatedWith: CodingKey?, targetName: String?)
+    case hasMany(associatedWith: String?)
+    case hasOne(associatedWith: String?)
+    case belongsTo(associatedWith: String?, targetName: String?)
 
     public static let belongsTo: ModelAssociation = .belongsTo(associatedWith: nil, targetName: nil)
 
@@ -107,37 +107,37 @@ extension ModelField {
         return association != nil
     }
 
-    /// If the field represents an association returns the `Model.Type`.
+    /// If the field represents an association returns the `ModelName`.
     /// - seealso: `ModelFieldType`
     /// - seealso: `ModelFieldAssociation`
     /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
     ///   by host applications. The behavior of this may change without warning.
-    public var associatedModel: Model.Type? {
+    public var associatedModelName: ModelName? {
         switch type {
-        case .model(let type), .collection(let type):
-            return type
+        case .model(let modelName), .collection(let modelName):
+            return modelName
         default:
             return nil
         }
     }
 
-    /// This calls `associatedModel` but enforces that the field must represent an association.
-    /// In case the field type is not a `Model.Type` is calls `preconditionFailure`. Consumers
+    /// This calls `associatedModelName` but enforces that the field must represent an association.
+    /// In case the field type is not a `Model` it calls `preconditionFailure`. Consumers
     /// should fix their models in order to recover from it, since associations are only
-    /// possible between two `Model.Type`.
+    /// possible between two `Model`.
     ///
     /// - Note: as a maintainer, make sure you use this computed property only when context
     /// allows (i.e. the field is a valid relationship, such as foreign keys).
     /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
     ///   by host applications. The behavior of this may change without warning.
-    public var requiredAssociatedModel: Model.Type {
-        guard let modelType = associatedModel else {
+    public var requiredAssociatedModel: ModelName {
+        guard let modelName = associatedModelName else {
             preconditionFailure("""
             Model fields that are foreign keys must be connected to another Model.
             Check the `ModelSchema` section of your "\(name)+Schema.swift" file.
             """)
         }
-        return modelType
+        return modelName
     }
 
     /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
@@ -157,13 +157,15 @@ extension ModelField {
             switch association {
             case .belongsTo(let associatedKey, _):
                 // TODO handle modelName casing (convert to camelCase)
-                let key = associatedKey?.stringValue ?? associatedModel.modelName
-                return associatedModel.schema.field(withName: key)
+                let key = associatedKey ?? associatedModel
+                let schema = ModelRegistry.modelSchema(from: associatedModel)
+                return schema?.field(withName: key)
             case .hasOne(let associatedKey),
                  .hasMany(let associatedKey):
                 // TODO handle modelName casing (convert to camelCase)
-                let key = associatedKey?.stringValue ?? associatedModel.modelName
-                return associatedModel.schema.field(withName: key)
+                let key = associatedKey ?? associatedModel
+                let schema = ModelRegistry.modelSchema(from: associatedModel)
+                return schema?.field(withName: key)
             case .none:
                 return nil
             }

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -23,8 +23,8 @@ public enum ModelFieldType {
     case `enum`(type: EnumPersistable.Type)
     case embedded(type: Codable.Type)
     case embeddedCollection(of: Codable.Type)
-    case model(type: Model.Type)
-    case collection(of: Model.Type)
+    case model(name: ModelName)
+    case collection(of: ModelName)
 
     public var isArray: Bool {
         switch self {
@@ -72,7 +72,7 @@ public enum ModelFieldType {
             return .enum(type: enumType)
         }
         if let modelType = type as? Model.Type {
-            return .model(type: modelType)
+            return .model(name: modelType.modelName)
         }
         if let embeddedType = type as? Codable.Type {
             return .embedded(type: embeddedType)
@@ -182,8 +182,8 @@ public enum ModelFieldDefinition {
                                associatedWith associatedKey: CodingKey) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
-                      ofType: .collection(of: type),
-                      association: .hasMany(associatedWith: associatedKey))
+                      ofType: .collection(of: type.modelName),
+                      association: .hasMany(associatedWith: associatedKey.stringValue))
     }
 
     public static func hasOne(_ key: CodingKey,
@@ -192,8 +192,8 @@ public enum ModelFieldDefinition {
                               associatedWith associatedKey: CodingKey) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
-                      ofType: .model(type: type),
-                      association: .hasOne(associatedWith: associatedKey))
+                      ofType: .model(name: type.modelName),
+                      association: .hasOne(associatedWith: associatedKey.stringValue))
     }
 
     public static func belongsTo(_ key: CodingKey,
@@ -203,8 +203,8 @@ public enum ModelFieldDefinition {
                                  targetName: String? = nil) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
-                      ofType: .model(type: type),
-                      association: .belongsTo(associatedWith: associatedKey, targetName: targetName))
+                      ofType: .model(name: type.modelName),
+                      association: .belongsTo(associatedWith: associatedKey?.stringValue, targetName: targetName))
     }
 
     public var modelField: ModelField {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
@@ -40,9 +40,11 @@ extension SelectionSet {
                 let child = SelectionSet(value: .init(name: field.name, fieldType: .embedded))
                 child.withCodableFields(embeddedType.schema.sortedFields)
                 self.addChild(settingParentOf: child)
-            } else if field.isAssociationOwner, let associatedModel = field.associatedModel {
+            } else if field.isAssociationOwner,
+                let associatedModelName = field.associatedModelName,
+                let schema = ModelRegistry.modelSchema(from: associatedModelName) {
                 let child = SelectionSet(value: .init(name: field.name, fieldType: .model))
-                child.withModelFields(associatedModel.schema.graphQLFields)
+                child.withModelFields(schema.graphQLFields)
                 self.addChild(settingParentOf: child)
             } else {
                 self.addChild(settingParentOf: .init(value: .init(name: field.graphQLName, fieldType: .value)))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
@@ -142,7 +142,7 @@ extension Array where Element == Model.Type {
             if !sortedKeys.contains(modelType.schema.name) {
                 let associatedModels = modelType.schema.sortedFields
                     .filter { $0.isForeignKey }
-                    .map { $0.requiredAssociatedModel }
+                    .map { ModelRegistry.modelType(from: $0.requiredAssociatedModel)! }
                 associatedModels.forEach(walkAssociatedModels(of:))
 
                 let key = modelType.schema.name

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
@@ -142,7 +142,15 @@ extension Array where Element == Model.Type {
             if !sortedKeys.contains(modelType.schema.name) {
                 let associatedModels = modelType.schema.sortedFields
                     .filter { $0.isForeignKey }
-                    .map { ModelRegistry.modelType(from: $0.requiredAssociatedModel)! }
+                    .map { (model) -> Model.Type in
+                        guard let modelType = ModelRegistry.modelType(from: model.requiredAssociatedModel) else {
+                            preconditionFailure("""
+                            Could not retrieve modelType for the model \(model.requiredAssociatedModel), verify that
+                            datastore is initialized.
+                            """)
+                        }
+                        return modelType
+                }
                 associatedModels.forEach(walkAssociatedModels(of:))
 
                 let key = modelType.schema.name
@@ -166,10 +174,19 @@ extension Array where Element == ModelSchema {
 
         func walkAssociatedModels(of schema: ModelSchema) {
             if !sortedKeys.contains(schema.name) {
-                let associatedModels = schema.sortedFields
+                let associatedModelSchemas = schema.sortedFields
                     .filter { $0.isForeignKey }
-                    .map { ModelRegistry.modelSchema(from: $0.requiredAssociatedModel )! }
-                associatedModels.forEach(walkAssociatedModels(of:))
+                    .map { (schema) -> ModelSchema in
+                        guard let associatedSchema = ModelRegistry.modelSchema(from: schema.requiredAssociatedModel)
+                            else {
+                            preconditionFailure("""
+                            Could not retrieve schema for the model \(schema.requiredAssociatedModel), verify that
+                            datastore is initialized.
+                            """)
+                        }
+                        return associatedSchema
+                    }
+                associatedModelSchemas.forEach(walkAssociatedModels(of:))
 
                 let key = schema.name
                 sortedKeys.append(key)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
@@ -50,8 +50,9 @@ struct CreateTableStatement: SQLStatement {
         for (index, foreignKey) in foreignKeys.enumerated() {
             statement += "  foreign key(\"\(foreignKey.sqlName)\") "
             let associatedModel = foreignKey.requiredAssociatedModel
-            let associatedId = associatedModel.schema.primaryKey
-            let associatedModelName = associatedModel.schema.name
+            let schema = ModelRegistry.modelSchema(from: associatedModel)!
+            let associatedId = schema.primaryKey
+            let associatedModelName = schema.name
             statement += "references \(associatedModelName)(\"\(associatedId.sqlName)\")\n"
             statement += "    on delete cascade"
             let isNotLastKey = index < foreignKeys.endIndex - 1

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
@@ -50,7 +50,11 @@ struct CreateTableStatement: SQLStatement {
         for (index, foreignKey) in foreignKeys.enumerated() {
             statement += "  foreign key(\"\(foreignKey.sqlName)\") "
             let associatedModel = foreignKey.requiredAssociatedModel
-            let schema = ModelRegistry.modelSchema(from: associatedModel)!
+            guard let schema = ModelRegistry.modelSchema(from: associatedModel) else {
+                preconditionFailure("""
+                Could not retrieve schema for the model \(associatedModel), verify that datastore is initialized.
+                """)
+            }
             let associatedId = schema.primaryKey
             let associatedModelName = schema.name
             statement += "references \(associatedModelName)(\"\(associatedId.sqlName)\")\n"

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Select.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Select.swift
@@ -94,8 +94,13 @@ struct SelectStatementMetadata {
         func visitAssociations(node: ModelSchema, namespace: String = "root") {
             for foreignKey in node.foreignKeys {
                 let associatedModelName = foreignKey.requiredAssociatedModel
-                // TODO: Handle force unwrap
-                let associatedSchema = ModelRegistry.modelSchema(from: associatedModelName)!
+
+                guard let associatedSchema = ModelRegistry.modelSchema(from: associatedModelName) else {
+                    preconditionFailure("""
+                    Could not retrieve schema for the model \(associatedModelName), verify that datastore is
+                    initialized.
+                    """)
+                }
                 let associatedTableName = associatedSchema.name
 
                 // columns

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Select.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Select.swift
@@ -93,9 +93,10 @@ struct SelectStatementMetadata {
 
         func visitAssociations(node: ModelSchema, namespace: String = "root") {
             for foreignKey in node.foreignKeys {
-                let associatedModelType = foreignKey.requiredAssociatedModel
-                let associatedSchema = associatedModelType.schema
-                let associatedTableName = associatedModelType.schema.name
+                let associatedModelName = foreignKey.requiredAssociatedModel
+                // TODO: Handle force unwrap
+                let associatedSchema = ModelRegistry.modelSchema(from: associatedModelName)!
+                let associatedTableName = associatedSchema.name
 
                 // columns
                 let alias = namespace == "root" ? foreignKey.name : "\(namespace).\(foreignKey.name)"
@@ -114,8 +115,7 @@ struct SelectStatementMetadata {
                 \(joinType) join \(associatedTableName) as "\(alias)"
                   on \(associatedColumn) = \(foreignKeyName)
                 """)
-                visitAssociations(node: associatedModelType.schema,
-                                  namespace: alias)
+                visitAssociations(node: associatedSchema, namespace: alias)
             }
         }
         visitAssociations(node: schema)


### PR DESCRIPTION
Removes dependency on Model.Type in registration of models. This PR is part of the larger work on removing the dependency on the static properties of Model.Type from Datastore.

Previous PRs:
Changed StorageEngineAdapter.exists api to accept ModelSchema instead of Model.Type (#736)
Removed dependency of Model.Type in setup (#734)
Removed the dependency on Model.Type from DataStoreStatement - #718

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
