### PR TITLE
AppSyncList POC

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -121,6 +121,11 @@
 		21C395B3245729EC00597EA2 /* AppSyncErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C395B2245729EC00597EA2 /* AppSyncErrorType.swift */; };
 		21D79FDA237617C60057D00D /* SubscriptionEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D79FD9237617C60057D00D /* SubscriptionEvent.swift */; };
 		21D79FE32377F4120057D00D /* SubscriptionConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D79FE22377F4120057D00D /* SubscriptionConnectionState.swift */; };
+		21DF40362509CAC000D649A8 /* Paginatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DF40352509CAC000D649A8 /* Paginatable.swift */; };
+		21DF4044250A90A800D649A8 /* AppSyncList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DF4043250A90A800D649A8 /* AppSyncList.swift */; };
+		21DF4046250A90B600D649A8 /* AppSyncList+Paginatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DF4045250A90B600D649A8 /* AppSyncList+Paginatable.swift */; };
+		21DF4048250A90C000D649A8 /* AppSyncListPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DF4047250A90C000D649A8 /* AppSyncListPayload.swift */; };
+		21DF404B250A994300D649A8 /* AppSyncListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DF404A250A994300D649A8 /* AppSyncListTests.swift */; };
 		21F40A3A23A294770074678E /* TestConfigHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F40A3923A294770074678E /* TestConfigHelper.swift */; };
 		21F40A3C23A2952C0074678E /* AuthHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F40A3B23A2952C0074678E /* AuthHelper.swift */; };
 		21F40A3E23A295390074678E /* AWSMobileClient+Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F40A3D23A295390074678E /* AWSMobileClient+Message.swift */; };
@@ -783,6 +788,11 @@
 		21C395B2245729EC00597EA2 /* AppSyncErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncErrorType.swift; sourceTree = "<group>"; };
 		21D79FD9237617C60057D00D /* SubscriptionEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionEvent.swift; sourceTree = "<group>"; };
 		21D79FE22377F4120057D00D /* SubscriptionConnectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionConnectionState.swift; sourceTree = "<group>"; };
+		21DF40352509CAC000D649A8 /* Paginatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paginatable.swift; sourceTree = "<group>"; };
+		21DF4043250A90A800D649A8 /* AppSyncList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncList.swift; sourceTree = "<group>"; };
+		21DF4045250A90B600D649A8 /* AppSyncList+Paginatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSyncList+Paginatable.swift"; sourceTree = "<group>"; };
+		21DF4047250A90C000D649A8 /* AppSyncListPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncListPayload.swift; sourceTree = "<group>"; };
+		21DF404A250A994300D649A8 /* AppSyncListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncListTests.swift; sourceTree = "<group>"; };
 		21F40A3923A294770074678E /* TestConfigHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestConfigHelper.swift; sourceTree = "<group>"; };
 		21F40A3B23A2952C0074678E /* AuthHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthHelper.swift; sourceTree = "<group>"; };
 		21F40A3D23A295390074678E /* AWSMobileClient+Message.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSMobileClient+Message.swift"; sourceTree = "<group>"; };
@@ -1491,6 +1501,7 @@
 		2129BE0223947FA3006363A1 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				21DF402B2509BFA000D649A8 /* Collection */,
 				FA8EE775238626C70097E4F1 /* AnyModel */,
 				212CE6FF23E9E938007D8E71 /* Decorator */,
 				2129BE0523948005006363A1 /* GraphQLDocument */,
@@ -1539,6 +1550,7 @@
 		2129BE2223948085006363A1 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				21DF4049250A993200D649A8 /* Collection */,
 				21AD4259249C0D7C0016FE95 /* AnyModel */,
 				21A3FDAD24630D4200E76120 /* Decorator */,
 				2129BE262394828A006363A1 /* GraphQLDocument */,
@@ -1747,6 +1759,24 @@
 				21C395B2245729EC00597EA2 /* AppSyncErrorType.swift */,
 			);
 			path = API;
