### PR TITLE
fix: move default operator outside of guard statement

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -20,10 +20,10 @@ extension Model {
         schema.fields.forEach {
             let field = $0.value
             let name = field.graphQLName
-            let fieldValue = self[field.name]
+            let fieldValue = self[field.name] ?? nil
 
             // swiftlint:disable:next syntactic_sugar
-            guard case .some(Optional<Any>.some(let value)) = fieldValue ?? nil else {
+            guard case .some(Optional<Any>.some(let value)) = fieldValue else {
                 input.updateValue(nil, forKey: name)
                 return
             }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/748

*Description of changes:*
This is a minor refactoring of the code as a workaround discovered in https://github.com/aws-amplify/amplify-ios/issues/748 by moving the default operator usage outside the guard statement. This would enable developers to build apps that use the APIPlugin with the Model-to-GraphQLRequest builders on Swift 5.3 while we continue to investigate the issue

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
