### PR TITLE
feat(API): Model-based GraphQL Search API

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		216E460824913D430035E3CE /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216E460724913D430035E3CE /* Color.swift */; };
 		216E460A249183230035E3CE /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216E4609249183230035E3CE /* Section.swift */; };
 		216E461A249189050035E3CE /* Embedded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216E4619249189050035E3CE /* Embedded.swift */; };
+		2177E40625C209C100C4A6FC /* AppSyncGraphQLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2177E40525C209C100C4A6FC /* AppSyncGraphQLRequest.swift */; };
 		217855C3237F84D700A30D19 /* RESTRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217855C2237F84D700A30D19 /* RESTRequest.swift */; };
 		217D5EB02577F9DF009F0639 /* Post4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217D5E9A2577F9DE009F0639 /* Post4.swift */; };
 		217D5EB12577F9DF009F0639 /* Team2+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217D5E9B2577F9DE009F0639 /* Team2+Schema.swift */; };
@@ -140,10 +141,10 @@
 		21A4ED5E259CD7F400E1047D /* CoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A4ED5D259CD7F400E1047D /* CoreError.swift */; };
 		21A4ED6E259CDA4600E1047D /* List+LazyLoad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A4ED6D259CDA4600E1047D /* List+LazyLoad.swift */; };
 		21A4ED77259CDF6800E1047D /* List+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A4ED76259CDF6800E1047D /* List+Combine.swift */; };
-		21A7C8AA25ACB6C8004355D6 /* ArrayLiteralListProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C8A925ACB6C8004355D6 /* ArrayLiteralListProviderTests.swift */; };
-		21A7C90225ACC4D1004355D6 /* MockDataStoreResponders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C90125ACC4D1004355D6 /* MockDataStoreResponders.swift */; };
 		21A4F26325A3CD3D00E1047D /* List+Pagination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A4F26225A3CD3D00E1047D /* List+Pagination.swift */; };
 		21A4F8F325A77D9100E1047D /* ListPaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A4F8F225A77D9100E1047D /* ListPaginationTests.swift */; };
+		21A7C8AA25ACB6C8004355D6 /* ArrayLiteralListProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C8A925ACB6C8004355D6 /* ArrayLiteralListProviderTests.swift */; };
+		21A7C90225ACC4D1004355D6 /* MockDataStoreResponders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C90125ACC4D1004355D6 /* MockDataStoreResponders.swift */; };
 		21AD424B249BF0DA0016FE95 /* AnyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACBAD522386160100E29E56 /* AnyModel.swift */; };
 		21AD424C249BF0DE0016FE95 /* AnyModel+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8EE776238626D60097E4F1 /* AnyModel+Codable.swift */; };
 		21AD424D249BF0E50016FE95 /* AnyModel+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8EE78223862DDB0097E4F1 /* AnyModel+Schema.swift */; };
