### PR TITLE
fix(DataStore): owner based auth, read operations

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelMultipleOwnerAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelMultipleOwnerAuthRuleTests.swift
@@ -220,8 +220,8 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, "111")))
         let document = documentBuilder.build()
         let expectedQueryDocument = """
-        subscription OnCreateModelMultipleOwner($owner: String!) {
-          onCreateModelMultipleOwner(owner: $owner) {
+        subscription OnCreateModelMultipleOwner($editors: String!, $owner: String!) {
+          onCreateModelMultipleOwner(editors: $editors, owner: $owner) {
             id
             content
             editors
@@ -275,8 +275,8 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onDelete, "111")))
         let document = documentBuilder.build()
         let expectedQueryDocument = """
-        subscription OnDeleteModelMultipleOwner($owner: String!) {
-          onDeleteModelMultipleOwner(owner: $owner) {
+        subscription OnDeleteModelMultipleOwner($editors: String!, $owner: String!) {
+          onDeleteModelMultipleOwner(editors: $editors, owner: $owner) {
             id
             content
             editors

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelReadUpdateAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelReadUpdateAuthRuleTests.swift
@@ -205,8 +205,8 @@ class ModelReadUpdateAuthRuleTests: XCTestCase {
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, "111")))
         let document = documentBuilder.build()
         let expectedQueryDocument = """
-        subscription OnCreateModelReadUpdateField($owner: String!) {
-          onCreateModelReadUpdateField(owner: $owner) {
+        subscription OnCreateModelReadUpdateField {
+          onCreateModelReadUpdateField {
             id
             content
             __typename
@@ -216,11 +216,7 @@ class ModelReadUpdateAuthRuleTests: XCTestCase {
         """
         XCTAssertEqual(document.name, "onCreateModelReadUpdateField")
         XCTAssertEqual(document.stringValue, expectedQueryDocument)
-        guard let variables = document.variables else {
-            XCTFail("The document doesn't contain variables")
-            return
-        }
-        XCTAssertEqual(variables["owner"] as? String, "111")
+        XCTAssert(document.variables.isEmpty)
     }
 
     // Others can `.update` this model, which means the update subscription does not require owner input
@@ -252,8 +248,8 @@ class ModelReadUpdateAuthRuleTests: XCTestCase {
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onDelete, "111")))
         let document = documentBuilder.build()
         let expectedQueryDocument = """
-        subscription OnDeleteModelReadUpdateField($owner: String!) {
-          onDeleteModelReadUpdateField(owner: $owner) {
+        subscription OnDeleteModelReadUpdateField {
+          onDeleteModelReadUpdateField {
             id
             content
             __typename
@@ -263,11 +259,7 @@ class ModelReadUpdateAuthRuleTests: XCTestCase {
         """
         XCTAssertEqual(document.name, "onDeleteModelReadUpdateField")
         XCTAssertEqual(document.stringValue, expectedQueryDocument)
-        guard let variables = document.variables else {
-            XCTFail("The document doesn't contain variables")
-            return
-        }
-        XCTAssertEqual(variables["owner"] as? String, "111")
+        XCTAssert(document.variables.isEmpty)
     }
 
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthRuleTests.swift
@@ -228,8 +228,8 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onUpdate, "111")))
         let document = documentBuilder.build()
         let documentStringValue = """
-        subscription OnUpdateArticle {
-          onUpdateArticle {
+        subscription OnUpdateArticle($owner: String!) {
+          onUpdateArticle(owner: $owner) {
             id
             authorNotes
             content
@@ -249,7 +249,11 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
         XCTAssertEqual(document.stringValue, request.document)
         XCTAssertEqual(documentStringValue, request.document)
         XCTAssert(request.responseType == MutationSyncResult.self)
-        XCTAssertNil(request.variables)
+        guard let variables = document.variables else {
+            XCTFail("The document doesn't contain variables")
+            return
+        }
+        XCTAssertEqual(variables["owner"] as? String, "111")
     }
 
     func testOnDeleteSubscriptionGraphQLRequest() throws {
@@ -260,8 +264,8 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onDelete, "111")))
         let document = documentBuilder.build()
         let documentStringValue = """
-        subscription OnDeleteArticle {
-          onDeleteArticle {
+        subscription OnDeleteArticle($owner: String!) {
+          onDeleteArticle(owner: $owner) {
             id
             authorNotes
             content
@@ -281,7 +285,11 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
         XCTAssertEqual(document.stringValue, request.document)
         XCTAssertEqual(documentStringValue, request.document)
         XCTAssert(request.responseType == MutationSyncResult.self)
-        XCTAssertNil(request.variables)
+        guard let variables = document.variables else {
+            XCTFail("The document doesn't contain variables")
+            return
+        }
+        XCTAssertEqual(variables["owner"] as? String, "111")
     }
 
     func testSyncQueryGraphQLRequest() throws {


### PR DESCRIPTION
In attempts to fix:
https://github.com/aws-amplify/amplify-ios/issues/691

Corresponding android change:
https://github.com/aws-amplify/amplify-android/pull/807/files#diff-5a6612b4d7b74db7c28a89d55c63cd09

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
