### PR TITLE
feat(datastore): Dispatch outboxMutationEnqueued, outboxMutationProcessed events

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreCategory+HubPayloadEventName.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+HubPayloadEventName.swift
@@ -39,10 +39,10 @@ public extension HubPayload.EventName.DataStore {
     static let syncQueriesStarted = "DataStore.syncQueriesStarted"
 
     /// Dispatched when a local mutation is enqueued into the outbox. (Doesn't matter if while online or offline)
-    /// Hubpayload `outboxMutationEvent` contains modelName `model` and instance of model `element`
+    /// HubPayload `outboxMutationEvent` contains modelName `model` and instance of model `element`
     static let outboxMutationEnqueued = "DataStore.outboxMutationEnqueued"
 
     /// Dispatched when a mutation from outbox is sent to backend and updated locally.
-    /// Hubpayload `outboxMutationEvent` contains modelName `model` and instance of model `element`
+    /// HubPayload `outboxMutationEvent` contains modelName `model` and instance of model `element`
     static let outboxMutationProcessed = "DataStore.outboxMutationProcessed"
 }

--- a/Amplify/Categories/DataStore/DataStoreCategory+HubPayloadEventName.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+HubPayloadEventName.swift
@@ -37,4 +37,12 @@ public extension HubPayload.EventName.DataStore {
     /// Dispatched when DataStore is about to start sync queries
     /// HubPayload `syncQueriesStartedEvent` contains an array of each model's `name`
     static let syncQueriesStarted = "DataStore.syncQueriesStarted"
+
+    /// Dispatched when a local mutation is enqueued into the outbox. (Doesn't matter if while online or offline)
+    /// Hubpayload `outboxMutationEvent` contains modelName `model` and instance of model `element`
+    static let outboxMutationEnqueued = "DataStore.outboxMutationEnqueued"
+
+    /// Dispatched when a mutation from outbox is sent to backend and updated locally.
+    /// Hubpayload `outboxMutationEvent` contains modelName `model` and instance of model `element`
+    static let outboxMutationProcessed = "DataStore.outboxMutationProcessed"
 }