+			sourceTree = "<group>";
+		};
+		21DF402B2509BFA000D649A8 /* Collection */ = {
+			isa = PBXGroup;
+			children = (
+				21DF4043250A90A800D649A8 /* AppSyncList.swift */,
+				21DF4045250A90B600D649A8 /* AppSyncList+Paginatable.swift */,
+				21DF4047250A90C000D649A8 /* AppSyncListPayload.swift */,
+			);
+			path = Collection;
+			sourceTree = "<group>";
+		};
+		21DF4049250A993200D649A8 /* Collection */ = {
+			isa = PBXGroup;
+			children = (
+				21DF404A250A994300D649A8 /* AppSyncListTests.swift */,
+			);
+			path = Collection;
 			sourceTree = "<group>";
 		};
 		21FFF999230C96E0005878EA /* Operation */ = {
@@ -2629,6 +2659,7 @@
 				B9FAA174238EFC59009414B4 /* String+Extensions.swift */,
 				B9A329CB243559BF00C5B80C /* TimeInterval+Helper.swift */,
 				219A88EC23F3309800BBC5F2 /* Tree.swift */,
+				21DF40352509CAC000D649A8 /* Paginatable.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -4042,6 +4073,7 @@
 				21AD424E249BF0E90016FE95 /* AnyModel+Subscript.swift in Sources */,
 				21420AA0237222A900FA140C /* AWSAuthorizationType.swift in Sources */,
 				B4EBEB64246204D000D06375 /* AuthAWSCredentialsProvider.swift in Sources */,
+				21DF4046250A90B600D649A8 /* AppSyncList+Paginatable.swift in Sources */,
 				212CE6FC23E9E523007D8E71 /* SelectionSet.swift in Sources */,
 				2129BE1F2394806B006363A1 /* Model+GraphQL.swift in Sources */,
 				212CE70323E9E967007D8E71 /* GraphQLMutation.swift in Sources */,
@@ -4061,6 +4093,7 @@
 				212CE70D23E9E991007D8E71 /* FilterDecorator.swift in Sources */,
 				219A888123EB629800BBC5F2 /* ModelBasedGraphQLDocumentDecorator.swift in Sources */,
 				212CE70423E9E967007D8E71 /* GraphQLSubscription.swift in Sources */,
+				21DF4044250A90A800D649A8 /* AppSyncList.swift in Sources */,
 				21420A99237222A900FA140C /* APIKeyProvider.swift in Sources */,
 				21A3FDB224630D9F00E76120 /* AuthRuleDecorator.swift in Sources */,
 				6BBECD7123ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift in Sources */,
@@ -4082,6 +4115,7 @@
 				B4EBEB66246204E400D06375 /* AuthCognitoTokensProvider.swift in Sources */,
 				21AD424D249BF0E50016FE95 /* AnyModel+Schema.swift in Sources */,
 				2129BE4F23949F1B006363A1 /* MutationSyncMetadata+Schema.swift in Sources */,
+				21DF4048250A90C000D649A8 /* AppSyncListPayload.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4108,6 +4142,7 @@
 				6BBECD7423ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift in Sources */,
 				21AD425A249C0D910016FE95 /* AnyModelTester.swift in Sources */,
 				2129BE3C2394828B006363A1 /* GraphQLRequestModelTests.swift in Sources */,
+				21DF404B250A994300D649A8 /* AppSyncListTests.swift in Sources */,
 				2183A56523EA4A8400232880 /* GraphQLListQueryTests.swift in Sources */,
 				21AD425B249C0DBE0016FE95 /* AnyModelTests.swift in Sources */,
 				D83C5160248964780091548E /* ModelGraphQLTests.swift in Sources */,
@@ -4198,6 +4233,7 @@
 				2142099823721F4400FA140C /* RESTOperationRequest.swift in Sources */,
 				6BB7441023A9954900B0EB6C /* DispatchSource+MakeOneOff.swift in Sources */,
 				21FFF994230C96CB005878EA /* StorageUploadDataOperation.swift in Sources */,
+				21DF40362509CAC000D649A8 /* Paginatable.swift in Sources */,
 				95DAAB30237E63370028544F /* IdentifyAction.swift in Sources */,
 				21D79FE32377F4120057D00D /* SubscriptionConnectionState.swift in Sources */,
 				B43DC73A2410526C00D40275 /* AuthError.swift in Sources */,

--- a/Amplify/Categories/DataStore/Model/Collection/List+Model.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+Model.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+public protocol ListModel { }
+
 /// `List<ModelType>` is a DataStore-aware custom `Collection` that is capable of loading
 /// records from the `DataStore` on-demand. This is specially useful when dealing with
 /// Model associations that need to be lazy loaded.
@@ -14,7 +16,7 @@ import Foundation
 /// When using `DataStore.query(_ modelType:)` some models might contain associations
 /// with other models and those aren't fetched automatically. This collection keeps track
 /// of the associated `id` and `field` and fetches the associated data on demand.
-public class List<ModelType: Model>: Collection, Codable, ExpressibleByArrayLiteral {
+open class List<ModelType: Model>: Collection, Codable, ExpressibleByArrayLiteral, ListModel {
 
     public typealias Index = Int
     public typealias Element = ModelType
@@ -46,9 +48,9 @@ public class List<ModelType: Model>: Collection, Codable, ExpressibleByArrayLite
         self.state = .loaded
     }
 
-    init(_ elements: Elements,
-         associatedId: Model.Identifier? = nil,
-         associatedField: ModelField? = nil) {
+    public init(_ elements: Elements,
+                associatedId: Model.Identifier? = nil,
+                associatedField: ModelField? = nil) {
         self.elements = elements
         self.associatedId = associatedId
         self.associatedField = associatedField

--- a/Amplify/Core/Support/Paginatable.swift
+++ b/Amplify/Core/Support/Paginatable.swift
@@ -1,0 +1,14 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+public protocol Paginatable {
+    associatedtype Page
+    associatedtype PageError: Error
+    typealias PageResult = ((Result<Page, PageError>) -> Void)
+    func next(onComplete: @escaping PageResult)
+    func hasNext() -> Bool
+}

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		21D7A118237B54D90057D00D /* APIKeyURLRequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0D5237B54D90057D00D /* APIKeyURLRequestInterceptor.swift */; };
 		21D7A119237B54D90057D00D /* IAMURLRequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0D6237B54D90057D00D /* IAMURLRequestInterceptor.swift */; };
 		21D7A11A237B54D90057D00D /* AWSAPICategoryPluginError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0D7237B54D90057D00D /* AWSAPICategoryPluginError.swift */; };
+		21DF403C2509D49300D649A8 /* GraphQLResponseDecoder+AppSyncList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DF403B2509D49300D649A8 /* GraphQLResponseDecoder+AppSyncList.swift */; };
 		21E2E2282451E66A007D7767 /* GraphQLResponseDecoder+DecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E2E2272451E66A007D7767 /* GraphQLResponseDecoder+DecodeError.swift */; };
 		21E2E22A2451E6B5007D7767 /* GraphQLResponseDecoderDecodeErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E2E2292451E6B5007D7767 /* GraphQLResponseDecoderDecodeErrorTests.swift */; };
 		21F40A2B23A0423C0074678E /* GraphQLSyncBasedTests-amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21F40A2923A0423C0074678E /* GraphQLSyncBasedTests-amplifyconfiguration.json */; };