@@ -899,6 +900,7 @@
 		216E460724913D430035E3CE /* Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		216E4609249183230035E3CE /* Section.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Section.swift; sourceTree = "<group>"; };
 		216E4619249189050035E3CE /* Embedded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Embedded.swift; sourceTree = "<group>"; };
+		2177E40525C209C100C4A6FC /* AppSyncGraphQLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncGraphQLRequest.swift; sourceTree = "<group>"; };
 		217855C2237F84D700A30D19 /* RESTRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTRequest.swift; sourceTree = "<group>"; };
 		217856BA2383320900A30D19 /* GraphQLQueryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLQueryType.swift; sourceTree = "<group>"; };
 		217856BD2383322700A30D19 /* GraphQLMutationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLMutationType.swift; sourceTree = "<group>"; };
@@ -946,10 +948,10 @@
 		21A4ED5D259CD7F400E1047D /* CoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreError.swift; sourceTree = "<group>"; };
 		21A4ED6D259CDA4600E1047D /* List+LazyLoad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "List+LazyLoad.swift"; sourceTree = "<group>"; };
 		21A4ED76259CDF6800E1047D /* List+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "List+Combine.swift"; sourceTree = "<group>"; };
-		21A7C8A925ACB6C8004355D6 /* ArrayLiteralListProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayLiteralListProviderTests.swift; sourceTree = "<group>"; };
-		21A7C90125ACC4D1004355D6 /* MockDataStoreResponders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDataStoreResponders.swift; sourceTree = "<group>"; };
 		21A4F26225A3CD3D00E1047D /* List+Pagination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "List+Pagination.swift"; sourceTree = "<group>"; };
 		21A4F8F225A77D9100E1047D /* ListPaginationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListPaginationTests.swift; sourceTree = "<group>"; };
+		21A7C8A925ACB6C8004355D6 /* ArrayLiteralListProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayLiteralListProviderTests.swift; sourceTree = "<group>"; };
+		21A7C90125ACC4D1004355D6 /* MockDataStoreResponders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDataStoreResponders.swift; sourceTree = "<group>"; };
 		21AD4255249BFFDF0016FE95 /* DeprecatedTodo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DeprecatedTodo.swift; path = Deprecated/DeprecatedTodo.swift; sourceTree = "<group>"; };
 		21C395B2245729EC00597EA2 /* AppSyncErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncErrorType.swift; sourceTree = "<group>"; };
 		21D79FD9237617C60057D00D /* SubscriptionEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionEvent.swift; sourceTree = "<group>"; };
@@ -1787,6 +1789,7 @@
 		2129BE1423948065006363A1 /* GraphQLRequest */ = {
 			isa = PBXGroup;
 			children = (
+				2177E40525C209C100C4A6FC /* AppSyncGraphQLRequest.swift */,
 				219A888423EB897700BBC5F2 /* GraphQLRequest+AnyModelWithSync.swift */,
 				2129BE1523948065006363A1 /* GraphQLRequest+Model.swift */,
 			);
@@ -4653,6 +4656,7 @@
 				6BBECD7123ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift in Sources */,
 				21AD424F249BF0EC0016FE95 /* Model+AnyModel.swift in Sources */,
 				B4EBEB682462050B00D06375 /* AuthCognitoIdentityProvider.swift in Sources */,
+				2177E40625C209C100C4A6FC /* AppSyncGraphQLRequest.swift in Sources */,
 				21AD424C249BF0DE0016FE95 /* AnyModel+Codable.swift in Sources */,
 				212CE6FE23E9E5A2007D8E71 /* GraphQLDocumentnputValue.swift in Sources */,
 				21420A90237222A900FA140C /* APIKeyConfiguration.swift in Sources */,

--- a/Amplify/Categories/DataStore/Query/ModelKey.swift
+++ b/Amplify/Categories/DataStore/Query/ModelKey.swift
@@ -132,4 +132,9 @@ extension CodingKey where Self: ModelKey {
         return key.ne(value)
     }
 
+    // MARK: - custom
+
+    public func evaluate(operator: String, value: Persistable) -> QueryPredicateOperation {
+        return field(stringValue).evaluate(operator: `operator`, value: value)
+    }
 }

