### PR TITLE
refactor(datastore): Remove dependency on ModelType from ModelDecorator

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -1638,13 +1638,6 @@
 			path = Decorator;
 			sourceTree = "<group>";
 		};
-		213481D7242AFA58001966DE /* Support */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Support;
-			sourceTree = "<group>";
-		};
 		21409C562384C57D000A53C9 /* GraphQL */ = {
 			isa = PBXGroup;
 			children = (
@@ -3166,7 +3159,6 @@
 				B99EF4B423DB020C00D821BC /* TemporalComparableTests.swift */,
 				B9AF547D23F37DF20059E6C4 /* TemporalOperationTests.swift */,
 				B91A87A323D64B0F0049A12F /* TemporalTests.swift */,
-				213481D7242AFA58001966DE /* Support */,
 				B4944D51251C141200BF0BFE /* JSONValueHolderTest.swift */,
 			);
 			path = DataStore;

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry+Syncable.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry+Syncable.swift
@@ -11,7 +11,7 @@ public extension ModelRegistry {
     ///   by host applications. The behavior of this may change without warning.
     static var hasSyncableModels: Bool {
         if #available(iOS 13.0, *) {
-            return models.contains { !$0.schema.isSystem }
+            return modelSchemas.contains { !$0.isSystem }
         } else {
             return false
         }

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
@@ -35,23 +35,21 @@ public struct ModelRegistry {
     }
 
     public static func register(modelType: Model.Type) {
-        register(modelName: modelType.modelName,
-                 modelSchema: modelType.schema,
-                 modelType: modelType) { (jsonString, jsonDecoder) -> Model in
+        register(modelType: modelType,
+                 modelSchema: modelType.schema) { (jsonString, jsonDecoder) -> Model in
             let model = try modelType.from(json: jsonString, decoder: jsonDecoder)
             return model
         }
     }
 
-    public static func register(modelName: ModelName,
+    public static func register(modelType: Model.Type,
                                 modelSchema: ModelSchema,
-                                modelType: Model.Type,
                                 jsonDecoder: @escaping (String, JSONDecoder?) throws -> Model) {
         concurrencyQueue.sync {
             let modelDecoder: ModelDecoder = { jsonString, decoder in
                 return try jsonDecoder(jsonString, decoder)
             }
-
+            let modelName = modelSchema.name
             modelSchemaMapping[modelName] = modelSchema
             modelTypes[modelName] = modelType
             modelDecoders[modelName] = modelDecoder

--- a/Amplify/Categories/DataStore/Model/JSONHelper/JSONValueHolder.swift
+++ b/Amplify/Categories/DataStore/Model/JSONHelper/JSONValueHolder.swift
@@ -18,7 +18,7 @@ import Foundation
 ///             let values: [String: Any]
 ///
 ///             public func internalValue(for key: String) -> Any? {
-///                 return values[key] 
+///                 return values[key]
 ///             }
 ///          }
 public protocol JSONValueHolder {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
@@ -33,7 +33,7 @@ public struct AuthRuleDecorator: ModelBasedGraphQLDocumentDecorator {
     public init(_ authRuleDecoratorInput: AuthRuleDecoratorInput) {
         self.input = authRuleDecoratorInput
     }
-    
+
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
         decorate(document, modelSchema: modelType.schema)

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
@@ -35,8 +35,8 @@ public struct AuthRuleDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
-                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
-        let authRules = modelType.schema.authRules
+                         modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
+        let authRules = modelSchema.authRules
         guard !authRules.isEmpty else {
             return document
         }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
@@ -33,6 +33,11 @@ public struct AuthRuleDecorator: ModelBasedGraphQLDocumentDecorator {
     public init(_ authRuleDecoratorInput: AuthRuleDecoratorInput) {
         self.input = authRuleDecoratorInput
     }
+    
+    public func decorate(_ document: SingleDirectiveGraphQLDocument,
+                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+        decorate(document, modelSchema: modelType.schema)
+    }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
@@ -21,6 +21,11 @@ public struct ConflictResolutionDecorator: ModelBasedGraphQLDocumentDecorator {
         self.version = version
         self.lastSync = lastSync
     }
+    
+    public func decorate(_ document: SingleDirectiveGraphQLDocument,
+                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+        decorate(document, modelSchema: modelType.schema)
+    }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
@@ -21,7 +21,7 @@ public struct ConflictResolutionDecorator: ModelBasedGraphQLDocumentDecorator {
         self.version = version
         self.lastSync = lastSync
     }
-    
+
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
         decorate(document, modelSchema: modelType.schema)

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
@@ -23,7 +23,7 @@ public struct ConflictResolutionDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
-                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+                         modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
 
         if let version = version,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/DirectiveNameDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/DirectiveNameDecorator.swift
@@ -36,18 +36,18 @@ public struct DirectiveNameDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
-                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+                         modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
 
         if let queryType = queryType {
-            return document.copy(name: modelType.schema.graphQLName(queryType: queryType))
+            return document.copy(name: modelSchema.graphQLName(queryType: queryType))
         }
 
         if let mutationType = mutationType {
-            return document.copy(name: modelType.schema.graphQLName(mutationType: mutationType))
+            return document.copy(name: modelSchema.graphQLName(mutationType: mutationType))
         }
 
         if let subscriptionType = subscriptionType {
-            return document.copy(name: modelType.schema.graphQLName(subscriptionType: subscriptionType))
+            return document.copy(name: modelSchema.graphQLName(subscriptionType: subscriptionType))
         }
 
         return document

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/DirectiveNameDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/DirectiveNameDecorator.swift
@@ -34,7 +34,7 @@ public struct DirectiveNameDecorator: ModelBasedGraphQLDocumentDecorator {
         self.mutationType = nil
         self.subscriptionType = type
     }
-    
+
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
         decorate(document, modelSchema: modelType.schema)

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/DirectiveNameDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/DirectiveNameDecorator.swift
@@ -34,6 +34,11 @@ public struct DirectiveNameDecorator: ModelBasedGraphQLDocumentDecorator {
         self.mutationType = nil
         self.subscriptionType = type
     }
+    
+    public func decorate(_ document: SingleDirectiveGraphQLDocument,
+                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+        decorate(document, modelSchema: modelType.schema)
+    }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/FilterDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/FilterDecorator.swift
@@ -19,9 +19,9 @@ public struct FilterDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
-                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+                         modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
-        let modelName = modelType.schema.name
+        let modelName = modelSchema.name
         if case .mutation = document.operationType {
             inputs["condition"] = GraphQLDocumentInput(type: "Model\(modelName)ConditionInput",
                 value: .object(filter))

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/FilterDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/FilterDecorator.swift
@@ -17,6 +17,11 @@ public struct FilterDecorator: ModelBasedGraphQLDocumentDecorator {
     public init(filter: GraphQLFilter) {
         self.filter = filter
     }
+    
+    public func decorate(_ document: SingleDirectiveGraphQLDocument,
+                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+        decorate(document, modelSchema: modelType.schema)
+    }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/FilterDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/FilterDecorator.swift
@@ -17,7 +17,7 @@ public struct FilterDecorator: ModelBasedGraphQLDocumentDecorator {
     public init(filter: GraphQLFilter) {
         self.filter = filter
     }
-    
+
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
         decorate(document, modelSchema: modelType.schema)

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelBasedGraphQLDocumentDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelBasedGraphQLDocumentDecorator.swift
@@ -9,5 +9,5 @@ import Foundation
 import Amplify
 
 public protocol ModelBasedGraphQLDocumentDecorator {
-    func decorate(_ document: SingleDirectiveGraphQLDocument, modelType: Model.Type) -> SingleDirectiveGraphQLDocument
+    func decorate(_ document: SingleDirectiveGraphQLDocument, modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelBasedGraphQLDocumentDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelBasedGraphQLDocumentDecorator.swift
@@ -9,11 +9,11 @@ import Foundation
 import Amplify
 
 public protocol ModelBasedGraphQLDocumentDecorator {
-    
+
     @available(*, deprecated, message: """
     Decorating using Model.Type is deprecated, instead use modelSchema method.
     """)
     func decorate(_ document: SingleDirectiveGraphQLDocument, modelType: Model.Type) -> SingleDirectiveGraphQLDocument
-    
+
     func decorate(_ document: SingleDirectiveGraphQLDocument, modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelBasedGraphQLDocumentDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelBasedGraphQLDocumentDecorator.swift
@@ -9,5 +9,11 @@ import Foundation
 import Amplify
 
 public protocol ModelBasedGraphQLDocumentDecorator {
+    
+    @available(*, deprecated, message: """
+    Decorating using Model.Type is deprecated, instead use modelSchema method.
+    """)
+    func decorate(_ document: SingleDirectiveGraphQLDocument, modelType: Model.Type) -> SingleDirectiveGraphQLDocument
+    
     func decorate(_ document: SingleDirectiveGraphQLDocument, modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelDecorator.swift
@@ -23,7 +23,7 @@ public struct ModelDecorator: ModelBasedGraphQLDocumentDecorator {
                          modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
         decorate(document, modelSchema: modelType.schema)
     }
-    
+
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelDecorator.swift
@@ -20,6 +20,11 @@ public struct ModelDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
+                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+        decorate(document, modelSchema: modelType.schema)
+    }
+    
+    public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
         var graphQLInput = model.graphQLInput

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelDecorator.swift
@@ -20,12 +20,12 @@ public struct ModelDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
-                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+                         modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
         var graphQLInput = model.graphQLInput
 
-        if !modelType.schema.authRules.isEmpty {
-            modelType.schema.authRules.forEach { authRule in
+        if !modelSchema.authRules.isEmpty {
+            modelSchema.authRules.forEach { authRule in
                 if authRule.allow == .owner {
                     let ownerField = authRule.getOwnerFieldOrDefault()
                     graphQLInput = graphQLInput.filter { (field, value) -> Bool in

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelIdDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelIdDecorator.swift
@@ -18,7 +18,7 @@ public struct ModelIdDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
-                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+                         modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
 
         if case .mutation = document.operationType {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelIdDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelIdDecorator.swift
@@ -21,7 +21,7 @@ public struct ModelIdDecorator: ModelBasedGraphQLDocumentDecorator {
                          modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
         decorate(document, modelSchema: modelType.schema)
     }
-    
+
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelIdDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelIdDecorator.swift
@@ -18,6 +18,11 @@ public struct ModelIdDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
+                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+        decorate(document, modelSchema: modelType.schema)
+    }
+    
+    public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/PaginationDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/PaginationDecorator.swift
@@ -20,6 +20,11 @@ public struct PaginationDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
+                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+        decorate(document, modelSchema: modelType.schema)
+    }
+    
+    public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/PaginationDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/PaginationDecorator.swift
@@ -20,7 +20,7 @@ public struct PaginationDecorator: ModelBasedGraphQLDocumentDecorator {
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
-                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+                         modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
 
         if let limit = limit {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/PaginationDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/PaginationDecorator.swift
@@ -23,7 +23,7 @@ public struct PaginationDecorator: ModelBasedGraphQLDocumentDecorator {
                          modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
         decorate(document, modelSchema: modelType.schema)
     }
-    
+
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/ModelBasedGraphQLDocumentBuilder.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/ModelBasedGraphQLDocumentBuilder.swift
@@ -42,7 +42,7 @@ public struct ModelBasedGraphQLDocumentBuilder {
     public mutating func build() -> SingleDirectiveGraphQLDocument {
 
         let decoratedDocument = decorators.reduce(document) { doc, decorator in
-            decorator.decorate(doc, modelType: self.modelType)
+            decorator.decorate(doc, modelSchema: self.modelType.schema)
         }
 
         return decoratedDocument

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
@@ -12,7 +12,7 @@ protocol ModelStorageBehavior {
 
     func save<M: Model>(_ model: M,
                         modelSchema: ModelSchema,
-                        where condition: QueryPredicate?,
+                        condition: QueryPredicate?,
                         completion: @escaping DataStoreCallback<M>)
 
     func save<M: Model>(_ model: M,
@@ -20,10 +20,12 @@ protocol ModelStorageBehavior {
                         completion: @escaping DataStoreCallback<M>)
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           withId id: Model.Identifier,
                           completion: @escaping DataStoreCallback<M?>)
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           predicate: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -97,12 +97,12 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
     }
 
     func save<M: Model>(_ model: M, condition: QueryPredicate? = nil, completion: @escaping DataStoreCallback<M>) {
-         save(model, modelSchema: model.schema, where: condition, completion: completion)
+         save(model, modelSchema: model.schema, condition: condition, completion: completion)
      }
 
     func save<M: Model>(_ model: M,
                         modelSchema: ModelSchema,
-                        where condition: QueryPredicate? = nil,
+                        condition: QueryPredicate? = nil,
                         completion: DataStoreCallback<M>) {
         do {
             let modelType = type(of: model)
@@ -159,10 +159,11 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
     }
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           predicate: QueryPredicate,
                           completion: (DataStoreResult<[M]>) -> Void) {
         do {
-            let statement = DeleteStatement(modelSchema: modelType.schema, predicate: predicate)
+            let statement = DeleteStatement(modelSchema: modelSchema, predicate: predicate)
             _ = try connection.prepare(statement.stringValue).run(statement.variables)
             completion(.success([]))
         } catch {
@@ -171,9 +172,10 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
     }
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           withId id: Model.Identifier,
                           completion: (DataStoreResult<M?>) -> Void) {
-        delete(untypedModelType: modelType, withId: id) { result in
+        delete(untypedModelType: modelType, modelSchema: modelSchema, withId: id) { result in
             switch result {
             case .success:
                 completion(.success(nil))
@@ -184,10 +186,11 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
     }
 
     func delete(untypedModelType modelType: Model.Type,
+                modelSchema: ModelSchema,
                 withId id: Model.Identifier,
                 completion: DataStoreCallback<Void>) {
         do {
-            let statement = DeleteStatement(modelSchema: modelType.schema, withId: id)
+            let statement = DeleteStatement(modelSchema: modelSchema, withId: id)
             _ = try connection.prepare(statement.stringValue).run(statement.variables)
             completion(.emptyResult)
         } catch {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -15,14 +15,17 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
     func save(untypedModel: Model, completion: @escaping DataStoreCallback<Model>)
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           withId id: Model.Identifier,
                           completion: DataStoreCallback<M?>)
 
     func delete(untypedModelType modelType: Model.Type,
+                modelSchema: ModelSchema,
                 withId id: Model.Identifier,
                 completion: DataStoreCallback<Void>)
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           predicate: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
@@ -145,7 +145,7 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
             let group = DispatchGroup()
             localEvents.forEach {
                 group.enter()
-                storageAdapter.delete(MutationEvent.self, withId: $0.id) { _ in group.leave() }
+                storageAdapter.delete(MutationEvent.self, modelSchema: MutationEvent.schema, withId: $0.id) { _ in group.leave() }
             }
             group.wait()
             completionPromise(.success(candidate))
@@ -166,7 +166,7 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
                 // TODO: Handle errors from delete
                 localEvents
                     .suffix(from: 1)
-                    .forEach { storageAdapter.delete(MutationEvent.self, withId: $0.id) { _ in } }
+                    .forEach { storageAdapter.delete(MutationEvent.self, modelSchema: MutationEvent.schema, withId: $0.id) { _ in } }
             }
 
             let resolvedEvent = getResolvedEvent(for: eventToUpdate, applying: candidate)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
@@ -275,7 +275,7 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
             return
         }
 
-        storageAdapter.delete(untypedModelType: modelType, withId: id) { response in
+        storageAdapter.delete(untypedModelType: modelType, modelSchema: modelType.schema, withId: id) { response in
             switch response {
             case .failure(let dataStoreError):
                 let error = DataStoreError.unknown("Delete failed \(dataStoreError)", "")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -217,7 +217,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
             return
         }
 
-        storageAdapter.delete(untypedModelType: modelType, withId: remoteModel.model.id) { response in
+        storageAdapter.delete(untypedModelType: modelType, modelSchema: modelType.schema, withId: remoteModel.model.id) { response in
             switch response {
             case .failure(let dataStoreError):
                 let errorAction = Action.errored(dataStoreError)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -274,7 +274,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             switch insertResult {
             case .success:
                 saveExpectation.fulfill()
-                self.storageAdapter.delete(Post.self, withId: post.id) {
+                self.storageAdapter.delete(Post.self, modelSchema: Post.schema, withId: post.id) {
                     switch $0 {
                     case .success:
                         deleteExpectation.fulfill()
@@ -306,7 +306,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                 saveExpectation.fulfill()
                 let postKeys = Post.keys
                 let predicate = postKeys.createdAt.gt(dateTestStart)
-                self.storageAdapter.delete(Post.self, predicate: predicate) { result in
+                self.storageAdapter.delete(Post.self, modelSchema: Post.schema, predicate: predicate) { result in
                     switch result {
                     case .success:
                         deleteExpectation.fulfill()
@@ -345,7 +345,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                     postsAdded.append(post.id)
                     if counter == maxCount - 1 {
                         saveExpectation.fulfill()
-                        self.storageAdapter.delete(Post.self, predicate: QueryPredicateConstant.all) { result in
+                        self.storageAdapter.delete(Post.self, modelSchema: Post.schema, predicate: QueryPredicateConstant.all) { result in
                             switch result {
                             case .success:
                                 deleteExpectation.fulfill()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -63,18 +63,21 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
     // MARK: - StorageEngineAdapter
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           withId id: Model.Identifier,
                           completion: DataStoreCallback<M?>) {
         XCTFail("Not expected to execute")
     }
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           predicate: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>) {
         XCTFail("Not expected to execute")
     }
 
     func delete(untypedModelType modelType: Model.Type,
+                modelSchema: ModelSchema,
                 withId id: String,
                 completion: (Result<Void, DataStoreError>) -> Void) {
         if let responder = responders[.deleteUntypedModel] as? DeleteUntypedModelCompletionResponder {
@@ -145,7 +148,7 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
 
     func save<M: Model>(_ model: M,
                         modelSchema: ModelSchema,
-                        where: QueryPredicate?,
+                        condition where: QueryPredicate?,
                         completion: @escaping DataStoreCallback<M>) {
         if let responder = responders[.saveModelCompletion] as? SaveModelCompletionResponder<M> {
             responder.callback((model, completion))
@@ -224,18 +227,20 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
 
     func save<M: Model>(_ model: M,
                         modelSchema: ModelSchema,
-                        where: QueryPredicate?,
+                        condition where: QueryPredicate?,
                         completion: @escaping DataStoreCallback<M>) {
         XCTFail("Not expected to execute")
     }
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           withId id: Model.Identifier,
                           completion: DataStoreCallback<M?>) {
         completion(.success(nil))
     }
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           predicate: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>) {
         XCTFail("Not expected to execute")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
@@ -53,10 +53,8 @@ struct TestJsonModelRegistration: AmplifyModelRegistration {
                                               rating.name: rating,
                                               comments.name: comments])
 
-        ModelRegistry.register(modelName: postSchema.name,
-                               modelSchema: postSchema,
-                               modelType: DynamicModel.self) { (_, _) -> Model in
-                                DynamicModel(id: "", values: [:])
+        ModelRegistry.register(modelType: DynamicModel.self, modelSchema: postSchema) { (_, _) -> Model in
+            DynamicModel(id: "", values: [:])
         }
 
         // Comment
@@ -75,10 +73,9 @@ struct TestJsonModelRegistration: AmplifyModelRegistration {
                                             commentContent.name: commentContent,
                                             commentCreatedAt.name: commentCreatedAt,
                                             belongsTo.name: belongsTo])
-        ModelRegistry.register(modelName: commentSchema.name,
-                               modelSchema: commentSchema,
-                               modelType: DynamicModel.self) { (_, _) -> Model in
-                                DynamicModel(id: "", values: [:])
+        ModelRegistry.register(modelType: DynamicModel.self, modelSchema: commentSchema
+        ) { (_, _) -> Model in
+            DynamicModel(id: "", values: [:])
         }
     }
 


### PR DESCRIPTION
*Description of changes:* Removes the modelType from model decorator. This is part of the larger work on removing dependency on Model.Type in Datastore.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