@@ -354,6 +355,7 @@
 		21D7A0D6237B54D90057D00D /* IAMURLRequestInterceptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IAMURLRequestInterceptor.swift; sourceTree = "<group>"; };
 		21D7A0D7237B54D90057D00D /* AWSAPICategoryPluginError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSAPICategoryPluginError.swift; sourceTree = "<group>"; };
 		21D7A0DE237B54D90057D00D /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		21DF403B2509D49300D649A8 /* GraphQLResponseDecoder+AppSyncList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLResponseDecoder+AppSyncList.swift"; sourceTree = "<group>"; };
 		21E2E2272451E66A007D7767 /* GraphQLResponseDecoder+DecodeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLResponseDecoder+DecodeError.swift"; sourceTree = "<group>"; };
 		21E2E2292451E6B5007D7767 /* GraphQLResponseDecoderDecodeErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLResponseDecoderDecodeErrorTests.swift; sourceTree = "<group>"; };
 		21F40A2923A0423C0074678E /* GraphQLSyncBasedTests-amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GraphQLSyncBasedTests-amplifyconfiguration.json"; sourceTree = "<group>"; };
@@ -826,6 +828,7 @@
 				21D7A0CB237B54D90057D00D /* GraphQLOperationRequestUtils.swift */,
 				21D7A0CD237B54D90057D00D /* GraphQLOperationRequestUtils+Validator.swift */,
 				21D7A0CE237B54D90057D00D /* GraphQLResponseDecoder.swift */,