--- a/Amplify/Categories/DataStore/Query/QueryField.swift
+++ b/Amplify/Categories/DataStore/Query/QueryField.swift
@@ -42,6 +42,7 @@ public protocol QueryFieldOperation {
     func lt(_ value: Persistable) -> QueryPredicateOperation
     func ne(_ value: Persistable?) -> QueryPredicateOperation
     func ne(_ value: EnumPersistable) -> QueryPredicateOperation
+    func evaluate(operator: String, value: Persistable) -> QueryPredicateOperation
 
     // MARK: - Operators
 
@@ -158,5 +159,11 @@ public struct QueryField: QueryFieldOperation {
 
     public static func != (key: Self, value: EnumPersistable) -> QueryPredicateOperation {
         return key.ne(value)
+    }
+
+    // MARK: - custom
+
+    public func evaluate(operator: String, value: Persistable) -> QueryPredicateOperation {
+        return QueryPredicateOperation(field: name, operator: .evaluate(operator: `operator`, value: value))
     }
 }

--- a/Amplify/Categories/DataStore/Query/QueryOperator.swift
+++ b/Amplify/Categories/DataStore/Query/QueryOperator.swift
@@ -17,6 +17,7 @@ public enum QueryOperator {
     case contains(_ value: String)
     case between(start: Persistable, end: Persistable)
     case beginsWith(_ value: String)
+    case evaluate(operator: String, value: Persistable)
 
     public func evaluate(target: Any) -> Bool {
         switch self {
@@ -43,6 +44,8 @@ public enum QueryOperator {
             if let targetString = target as? String {
                 return targetString.starts(with: predicateValue)
             }
+        case .evaluate:
+            return false
         }
         return false
     }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Decode/GraphQLResponseDecoder+DecodeData.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Decode/GraphQLResponseDecoder+DecodeData.swift
@@ -30,7 +30,8 @@ extension GraphQLResponseDecoder {
         } else if request.responseType is ModelListMarker.Type {
             let payload = AppSyncListPayload(graphQLData: graphQLData,
                                              apiName: request.apiName,
-                                             variables: try getVariablesJSON())
+                                             variables: try getVariablesJSON(),
+                                             documentName: request.decodePath)
             serializedJSON = try encoder.encode(payload)
         } else if AppSyncModelMetadataUtils.shouldAddMetadata(toModel: graphQLData) {
             let modelJSON = AppSyncModelMetadataUtils.addMetadata(toModel: graphQLData,

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/README.md
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/README.md
@@ -136,13 +136,13 @@ type User5 @model {
 # > Choose a schema template: `One-to-many relationship (e.g., “Blogs” with “Posts” and “Comments”)`
 
 # 6 - Blog Post Comment
-type Blog6 @model {
+type Blog6 @model @searchable {
   id: ID!
   name: String!
   posts: [Post6] @connection(keyName: "byBlog", fields: ["id"])
 }
 
-type Post6 @model @key(name: "byBlog", fields: ["blogID"]) {
+type Post6 @model @key(name: "byBlog", fields: ["blogID"]) @searchable {
   id: ID!
   title: String!
   blogID: ID!
@@ -150,7 +150,7 @@ type Post6 @model @key(name: "byBlog", fields: ["blogID"]) {
   comments: [Comment6] @connection(keyName: "byPost", fields: ["id"])
 }
 
-type Comment6 @model @key(name: "byPost", fields: ["postID", "content"]) {
+type Comment6 @model @key(name: "byPost", fields: ["postID", "content"]) @searchable {
   id: ID!
   postID: ID!
   post: Post6 @connection(fields: ["postID"])

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListDecoderTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListDecoderTests.swift
@@ -47,7 +47,7 @@ class AppSyncListDecoderTests: XCTestCase {
             ],
             "nextToken": "nextToken"
         ]
-        let appSyncPayload = AppSyncListPayload(graphQLData: json, apiName: nil, variables: nil)
+        let appSyncPayload = AppSyncListPayload(graphQLData: json, apiName: nil, variables: nil, documentName: nil)
         let data = try encoder.encode(appSyncPayload)
 
         let harness = try decoder.decode(AppSyncListDecoderHarness<Post4>.self, from: data)
@@ -57,7 +57,7 @@ class AppSyncListDecoderTests: XCTestCase {
             XCTFail("Could get AppSyncListProvider")
             return
         }
-        guard case .loaded(let elements, let nextToken, let filter) = provider.loadedState else {
+        guard case .loaded(let elements, let nextToken, let filter, _, _) = provider.loadedState else {
             XCTFail("Should be in loaded state")
             return
         }
@@ -76,7 +76,7 @@ class AppSyncListDecoderTests: XCTestCase {
             ],
             "nextToken": "nextToken"
         ]
-        let appSyncPayload = AppSyncListPayload(graphQLData: json, apiName: nil, variables: nil)
+        let appSyncPayload = AppSyncListPayload(graphQLData: json, apiName: nil, variables: nil, documentName: nil)
         let data = try encoder.encode(appSyncPayload)
         do {
             _ = try decoder.decode(AppSyncListDecoderHarness<Post4>.self, from: data)
@@ -120,7 +120,7 @@ class AppSyncListDecoderTests: XCTestCase {
             XCTFail("Could get AppSyncListProvider")
             return
         }
-        guard case .loaded(let elements, let nextToken, let filter) = provider.loadedState else {
+        guard case .loaded(let elements, let nextToken, let filter, _, _) = provider.loadedState else {
             XCTFail("Should be in loaded state")
             return
         }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListPayloadTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListPayloadTests.swift
@@ -22,7 +22,8 @@ class AppSyncListPayloadTests: XCTestCase {
         ]
         let payload = AppSyncListPayload(graphQLData: JSONValue.null,
                                          apiName: "apiName",
-                                         variables: variables)
+                                         variables: variables,
+                                         documentName: nil)
 
         guard let limit = payload.limit else {
             XCTFail("Could not get limit from payload")
@@ -52,7 +53,8 @@ class AppSyncListPayloadTests: XCTestCase {
         ]
         let payload = AppSyncListPayload(graphQLData: JSONValue.null,
                                          apiName: "apiName",
-                                         variables: variables)
+                                         variables: variables,
+                                         documentName: nil)
 
         XCTAssertNil(payload.graphQLFilter)
         XCTAssertNil(payload.limit)
@@ -61,7 +63,8 @@ class AppSyncListPayloadTests: XCTestCase {
     func testRetrieveNilFilterAndLimit_MissingVariables() {
         let payload = AppSyncListPayload(graphQLData: JSONValue.null,
                                          apiName: "apiName",
-                                         variables: nil)
+                                         variables: nil,
+                                         documentName: nil)
 
         XCTAssertNil(payload.graphQLFilter)
         XCTAssertNil(payload.limit)

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListProviderTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListProviderTests.swift
@@ -59,9 +59,12 @@ class AppSyncListProviderTests: XCTestCase {
             ],
             "limit": 500
         ]
-        let appSyncPayload = AppSyncListPayload(graphQLData: json, apiName: "apiName", variables: variables)
+        let appSyncPayload = AppSyncListPayload(graphQLData: json,
+                                                apiName: "apiName",
+                                                variables: variables,
+                                                documentName: nil)
         let provider = try AppSyncListProvider<Post4>(payload: appSyncPayload)
-        guard case .loaded(let elements, let nextToken, let filter) = provider.loadedState else {
+        guard case .loaded(let elements, let nextToken, let filter, _, _) = provider.loadedState else {
             XCTFail("Should be in loaded state")
             return
         }
@@ -82,7 +85,7 @@ class AppSyncListProviderTests: XCTestCase {
             ],
             "nextToken": "nextToken"
         ]
-        let appSyncPayload = AppSyncListPayload(graphQLData: json, apiName: nil, variables: nil)
+        let appSyncPayload = AppSyncListPayload(graphQLData: json, apiName: nil, variables: nil, documentName: nil)
         do {
             _ = try AppSyncListProvider<Post4>(payload: appSyncPayload)
         } catch _ as DecodingError {
@@ -149,7 +152,7 @@ class AppSyncListProviderTests: XCTestCase {
             XCTFail("Should have been success")
             return
         }
-        guard case .loaded(let elements, let nextToken, let filterOptional) = provider.loadedState else {
+        guard case .loaded(let elements, let nextToken, let filterOptional, _, _) = provider.loadedState else {
             XCTFail("Should be loaded")
             return
         }
@@ -254,7 +257,7 @@ class AppSyncListProviderTests: XCTestCase {
             }
         }
         wait(for: [loadComplete], timeout: 1)
-        guard case .loaded(let elements, let nextToken, let filterOptional) = provider.loadedState else {
+        guard case .loaded(let elements, let nextToken, let filterOptional, _, _) = provider.loadedState else {
             XCTFail("Should be loaded")
             return
         }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/AppSyncGraphQLRequest.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/AppSyncGraphQLRequest.swift
@@ -1,0 +1,84 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+
+public struct AppSyncGraphQLRequest {
+
+    /// Create a valid GraphQL search query against an Amplify provisioned AppSync service. The search API is available
+    /// when the schema used to provision the API contains a model annotated with `@searchable`.
+    /// This is an AppSync specific builder that exposes the fields directly from the service, such as `nextToken`,
+    /// `from`, `limit`, etc, and provides a direct interface to the search query API to make successful requests to AppSync.
+    /// For developers using the Model-based GraphQL APIs, use `Amplify.API.query(request: .search(modelType:where:limit:sort))` instead.
+    ///
+    /// TODO: Implement this using decorators and modify as needed to introduce a new case in `GraphQLQuery` search
+    ///
+    /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+    ///   by host applications. The behavior of this may change without warning.
+    public static func searchQuery<ResponseType: Decodable>(responseType: ResponseType.Type,
+                                                            modelSchema: ModelSchema,
+                                                            filter: [String: Any]? = nil,
+                                                            from: Int? = nil,
+                                                            limit: Int? = nil,
+                                                            nextToken: String? = nil,
+                                                            sort: QuerySortBy? = nil,
+                                                            apiName: String? = nil) -> GraphQLRequest<ResponseType> {
+        let name = modelSchema.name
+        let documentName = "search" + name + "s"
+        var variables = [String: Any]()
+        if let filter = filter {
+            variables.updateValue(filter, forKey: "filter")
+        }
+        if let from = from {
+            variables.updateValue(from, forKey: "from")
+        }
+        if let limit = limit {
+            variables.updateValue(limit, forKey: "limit")
+        }
+        if let nextToken = nextToken {
+            variables.updateValue(nextToken, forKey: "nextToken")
+        }
+        if let sort = sort {
+            switch sort {
+            case .ascending(let field):
+                let sort = [
+                    "direction": "asc",
+                    "field": field.stringValue
+                ]
+                variables.updateValue(sort, forKey: "sort")
+            case .descending(let field):
+                let sort = [
+                    "direction": "desc",
+                    "field": field.stringValue
+                ]
+                variables.updateValue(sort, forKey: "sort")
+            }
+        }
+        let graphQLFields = modelSchema.sortedFields.filter { field in
+            !field.hasAssociation || field.isAssociationOwner
+        }.map { (field) -> String in
+            field.name
+        }.joined(separator: "\n      ")
+        let document = """
+        query \(documentName)($filter: Searchable\(name)FilterInput, $from: Int, $limit: Int, $nextToken: String, $sort: Searchable\(name)SortInput) {
+          \(documentName)(filter: $filter, from: $from, limit: $limit, nextToken: $nextToken, sort: $sort) {
+            items {
+              \(graphQLFields)
+              __typename
+            }
+            nextToken
+            total
+          }
+        }
+        """
+        return GraphQLRequest<ResponseType>(apiName: apiName,
+                                            document: document,
+                                            variables: !variables.isEmpty ? variables : nil,
+                                            responseType: ResponseType.self,
+                                            decodePath: documentName)
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
@@ -117,6 +117,21 @@ protocol ModelGraphQLRequestFactory {
     /// - seealso: `GraphQLSubscription`, `GraphQLSubscriptionType`
     static func subscription<M: Model>(of: M.Type,
                                        type: GraphQLSubscriptionType) -> GraphQLRequest<M>
+
+    // MARK: Searchable
+
+    /// Creates a `GraphQLRequest` that represents a search query that expects multiple values as a result.
+    ///
+    /// - Parameters:
+    ///   - modelType: the metatype of the model
+    ///   - predicate: an optional predicate containing the criteria for the query
+    ///   - limit: the maximum number of results to be retrieved. The result list may be less than the `limit`
+    ///   - sort: the sort direction for a field on the model.
+    /// - Returns: a valid `GraphQLRequest` instance
+    static func search<M: Model>(_ modelType: M.Type,
+                                 where predicate: QueryPredicate?,
+                                 limit: Int?,
+                                 sort: QuerySortBy?) -> GraphQLRequest<List<M>>
 }
 
 // MARK: - Extension
@@ -263,5 +278,17 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
                                  variables: document.variables,
                                  responseType: modelType,
                                  decodePath: document.name)
+    }
+
+    public static func search<M: Model>(_ modelType: M.Type,
+                                        where predicate: QueryPredicate? = nil,
+                                        limit: Int? = nil,
+                                        sort: QuerySortBy? = nil) -> GraphQLRequest<List<M>> {
+        AppSyncGraphQLRequest.searchQuery(responseType: List<M>.self,
+                                          modelSchema: modelType.schema,
+                                          filter: predicate?.graphQLFilter(for: modelType.schema, isSearch: true),
+                                          limit: limit,
+                                          sort: sort)
+
     }
 }


### PR DESCRIPTION
*Related Issues*
https://github.com/aws-amplify/amplify-ios/issues/585

*Previous PR*
https://github.com/aws-amplify/amplify-ios/pull/1009

*Description*
First-class support for models with `@searchable` enabled (https://docs.amplify.aws/cli/graphql-transformer/searchable)

Example schema:
```
type Post @model @searchable {
  id: ID!
  title: String!
  name: String!
  createdAt: String!
  updatedAt: String!
  upvotes: Int
}
```

### Public APIs
1. A public facing GraphQLRequest builder to create a valid search query on a model.
```swift
protocol ModelGraphQLRequestFactory {
    static func search<M: Model>(_ modelType: M.Type,
                                 where predicate: QueryPredicate?,
                                 limit: Int?,
                                 sort: QuerySortBy?) -> GraphQLRequest<List<M>>
}
```
This provides developers an Model-based API to perform search queries on their data. The intention is to get out of the way of developers since they are explicitly enabling `@searchable` on particular models, we do not make the assumption that they always want to perform the search over a list query. The alternative, rather more complex implementation, is for the library to be smart enough to detect that `@searchable` is enabled on the model and to always call search from the `.list` API.

2. QueryPredicate that takes in a custom operator and value
```swift
public struct QueryField {
    public func evaluate(operator: String, value: Persistable) -> QueryPredicateOperation
}
```
This new `QueryPredicationOperation` allows for more advanced use cases of search filters specific to AppSync. This acts as the _escape hatch_, similar to the workaround of using `field(_ name: String) -> QueryField`. This allows developers to fully control their request by providing their own operator and value:
```swift
let predicate = Post.keys.field("title").evaluate(operator: "regexp", value: "k.*y")
```

### Developer experience

1. As a developer, I understand the cost vs performance benefit of performing a search query vs a list query. Based on the app experience I am building, I can decide when perform a search, ie. from map view or search box, or when to perform a list query else where.
```swift
let post = Post.keys
Amplify.API.query(.search(Post.self, where: post.name.contains("myName"), limit: 1000, sort: .ascending(Post.keys.name))
```

2. QueryPredicate parameter `where` allows the developer to search based on a condition. 
```swift
let post = Post.keys
let predicate = post.name.contains("middleName") && post.name.beginsWith("firstName")
```
Internally, the plugin maps these as closely as possible to their expected behavior. Developers should not need to know the following mapping and using the predicates should be intuitive.

| QueryPredicate  | AppSync FilterInput  | ElasticSearch filters (AppSync SearchFilterInput) |
| :------------:|:---------------:|:-----:|
| .notEqual (`!=`)             | "ne" | "ne" |
| .equals (`==`)               |  "eq"  |  "eq" |
| .lessOrEqual (`<=`)      |  "le"  |  "lte" |
| .lessThan (`<`)           |  "lt"  |  "lt" |
| .greaterOrEqual (`>=`)|  "ge"  |  "gte" |
| .greaterThan (`>`)      |  "gt"  |  "gt" |
| .contains             |  "contains"  |  "match" |
| .between            |  "between"  |  "range" |
| .beginsWith         |  "beginsWith"  |  "matchPhrasePrefix" |

*Note*: This mapping is also important for plugin developers to maintain parity across Android and iOS.

Advanced users can use the `evaluate(operator:value)` to pass in any of the Elasticsearch keywords 

```swift
let post = Post.keys
let predicate = post.name.evaluate(operator: "matchPhrase", value: "this is a test")
let predicate = post.name.evaluate(operator: "multiMatch", value: "this is a test")
let predicate = post.name.evaluate(operator: "exists", value: true)
let predicate = post.name.evaluate(operator: "wildcard", value: "S*Elasticsearch!")
let predicate = post.name.evaluate(operator: "regexp", value: "k.*y")
```
Above operators are from [ElasticSearch filters](https://docs.amplify.aws/cli/graphql-transformer/searchable#usage)

4. Pagination. As a developer, I can perform a search query, and retrieve the next page of results.
```swift
let blog = Blog6.keys
let predicate = blog.id.evaluate(operator: "matchPhrasePrefix", value: blogId)
Amplify.API.query(request: .search(Blog6.self, where: predicate, limit: 1)) { result in
    switch result {
    case .success(let result):
        switch result {
        case .success(let blogs):
            for blog in blogs {
               print(blog)
            }
            if blog.hasNextPage() {
                blogs.getNextPage { result in
                        switch result {
                        case .success(let nextPage):
                            print(nextPage)
                        case .failure(let error):
                        }
                    }
           }

```

5. As there are additional parameters and fields that this API does not support. What is not supported:
- `from` parameter in the input
- `total` field in the response
Let us know if this is useful for you and what your use caes is, and as a workaround you create your own custom GraphQLRequest like this [SampleApp](https://github.com/lawmicha/apiSearchable) /  [Code Snippet](https://gist.github.com/lawmicha/d8a9453a3dfdc976f4cfa976a9c4eb30)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