--- a/Amplify/Categories/DataStore/DataStoreCategory+HubPayloadEventName.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+HubPayloadEventName.swift
@@ -38,11 +38,11 @@ public extension HubPayload.EventName.DataStore {
     /// HubPayload `syncQueriesStartedEvent` contains an array of each model's `name`
     static let syncQueriesStarted = "DataStore.syncQueriesStarted"
 
-    /// Dispatched when a local mutation is enqueued into the outbox. (Doesn't matter if while online or offline)
-    /// HubPayload `outboxMutationEvent` contains modelName `model` and instance of model `element`
+    /// Dispatched when a local mutation is enqueued into the outgoing mutation queue `outbox`
+    /// HubPayload `outboxMutationEvent` contains the name and instance of the model
     static let outboxMutationEnqueued = "DataStore.outboxMutationEnqueued"
 
-    /// Dispatched when a mutation from outbox is sent to backend and updated locally.
-    /// HubPayload `outboxMutationEvent` contains modelName `model` and instance of model `element`
+    /// Dispatched when a mutation from outgoing mutation queue `outbox` is sent to backend and updated locally.
+    /// HubPayload `outboxMutationEvent` contains the name and instance of the model
     static let outboxMutationProcessed = "DataStore.outboxMutationProcessed"
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/OutboxMutationEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/OutboxMutationEvent.swift
@@ -8,6 +8,7 @@
 import Amplify
 import AWSPluginsCore
 
+/// Used as HubPayload for `OutboxMutationEnqueued` and `OutboxMutationProcessed`
 public struct OutboxMutationEvent {
     public var modelName: String
     public var element: OutboxMutationEventElement

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/OutboxMutationEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/OutboxMutationEvent.swift
@@ -10,8 +10,8 @@ import AWSPluginsCore
 
 /// Used as HubPayload for `OutboxMutationEnqueued` and `OutboxMutationProcessed`
 public struct OutboxMutationEvent {
-    public var modelName: String
-    public var element: OutboxMutationEventElement
+    public let modelName: String
+    public let element: OutboxMutationEventElement
 
     public init(modelName: String, element: OutboxMutationEventElement) {
         self.modelName = modelName

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/OutboxMutationEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/OutboxMutationEvent.swift
@@ -10,12 +10,12 @@ import AWSPluginsCore
 
 public struct OutboxMutationEvent {
     public var modelName: String
-    public var element: OutboxMutationEventMetadata
+    public var element: OutboxMutationEventElement
 
     public static func fromModelWithMetadata(modelName: String,
                                              model: Model,
                                              mutationSync: MutationSync<AnyModel>) -> OutboxMutationEvent {
-        let element = OutboxMutationEventMetadata(model: model,
+        let element = OutboxMutationEventElement(model: model,
                                                   version: mutationSync.syncMetadata.version,
                                                   lastChangedAt: mutationSync.syncMetadata.lastChangedAt,
                                                   deleted: mutationSync.syncMetadata.deleted)
@@ -24,16 +24,16 @@ public struct OutboxMutationEvent {
 
     public static func fromModelWithoutMetadata(modelName: String,
                                                 model: Model) -> OutboxMutationEvent {
-        let element = OutboxMutationEventMetadata(model: model)
+        let element = OutboxMutationEventElement(model: model)
         return fromModel(modelName: modelName, element: element)
     }
 
-    public static func fromModel(modelName: String, element: OutboxMutationEventMetadata) -> OutboxMutationEvent {
+    public static func fromModel(modelName: String, element: OutboxMutationEventElement) -> OutboxMutationEvent {
         return OutboxMutationEvent(modelName: modelName, element: element)
     }
 }
 
-public struct OutboxMutationEventMetadata {
+public struct OutboxMutationEventElement {
     public let model: Model
     public var version: Int?
     public var lastChangedAt: Int?

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/OutboxMutationEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/OutboxMutationEvent.swift
@@ -13,6 +13,10 @@ public struct OutboxMutationEvent {
     public var modelName: String
     public var element: OutboxMutationEventElement
 
+    public init(modelName: String, element: OutboxMutationEventElement) {
+        self.modelName = modelName
+        self.element = element
+    }
     public static func fromModelWithMetadata(modelName: String,
                                              model: Model,
                                              mutationSync: MutationSync<AnyModel>) -> OutboxMutationEvent {
@@ -20,23 +24,19 @@ public struct OutboxMutationEvent {
                                                  version: mutationSync.syncMetadata.version,
                                                  lastChangedAt: mutationSync.syncMetadata.lastChangedAt,
                                                  deleted: mutationSync.syncMetadata.deleted)
-        return fromModel(modelName: modelName, element: element)
+        return OutboxMutationEvent(modelName: modelName, element: element)
     }
 
     public static func fromModelWithoutMetadata(modelName: String,
                                                 model: Model) -> OutboxMutationEvent {
         let element = OutboxMutationEventElement(model: model)
-        return fromModel(modelName: modelName, element: element)
-    }
-
-    public static func fromModel(modelName: String, element: OutboxMutationEventElement) -> OutboxMutationEvent {
         return OutboxMutationEvent(modelName: modelName, element: element)
     }
-}
 
-public struct OutboxMutationEventElement {
-    public let model: Model
-    public var version: Int?
-    public var lastChangedAt: Int?
-    public var deleted: Bool?
+    public struct OutboxMutationEventElement {
+        public let model: Model
+        public var version: Int?
+        public var lastChangedAt: Int?
+        public var deleted: Bool?
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/OutboxMutationEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/OutboxMutationEvent.swift
@@ -1,0 +1,41 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import AWSPluginsCore
+
+public struct OutboxMutationEvent {
+    public var modelName: String
+    public var element: OutboxMutationEventMetadata
+
+    public static func fromModelWithMetadata(modelName: String,
+                                             model: Model,
+                                             mutationSync: MutationSync<AnyModel>) -> OutboxMutationEvent {
+        let element = OutboxMutationEventMetadata(model: model,
+                                                  version: mutationSync.syncMetadata.version,
+                                                  lastChangedAt: mutationSync.syncMetadata.lastChangedAt,
+                                                  deleted: mutationSync.syncMetadata.deleted)
+        return fromModel(modelName: modelName, element: element)
+    }
+
+    public static func fromModelWithoutMetadata(modelName: String,
+                                                model: Model) -> OutboxMutationEvent {
+        let element = OutboxMutationEventMetadata(model: model)
+        return fromModel(modelName: modelName, element: element)
+    }
+
+    public static func fromModel(modelName: String, element: OutboxMutationEventMetadata) -> OutboxMutationEvent {
+        return OutboxMutationEvent(modelName: modelName, element: element)
+    }
+}
+
+public struct OutboxMutationEventMetadata {
+    public let model: Model
+    public var version: Int?
+    public var lastChangedAt: Int?
+    public var deleted: Bool?
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/OutboxMutationEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/OutboxMutationEvent.swift
@@ -16,9 +16,9 @@ public struct OutboxMutationEvent {
                                              model: Model,
                                              mutationSync: MutationSync<AnyModel>) -> OutboxMutationEvent {
         let element = OutboxMutationEventElement(model: model,
-                                                  version: mutationSync.syncMetadata.version,
-                                                  lastChangedAt: mutationSync.syncMetadata.lastChangedAt,
-                                                  deleted: mutationSync.syncMetadata.deleted)
+                                                 version: mutationSync.syncMetadata.version,
+                                                 lastChangedAt: mutationSync.syncMetadata.lastChangedAt,
+                                                 deleted: mutationSync.syncMetadata.deleted)
         return fromModel(modelName: modelName, element: element)
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -205,8 +205,6 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
             stateMachine.notify(action: .enqueuedEvent)
         } catch {
             log.error("Couldn't decode local model")
-//            operationQueue.addOperation(syncMutationToCloudOperation)
-//            stateMachine.notify(action: .enqueuedEvent)
             return
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -253,7 +253,7 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
 
             if let mutationSyncMetadata = mutationSyncMetadata {
                 self.dispatchOutboxMutationProcessedEvent(mutationEvent: mutationEvent,
-                                                          mutationSyncMetadata: mutationSyncMetadata)
+                                                          mutationSync: mutationSyncMetadata)
             }
             self.queryMutationEventsFromStorage {
                 self.stateMachine.notify(action: .processedEvent)
@@ -280,18 +280,18 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
     }
 
     private func dispatchOutboxMutationProcessedEvent(mutationEvent: MutationEvent,
-                                                      mutationSyncMetadata: MutationSync<AnyModel>) {
+                                                      mutationSync: MutationSync<AnyModel>) {
         do {
             let localModel = try mutationEvent.decodeModel()
             let outboxMutationProcessedEvent = OutboxMutationEvent
                 .fromModelWithMetadata(modelName: mutationEvent.modelName,
                                        model: localModel,
-                                       mutationSync: mutationSyncMetadata)
+                                       mutationSync: mutationSync)
             let payload = HubPayload(eventName: HubPayload.EventName.DataStore.outboxMutationProcessed,
                                      data: outboxMutationProcessedEvent)
             Amplify.Hub.dispatch(to: .dataStore, payload: payload)
         } catch {
-            log.error("Couldn't decode local model")
+            log.error("\(#function) Couldn't decode local model as \(mutationEvent.modelName)")
             return
         }
     }
@@ -306,7 +306,7 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
                                      data: outboxMutationEnqueuedEvent)
             Amplify.Hub.dispatch(to: .dataStore, payload: payload)
         } catch {
-            log.error("Couldn't decode local model")
+            log.error("\(#function) Couldn't decode local model as \(mutationEvent.modelName)")
             return
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -272,22 +272,15 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
                 return
             }
 
-            let outboxMutationProcessedEvent: OutboxMutationEvent
-            if mutationSyncMetadata == nil {
-                outboxMutationProcessedEvent = OutboxMutationEvent
-                .fromModelWithoutMetadata(modelName: mutationEvent.modelName,
-                                          model: localModel)
-            } else {
-                guard let mutationSyncMetadata = mutationSyncMetadata else {
-                    self.log.error("Couldn't get mutationSyncMetadata")
-                    self.stateMachine.notify(action: .processedEvent)
-                    return
-                }
-                outboxMutationProcessedEvent = OutboxMutationEvent
-                    .fromModelWithMetadata(modelName: mutationEvent.modelName,
-                                           model: localModel,
-                                           mutationSync: mutationSyncMetadata)
+            /// Only emit `outboxMutationProcessed` when a successful response returns
+            guard let mutationSyncMetadata = mutationSyncMetadata else {
+                self.stateMachine.notify(action: .processedEvent)
+                return
             }
+            let outboxMutationProcessedEvent = OutboxMutationEvent
+                .fromModelWithMetadata(modelName: mutationEvent.modelName,
+                                       model: localModel,
+                                       mutationSync: mutationSyncMetadata)
 
             self.dispatchOutboxMutationEvent(eventName: HubPayload.EventName.DataStore.outboxMutationProcessed,
                                              outboxMutationEvent: outboxMutationProcessedEvent)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreHubEventsTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreHubEventsTests.swift
@@ -63,6 +63,7 @@ class DataStoreHubEventTests: HubEventsIntegrationTestBase {
         }
 
         waitForExpectations(timeout: networkTimeout, handler: nil)
+        Amplify.Hub.removeListener(hubListener)
     }
 
     /// - Given:
@@ -72,13 +73,13 @@ class DataStoreHubEventTests: HubEventsIntegrationTestBase {
     ///    - Call `Amplify.DataStore.save()` to save a Post model
     /// - Then:
     ///    - outboxMutationEnqueued received, payload should be:
-    ///      {modelName: "Post", element: {id: #, content: "some content}}
+    ///      {modelName: "Post", element: {id: #, content: "some content"}}
     ///    - outboxMutationProcessed received, payload should be:
-    ///      {modelName: "Post", element: {model: {id: #, content: "some content}, version: 1, deleted: false, lastChangedAt: "some time"}}
+    ///      {modelName: "Post", element: {model: {id: #, content: "some content"}, version: 1, deleted: false, lastChangedAt: "some time"}}
     func testOutboxMutationEvents() throws {
 
         let post = Post(title: "title", content: "content", createdAt: .now())
-        
+
         let outboxMutationEnqueuedReceived = expectation(description: "outboxMutationEnqueued received")
         let outboxMutationProcessedReceived = expectation(description: "outboxMutationProcessed received")
 
@@ -115,9 +116,9 @@ class DataStoreHubEventTests: HubEventsIntegrationTestBase {
             return
         }
 
-        
         Amplify.DataStore.save(post) { _ in }
 
         waitForExpectations(timeout: networkTimeout, handler: nil)
+        Amplify.Hub.removeListener(hubListener)
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreHubEventsTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreHubEventsTests.swift
@@ -102,7 +102,6 @@ class DataStoreHubEventTests: HubEventsIntegrationTestBase {
                     return
                 }
                 XCTAssertEqual(outboxMutationProcessedEvent.modelName, "Post")
-                XCTAssertEqual(outboxMutationProcessedEvent.modelName, "Post")
                 XCTAssertEqual(outboxMutationProcessedEvent.element.model.modelName, "Post")
                 XCTAssertEqual(outboxMutationProcessedEvent.element.version, 1)
                 XCTAssertNotNil(outboxMutationProcessedEvent.element.lastChangedAt)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreHubEventsTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreHubEventsTests.swift
@@ -64,4 +64,61 @@ class DataStoreHubEventTests: HubEventsIntegrationTestBase {
 
         waitForExpectations(timeout: networkTimeout, handler: nil)
     }
+
+    /// - Given:
+    ///    - registered two models from `TestModelRegistration`
+    ///    - no pending MutationEvents in MutationEvent database
+    /// - When:
+    ///    - Call `Amplify.DataStore.save()` to save a Post model
+    /// - Then:
+    ///    - outboxMutationEnqueued received, payload should be:
+    ///      {modelName: "Post", element: {id: #, content: "some content}}
+    ///    - outboxMutationProcessed received, payload should be:
+    ///      {modelName: "Post", element: {model: {id: #, content: "some content}, version: 1, deleted: false, lastChangedAt: "some time"}}
+    func testOutboxMutationEvents() throws {
+
+        let post = Post(title: "title", content: "content", createdAt: .now())
+        
+        let outboxMutationEnqueuedReceived = expectation(description: "outboxMutationEnqueued received")
+        let outboxMutationProcessedReceived = expectation(description: "outboxMutationProcessed received")
+
+        let hubListener = Amplify.Hub.listen(to: .dataStore) { payload in
+            if payload.eventName == HubPayload.EventName.DataStore.outboxMutationEnqueued {
+                guard let outboxMutationEnqueuedEvent = payload.data as? OutboxMutationEvent else {
+                    XCTFail("Failed to cast payload data as OutboxMutationEvent")
+                    return
+                }
+                XCTAssertEqual(outboxMutationEnqueuedEvent.modelName, "Post")
+                XCTAssertEqual(outboxMutationEnqueuedEvent.element.model.modelName, "Post")
+                XCTAssertNil(outboxMutationEnqueuedEvent.element.version)
+                XCTAssertNil(outboxMutationEnqueuedEvent.element.lastChangedAt)
+                XCTAssertNil(outboxMutationEnqueuedEvent.element.deleted)
+                outboxMutationEnqueuedReceived.fulfill()
+            }
+
+            if payload.eventName == HubPayload.EventName.DataStore.outboxMutationProcessed {
+                guard let outboxMutationProcessedEvent = payload.data as? OutboxMutationEvent else {
+                    XCTFail("Failed to cast payload data as OutboxMutationEvent")
+                    return
+                }
+                XCTAssertEqual(outboxMutationProcessedEvent.modelName, "Post")
+                XCTAssertEqual(outboxMutationProcessedEvent.modelName, "Post")
+                XCTAssertEqual(outboxMutationProcessedEvent.element.model.modelName, "Post")
+                XCTAssertEqual(outboxMutationProcessedEvent.element.version, 1)
+                XCTAssertNotNil(outboxMutationProcessedEvent.element.lastChangedAt)
+                XCTAssertEqual(outboxMutationProcessedEvent.element.deleted, false)
+                outboxMutationProcessedReceived.fulfill()
+            }
+        }
+
+        guard try HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
+            XCTFail("Listener not registered for hub")
+            return
+        }
+
+        
+        Amplify.DataStore.save(post) { _ in }
+
+        waitForExpectations(timeout: networkTimeout, handler: nil)
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/README.md
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/README.md
@@ -27,6 +27,6 @@ The following steps demonstrate how to set up DataStore with a conflict resoluti
 
 4. `amplify push`
 
-5. Copy `awsconfiguration.json` over to the Config folder
+5. Copy `amplifyconfiguration.json` over to the Config folder
 
 You should now be able to run all of the tests 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
@@ -65,7 +65,7 @@ class OutgoingMutationQueueMockStateTest: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    func testRequestingEvent_subscriptionSetup() {
+    func testRequestingEvent_subscriptionSetup() throws {
         let semaphore = DispatchSemaphore(value: 0)
         stateMachine.pushExpectActionCriteria { action in
             XCTAssertEqual(action, OutgoingMutationQueue.Action.receivedSubscription)
@@ -73,6 +73,7 @@ class OutgoingMutationQueueMockStateTest: XCTestCase {
         }
         stateMachine.state = .starting(apiBehavior, publisher)
         semaphore.wait()
+
         let json = "{\"id\":\"1234\",\"title\":\"t\",\"content\":\"c\",\"createdAt\":\"2020-09-03T22:55:13.424Z\"}"
         let futureResult = MutationEvent(modelId: "1",
                                          modelName: "Post",
@@ -81,18 +82,41 @@ class OutgoingMutationQueueMockStateTest: XCTestCase {
         eventSource.pushMutationEvent(futureResult: .success(futureResult))
 
         let enqueueEvent = expectation(description: "state requestingEvent, enqueueEvent")
-//        let processEvent = expectation(description: "state requestingEvent, processedEvent")
+        let processEvent = expectation(description: "state requestingEvent, processedEvent")
+
         stateMachine.pushExpectActionCriteria { action in
             XCTAssertEqual(action, OutgoingMutationQueue.Action.enqueuedEvent)
             enqueueEvent.fulfill()
         }
-//        stateMachine.pushExpectActionCriteria { action in
-//            XCTAssertEqual(action, OutgoingMutationQueue.Action.processedEvent)
-//            processEvent.fulfill()
-//        }
+
+        let mutateAPICallExpecation = expectation(description: "Call to api category for mutate")
+        var listenerFromRequest: GraphQLOperation<MutationSync<AnyModel>>.ResultListener!
+        let responder = MutateRequestListenerResponder<MutationSync<AnyModel>> { _, eventListener in
+            mutateAPICallExpecation.fulfill()
+            listenerFromRequest = eventListener
+            return nil
+        }
+        apiBehavior.responders[.mutateRequestListener] = responder
+
         stateMachine.state = .requestingEvent
 
-        waitForExpectations(timeout: 1)
+        wait(for: [enqueueEvent, mutateAPICallExpecation], timeout: 1)
+
+        stateMachine.pushExpectActionCriteria { action in
+            XCTAssertEqual(action, OutgoingMutationQueue.Action.processedEvent)
+            processEvent.fulfill()
+        }
+
+        let model = MockSynced(id: "id-1")
+        let anyModel = try model.eraseToAnyModel()
+        let remoteSyncMetadata = MutationSyncMetadata(id: model.id,
+                                                      deleted: false,
+                                                      lastChangedAt: Date().unixSeconds,
+                                                      version: 2)
+        let remoteMutationSync = MutationSync(model: anyModel, syncMetadata: remoteSyncMetadata)
+        listenerFromRequest(.success(.success(remoteMutationSync)))
+
+        wait(for: [processEvent], timeout: 1)
     }
 
     func testRequestingEvent_nosubscription() {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
@@ -73,22 +73,23 @@ class OutgoingMutationQueueMockStateTest: XCTestCase {
         }
         stateMachine.state = .starting(apiBehavior, publisher)
         semaphore.wait()
+        let json = "{\"id\":\"1234\",\"title\":\"t\",\"content\":\"c\",\"createdAt\":\"2020-09-03T22:55:13.424Z\"}"
         let futureResult = MutationEvent(modelId: "1",
                                          modelName: "Post",
-                                         json: "{}",
+                                         json: json,
                                          mutationType: MutationEvent.MutationType.create)
         eventSource.pushMutationEvent(futureResult: .success(futureResult))
 
         let enqueueEvent = expectation(description: "state requestingEvent, enqueueEvent")
-        let processEvent = expectation(description: "state requestingEvent, processedEvent")
+//        let processEvent = expectation(description: "state requestingEvent, processedEvent")
         stateMachine.pushExpectActionCriteria { action in
             XCTAssertEqual(action, OutgoingMutationQueue.Action.enqueuedEvent)
             enqueueEvent.fulfill()
         }
-        stateMachine.pushExpectActionCriteria { action in
-            XCTAssertEqual(action, OutgoingMutationQueue.Action.processedEvent)
-            processEvent.fulfill()
-        }
+//        stateMachine.pushExpectActionCriteria { action in
+//            XCTAssertEqual(action, OutgoingMutationQueue.Action.processedEvent)
+//            processEvent.fulfill()
+//        }
         stateMachine.state = .requestingEvent
 
         waitForExpectations(timeout: 1)

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		D80064F62499297800935DA3 /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80064F52499297800935DA3 /* MockFileManager.swift */; };
 		D838AB4424FF264600BF4940 /* OutboxStatusEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838AB4324FF264600BF4940 /* OutboxStatusEvent.swift */; };
 		D838AB4624FF268400BF4940 /* SyncQueriesStartedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838AB4524FF268400BF4940 /* SyncQueriesStartedEvent.swift */; };
+		D88666A425070FC6000F7A14 /* OutboxMutationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88666A325070FC6000F7A14 /* OutboxMutationEvent.swift */; };
 		D888E80A24A65B3800F4CE3E /* DataStoreLocalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D888E80924A65B3800F4CE3E /* DataStoreLocalStoreTests.swift */; };
 		D888E80C24A65DC200F4CE3E /* LocalStoreIntegrationTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D888E80B24A65DC200F4CE3E /* LocalStoreIntegrationTestBase.swift */; };
 		D8B90862249839D4002593F5 /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21233DD7247591D100039337 /* amplifyconfiguration.json */; };
@@ -317,6 +318,7 @@
 		D80064F52499297800935DA3 /* MockFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFileManager.swift; sourceTree = "<group>"; };
 		D838AB4324FF264600BF4940 /* OutboxStatusEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutboxStatusEvent.swift; sourceTree = "<group>"; };
 		D838AB4524FF268400BF4940 /* SyncQueriesStartedEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncQueriesStartedEvent.swift; sourceTree = "<group>"; };
+		D88666A325070FC6000F7A14 /* OutboxMutationEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutboxMutationEvent.swift; sourceTree = "<group>"; };
 		D888E80924A65B3800F4CE3E /* DataStoreLocalStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreLocalStoreTests.swift; sourceTree = "<group>"; };
 		D888E80B24A65DC200F4CE3E /* LocalStoreIntegrationTestBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalStoreIntegrationTestBase.swift; sourceTree = "<group>"; };
 		D8C5BA58249815A6007C3A68 /* DataStoreConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreConfigurationTests.swift; sourceTree = "<group>"; };
@@ -665,6 +667,7 @@
 			children = (
 				D838AB4524FF268400BF4940 /* SyncQueriesStartedEvent.swift */,
 				D838AB4324FF264600BF4940 /* OutboxStatusEvent.swift */,
+				D88666A325070FC6000F7A14 /* OutboxMutationEvent.swift */,
 			);
 			path = Events;
 			sourceTree = "<group>";
@@ -1524,6 +1527,7 @@
 				FAED5738238B3A2A008EBED8 /* AWSIncomingSubscriptionEventPublisher.swift in Sources */,
 				FACBA78F23949C75006349C8 /* AWSMutationDatabaseAdapter.swift in Sources */,
 				FA55A54D2391F96E002AFF2D /* AWSMutationDatabaseAdapter+MutationEventSource.swift in Sources */,
+				D88666A425070FC6000F7A14 /* OutboxMutationEvent.swift in Sources */,
 				2149E5CE2388684F00873955 /* SQLStatement+CreateTable.swift in Sources */,
 				6B3CC68023F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift in Sources */,
 				FACBB2AE238AFAE800C29602 /* AWSDataStorePlugin+DataStoreBaseBehavior.swift in Sources */,

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -49,6 +49,7 @@ class MockAPICategoryPlugin: MessageReporter, APICategoryPlugin {
                                                  responseType: request.responseType,
                                                  options: options)
         let operation = MockGraphQLOperation(request: request, responseType: request.responseType)
+        
         return operation
     }
 


### PR DESCRIPTION
*Description of changes:*

In this PR, I will implement:

- outboxMutationEnqueued
- outboxMutationProcessed

### outboxMutation
```swift
{
    "model": "Note",
    "element": {
        "id": "d98f54ff-53dd-44d0-b99f-562e8f58ae3c",
        "content": "I am some content",
        "_version": 1,
        "_lastChangedAt": 1594938571692,
        "_deleted": null
    }
}
 // iOS equivalent
 struct OutboxMutationEvent {
    let modelName: String
    let element: OutboxMutationEventElement
 }

struct OutboxMutationEventElement {
    let model: Model
    let version: Int?
    let lastChangedAt: Int?
    let deleted: Bool?
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