+				21DF403B2509D49300D649A8 /* GraphQLResponseDecoder+AppSyncList.swift */,
 				21E2E2272451E66A007D7767 /* GraphQLResponseDecoder+DecodeError.swift */,
 				21409C5F2384DF17000A53C9 /* RESTOperationRequest+RESTRequest.swift */,
 				21D7A0C7237B54D90057D00D /* RESTOperationRequest+Validate.swift */,
@@ -2161,6 +2164,7 @@
 				21D7A0E0237B54D90057D00D /* AWSGraphQLSubscriptionOperation.swift in Sources */,
 				21D7A10B237B54D90057D00D /* AWSAppSyncGraphQLResponse.swift in Sources */,
 				2129BE3E239486D2006363A1 /* AnyModel+JSONInit.swift in Sources */,
+				21DF403C2509D49300D649A8 /* GraphQLResponseDecoder+AppSyncList.swift in Sources */,
 				214BD3B223FB5C4C0059A286 /* SubscriptionConnectionFactory.swift in Sources */,
 				21D7A0E4237B54D90057D00D /* APIOperation.swift in Sources */,
 				21D7A11A237B54D90057D00D /* AWSAPICategoryPluginError.swift in Sources */,

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLOperation+APIOperation.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLOperation+APIOperation.swift
@@ -64,7 +64,9 @@ extension AWSGraphQLOperation: APIOperation {
             let graphQLResponse = try GraphQLResponseDecoder.decode(graphQLServiceResponse: graphQLServiceResponse,
                                                                     responseType: request.responseType,
                                                                     decodePath: request.decodePath,
-                                                                    rawGraphQLResponse: graphQLResponseData)
+                                                                    rawGraphQLResponse: graphQLResponseData,
+                                                                    document: request.document,
+                                                                    variables: request.variables)
 
             dispatch(result: .success(graphQLResponse))
             finish()

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/GraphQLResponseDecoder+AppSyncList.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/GraphQLResponseDecoder+AppSyncList.swift
@@ -1,0 +1,42 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Amplify
+import AWSPluginsCore
+
+extension GraphQLResponseDecoder {
+
+    static func decodeToAppSyncList<R: Decodable>(responseData: R,
+                                                  responseType: R.Type,
+                                                  graphQLData: JSONValue,
+                                                  document: String? = nil,
+                                                  variables: [String: Any]? = nil) throws -> R {
+        if responseData is ListModel, let document = document {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = ModelDateFormatting.decodingStrategy
+            let payload: AppSyncListPayload
+            if let variables = variables {
+                let variablesData = try JSONSerialization.data(withJSONObject: variables)
+                let variablesJSON = try decoder.decode([String: JSONValue].self, from: variablesData)
+                payload = AppSyncListPayload(document: document,
+                                             variables: variablesJSON,
+                                             graphQLData: graphQLData)
+            } else {
+                payload = AppSyncListPayload(document: document,
+                                             graphQLData: graphQLData)
+            }
+
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
+            let encodedData = try encoder.encode(payload)
+            return try decoder.decode(responseType, from: encodedData)
+        }
+
+        return responseData
+    }
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/README.md
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/README.md
@@ -44,7 +44,7 @@ type Comment @model {
     id: ID!
     content: String!
     createdAt: AWSDateTime!
-    post: Post @connection(name: "PostComment")
+    post: Post! @connection(name: "PostComment")
 }
 ```
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Collection/AppSyncList+Paginatable.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Collection/AppSyncList+Paginatable.swift
@@ -1,0 +1,59 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+
+extension AppSyncList: Paginatable {
+
+    public typealias Page = AppSyncList<ModelType>
+    public typealias PageError = APIError
+
+    public func next(onComplete: @escaping PageResult) {
+        guard let nextToken = nextToken, let document = document else {
+            onComplete(.failure(APIError.operationError("Missing next Token", "check hasNext()")))
+            return
+        }
+
+        let updatedVariables: [String: JSONValue]
+        if var storedVariables = variables {
+            storedVariables.updateValue(.string(nextToken), forKey: "nextToken")
+            updatedVariables = storedVariables
+        } else {
+            updatedVariables = ["nextToken": .string(nextToken)]
+        }
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
+
+        guard let variablesData = try? encoder.encode(updatedVariables),
+              let variablesJSON = try? JSONSerialization.jsonObject(with: variablesData) as? [String: Any] else {
+            onComplete(.failure(APIError.operationError("Could not serialize request", "")))
+            return
+        }
+
+        let request = GraphQLRequest<AppSyncList<ModelType>>(document: document,
+                                                             variables: variablesJSON,
+                                                             responseType: AppSyncList<ModelType>.self)
+        Amplify.API.query(request: request) { result in
+            switch result {
+            case .success(let graphQLResponse):
+                switch graphQLResponse {
+                case .success(let list):
+                    onComplete(.success(list))
+                case .failure(let graphQLError):
+                    onComplete(.failure(APIError(error: graphQLError)))
+                }
+            case .failure(let apiError):
+                onComplete(.failure(apiError))
+            }
+        }
+    }
+
+    public func hasNext() -> Bool {
+        return nextToken != nil
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Collection/AppSyncList.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Collection/AppSyncList.swift
@@ -1,0 +1,68 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+
+public class AppSyncList<ModelType: Model>: List<ModelType> {
+
+    let nextToken: String?
+    let document: String?
+    let variables: [String: JSONValue]?
+
+    // MARK: - Initializers
+
+    init(_ elements: [Element],
+         nextToken: String? = nil,
+         document: String? = nil,
+         variables: [String: JSONValue]? = nil) {
+        self.nextToken = nextToken
+        self.document = document
+        self.variables = variables
+        super.init(elements, associatedId: nil, associatedField: nil)
+    }
+
+    required convenience init(arrayLiteral elements: List<ModelType>.Element...) {
+        self.init(elements)
+    }
+
+    required convenience public init(from decoder: Decoder) throws {
+        let json = try JSONValue(from: decoder)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
+
+        if let payload = try? AppSyncListPayload.init(from: decoder) {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = ModelDateFormatting.decodingStrategy
+            let elements = try payload.getItems().map { (jsonElement) -> ModelType in
+                let serializedJSON = try encoder.encode(jsonElement)
+                return try decoder.decode(ModelType.self, from: serializedJSON)
+            }
+
+            self.init(elements,
+                      nextToken: payload.getNextToken(),
+                      document: payload.document,
+                      variables: payload.variables)
+            return
+        }
+
+        guard case let .object(jsonObject) = json,
+              case let .array(jsonArray) = jsonObject["items"] else {
+            self.init([ModelType]())
+            return
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = ModelDateFormatting.decodingStrategy
+        let elements = try jsonArray.map { (jsonElement) -> ModelType in
+            let serializedJSON = try encoder.encode(jsonElement)
+            return try decoder.decode(ModelType.self, from: serializedJSON)
+        }
+
+        self.init(elements)
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Collection/AppSyncListPayload.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Collection/AppSyncListPayload.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+
+public struct AppSyncListPayload: Codable {
+    let document: String
+    let variables: [String: JSONValue]?
+    private let graphQLData: JSONValue
+
+    public init(document: String, variables: [String: JSONValue]? = nil, graphQLData: JSONValue) {
+        self.document = document
+        self.variables = variables
+        self.graphQLData = graphQLData
+    }
+
+    func getNextToken() -> String? {
+        if case let .string(nextToken) = graphQLData["nextToken"] {
+            return nextToken
+        }
+        return nil
+    }
+
+    func getItems() -> [JSONValue] {
+        if case let .array(jsonArray) = graphQLData["items"] {
+            return jsonArray
+        }
+        return []
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Collection/AppSyncListTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Collection/AppSyncListTests.swift
@@ -1,0 +1,124 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+@testable import AWSPluginsCore
+@testable import AmplifyTestCommon
+
+class AppSyncListTests: XCTestCase {
+
+    override func setUp() {
+        Amplify.reset()
+        ModelRegistry.register(modelType: Post.self)
+        do {
+            let configWithAPI = try setUpAPICategory()
+            try Amplify.configure(configWithAPI)
+        } catch {
+            XCTFail(String(describing: "Unable to setup API category for unit tests"))
+        }
+    }
+
+    func testAppSyncListDeserializeFromGraphQLResponse() throws {
+        let graphQLData: JSONValue = [
+            "items": [[
+                "id": "1",
+                "title": JSONValue.init(stringLiteral: "title"),
+                "content": JSONValue.init(stringLiteral: "content"),
+                "createdAt": JSONValue.init(stringLiteral: Temporal.DateTime.now().iso8601String)
+            ], [
+                "id": "2",
+                "title": JSONValue.init(stringLiteral: "title"),
+                "content": JSONValue.init(stringLiteral: "content"),
+                "createdAt": JSONValue.init(stringLiteral: Temporal.DateTime.now().iso8601String)
+            ]],
+            "nextToken": "nextToken"
+        ]
+        let serializedData = try AppSyncListTests.serialize(json: graphQLData)
+
+        let list = try AppSyncListTests.deserialize(serializedData, responseType: Post.self)
+        XCTAssertNotNil(list)
+    }
+
+    func testAppSyncListDeserializeFromAppSyncListPayload() throws {
+        let graphQLData: JSONValue = [
+            "items": [[
+                "id": "1",
+                "title": JSONValue.init(stringLiteral: "title"),
+                "content": JSONValue.init(stringLiteral: "content"),
+                "createdAt": JSONValue.init(stringLiteral: Temporal.DateTime.now().iso8601String)
+            ], [
+                "id": "2",
+                "title": JSONValue.init(stringLiteral: "title"),
+                "content": JSONValue.init(stringLiteral: "content"),
+                "createdAt": JSONValue.init(stringLiteral: Temporal.DateTime.now().iso8601String)
+            ]],
+            "nextToken": "nextToken"
+        ]
+        let document = "query listPost"
+        let variables: [String: JSONValue] = ["limit": "1000"]
+        let payload = AppSyncListPayload(document: document,
+                                         variables: variables,
+                                         graphQLData: graphQLData)
+        let serializedPayload = try AppSyncListTests.serialize(payload: payload)
+
+        let list = try AppSyncListTests.deserialize(serializedPayload, responseType: Post.self)
+        guard let appSyncList = list as? AppSyncList else {
+            XCTFail("Could not cast to AppSyncList")
+            return
+        }
+
+        XCTAssertTrue(appSyncList.hasNext())
+        let nextPageSuccess = expectation(description: "Retrieve next page successfully")
+
+        appSyncList.next { result in
+            switch result {
+            case .success(let nextPage):
+                XCTAssertFalse(nextPage.hasNext())
+                nextPageSuccess.fulfill()
+            case .failure(let error):
+                XCTFail("Failed to get next page: \(error)")
+            }
+        }
+        wait(for: [nextPageSuccess], timeout: 1.0)
+    }
+
+    private static func serialize(json: JSONValue) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
+        return try encoder.encode(json)
+    }
+
+    private static func serialize(payload: AppSyncListPayload) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
+        return try encoder.encode(payload)
+    }
+
+    private static func deserialize<R: Decodable>(_ data: Data, responseType: R.Type) throws -> List<R> {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = ModelDateFormatting.decodingStrategy
+        return try decoder.decode(AppSyncList<R>.self, from: data)
+    }
+
+    private func setUpAPICategory() throws -> AmplifyConfiguration {
+        let apiPlugin = MockAPICategoryPlugin()
+        apiPlugin.responders[.queryRequestListener] = QueryRequestListenerResponder<AppSyncList<Post>> { _, listener in
+            let list = AppSyncList<Post>()
+            let event: GraphQLOperation<AppSyncList<Post>>.OperationResult = .success(.success(list))
+            listener?(event)
+            return nil
+        }
+        try Amplify.add(plugin: apiPlugin)
+
+        let apiConfig = APICategoryConfiguration(plugins: [
+            "MockAPICategoryPlugin": true
+        ])
+        let amplifyConfig = AmplifyConfiguration(api: apiConfig)
+        return amplifyConfig
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Retrieving top level list of models with pagination functionality
```
static func paginatedList<M: Model>(_ modelType: M.Type, where predicate: QueryPredicate?, limit: Int?) 
      -> GraphQLRequest<AppSyncList<M>>
```
This introduces a new Model-to-GraphQLRequest builder that returns `AppSyncList`, and can be used for retrieve subseqential pages of data.

Alternatively, we can introduce a breaking change to replace `.list` which returns `[M]` instead of namespacing this `.paginatedList`.


**High level details**
`AppSyncList` is a subclass of `List` (now made as an open class), and conforms to `Paginatable`.
```
public class AppSyncList<ModelType: Model>: List<ModelType>, Paginatable
```
`List`, made open for `AppSyncList` to subclass and conforms to an empty protocol `ListModel`
```
open class List<ModelType: Model>: Collection, Codable, ExpressibleByArrayLiteral, ListModel
```

`Paginatable`, contains pagination related interface. *To be reviewed*
```
public protocol Paginatable {
    associatedtype Page
    associatedtype PageError: Error
    typealias PageResult = ((Result<Page, PageError>) -> Void)
    func next(onComplete: @escaping PageResult)
    func hasNext() -> Bool
}
```
*note: in lazy load functionality of list, it uses a lock to turn the async operation into syncrhonous, whereas here i've opt-d to keep it a callback*

`ListModel`, empty protocol, used in APIPlugin to indicate a second decode attempt can be done to store additional information in the response.
```
public protocol ListModel { }
```
*TODO: this empty protocol "marker" should probably be conformed to by AppSyncList, not on the List. 

**APIPlugin decoding logic**
APIPlugin does two decode passes. First pass decodes data from AppSync. Second pass is only taken when the data is successfully decoded from the first pass and is of  type `ListModel`. For ListModel types, a second decoding attempt is done to decode with `AppSyncListPayload` as the data.

`AppSyncListPayload`, contains additional request information to be stored in the responseType
```
public struct AppSyncListPayload: Codable {
    let document: String
    let variables: [String: JSONValue]?
    private let graphQLData: JSONValue
}
```

The second decoding attempt is required to store non-response data back in the response, such as the document and variables from the request. Having this request information in the response allows the pagination functionality to work. ie.

```
func hasNext() {
  // retrieve from graphQLData, check if nextToken is nil
}
```

```
func getNextPage() {
   // construct request with document, update variables with nextToken from graphQLData, perform API.query
  // return new results as next page
}
```





By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
