### PR TITLE
refactor(datastore): Removing dependency on Model.Type in SyncEngine

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -1638,13 +1638,6 @@
 			path = Decorator;
 			sourceTree = "<group>";
 		};
-		213481D7242AFA58001966DE /* Support */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Support;
-			sourceTree = "<group>";
-		};
 		21409C562384C57D000A53C9 /* GraphQL */ = {
 			isa = PBXGroup;
 			children = (
@@ -3166,7 +3159,6 @@
 				B99EF4B423DB020C00D821BC /* TemporalComparableTests.swift */,
 				B9AF547D23F37DF20059E6C4 /* TemporalOperationTests.swift */,
 				B91A87A323D64B0F0049A12F /* TemporalTests.swift */,
-				213481D7242AFA58001966DE /* Support */,
 				B4944D51251C141200BF0BFE /* JSONValueHolderTest.swift */,
 			);
 			path = DataStore;

--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -230,6 +230,8 @@
 		B493E69E245394E200D9E521 /* AuthSignUpStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = B493E69D245394E200D9E521 /* AuthSignUpStep.swift */; };
 		B493E6A22453A29C00D9E521 /* AuthSignInStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = B493E6A12453A29C00D9E521 /* AuthSignInStep.swift */; };
 		B493E6A42453A32C00D9E521 /* AuthSocialWebUISignInOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B493E6A32453A32C00D9E521 /* AuthSocialWebUISignInOperation.swift */; };
+		B4944D21251C06EA00BF0BFE /* JSONValueHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4944D20251C06EA00BF0BFE /* JSONValueHolder.swift */; };
+		B4944D52251C141200BF0BFE /* JSONValueHolderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4944D51251C141200BF0BFE /* JSONValueHolderTest.swift */; };
 		B49A02F92410BEBE00B42A25 /* AuthCategory+CategoryConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49A02F82410BEBD00B42A25 /* AuthCategory+CategoryConfigurable.swift */; };
 		B49A02FB2410BEDF00B42A25 /* AuthCategory+Resettable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49A02FA2410BEDF00B42A25 /* AuthCategory+Resettable.swift */; };
 		B4A19DAB24101EEB00DE2E55 /* AuthCategoryBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A19DAA24101EEB00DE2E55 /* AuthCategoryBehavior.swift */; };
@@ -986,6 +988,8 @@
 		B493E69D245394E200D9E521 /* AuthSignUpStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSignUpStep.swift; sourceTree = "<group>"; };
 		B493E6A12453A29C00D9E521 /* AuthSignInStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSignInStep.swift; sourceTree = "<group>"; };
 		B493E6A32453A32C00D9E521 /* AuthSocialWebUISignInOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSocialWebUISignInOperation.swift; sourceTree = "<group>"; };
+		B4944D20251C06EA00BF0BFE /* JSONValueHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueHolder.swift; sourceTree = "<group>"; };
+		B4944D51251C141200BF0BFE /* JSONValueHolderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueHolderTest.swift; sourceTree = "<group>"; };
 		B49A02F82410BEBD00B42A25 /* AuthCategory+CategoryConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AuthCategory+CategoryConfigurable.swift"; sourceTree = "<group>"; };
 		B49A02FA2410BEDF00B42A25 /* AuthCategory+Resettable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AuthCategory+Resettable.swift"; sourceTree = "<group>"; };
 		B4A19DAA24101EEB00DE2E55 /* AuthCategoryBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCategoryBehavior.swift; sourceTree = "<group>"; };
@@ -2029,6 +2033,14 @@
 			path = AuthPluginBehavior;
 			sourceTree = "<group>";
 		};
+		B4944D1F251C06D300BF0BFE /* JSONHelper */ = {
+			isa = PBXGroup;
+			children = (
+				B4944D20251C06EA00BF0BFE /* JSONValueHolder.swift */,
+			);
+			path = JSONHelper;
+			sourceTree = "<group>";
+		};
 		B49A02F72410BEBD00B42A25 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
@@ -2269,6 +2281,7 @@
 		B92E03A62367CE7A006CEB8D /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				B4944D1F251C06D300BF0BFE /* JSONHelper */,
 				B92E03A72367CE7A006CEB8D /* Model.swift */,
 				FA8EE778238627040097E4F1 /* Model+ModelName.swift */,
 				2129BE502395A66F006363A1 /* AmplifyModelRegistration.swift */,
@@ -3154,6 +3167,7 @@
 				B9AF547D23F37DF20059E6C4 /* TemporalOperationTests.swift */,
 				B91A87A323D64B0F0049A12F /* TemporalTests.swift */,
 				213481D7242AFA58001966DE /* Support */,
+				B4944D51251C141200BF0BFE /* JSONValueHolderTest.swift */,
 			);
 			path = DataStore;
 			sourceTree = "<group>";
@@ -4205,6 +4219,7 @@
 				95DAAB21237E63370028544F /* LanguageDetectionResult.swift in Sources */,
 				FAC2351E227A053D00424678 /* APICategory.swift in Sources */,
 				B9B50DC223D9179F0086F1E1 /* TemporalFormat+DateTime.swift in Sources */,
+				B4944D21251C06EA00BF0BFE /* JSONValueHolder.swift in Sources */,
 				FAC2351B227A053D00424678 /* APICategoryBehavior.swift in Sources */,
 				B473B540245DE93100C45C72 /* AuthConfirmSignInRequest.swift in Sources */,
 				B46884102460A85200221268 /* AuthDevice.swift in Sources */,
@@ -4514,6 +4529,7 @@
 				B9AF547E23F37DF20059E6C4 /* TemporalOperationTests.swift in Sources */,
 				FAD3937D23820D0200463F5E /* DataStoreCategoryConfigurationTests.swift in Sources */,
 				FA607FE2233D131B00DFEA24 /* AmplifyOperationHubTests.swift in Sources */,
+				B4944D52251C141200BF0BFE /* JSONValueHolderTest.swift in Sources */,
 				FAC2356A227A056600424678 /* LoggingCategoryConfigurationTests.swift in Sources */,
 				B91A87A423D64B0F0049A12F /* TemporalTests.swift in Sources */,
 				FA00F69024DA3F95003E8A71 /* HubCombineTests.swift in Sources */,

--- a/Amplify/Categories/DataStore/DataStoreStatement.swift
+++ b/Amplify/Categories/DataStore/DataStoreStatement.swift
@@ -16,7 +16,14 @@ public protocol DataStoreStatement {
     associatedtype Variables
 
     /// The type of the `Model` associated with a particular statement
+    @available(*, deprecated, message: """
+    Use of modelType inside the DatastoreStatement is deprecated, use modelSchema instead.
+    """)
+
     var modelType: Model.Type { get }
+
+    /// The model schema of the `Model` associated with a particular statement
+    var modelSchema: ModelSchema { get }
 
     /// The actual string content of the statement (e.g. a SQL query or a GraphQL document)
     var stringValue: String { get }

--- a/Amplify/Categories/DataStore/DataStoreStatement.swift
+++ b/Amplify/Categories/DataStore/DataStoreStatement.swift
@@ -19,7 +19,6 @@ public protocol DataStoreStatement {
     @available(*, deprecated, message: """
     Use of modelType inside the DatastoreStatement is deprecated, use modelSchema instead.
     """)
-
     var modelType: Model.Type { get }
 
     /// The model schema of the `Model` associated with a particular statement

--- a/Amplify/Categories/DataStore/Model/Internal/Model+Subscript.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Model+Subscript.swift
@@ -15,6 +15,12 @@ extension Model {
     /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
     ///   by host applications. The behavior of this may change without warning.
     public subscript(_ key: String) -> Any?? {
+
+        if let jsonModel = self as? JSONValueHolder {
+            let value = jsonModel.jsonValue(for: key)
+            return value
+        }
+
         let mirror = Mirror(reflecting: self)
         let firstChild = mirror.children.first { $0.label == key }
         guard let property = firstChild else {

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry+Syncable.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry+Syncable.swift
@@ -11,7 +11,7 @@ public extension ModelRegistry {
     ///   by host applications. The behavior of this may change without warning.
     static var hasSyncableModels: Bool {
         if #available(iOS 13.0, *) {
-            return models.contains { !$0.schema.isSystem }
+            return modelSchemas.contains { !$0.isSystem }
         } else {
             return false
         }

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
@@ -16,9 +16,11 @@ public struct ModelRegistry {
     /// ModelDecoders are used to decode untyped model data, looking up by model name
     private typealias ModelDecoder = (String, JSONDecoder?) throws -> Model
 
-    private static var modelTypes = [String: Model.Type]()
+    private static var modelTypes = [ModelName: Model.Type]()
 
-    private static var modelDecoders = [String: ModelDecoder]()
+    private static var modelDecoders = [ModelName: ModelDecoder]()
+
+    private static var modelSchemaMapping = [ModelName: ModelSchema]()
 
     public static var models: [Model.Type] {
         concurrencyQueue.sync {
@@ -28,7 +30,7 @@ public struct ModelRegistry {
 
     public static var modelSchemas: [ModelSchema] {
         concurrencyQueue.sync {
-            Array(modelTypes.values.map { $0.schema })
+            Array(modelSchemaMapping.values)
         }
     }
 
@@ -42,22 +44,31 @@ public struct ModelRegistry {
             modelDecoders[modelType.modelName] = modelDecoder
 
             modelTypes[modelType.modelName] = modelType
+
+            modelSchemaMapping[modelType.modelName] = modelType.schema
         }
     }
 
-    public static func modelType(from name: String) -> Model.Type? {
+    public static func modelType(from name: ModelName) -> Model.Type? {
         concurrencyQueue.sync {
             modelTypes[name]
         }
     }
 
+    @available(*, deprecated, message: """
+    Retrieving model schema using Model.Type is deprecated, instead retrieve using model name.
+    """)
     public static func modelSchema(from modelType: Model.Type) -> ModelSchema? {
+        return modelSchema(from: modelType.modelName)
+    }
+
+    public static func modelSchema(from name: ModelName) -> ModelSchema? {
         concurrencyQueue.sync {
-            modelType.schema
+            modelSchemaMapping[name]
         }
     }
 
-    public static func decode(modelName: String,
+    public static func decode(modelName: ModelName,
                               from jsonString: String,
                               jsonDecoder: JSONDecoder? = nil) throws -> Model {
         try concurrencyQueue.sync {

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
@@ -26,6 +26,12 @@ public struct ModelRegistry {
         }
     }
 
+    public static var modelSchemas: [ModelSchema] {
+        concurrencyQueue.sync {
+            Array(modelTypes.values.map { $0.schema })
+        }
+    }
+
     public static func register(modelType: Model.Type) {
         concurrencyQueue.sync {
             let modelDecoder: ModelDecoder = { jsonString, jsonDecoder in
@@ -42,6 +48,12 @@ public struct ModelRegistry {
     public static func modelType(from name: String) -> Model.Type? {
         concurrencyQueue.sync {
             modelTypes[name]
+        }
+    }
+
+    public static func modelSchema(from modelType: Model.Type) -> ModelSchema? {
+        concurrencyQueue.sync {
+            modelType.schema
         }
     }
 

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
@@ -35,23 +35,21 @@ public struct ModelRegistry {
     }
 
     public static func register(modelType: Model.Type) {
-        register(modelName: modelType.modelName,
-                 modelSchema: modelType.schema,
-                 modelType: modelType) { (jsonString, jsonDecoder) -> Model in
+        register(modelType: modelType,
+                 modelSchema: modelType.schema) { (jsonString, jsonDecoder) -> Model in
             let model = try modelType.from(json: jsonString, decoder: jsonDecoder)
             return model
         }
     }
 
-    public static func register(modelName: ModelName,
+    public static func register(modelType: Model.Type,
                                 modelSchema: ModelSchema,
-                                modelType: Model.Type,
                                 jsonDecoder: @escaping (String, JSONDecoder?) throws -> Model) {
         concurrencyQueue.sync {
             let modelDecoder: ModelDecoder = { jsonString, decoder in
                 return try jsonDecoder(jsonString, decoder)
             }
-
+            let modelName = modelSchema.name
             modelSchemaMapping[modelName] = modelSchema
             modelTypes[modelName] = modelType
             modelDecoders[modelName] = modelDecoder

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
@@ -98,6 +98,7 @@ extension ModelRegistry {
         concurrencyQueue.sync {
             modelTypes = [:]
             modelDecoders = [:]
+            modelSchemaMapping = [:]
         }
     }
 }

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
@@ -87,9 +87,9 @@ import Foundation
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
 public enum ModelAssociation {
-    case hasMany(associatedWith: CodingKey?)
-    case hasOne(associatedWith: CodingKey?)
-    case belongsTo(associatedWith: CodingKey?, targetName: String?)
+    case hasMany(associatedWith: String?)
+    case hasOne(associatedWith: String?)
+    case belongsTo(associatedWith: String?, targetName: String?)
 
     public static let belongsTo: ModelAssociation = .belongsTo(associatedWith: nil, targetName: nil)
 
@@ -107,37 +107,37 @@ extension ModelField {
         return association != nil
     }
 
-    /// If the field represents an association returns the `Model.Type`.
+    /// If the field represents an association returns the `ModelName`.
     /// - seealso: `ModelFieldType`
     /// - seealso: `ModelFieldAssociation`
     /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
     ///   by host applications. The behavior of this may change without warning.
-    public var associatedModel: Model.Type? {
+    public var associatedModelName: ModelName? {
         switch type {
-        case .model(let type), .collection(let type):
-            return type
+        case .model(let modelName), .collection(let modelName):
+            return modelName
         default:
             return nil
         }
     }
 
-    /// This calls `associatedModel` but enforces that the field must represent an association.
-    /// In case the field type is not a `Model.Type` is calls `preconditionFailure`. Consumers
+    /// This calls `associatedModelName` but enforces that the field must represent an association.
+    /// In case the field type is not a `Model` it calls `preconditionFailure`. Consumers
     /// should fix their models in order to recover from it, since associations are only
-    /// possible between two `Model.Type`.
+    /// possible between two `Model`.
     ///
     /// - Note: as a maintainer, make sure you use this computed property only when context
     /// allows (i.e. the field is a valid relationship, such as foreign keys).
     /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
     ///   by host applications. The behavior of this may change without warning.
-    public var requiredAssociatedModel: Model.Type {
-        guard let modelType = associatedModel else {
+    public var requiredAssociatedModel: ModelName {
+        guard let modelName = associatedModelName else {
             preconditionFailure("""
             Model fields that are foreign keys must be connected to another Model.
             Check the `ModelSchema` section of your "\(name)+Schema.swift" file.
             """)
         }
-        return modelType
+        return modelName
     }
 
     /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
@@ -157,13 +157,15 @@ extension ModelField {
             switch association {
             case .belongsTo(let associatedKey, _):
                 // TODO handle modelName casing (convert to camelCase)
-                let key = associatedKey?.stringValue ?? associatedModel.modelName
-                return associatedModel.schema.field(withName: key)
+                let key = associatedKey ?? associatedModel
+                let schema = ModelRegistry.modelSchema(from: associatedModel)
+                return schema?.field(withName: key)
             case .hasOne(let associatedKey),
                  .hasMany(let associatedKey):
                 // TODO handle modelName casing (convert to camelCase)
-                let key = associatedKey?.stringValue ?? associatedModel.modelName
-                return associatedModel.schema.field(withName: key)
+                let key = associatedKey ?? associatedModel
+                let schema = ModelRegistry.modelSchema(from: associatedModel)
+                return schema?.field(withName: key)
             case .none:
                 return nil
             }

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -23,8 +23,8 @@ public enum ModelFieldType {
     case `enum`(type: EnumPersistable.Type)
     case embedded(type: Codable.Type)
     case embeddedCollection(of: Codable.Type)
-    case model(type: Model.Type)
-    case collection(of: Model.Type)
+    case model(name: ModelName)
+    case collection(of: ModelName)
 
     public var isArray: Bool {
         switch self {
@@ -72,7 +72,7 @@ public enum ModelFieldType {
             return .enum(type: enumType)
         }
         if let modelType = type as? Model.Type {
-            return .model(type: modelType)
+            return .model(name: modelType.modelName)
         }
         if let embeddedType = type as? Codable.Type {
             return .embedded(type: embeddedType)
@@ -182,8 +182,8 @@ public enum ModelFieldDefinition {
                                associatedWith associatedKey: CodingKey) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
-                      ofType: .collection(of: type),
-                      association: .hasMany(associatedWith: associatedKey))
+                      ofType: .collection(of: type.modelName),
+                      association: .hasMany(associatedWith: associatedKey.stringValue))
     }
 
     public static func hasOne(_ key: CodingKey,
@@ -192,8 +192,8 @@ public enum ModelFieldDefinition {
                               associatedWith associatedKey: CodingKey) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
-                      ofType: .model(type: type),
-                      association: .hasOne(associatedWith: associatedKey))
+                      ofType: .model(name: type.modelName),
+                      association: .hasOne(associatedWith: associatedKey.stringValue))
     }
 
     public static func belongsTo(_ key: CodingKey,
@@ -203,8 +203,8 @@ public enum ModelFieldDefinition {
                                  targetName: String? = nil) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
-                      ofType: .model(type: type),
-                      association: .belongsTo(associatedWith: associatedKey, targetName: targetName))
+                      ofType: .model(name: type.modelName),
+                      association: .belongsTo(associatedWith: associatedKey?.stringValue, targetName: targetName))
     }
 
     public var modelField: ModelField {

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
@@ -39,12 +39,12 @@ public struct ModelField {
     }
 
     public init(name: String,
-         type: ModelFieldType,
-         isRequired: Bool = false,
-         isArray: Bool = false,
-         attributes: [ModelFieldAttribute] = [],
-         association: ModelAssociation? = nil,
-         authRules: AuthRules = []) {
+                type: ModelFieldType,
+                isRequired: Bool = false,
+                isArray: Bool = false,
+                attributes: [ModelFieldAttribute] = [],
+                association: ModelAssociation? = nil,
+                authRules: AuthRules = []) {
         self.name = name
         self.type = type
         self.isRequired = isRequired
@@ -83,10 +83,10 @@ public struct ModelSchema {
     }
 
     public init(name: String,
-         pluralName: String? = nil,
-         authRules: AuthRules = [],
-         attributes: [ModelAttribute] = [],
-         fields: ModelFields = [:]) {
+                pluralName: String? = nil,
+                authRules: AuthRules = [],
+                attributes: [ModelAttribute] = [],
+                fields: ModelFields = [:]) {
         self.name = name
         self.pluralName = pluralName
         self.authRules = authRules

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
@@ -61,6 +61,10 @@ public typealias ModelFields = [String: ModelField]
 
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
+public typealias ModelName = String
+
+/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+///   by host applications. The behavior of this may change without warning.
 public struct ModelSchema {
 
     public let name: String

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
@@ -38,7 +38,7 @@ public struct ModelField {
         return name == "id"
     }
 
-    init(name: String,
+    public init(name: String,
          type: ModelFieldType,
          isRequired: Bool = false,
          isArray: Bool = false,
@@ -82,7 +82,7 @@ public struct ModelSchema {
         return primaryKey.value
     }
 
-    init(name: String,
+    public init(name: String,
          pluralName: String? = nil,
          authRules: AuthRules = [],
          attributes: [ModelAttribute] = [],

--- a/Amplify/Categories/DataStore/Model/JSONHelper/JSONValueHolder.swift
+++ b/Amplify/Categories/DataStore/Model/JSONHelper/JSONValueHolder.swift
@@ -18,7 +18,7 @@ import Foundation
 ///             let values: [String: Any]
 ///
 ///             public func internalValue(for key: String) -> Any? {
-///                 return values[key] 
+///                 return values[key]
 ///             }
 ///          }
 public protocol JSONValueHolder {

--- a/Amplify/Categories/DataStore/Model/JSONHelper/JSONValueHolder.swift
+++ b/Amplify/Categories/DataStore/Model/JSONHelper/JSONValueHolder.swift
@@ -1,0 +1,37 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// A type that holds internal data in json format
+///
+/// Internally  a `JSONValueHolder` will have the data stored as a json map. Properties of the type can be retrieved
+/// using the function `jsonValue(for:)` passing in the key of the property.
+///
+/// Example:
+/// ==============================================
+///         struct DynamicModel: JSONValueHolder {
+///             let values: [String: Any]
+///
+///             public func internalValue(for key: String) -> Any? {
+///                 return values[key] 
+///             }
+///          }
+public protocol JSONValueHolder {
+
+    /// Return the value for the given key.
+    ///
+    /// If a particular key has nil as it value, this method should return .some(nil) as the value.
+    func jsonValue(for key: String) -> Any??
+}
+
+extension JSONValueHolder {
+
+    public func jsonValue(for key: String) -> Any?? {
+        return nil
+    }
+}

--- a/Amplify/Categories/DataStore/Model/Model.swift
+++ b/Amplify/Categories/DataStore/Model/Model.swift
@@ -28,5 +28,4 @@ public protocol Model: Codable {
 
     /// The Model identifier (aka primary key)
     var id: Identifier { get }
-
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
@@ -36,7 +36,12 @@ public struct AuthRuleDecorator: ModelBasedGraphQLDocumentDecorator {
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
-        let authRules = modelType.schema.authRules
+        decorate(document, modelSchema: modelType.schema)
+    }
+
+    public func decorate(_ document: SingleDirectiveGraphQLDocument,
+                         modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
+        let authRules = modelSchema.authRules
         guard !authRules.isEmpty else {
             return document
         }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
@@ -24,6 +24,11 @@ public struct ConflictResolutionDecorator: ModelBasedGraphQLDocumentDecorator {
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+        decorate(document, modelSchema: modelType.schema)
+    }
+
+    public func decorate(_ document: SingleDirectiveGraphQLDocument,
+                         modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
 
         if let version = version,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/DirectiveNameDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/DirectiveNameDecorator.swift
@@ -37,17 +37,22 @@ public struct DirectiveNameDecorator: ModelBasedGraphQLDocumentDecorator {
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+        decorate(document, modelSchema: modelType.schema)
+    }
+
+    public func decorate(_ document: SingleDirectiveGraphQLDocument,
+                         modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
 
         if let queryType = queryType {
-            return document.copy(name: modelType.schema.graphQLName(queryType: queryType))
+            return document.copy(name: modelSchema.graphQLName(queryType: queryType))
         }
 
         if let mutationType = mutationType {
-            return document.copy(name: modelType.schema.graphQLName(mutationType: mutationType))
+            return document.copy(name: modelSchema.graphQLName(mutationType: mutationType))
         }
 
         if let subscriptionType = subscriptionType {
-            return document.copy(name: modelType.schema.graphQLName(subscriptionType: subscriptionType))
+            return document.copy(name: modelSchema.graphQLName(subscriptionType: subscriptionType))
         }
 
         return document

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/FilterDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/FilterDecorator.swift
@@ -20,8 +20,13 @@ public struct FilterDecorator: ModelBasedGraphQLDocumentDecorator {
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+        decorate(document, modelSchema: modelType.schema)
+    }
+
+    public func decorate(_ document: SingleDirectiveGraphQLDocument,
+                         modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
-        let modelName = modelType.schema.name
+        let modelName = modelSchema.name
         if case .mutation = document.operationType {
             inputs["condition"] = GraphQLDocumentInput(type: "Model\(modelName)ConditionInput",
                 value: .object(filter))

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelBasedGraphQLDocumentDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelBasedGraphQLDocumentDecorator.swift
@@ -9,5 +9,11 @@ import Foundation
 import Amplify
 
 public protocol ModelBasedGraphQLDocumentDecorator {
+
+    @available(*, deprecated, message: """
+    Decorating using Model.Type is deprecated, instead use modelSchema method.
+    """)
     func decorate(_ document: SingleDirectiveGraphQLDocument, modelType: Model.Type) -> SingleDirectiveGraphQLDocument
+
+    func decorate(_ document: SingleDirectiveGraphQLDocument, modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelBasedGraphQLDocumentDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelBasedGraphQLDocumentDecorator.swift
@@ -13,7 +13,9 @@ public protocol ModelBasedGraphQLDocumentDecorator {
     @available(*, deprecated, message: """
     Decorating using Model.Type is deprecated, instead use modelSchema method.
     """)
-    func decorate(_ document: SingleDirectiveGraphQLDocument, modelType: Model.Type) -> SingleDirectiveGraphQLDocument
+    func decorate(_ document: SingleDirectiveGraphQLDocument,
+                  modelType: Model.Type) -> SingleDirectiveGraphQLDocument
 
-    func decorate(_ document: SingleDirectiveGraphQLDocument, modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument
+    func decorate(_ document: SingleDirectiveGraphQLDocument,
+                  modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelDecorator.swift
@@ -21,11 +21,16 @@ public struct ModelDecorator: ModelBasedGraphQLDocumentDecorator {
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+        decorate(document, modelSchema: modelType.schema)
+    }
+
+    public func decorate(_ document: SingleDirectiveGraphQLDocument,
+                         modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
         var graphQLInput = model.graphQLInput
 
-        if !modelType.schema.authRules.isEmpty {
-            modelType.schema.authRules.forEach { authRule in
+        if !modelSchema.authRules.isEmpty {
+            modelSchema.authRules.forEach { authRule in
                 if authRule.allow == .owner {
                     let ownerField = authRule.getOwnerFieldOrDefault()
                     graphQLInput = graphQLInput.filter { (field, value) -> Bool in

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelIdDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelIdDecorator.swift
@@ -19,6 +19,11 @@ public struct ModelIdDecorator: ModelBasedGraphQLDocumentDecorator {
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+        decorate(document, modelSchema: modelType.schema)
+    }
+
+    public func decorate(_ document: SingleDirectiveGraphQLDocument,
+                         modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
 
         if case .mutation = document.operationType {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/PaginationDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/PaginationDecorator.swift
@@ -21,6 +21,11 @@ public struct PaginationDecorator: ModelBasedGraphQLDocumentDecorator {
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
+        decorate(document, modelSchema: modelType.schema)
+    }
+
+    public func decorate(_ document: SingleDirectiveGraphQLDocument,
+                         modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
 
         if let limit = limit {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLMutation.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLMutation.swift
@@ -21,8 +21,15 @@ public struct GraphQLMutation: SingleDirectiveGraphQLDocument {
         self.selectionSet = selectionSet
     }
 
+    @available(*, deprecated, message: """
+    Init with modelType is deprecated, use init with modelSchema instead.
+    """)
     public init(modelType: Model.Type) {
-        self.selectionSet = SelectionSet(fields: modelType.schema.graphQLFields)
+        self.init(modelSchema: modelType.schema)
+    }
+
+    public init(modelSchema: ModelSchema) {
+        self.selectionSet = SelectionSet(fields: modelSchema.graphQLFields)
     }
 
     public var name: String = ""

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLQuery.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLQuery.swift
@@ -21,8 +21,15 @@ public struct GraphQLQuery: SingleDirectiveGraphQLDocument {
         self.selectionSet = selectionSet
     }
 
+    @available(*, deprecated, message: """
+    Init with modelType is deprecated, use init with modelSchema instead.
+    """)
     public init(modelType: Model.Type) {
-        self.selectionSet = SelectionSet(fields: modelType.schema.graphQLFields)
+        self.init(modelSchema: modelType.schema)
+    }
+
+    public init(modelSchema: ModelSchema) {
+        self.selectionSet = SelectionSet(fields: modelSchema.graphQLFields)
     }
 
     public var name: String = ""

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLSubscription.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLSubscription.swift
@@ -21,8 +21,15 @@ public struct GraphQLSubscription: SingleDirectiveGraphQLDocument {
         self.selectionSet = selectionSet
     }
 
+    @available(*, deprecated, message: """
+    Init with modelType is deprecated, use init with modelSchema instead.
+    """)
     public init(modelType: Model.Type) {
-        self.selectionSet = SelectionSet(fields: modelType.schema.graphQLFields)
+        self.init(modelSchema: modelType.schema)
+    }
+
+    public init(modelSchema: ModelSchema) {
+        self.selectionSet = SelectionSet(fields: modelSchema.graphQLFields)
     }
 
     public var operationType: GraphQLOperationType = .subscription

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/ModelBasedGraphQLDocumentBuilder.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/ModelBasedGraphQLDocumentBuilder.swift
@@ -42,7 +42,7 @@ public struct ModelBasedGraphQLDocumentBuilder {
     public mutating func build() -> SingleDirectiveGraphQLDocument {
 
         let decoratedDocument = decorators.reduce(document) { doc, decorator in
-            decorator.decorate(doc, modelType: self.modelType)
+            decorator.decorate(doc, modelSchema: self.modelType.schema)
         }
 
         return decoratedDocument

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/ModelBasedGraphQLDocumentBuilder.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/ModelBasedGraphQLDocumentBuilder.swift
@@ -13,25 +13,32 @@ import Amplify
 public struct ModelBasedGraphQLDocumentBuilder {
     private var decorators = [ModelBasedGraphQLDocumentDecorator]()
     private var document: SingleDirectiveGraphQLDocument
-    private let modelType: Model.Type
+    private let modelSchema: ModelSchema
 
     public init(modelName: String, operationType: GraphQLOperationType) {
-        guard let modelType = ModelRegistry.modelType(from: modelName) else {
-            preconditionFailure("Missing ModelType in ModelRegistry for model name: \(modelName)")
+        guard let modelSchema = ModelRegistry.modelSchema(from: modelName) else {
+            preconditionFailure("Missing ModelSchema in ModelRegistry for model name: \(modelName)")
         }
 
-        self.init(modelType: modelType, operationType: operationType)
+        self.init(modelSchema: modelSchema, operationType: operationType)
     }
 
+    @available(*, deprecated, message: """
+    Init with modelType is deprecated, use init with modelSchema instead.
+    """)
     public init(modelType: Model.Type, operationType: GraphQLOperationType) {
-        self.modelType = modelType
+        self.init(modelSchema: modelType.schema, operationType: operationType)
+    }
+
+    public init(modelSchema: ModelSchema, operationType: GraphQLOperationType) {
+        self.modelSchema = modelSchema
         switch operationType {
         case .query:
-            self.document = GraphQLQuery(modelType: modelType)
+            self.document = GraphQLQuery(modelSchema: modelSchema)
         case .mutation:
-            self.document = GraphQLMutation(modelType: modelType)
+            self.document = GraphQLMutation(modelSchema: modelSchema)
         case .subscription:
-            self.document = GraphQLSubscription(modelType: modelType)
+            self.document = GraphQLSubscription(modelSchema: modelSchema)
         }
     }
 
@@ -42,7 +49,7 @@ public struct ModelBasedGraphQLDocumentBuilder {
     public mutating func build() -> SingleDirectiveGraphQLDocument {
 
         let decoratedDocument = decorators.reduce(document) { doc, decorator in
-            decorator.decorate(doc, modelSchema: self.modelType.schema)
+            decorator.decorate(doc, modelSchema: self.modelSchema)
         }
 
         return decoratedDocument

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -29,14 +29,14 @@ protocol ModelSyncGraphQLRequestFactory {
                                where filter: GraphQLFilter?,
                                version: Int?) -> GraphQLRequest<MutationSyncResult>
 
-    static func subscription(to modelType: Model.Type,
+    static func subscription(to modelSchema: ModelSchema,
                              subscriptionType: GraphQLSubscriptionType) -> GraphQLRequest<MutationSyncResult>
 
-    static func subscription(to modelType: Model.Type,
+    static func subscription(to modelSchema: ModelSchema,
                              subscriptionType: GraphQLSubscriptionType,
                              ownerId: String) -> GraphQLRequest<MutationSyncResult>
 
-    static func syncQuery(modelType: Model.Type,
+    static func syncQuery(modelSchema: ModelSchema,
                           where predicate: QueryPredicate?,
                           limit: Int?,
                           nextToken: String?,
@@ -93,10 +93,11 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                                   decodePath: document.name)
     }
 
-    public static func subscription(to modelType: Model.Type,
+    public static func subscription(to modelSchema: ModelSchema,
                                     subscriptionType: GraphQLSubscriptionType) -> GraphQLRequest<MutationSyncResult> {
 
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelSchema,
+                                                               operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: subscriptionType))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         let document = documentBuilder.build()
@@ -107,11 +108,12 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                                   decodePath: document.name)
     }
 
-    public static func subscription(to modelType: Model.Type,
+    public static func subscription(to modelSchema: ModelSchema,
                                     subscriptionType: GraphQLSubscriptionType,
                                     ownerId: String) -> GraphQLRequest<MutationSyncResult> {
 
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelSchema,
+                                                               operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: subscriptionType))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(subscriptionType, ownerId)))
@@ -123,12 +125,13 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                                   decodePath: document.name)
     }
 
-    public static func syncQuery(modelType: Model.Type,
+    public static func syncQuery(modelSchema: ModelSchema,
                                  where predicate: QueryPredicate? = nil,
                                  limit: Int? = nil,
                                  nextToken: String? = nil,
                                  lastSync: Int? = nil) -> GraphQLRequest<SyncQueryResult> {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelSchema,
+                                                               operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .sync))
         if let predicate = predicate {
             documentBuilder.add(decorator: FilterDecorator(filter: predicate.graphQLFilter))
@@ -151,7 +154,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                                type: GraphQLMutationType,
                                                version: Int? = nil) -> GraphQLRequest<MutationSyncResult> {
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: model.modelName,
-                                                                    operationType: .mutation)
+                                                               operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: type))
         documentBuilder.add(decorator: ModelDecorator(model: model))
         if let filter = filter {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
@@ -130,7 +130,8 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
                                           type: GraphQLMutationType) -> GraphQLRequest<M> {
         let modelType = ModelRegistry.modelType(from: model.modelName) ?? Swift.type(of: model)
 
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .mutation)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: type))
 
         switch type {
@@ -157,7 +158,8 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
 
     public static func get<M: Model>(_ modelType: M.Type,
                                      byId id: String) -> GraphQLRequest<M?> {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
         documentBuilder.add(decorator: ModelIdDecorator(id: id))
         let document = documentBuilder.build()
@@ -170,7 +172,8 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
 
     public static func list<M: Model>(_ modelType: M.Type,
                                       where predicate: QueryPredicate? = nil) -> GraphQLRequest<[M]> {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
 
         if let predicate = predicate {
@@ -188,7 +191,8 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
 
     public static func subscription<M: Model>(of modelType: M.Type,
                                               type: GraphQLSubscriptionType) -> GraphQLRequest<M> {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: type))
         let document = documentBuilder.build()
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
@@ -40,9 +40,11 @@ extension SelectionSet {
                 let child = SelectionSet(value: .init(name: field.name, fieldType: .embedded))
                 child.withCodableFields(embeddedType.schema.sortedFields)
                 self.addChild(settingParentOf: child)
-            } else if field.isAssociationOwner, let associatedModel = field.associatedModel {
+            } else if field.isAssociationOwner,
+                let associatedModelName = field.associatedModelName,
+                let schema = ModelRegistry.modelSchema(from: associatedModelName) {
                 let child = SelectionSet(value: .init(name: field.name, fieldType: .model))
-                child.withModelFields(associatedModel.schema.graphQLFields)
+                child.withModelFields(schema.graphQLFields)
                 self.addChild(settingParentOf: child)
             } else {
                 self.addChild(settingParentOf: .init(value: .init(name: field.graphQLName, fieldType: .value)))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelMultipleOwnerAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelMultipleOwnerAuthRuleTests.swift
@@ -66,7 +66,7 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
 
     // Ensure that the `owner` field is added to the model fields
     func testModelMultipleOwner_CreateMutation() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelMultipleOwner.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelMultipleOwner.schema,
                                                                operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
         documentBuilder.add(decorator: AuthRuleDecorator(.mutation))
@@ -89,7 +89,7 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
 
     // Ensure that the `owner` field is added to the model fields
     func testModelMultipleOwner_DeleteMutation() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelMultipleOwner.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelMultipleOwner.schema,
                                                                operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .delete))
         documentBuilder.add(decorator: AuthRuleDecorator(.mutation))
@@ -112,7 +112,7 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
 
     // Ensure that the `owner` field is added to the model fields
     func testModelMultipleOwner_UpdateMutation() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelMultipleOwner.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelMultipleOwner.schema,
                                                                operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .update))
         documentBuilder.add(decorator: AuthRuleDecorator(.mutation))
@@ -135,7 +135,7 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
 
     // Ensure that the `owner` field is added to the model fields
     func testModelMultipleOwner_GetQuery() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelMultipleOwner.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelMultipleOwner.schema,
                                                                operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
         documentBuilder.add(decorator: AuthRuleDecorator(.query))
@@ -158,7 +158,7 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
 
     // A List query is a paginated selection set, make sure the `owner` field is added to the model fields
     func testModelMultipleOwner_ListQuery() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelMultipleOwner.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelMultipleOwner.schema,
                                                                operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
         documentBuilder.add(decorator: PaginationDecorator())
@@ -183,7 +183,7 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
     }
 
     func testModelMultipleOwner_SyncQuery() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelMultipleOwner.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelMultipleOwner.schema,
                                                                operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .sync))
         documentBuilder.add(decorator: PaginationDecorator())
@@ -214,7 +214,7 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
 
     // Only the 'owner' inherently has `.create` operation, requiring the subscription operation to contain the input
     func testModelMultipleOwner_OnCreateSubscription() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelMultipleOwner.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelMultipleOwner.schema,
                                                                operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, "111")))
@@ -241,7 +241,7 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
 
     // Each owner with `.update` operation requires the ownerField on the corresponding subscription operation
     func testModelMultipleOwner_OnUpdateSubscription() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelMultipleOwner.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelMultipleOwner.schema,
                                                                operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onUpdate))
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onUpdate, "111")))
@@ -269,7 +269,7 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
 
     // Only the 'owner' inherently has `.delete` operation, requiring the subscription operation to contain the input
     func testModelMultipleOwner_OnDeleteSubscription() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelMultipleOwner.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelMultipleOwner.schema,
                                                                operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onDelete))
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onDelete, "111")))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelReadUpdateAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelReadUpdateAuthRuleTests.swift
@@ -57,7 +57,7 @@ class ModelReadUpdateAuthRuleTests: XCTestCase {
 
     // Ensure that the `owner` field is added to the model fields
     func testModelReadUpdateField_CreateMutation() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelReadUpdateField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelReadUpdateField.schema,
                                                                operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
         documentBuilder.add(decorator: AuthRuleDecorator(.mutation))
@@ -79,7 +79,7 @@ class ModelReadUpdateAuthRuleTests: XCTestCase {
 
     // Ensure that the `owner` field is added to the model fields
     func testModelReadUpdateField_DeleteMutation() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelReadUpdateField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelReadUpdateField.schema,
                                                                operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .delete))
         documentBuilder.add(decorator: AuthRuleDecorator(.mutation))
@@ -101,7 +101,7 @@ class ModelReadUpdateAuthRuleTests: XCTestCase {
 
     // Ensure that the `owner` field is added to the model fields
     func testModelReadUpdateField_UpdateMutation() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelReadUpdateField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelReadUpdateField.schema,
                                                                operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .update))
         documentBuilder.add(decorator: AuthRuleDecorator(.mutation))
@@ -123,7 +123,7 @@ class ModelReadUpdateAuthRuleTests: XCTestCase {
 
     // Ensure that the `owner` field is added to the model fields
     func testModelReadUpdateField_GetQuery() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelReadUpdateField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelReadUpdateField.schema,
                                                                operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
         documentBuilder.add(decorator: AuthRuleDecorator(.query))
@@ -145,7 +145,7 @@ class ModelReadUpdateAuthRuleTests: XCTestCase {
 
     // A List query is a paginated selection set, make sure the `owner` field is added to the model fields
     func testModelReadUpdateField_ListQuery() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelReadUpdateField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelReadUpdateField.schema,
                                                                operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
         documentBuilder.add(decorator: PaginationDecorator())
@@ -169,7 +169,7 @@ class ModelReadUpdateAuthRuleTests: XCTestCase {
     }
 
     func testModelReadUpdateField_SyncQuery() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelReadUpdateField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelReadUpdateField.schema,
                                                                operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .sync))
         documentBuilder.add(decorator: PaginationDecorator())
@@ -199,7 +199,7 @@ class ModelReadUpdateAuthRuleTests: XCTestCase {
 
     // The owner auth rule contains `.create` operation, requiring the subscription operation to contain the input
     func testModelReadUpdateField_OnCreateSubscription() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelReadUpdateField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelReadUpdateField.schema,
                                                                operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, "111")))
@@ -225,7 +225,7 @@ class ModelReadUpdateAuthRuleTests: XCTestCase {
 
     // Others can `.update` this model, which means the update subscription does not require owner input
     func testModelReadUpdateField_OnUpdateSubscription() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelReadUpdateField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelReadUpdateField.schema,
                                                                operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onUpdate))
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onUpdate, "111")))
@@ -246,7 +246,7 @@ class ModelReadUpdateAuthRuleTests: XCTestCase {
 
     // The owner auth rule contains `.delete` operation, requiring the subscription operation to contain the input
     func testModelReadUpdateField_OnDeleteSubscription() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelReadUpdateField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelReadUpdateField.schema,
                                                                operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onDelete))
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onDelete, "111")))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerFieldAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerFieldAuthRuleTests.swift
@@ -63,7 +63,7 @@ class ModelWithOwnerFieldAuthRuleTests: XCTestCase {
 
     // Since the owner field already exists on the model, ensure that it is not added again
     func testModelWithOwnerField_CreateMutation() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelWithOwnerField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelWithOwnerField.schema,
                                                                operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
         documentBuilder.add(decorator: AuthRuleDecorator(.mutation))
@@ -85,7 +85,7 @@ class ModelWithOwnerFieldAuthRuleTests: XCTestCase {
 
     // Since the owner field already exists on the model, ensure that it is not added again
     func testModelWithOwnerField_DeleteMutation() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelWithOwnerField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelWithOwnerField.schema,
                                                                operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .delete))
         documentBuilder.add(decorator: AuthRuleDecorator(.mutation))
@@ -107,7 +107,7 @@ class ModelWithOwnerFieldAuthRuleTests: XCTestCase {
 
     // Since the owner field already exists on the model, ensure that it is not added again
     func testModelWithOwnerField_UpdateMutation() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelWithOwnerField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelWithOwnerField.schema,
                                                                operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .update))
         documentBuilder.add(decorator: AuthRuleDecorator(.mutation))
@@ -129,7 +129,7 @@ class ModelWithOwnerFieldAuthRuleTests: XCTestCase {
 
     // Since the owner field already exists on the model, ensure that it is not added again
     func testModelWithOwnerField_GetQuery() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelWithOwnerField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelWithOwnerField.schema,
                                                                operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
         documentBuilder.add(decorator: AuthRuleDecorator(.query))
@@ -151,7 +151,7 @@ class ModelWithOwnerFieldAuthRuleTests: XCTestCase {
 
     // Since the owner field already exists on the model, ensure that it is not added again
     func testModelWithOwnerField_ListQuery() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelWithOwnerField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelWithOwnerField.schema,
                                                                operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
         documentBuilder.add(decorator: PaginationDecorator())
@@ -175,7 +175,7 @@ class ModelWithOwnerFieldAuthRuleTests: XCTestCase {
     }
 
     func testModelWithOwnerField_SyncQuery() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelWithOwnerField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelWithOwnerField.schema,
                                                                operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .sync))
         documentBuilder.add(decorator: PaginationDecorator())
@@ -205,7 +205,7 @@ class ModelWithOwnerFieldAuthRuleTests: XCTestCase {
 
     // The owner auth rule contains `.create` operation, requiring the subscription operation to contain the input
     func testModelWithOwnerField_OnCreateSubscription() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelWithOwnerField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelWithOwnerField.schema,
                                                                operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, "111")))
@@ -231,7 +231,7 @@ class ModelWithOwnerFieldAuthRuleTests: XCTestCase {
 
     // The owner auth rule contains `.update` operation, requiring the subscription operation to contain the input
     func testModelWithOwnerField_OnUpdateSubscription() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelWithOwnerField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelWithOwnerField.schema,
                                                                operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onUpdate))
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onUpdate, "111")))
@@ -257,7 +257,7 @@ class ModelWithOwnerFieldAuthRuleTests: XCTestCase {
 
     // The owner auth rule contains `.delete` operation, requiring the subscription operation to contain the input
     func testModelWithOwnerField_OnDeleteSubscription() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelWithOwnerField.self,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelWithOwnerField.schema,
                                                                operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onDelete))
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onDelete, "111")))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
@@ -37,7 +37,7 @@ class GraphQLCreateMutationTests: XCTestCase {
                         content: "content",
                         createdAt: .now(),
                         status: .private)
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
         documentBuilder.add(decorator: ModelDecorator(model: post))
         let document = documentBuilder.build()
@@ -86,7 +86,7 @@ class GraphQLCreateMutationTests: XCTestCase {
     func testCreateGraphQLMutationFromModelWithAssociation() {
         let post = Post(title: "title", content: "content", createdAt: .now())
         let comment = Comment(content: "comment", createdAt: .now(), post: post)
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Comment.self, operationType: .mutation)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Comment.schema, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
         documentBuilder.add(decorator: ModelDecorator(model: comment))
         let document = documentBuilder.build()
@@ -137,7 +137,7 @@ class GraphQLCreateMutationTests: XCTestCase {
     ///     - it has a list of fields with no nested models
     func testCreateGraphQLMutationFromSimpleModelWithSyncEnabled() {
         let post = Post(title: "title", content: "content", createdAt: .now())
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
         documentBuilder.add(decorator: ModelDecorator(model: post))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
@@ -190,7 +190,7 @@ class GraphQLCreateMutationTests: XCTestCase {
         let post = Post(title: "title", content: "content", createdAt: .now())
         let comment = Comment(content: "comment", createdAt: .now(), post: post)
 
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Comment.self, operationType: .mutation)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Comment.schema, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
         documentBuilder.add(decorator: ModelDecorator(model: comment))
         documentBuilder.add(decorator: ConflictResolutionDecorator())

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDeleteMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDeleteMutationTests.swift
@@ -34,7 +34,7 @@ class GraphQLDeleteMutationTests: XCTestCase {
     ///     - it has a list of fields with no nested models
     func testDeleteGraphQLMutationFromSimpleModel() {
         let post = Post(title: "title", content: "content", createdAt: .now())
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .delete))
         documentBuilder.add(decorator: ModelIdDecorator(id: post.id))
         let document = documentBuilder.build()
@@ -80,7 +80,7 @@ class GraphQLDeleteMutationTests: XCTestCase {
     ///     - it has a list of fields with no nested models
     func testDeleteGraphQLMutationFromSimpleModelWithVersion() {
         let post = Post(title: "title", content: "content", createdAt: .now())
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .delete))
         documentBuilder.add(decorator: ModelIdDecorator(id: post.id))
         documentBuilder.add(decorator: ConflictResolutionDecorator(version: 5))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLGetQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLGetQueryTests.swift
@@ -30,7 +30,7 @@ class GraphQLGetQueryTests: XCTestCase {
     ///     - it has a list of fields with no nested models
     ///     - it has variables containing `id`
     func testGetGraphQLQueryFromSimpleModel() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
         documentBuilder.add(decorator: ModelIdDecorator(id: "id"))
         let document = documentBuilder.build()
@@ -59,7 +59,7 @@ class GraphQLGetQueryTests: XCTestCase {
     }
 
     func testGetGraphQLQueryFromSimpleModelWithSyncEnabled() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
         documentBuilder.add(decorator: ModelIdDecorator(id: "id"))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
@@ -102,7 +102,7 @@ class GraphQLGetQueryTests: XCTestCase {
     ///     - it is named `getComment`
     ///     - it has a list of fields with a nested `post`
     func testGetGraphQLQueryFromModelWithAssociation() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Comment.self, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Comment.schema, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
         documentBuilder.add(decorator: ModelIdDecorator(id: "id"))
         let document = documentBuilder.build()
@@ -137,7 +137,7 @@ class GraphQLGetQueryTests: XCTestCase {
     }
 
     func testGetGraphQLQueryFromModelWithAssociationAndSyncEnabled() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Comment.self, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Comment.schema, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
         documentBuilder.add(decorator: ModelIdDecorator(id: "id"))
         documentBuilder.add(decorator: ConflictResolutionDecorator())

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLListQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLListQueryTests.swift
@@ -40,7 +40,7 @@ class GraphQLListQueryTests: XCTestCase {
             && (post.title.beginsWith("Title")
             || post.content.contains("content"))
 
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
         documentBuilder.add(decorator: PaginationDecorator())
         documentBuilder.add(decorator: FilterDecorator(filter: predicate.graphQLFilter))
@@ -119,7 +119,7 @@ class GraphQLListQueryTests: XCTestCase {
         let post = Post.keys
         let predicate = post.id.eq("id") && (post.title.beginsWith("Title") || post.content.contains("content"))
 
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
         documentBuilder.add(decorator: PaginationDecorator())
         documentBuilder.add(decorator: FilterDecorator(filter: predicate.graphQLFilter))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSubscriptionTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSubscriptionTests.swift
@@ -33,7 +33,7 @@ class GraphQLSubscriptionTests: XCTestCase {
     ///   - check if the generated GraphQL document is a valid subscription
     ///     - it has a list of fields with no nested models
     func testOnCreateGraphQLSubscriptionFromSimpleModel() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
         let document = documentBuilder.build()
         let expectedQueryDocument = """
@@ -57,7 +57,7 @@ class GraphQLSubscriptionTests: XCTestCase {
     }
 
     func testOnCreateGraphQLSubscriptionFromSimpleModelWithSyncEnabled() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         let document = documentBuilder.build()
@@ -93,7 +93,7 @@ class GraphQLSubscriptionTests: XCTestCase {
     ///   - check if the generated GraphQL document is a valid subscription
     ///     - it has a list of fields with no nested models
     func testOnCreateGraphQLSubscriptionFromModelWithAssociation() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Comment.self, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Comment.schema, operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
         let document = documentBuilder.build()
         let expectedQueryDocument = """
@@ -123,7 +123,7 @@ class GraphQLSubscriptionTests: XCTestCase {
     }
 
     func testOnCreateGraphQLSubscriptionFromModelWithAssociationWithSyncEnabled() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Comment.self, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Comment.schema, operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         let document = documentBuilder.build()
@@ -167,7 +167,7 @@ class GraphQLSubscriptionTests: XCTestCase {
     ///   - check if the generated GraphQL document is a valid subscription
     ///     - it has a list of fields with no nested models
     func testOnUpdateGraphQLSubscriptionFromSimpleModel() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onUpdate))
         let document = documentBuilder.build()
 
@@ -192,7 +192,7 @@ class GraphQLSubscriptionTests: XCTestCase {
     }
 
     func testOnUpdateGraphQLSubscriptionFromSimpleModelWithSyncEnabled() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onUpdate))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         let document = documentBuilder.build()
@@ -227,7 +227,7 @@ class GraphQLSubscriptionTests: XCTestCase {
     ///   - check if the generated GraphQL document is a valid subscription
     ///     - it has a list of fields with no nested models
     func testOnDeleteGraphQLSubscriptionFromSimpleModel() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onDelete))
         let document = documentBuilder.build()
         let expectedQueryDocument = """
@@ -251,7 +251,7 @@ class GraphQLSubscriptionTests: XCTestCase {
     }
 
     func testOnDeleteGraphQLSubscriptionFromSimpleModelWithSyncEnabled() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onDelete))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         let document = documentBuilder.build()

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSyncQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSyncQueryTests.swift
@@ -36,7 +36,7 @@ class GraphQLSyncQueryTests: XCTestCase {
         let post = Post.keys
         let predicate = post.id.eq("id") && (post.title.beginsWith("Title") || post.content.contains("content"))
 
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .sync))
         documentBuilder.add(decorator: FilterDecorator(filter: predicate.graphQLFilter))
         documentBuilder.add(decorator: PaginationDecorator(limit: 100, nextToken: "token"))
@@ -81,7 +81,7 @@ class GraphQLSyncQueryTests: XCTestCase {
     }
 
     func testSyncGraphQLQueryForComment() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Comment.self, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Comment.schema, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .sync))
         documentBuilder.add(decorator: PaginationDecorator(limit: 100, nextToken: "token"))
         documentBuilder.add(decorator: ConflictResolutionDecorator(lastSync: 123))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLUpdateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLUpdateMutationTests.swift
@@ -34,7 +34,7 @@ class GraphQLUpdateMutationTests: XCTestCase {
     ///     - it has a list of fields with no nested models
     func testUpdateGraphQLMutationFromSimpleModel() {
         let post = Post(title: "title", content: "content", createdAt: .now())
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .update))
         documentBuilder.add(decorator: ModelDecorator(model: post))
         let document = documentBuilder.build()
@@ -81,7 +81,7 @@ class GraphQLUpdateMutationTests: XCTestCase {
     ///     - it has a list of fields with no nested models
     func testUpdateGraphQLMutationFromSimpleModelWithVersion() {
         let post = Post(title: "title", content: "content", createdAt: .now())
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .update))
         documentBuilder.add(decorator: ModelDecorator(model: post))
         documentBuilder.add(decorator: ConflictResolutionDecorator(version: 5))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAnyModelWithSyncTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAnyModelWithSyncTests.swift
@@ -190,7 +190,8 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
 
     func testCreateSubscriptionGraphQLRequest() throws {
         let modelType = Post.self as Model.Type
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         let document = documentBuilder.build()
@@ -212,7 +213,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
           }
         }
         """
-        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType,
+        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType.schema,
                                                                       subscriptionType: .onCreate)
 
         XCTAssertEqual(document.stringValue, request.document)
@@ -226,7 +227,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
         let nextToken = "nextToken"
         let limit = 100
         let lastSync = 123
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .sync))
         documentBuilder.add(decorator: PaginationDecorator(limit: limit, nextToken: nextToken))
         documentBuilder.add(decorator: ConflictResolutionDecorator(lastSync: lastSync))
@@ -254,7 +255,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
         }
         """
 
-        let request = GraphQLRequest<SyncQueryResult>.syncQuery(modelType: modelType,
+        let request = GraphQLRequest<SyncQueryResult>.syncQuery(modelSchema: modelType.schema,
                                                                 limit: limit,
                                                                 nextToken: nextToken,
                                                                 lastSync: lastSync)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthRuleTests.swift
@@ -182,7 +182,8 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
     func testOnCreateSubscriptionGraphQLRequest() throws {
         let modelType = Article.self as Model.Type
         let ownerId = "111"
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, ownerId)))
@@ -202,7 +203,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
           }
         }
         """
-        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType,
+        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType.schema,
                                                                       subscriptionType: .onCreate,
                                                                       ownerId: ownerId)
 
@@ -222,7 +223,8 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
 
     func testOnUpdateSubscriptionGraphQLRequest() throws {
         let modelType = Article.self as Model.Type
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onUpdate))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onUpdate, "111")))
@@ -242,7 +244,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
           }
         }
         """
-        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType,
+        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType.schema,
                                                                       subscriptionType: .onUpdate,
                                                                       ownerId: "111")
 
@@ -254,7 +256,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
 
     func testOnDeleteSubscriptionGraphQLRequest() throws {
         let modelType = Article.self as Model.Type
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema, operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onDelete))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onDelete, "111")))
@@ -274,7 +276,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
           }
         }
         """
-        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType,
+        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType.schema,
                                                                       subscriptionType: .onDelete,
                                                                       ownerId: "111")
 
@@ -289,7 +291,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
         let nextToken = "nextToken"
         let limit = 100
         let lastSync = 123
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .sync))
         documentBuilder.add(decorator: PaginationDecorator(limit: limit, nextToken: nextToken))
         documentBuilder.add(decorator: ConflictResolutionDecorator(lastSync: lastSync))
@@ -315,7 +317,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
         }
         """
 
-        let request = GraphQLRequest<SyncQueryResult>.syncQuery(modelType: modelType,
+        let request = GraphQLRequest<SyncQueryResult>.syncQuery(modelSchema: modelType.schema,
                                                                 limit: limit,
                                                                 nextToken: nextToken,
                                                                 lastSync: lastSync)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestModelTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestModelTests.swift
@@ -33,7 +33,7 @@ class GraphQLRequestModelTests: XCTestCase {
     ///     - the `variables` is non-nil
     func testCreateMutationGraphQLRequest() {
         let post = Post(title: "title", content: "content", createdAt: .now())
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
         documentBuilder.add(decorator: ModelDecorator(model: post))
         let document = documentBuilder.build()
@@ -47,7 +47,7 @@ class GraphQLRequestModelTests: XCTestCase {
 
     func testUpdateMutationGraphQLRequest() {
         let post = Post(title: "title", content: "content", createdAt: .now())
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .update))
         documentBuilder.add(decorator: ModelDecorator(model: post))
         let document = documentBuilder.build()
@@ -61,7 +61,7 @@ class GraphQLRequestModelTests: XCTestCase {
 
     func testDeleteMutationGraphQLRequest() {
         let post = Post(title: "title", content: "content", createdAt: .now())
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .mutation)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .delete))
         documentBuilder.add(decorator: ModelDecorator(model: post))
         let document = documentBuilder.build()
@@ -74,7 +74,7 @@ class GraphQLRequestModelTests: XCTestCase {
     }
 
     func testQueryByIdGraphQLRequest() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
         documentBuilder.add(decorator: ModelIdDecorator(id: "id"))
         let document = documentBuilder.build()
@@ -90,7 +90,7 @@ class GraphQLRequestModelTests: XCTestCase {
         let post = Post.keys
         let predicate = post.id.eq("id") && (post.title.beginsWith("Title") || post.content.contains("content"))
 
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .query)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
         documentBuilder.add(decorator: FilterDecorator(filter: predicate.graphQLFilter))
         documentBuilder.add(decorator: PaginationDecorator())
@@ -104,7 +104,7 @@ class GraphQLRequestModelTests: XCTestCase {
     }
 
     func testOnCreateSubscriptionGraphQLRequest() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
         let document = documentBuilder.build()
 
@@ -116,7 +116,7 @@ class GraphQLRequestModelTests: XCTestCase {
     }
 
     func testOnUpdateSubscriptionGraphQLRequest() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onUpdate))
         let document = documentBuilder.build()
 
@@ -127,7 +127,7 @@ class GraphQLRequestModelTests: XCTestCase {
     }
 
     func testOnDeleteSubscriptionGraphQLRequest() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: Post.self, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onDelete))
         let document = documentBuilder.build()
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -24,7 +24,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                 throw DataStoreError.configuration("Unable to get storage adapter",
                                                    "")
             }
-            modelExists = try engine.storageAdapter.exists(M.self, withId: model.id, predicate: nil)
+            modelExists = try engine.storageAdapter.exists(M.schema, withId: model.id, predicate: nil)
         } catch {
             if let dataStoreError = error as? DataStoreError {
                 completion(.failure(dataStoreError))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -78,14 +78,14 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
 
     /// By the time this method gets called, DataStore will already have invoked
     /// `AmplifyModelRegistration.registerModels`, so we can inspect those models to derive isSyncEnabled, and pass
-    /// them to `StorageEngine.setUp(models:)`
+    /// them to `StorageEngine.setUp(modelSchemas:)`
     public func configure(using amplifyConfiguration: Any?) throws {
         modelRegistration.registerModels(registry: ModelRegistry.self)
         resolveSyncEnabled()
 
         try resolveStorageEngine(dataStoreConfiguration: dataStoreConfiguration)
 
-        try storageEngine.setUp(models: ModelRegistry.models)
+        try storageEngine.setUp(modelSchemas: ModelRegistry.modelSchemas)
 
         let filter = HubFilters.forEventName(HubPayload.EventName.Amplify.configured)
         var token: UnsubscribeToken?
@@ -106,7 +106,7 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
                 self.dataStorePublisher = DataStorePublisher()
             }
             try resolveStorageEngine(dataStoreConfiguration: dataStoreConfiguration)
-            try storageEngine.setUp(models: ModelRegistry.models)
+            try storageEngine.setUp(modelSchemas: ModelRegistry.modelSchemas)
             storageEngine.startSync()
         } catch {
             log.error(error: error)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
@@ -11,6 +11,11 @@ protocol ModelStorageBehavior {
     func setUp(modelSchemas: [ModelSchema]) throws
 
     func save<M: Model>(_ model: M,
+                        modelSchema: ModelSchema,
+                        where condition: QueryPredicate?,
+                        completion: @escaping DataStoreCallback<M>)
+
+    func save<M: Model>(_ model: M,
                         condition: QueryPredicate?,
                         completion: @escaping DataStoreCallback<M>)
 
@@ -23,6 +28,13 @@ protocol ModelStorageBehavior {
                           completion: @escaping DataStoreCallback<[M]>)
 
     func query<M: Model>(_ modelType: M.Type,
+                         predicate: QueryPredicate?,
+                         sort: QuerySortInput?,
+                         paginationInput: QueryPaginationInput?,
+                         completion: DataStoreCallback<[M]>)
+
+    func query<M: Model>(_ modelType: M.Type,
+                         modelSchema: ModelSchema,
                          predicate: QueryPredicate?,
                          sort: QuerySortInput?,
                          paginationInput: QueryPaginationInput?,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
@@ -12,7 +12,7 @@ protocol ModelStorageBehavior {
 
     func save<M: Model>(_ model: M,
                         modelSchema: ModelSchema,
-                        where condition: QueryPredicate?,
+                        condition: QueryPredicate?,
                         completion: @escaping DataStoreCallback<M>)
 
     func save<M: Model>(_ model: M,
@@ -20,10 +20,12 @@ protocol ModelStorageBehavior {
                         completion: @escaping DataStoreCallback<M>)
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           withId id: Model.Identifier,
                           completion: @escaping DataStoreCallback<M?>)
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           predicate: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
@@ -8,7 +8,7 @@
 import Amplify
 
 protocol ModelStorageBehavior {
-    func setUp(models: [Model.Type]) throws
+    func setUp(modelSchemas: [ModelSchema]) throws
 
     func save<M: Model>(_ model: M,
                         condition: QueryPredicate?,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
@@ -157,3 +157,29 @@ extension Array where Element == Model.Type {
     }
 
 }
+
+extension Array where Element == ModelSchema {
+
+    func sortByDependencyOrder() -> Self {
+        var sortedKeys: [String] = []
+        var sortMap: [String: ModelSchema] = [:]
+
+        func walkAssociatedModels(of schema: ModelSchema) {
+            if !sortedKeys.contains(schema.name) {
+                let associatedModels = schema.sortedFields
+                    .filter { $0.isForeignKey }
+                    .map { ModelRegistry.modelSchema(from: $0.requiredAssociatedModel )! }
+                associatedModels.forEach(walkAssociatedModels(of:))
+
+                let key = schema.name
+                sortedKeys.append(key)
+                sortMap[key] = schema
+            }
+        }
+
+        let sortedStartList = sorted { $0.name < $1.name }
+        sortedStartList.forEach(walkAssociatedModels(of:))
+        return sortedKeys.map { sortMap[$0]! }
+    }
+
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
@@ -15,10 +15,10 @@ typealias SQLPredicate = (String, [Binding?])
 /// It walks all nodes of a predicate tree and output the appropriate SQL statement.
 ///
 /// - Parameters:
-///   - modelType: the metatype of the `Model`
+///   - modelSchema: the model schema of the `Model`
 ///   - predicate: the query predicate
 /// - Returns: a tuple containing the SQL string and the associated values
-private func translateQueryPredicate(from modelType: Model.Type,
+private func translateQueryPredicate(from modelSchema: ModelSchema,
                                      predicate: QueryPredicate,
                                      namespace: Substring? = nil) -> SQLPredicate {
     var sql: [String] = []
@@ -65,14 +65,14 @@ private func translateQueryPredicate(from modelType: Model.Type,
 /// compose `insert`, `update`, `delete` and `select` statements with conditions.
 struct ConditionStatement: SQLStatement {
 
-    let modelType: Model.Type
+    let modelSchema: ModelSchema
     let stringValue: String
     let variables: [Binding?]
 
-    init(modelType: Model.Type, predicate: QueryPredicate, namespace: Substring? = nil) {
-        self.modelType = modelType
+    init(modelSchema: ModelSchema, predicate: QueryPredicate, namespace: Substring? = nil) {
+        self.modelSchema = modelSchema
 
-        let (sql, variables) = translateQueryPredicate(from: modelType,
+        let (sql, variables) = translateQueryPredicate(from: modelSchema,
                                                        predicate: predicate,
                                                        namespace: namespace)
         self.stringValue = sql

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
@@ -50,8 +50,13 @@ struct CreateTableStatement: SQLStatement {
         for (index, foreignKey) in foreignKeys.enumerated() {
             statement += "  foreign key(\"\(foreignKey.sqlName)\") "
             let associatedModel = foreignKey.requiredAssociatedModel
-            let associatedId = associatedModel.schema.primaryKey
-            let associatedModelName = associatedModel.schema.name
+            guard let schema = ModelRegistry.modelSchema(from: associatedModel) else {
+                preconditionFailure("""
+                Could not retrieve schema for the model \(associatedModel), verify that datastore is initialized.
+                """)
+            }
+            let associatedId = schema.primaryKey
+            let associatedModelName = schema.name
             statement += "references \(associatedModelName)(\"\(associatedId.sqlName)\")\n"
             statement += "    on delete cascade"
             let isNotLastKey = index < foreignKeys.endIndex - 1

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
@@ -9,22 +9,20 @@ import Amplify
 import Foundation
 
 /// Represents a `create table` SQL statement. The table is created based on the `ModelSchema`
-/// associated with the passed `Model.Type`.
 struct CreateTableStatement: SQLStatement {
 
-    let modelType: Model.Type
+    let modelSchema: ModelSchema
 
-    init(modelType: Model.Type) {
-        self.modelType = modelType
+    init(modelSchema: ModelSchema) {
+        self.modelSchema = modelSchema
     }
 
     var stringValue: String {
-        let schema = modelType.schema
-        let name = schema.name
+        let name = modelSchema.name
         var statement = "create table if not exists \(name) (\n"
 
-        let columns = schema.columns
-        let foreignKeys = schema.foreignKeys
+        let columns = modelSchema.columns
+        let foreignKeys = modelSchema.foreignKeys
 
         for (index, column) in columns.enumerated() {
             statement += "  \"\(column.sqlName)\" \(column.sqlType.rawValue)"

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Delete.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Delete.swift
@@ -12,16 +12,16 @@ import SQLite
 /// Represents a `delete` SQL statement that is optionally composed by a `ConditionStatement`.
 struct DeleteStatement: SQLStatement {
 
-    let modelType: Model.Type
+    let modelSchema: ModelSchema
     let conditionStatement: ConditionStatement?
     let namespace = "root"
 
-    init(modelType: Model.Type, predicate: QueryPredicate? = nil) {
-        self.modelType = modelType
+    init(modelSchema: ModelSchema, predicate: QueryPredicate? = nil) {
+        self.modelSchema = modelSchema
 
         var conditionStatement: ConditionStatement?
         if let predicate = predicate {
-            let statement = ConditionStatement(modelType: modelType,
+            let statement = ConditionStatement(modelSchema: modelSchema,
                                                predicate: predicate,
                                                namespace: namespace[...])
             conditionStatement = statement
@@ -29,18 +29,17 @@ struct DeleteStatement: SQLStatement {
         self.conditionStatement = conditionStatement
     }
 
-    init(modelType: Model.Type, withId id: Model.Identifier) {
-        self.init(modelType: modelType, predicate: field("id") == id)
+    init(modelSchema: ModelSchema, withId id: Model.Identifier) {
+        self.init(modelSchema: modelSchema, predicate: field("id") == id)
     }
 
     init(model: Model) {
-        self.init(modelType: type(of: model))
+        self.init(modelSchema: model.schema)
     }
 
     var stringValue: String {
-        let schema = modelType.schema
         let sql = """
-        delete from \(schema.name) as \(namespace)
+        delete from \(modelSchema.name) as \(namespace)
         """
 
         if let conditionStatement = conditionStatement {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
@@ -11,20 +11,18 @@ import SQLite
 
 /// Represents a `insert` SQL statement associated with a `Model` instance.
 struct InsertStatement: SQLStatement {
-
-    let modelType: Model.Type
+    let modelSchema: ModelSchema
     let variables: [Binding?]
 
-    init(model: Model) {
-        self.modelType = type(of: model)
-        self.variables = model.sqlValues(for: modelType.schema.columns)
+    init(model: Model, modelSchema: ModelSchema) {
+        self.modelSchema = modelSchema
+        self.variables = model.sqlValues(for: modelSchema.columns)
     }
 
     var stringValue: String {
-        let schema = modelType.schema
-        let fields = schema.columns
+        let fields = modelSchema.columns
         let columns = fields.map { $0.columnName() }
-        var statement = "insert into \(schema.name) "
+        var statement = "insert into \(modelSchema.name) "
         statement += "(\(columns.joined(separator: ", ")))\n"
 
         let variablePlaceholders = Array(repeating: "?", count: columns.count).joined(separator: ", ")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
@@ -16,7 +16,7 @@ struct InsertStatement: SQLStatement {
 
     init(model: Model, modelSchema: ModelSchema) {
         self.modelSchema = modelSchema
-        self.variables = model.sqlValues(for: modelSchema.columns)
+        self.variables = model.sqlValues(for: modelSchema.columns, modelSchema: modelSchema)
     }
 
     var stringValue: String {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Update.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Update.swift
@@ -12,18 +12,18 @@ import SQLite
 /// Represents a `update` SQL statement.
 struct UpdateStatement: SQLStatement {
 
-    let modelType: Model.Type
+    let modelSchema: ModelSchema
     let conditionStatement: ConditionStatement?
 
     private let model: Model
 
-    init(model: Model, condition: QueryPredicate? = nil) {
-        self.modelType = type(of: model)
+    init(model: Model, modelSchema: ModelSchema, condition: QueryPredicate? = nil) {
         self.model = model
+        self.modelSchema = model.schema
 
         var conditionStatement: ConditionStatement?
         if let condition = condition {
-            let statement = ConditionStatement(modelType: modelType,
+            let statement = ConditionStatement(modelSchema: modelSchema,
                                                predicate: condition)
             conditionStatement = statement
         }
@@ -32,7 +32,6 @@ struct UpdateStatement: SQLStatement {
     }
 
     var stringValue: String {
-        let schema = modelType.schema
         let columns = updateColumns.map { $0.columnName() }
 
         let columnsStatement = columns.map { column in
@@ -40,10 +39,10 @@ struct UpdateStatement: SQLStatement {
         }
 
         var sql = """
-        update \(schema.name)
+        update \(modelSchema.name)
         set
         \(columnsStatement.joined(separator: ",\n"))
-        where \(schema.primaryKey.columnName()) = ?
+        where \(modelSchema.primaryKey.columnName()) = ?
         """
 
         if let conditionStatement = conditionStatement {
@@ -66,6 +65,6 @@ struct UpdateStatement: SQLStatement {
     }
 
     private var updateColumns: [ModelField] {
-        modelType.schema.columns.filter { !$0.isPrimaryKey }
+        modelSchema.columns.filter { !$0.isPrimaryKey }
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Update.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Update.swift
@@ -19,7 +19,7 @@ struct UpdateStatement: SQLStatement {
 
     init(model: Model, modelSchema: ModelSchema, condition: QueryPredicate? = nil) {
         self.model = model
-        self.modelSchema = model.schema
+        self.modelSchema = modelSchema
 
         var conditionStatement: ConditionStatement?
         if let condition = condition {
@@ -56,7 +56,7 @@ struct UpdateStatement: SQLStatement {
     }
 
     var variables: [Binding?] {
-        var bindings = model.sqlValues(for: updateColumns)
+        var bindings = model.sqlValues(for: updateColumns, modelSchema: modelSchema)
         bindings.append(model.id)
         if let conditionStatement = conditionStatement {
             bindings.append(contentsOf: conditionStatement.variables)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement.swift
@@ -22,3 +22,15 @@ extension SQLStatement {
         return []
     }
 }
+
+extension SQLStatement {
+
+    // `modelType` is deprecated, instead modelSchema should be used.
+    var modelType: Model.Type {
+        fatalError("""
+        DataStoreStatement.modelType is deprecated. SQLStatement is an internal type and there should be \
+        no references to modelType. If you encounter this error, please open a GitHub issue. \
+        https://github.com/aws-amplify/amplify-ios/issues/new/choose
+        """)
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -97,12 +97,12 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
     }
 
     func save<M: Model>(_ model: M, condition: QueryPredicate? = nil, completion: @escaping DataStoreCallback<M>) {
-         save(model, modelSchema: model.schema, where: condition, completion: completion)
+         save(model, modelSchema: model.schema, condition: condition, completion: completion)
      }
 
     func save<M: Model>(_ model: M,
                         modelSchema: ModelSchema,
-                        where condition: QueryPredicate? = nil,
+                        condition: QueryPredicate? = nil,
                         completion: DataStoreCallback<M>) {
         do {
             let modelType = type(of: model)
@@ -159,10 +159,11 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
     }
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           predicate: QueryPredicate,
                           completion: (DataStoreResult<[M]>) -> Void) {
         do {
-            let statement = DeleteStatement(modelSchema: modelType.schema, predicate: predicate)
+            let statement = DeleteStatement(modelSchema: modelSchema, predicate: predicate)
             _ = try connection.prepare(statement.stringValue).run(statement.variables)
             completion(.success([]))
         } catch {
@@ -171,9 +172,10 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
     }
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           withId id: Model.Identifier,
                           completion: (DataStoreResult<M?>) -> Void) {
-        delete(untypedModelType: modelType, withId: id) { result in
+        delete(untypedModelType: modelType, modelSchema: modelSchema, withId: id) { result in
             switch result {
             case .success:
                 completion(.success(nil))
@@ -184,10 +186,11 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
     }
 
     func delete(untypedModelType modelType: Model.Type,
+                modelSchema: ModelSchema,
                 withId id: Model.Identifier,
                 completion: DataStoreCallback<Void>) {
         do {
-            let statement = DeleteStatement(modelSchema: modelType.schema, withId: id)
+            let statement = DeleteStatement(modelSchema: modelSchema, withId: id)
             _ = try connection.prepare(statement.stringValue).run(statement.variables)
             completion(.emptyResult)
         } catch {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -81,12 +81,12 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
         return documentsPath.appendingPathComponent("\(databaseName).db")
     }
 
-    func setUp(models: [Model.Type]) throws {
-        log.debug("Setting up \(models.count) models")
+    func setUp(modelSchemas: [ModelSchema]) throws {
+        log.debug("Setting up \(modelSchemas.count) models")
 
-        let createTableStatements = models
+        let createTableStatements = modelSchemas
             .sortByDependencyOrder()
-            .map { CreateTableStatement(modelSchema: $0.schema).stringValue }
+            .map { CreateTableStatement(modelSchema: $0).stringValue }
             .joined(separator: "\n")
 
         do {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -296,9 +296,9 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
         return try result.unique()
     }
 
-    func queryModelSyncMetadata(for modelType: Model.Type) throws -> ModelSyncMetadata? {
+    func queryModelSyncMetadata(for modelSchema: ModelSchema) throws -> ModelSyncMetadata? {
         let statement = SelectStatement(from: ModelSyncMetadata.schema,
-                                        predicate: field("id").eq(modelType.modelName))
+                                        predicate: field("id").eq(modelSchema.name))
         let rows = try connection.prepare(statement.stringValue).run(statement.variables)
         let result = try rows.convert(to: ModelSyncMetadata.self,
                                       using: statement)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
@@ -22,10 +22,10 @@ extension SQLiteStorageEngineAdapter {
             // TODO serialize result and create a new instance of the model
             // (some columns might be auto-generated after DB insert/update)
             if shouldUpdate {
-                let statement = UpdateStatement(model: untypedModel)
+                let statement = UpdateStatement(model: untypedModel, modelSchema: modelType.schema)
                 _ = try connection.prepare(statement.stringValue).run(statement.variables)
             } else {
-                let statement = InsertStatement(model: untypedModel)
+                let statement = InsertStatement(model: untypedModel, modelSchema: modelType.schema)
                 _ = try connection.prepare(statement.stringValue).run(statement.variables)
             }
 
@@ -39,7 +39,7 @@ extension SQLiteStorageEngineAdapter {
                predicate: QueryPredicate? = nil,
                completion: DataStoreCallback<[Model]>) {
         do {
-            let statement = SelectStatement(from: modelType, predicate: predicate)
+            let statement = SelectStatement(from: modelType.schema, predicate: predicate)
             let rows = try connection.prepare(statement.stringValue).run(statement.variables)
             let result: [Model] = try rows.convert(toUntypedModel: modelType, using: statement)
             completion(.success(result))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
@@ -22,10 +22,10 @@ extension SQLiteStorageEngineAdapter {
             // TODO serialize result and create a new instance of the model
             // (some columns might be auto-generated after DB insert/update)
             if shouldUpdate {
-                let statement = UpdateStatement(model: untypedModel, modelSchema: modelType.schema)
+                let statement = UpdateStatement(model: untypedModel, modelSchema: untypedModel.schema)
                 _ = try connection.prepare(statement.stringValue).run(statement.variables)
             } else {
-                let statement = InsertStatement(model: untypedModel, modelSchema: modelType.schema)
+                let statement = InsertStatement(model: untypedModel, modelSchema: untypedModel.schema)
                 _ = try connection.prepare(statement.stringValue).run(statement.variables)
             }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
@@ -17,7 +17,7 @@ extension SQLiteStorageEngineAdapter {
                 throw error
             }
 
-            let shouldUpdate = try exists(modelType, withId: untypedModel.id)
+            let shouldUpdate = try exists(modelType.schema, withId: untypedModel.id)
 
             // TODO serialize result and create a new instance of the model
             // (some columns might be auto-generated after DB insert/update)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -54,11 +54,11 @@ final class StorageEngine: StorageEngineBehavior {
         return storageEnginePublisher.eraseToAnyPublisher()
     }
 
-    static var systemModels: [Model.Type] {
+    static var systemModelSchemas: [ModelSchema] {
         return [
-            ModelSyncMetadata.self,
-            MutationEvent.self,
-            MutationSyncMetadata.self
+            ModelSyncMetadata.schema,
+            MutationEvent.schema,
+            MutationSyncMetadata.schema
         ]
     }
 
@@ -88,7 +88,7 @@ final class StorageEngine: StorageEngineBehavior {
 
         let storageAdapter = try SQLiteStorageEngineAdapter(version: modelRegistryVersion, databaseName: databaseName)
 
-        try storageAdapter.setUp(models: StorageEngine.systemModels)
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
         if #available(iOS 13.0, *) {
             let syncEngine = isSyncEnabled ? try? RemoteSyncEngine(storageAdapter: storageAdapter,
                                                                    dataStoreConfiguration: dataStoreConfiguration) : nil
@@ -126,8 +126,8 @@ final class StorageEngine: StorageEngineBehavior {
         }
     }
 
-    func setUp(models: [Model.Type]) throws {
-        try storageAdapter.setUp(models: models)
+    func setUp(modelSchemas: [ModelSchema]) throws {
+        try storageAdapter.setUp(modelSchemas: modelSchemas)
     }
 
     func save<M: Model>(_ model: M, condition: QueryPredicate? = nil, completion: @escaping DataStoreCallback<M>) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -135,7 +135,7 @@ final class StorageEngine: StorageEngineBehavior {
         // mutation type
         let modelExists: Bool
         do {
-            modelExists = try storageAdapter.exists(M.self, withId: model.id, predicate: nil)
+            modelExists = try storageAdapter.exists(M.schema, withId: model.id, predicate: nil)
         } catch {
             let dataStoreError = DataStoreError.invalidOperation(causedBy: error)
             completion(.failure(dataStoreError))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -15,21 +15,19 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
     func save(untypedModel: Model, completion: @escaping DataStoreCallback<Model>)
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           withId id: Model.Identifier,
                           completion: @escaping DataStoreCallback<M?>)
-
-    func delete(untypedModelType modelType: Model.Type,
-                withId id: Model.Identifier,
-                completion: DataStoreCallback<Void>)
-
-    func delete<M: Model>(_ modelType: M.Type,
-                          predicate: QueryPredicate,
-                          completion: @escaping DataStoreCallback<[M]>)
 
     func delete(untypedModelType modelType: Model.Type,
                 modelSchema: ModelSchema,
                 withId id: Model.Identifier,
                 completion: DataStoreCallback<Void>)
+
+    func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
+                          predicate: QueryPredicate,
+                          completion: @escaping DataStoreCallback<[M]>)
 
     func query(untypedModel modelType: Model.Type,
                predicate: QueryPredicate?,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -16,7 +16,7 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
 
     func delete<M: Model>(_ modelType: M.Type,
                           withId id: Model.Identifier,
-                          completion: DataStoreCallback<M?>)
+                          completion: @escaping DataStoreCallback<M?>)
 
     func delete(untypedModelType modelType: Model.Type,
                 withId id: Model.Identifier,
@@ -26,16 +26,14 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
                           predicate: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>)
 
+    func delete(untypedModelType modelType: Model.Type,
+                modelSchema: ModelSchema,
+                withId id: Model.Identifier,
+                completion: DataStoreCallback<Void>)
+
     func query(untypedModel modelType: Model.Type,
                predicate: QueryPredicate?,
                completion: DataStoreCallback<[Model]>)
-
-    func query<M: Model>(_ modelType: M.Type,
-                         modelSchema: ModelSchema,
-                         predicate: QueryPredicate?,
-                         sort: QuerySortInput?,
-                         paginationInput: QueryPaginationInput?,
-                         completion: DataStoreCallback<[M]>)
 
     // MARK: - Synchronous APIs
 
@@ -54,4 +52,25 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
     func transaction(_ basicClosure: BasicThrowableClosure) throws
 
     func clear(completion: @escaping DataStoreCallback<Void>)
+}
+
+extension StorageEngineAdapter {
+
+    func delete<M: Model>(_ modelType: M.Type,
+                          predicate: QueryPredicate,
+                          completion: @escaping DataStoreCallback<[M]>) {
+        delete(modelType, modelSchema: modelType.schema, predicate: predicate, completion: completion)
+    }
+
+    func delete<M: Model>(_ modelType: M.Type,
+                          withId id: Model.Identifier,
+                          completion: @escaping DataStoreCallback<M?>) {
+        delete(modelType, modelSchema: modelType.schema, withId: id, completion: completion)
+    }
+
+    func delete(untypedModelType modelType: Model.Type,
+                withId id: Model.Identifier,
+                completion: DataStoreCallback<Void>) {
+        delete(untypedModelType: modelType, modelSchema: modelType.schema, withId: id, completion: completion)
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -31,6 +31,7 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
                completion: DataStoreCallback<[Model]>)
 
     func query<M: Model>(_ modelType: M.Type,
+                         modelSchema: ModelSchema,
                          predicate: QueryPredicate?,
                          sort: QuerySortInput?,
                          paginationInput: QueryPaginationInput?,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -38,7 +38,7 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
 
     // MARK: - Synchronous APIs
 
-    func exists(_ modelType: Model.Type,
+    func exists(_ modelSchema: ModelSchema,
                 withId id: Model.Identifier,
                 predicate: QueryPredicate?) throws -> Bool
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -45,7 +45,7 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
 
     func queryMutationSyncMetadata(for modelId: Model.Identifier) throws -> MutationSyncMetadata?
 
-    func queryModelSyncMetadata(for modelType: Model.Type) throws -> ModelSyncMetadata?
+    func queryModelSyncMetadata(for modelSchema: ModelSchema) throws -> ModelSyncMetadata?
 
     func transaction(_ basicClosure: BasicThrowableClosure) throws
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -112,7 +112,7 @@ final class InitialSyncOperation: AsynchronousOperation {
         }
         let minSyncPageSize = Int(min(syncMaxRecords - recordsReceived, syncPageSize))
         let limit = minSyncPageSize < 0 ? Int(syncPageSize) : minSyncPageSize
-        let request = GraphQLRequest<SyncQueryResult>.syncQuery(modelType: modelType,
+        let request = GraphQLRequest<SyncQueryResult>.syncQuery(modelSchema: modelType.schema,
                                                                 limit: limit,
                                                                 nextToken: nextToken,
                                                                 lastSync: lastSyncTime)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
@@ -145,7 +145,7 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
             let group = DispatchGroup()
             localEvents.forEach {
                 group.enter()
-                storageAdapter.delete(MutationEvent.self, withId: $0.id) { _ in group.leave() }
+                storageAdapter.delete(MutationEvent.self, modelSchema: MutationEvent.schema, withId: $0.id) { _ in group.leave() }
             }
             group.wait()
             completionPromise(.success(candidate))
@@ -166,7 +166,7 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
                 // TODO: Handle errors from delete
                 localEvents
                     .suffix(from: 1)
-                    .forEach { storageAdapter.delete(MutationEvent.self, withId: $0.id) { _ in } }
+                    .forEach { storageAdapter.delete(MutationEvent.self, modelSchema: MutationEvent.schema, withId: $0.id) { _ in } }
             }
 
             let resolvedEvent = getResolvedEvent(for: eventToUpdate, applying: candidate)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
@@ -275,7 +275,7 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
             return
         }
 
-        storageAdapter.delete(untypedModelType: modelType, withId: id) { response in
+        storageAdapter.delete(untypedModelType: modelType, modelSchema: modelType.schema, withId: id) { response in
             switch response {
             case .failure(let dataStoreError):
                 let error = DataStoreError.unknown("Delete failed \(dataStoreError)", "")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -65,17 +65,23 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
                      stateMachine: StateMachine<State, Action>? = nil,
                      networkReachabilityPublisher: AnyPublisher<ReachabilityUpdate, Never>? = nil,
                      requestRetryablePolicy: RequestRetryablePolicy? = nil) throws {
+        
         let mutationDatabaseAdapter = try AWSMutationDatabaseAdapter(storageAdapter: storageAdapter)
         let awsMutationEventPublisher = AWSMutationEventPublisher(eventSource: mutationDatabaseAdapter)
+        
         let outgoingMutationQueue = outgoingMutationQueue ??
             OutgoingMutationQueue(storageAdapter: storageAdapter, dataStoreConfiguration: dataStoreConfiguration)
+        
         let reconciliationQueueFactory = reconciliationQueueFactory ??
-            AWSIncomingEventReconciliationQueue.init(modelTypes:api:storageAdapter:auth:modelReconciliationQueueFactory:)
+            AWSIncomingEventReconciliationQueue.init(modelSchemas:api:storageAdapter:auth:modelReconciliationQueueFactory:)
+        
         let initialSyncOrchestratorFactory = initialSyncOrchestratorFactory ??
             AWSInitialSyncOrchestrator.init(dataStoreConfiguration:api:reconciliationQueue:storageAdapter:)
+        
         let resolver = RemoteSyncEngine.Resolver.resolve(currentState:action:)
         let stateMachine = stateMachine ?? StateMachine(initialState: .notStarted,
                                                         resolver: resolver)
+        
         let requestRetryablePolicy = requestRetryablePolicy ?? RequestRetryablePolicy()
 
         self.init(storageAdapter: storageAdapter,
@@ -240,8 +246,8 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     private func initializeSubscriptions(api: APICategoryGraphQLBehavior,
                                          storageAdapter: StorageEngineAdapter) {
         log.debug(#function)
-        let syncableModelTypes = ModelRegistry.models.filter { $0.schema.isSyncable }
-        reconciliationQueue = reconciliationQueueFactory(syncableModelTypes, api, storageAdapter, auth, nil)
+        let syncableModelSchemas = ModelRegistry.modelSchemas.filter { $0.isSyncable }
+        reconciliationQueue = reconciliationQueueFactory(syncableModelSchemas, api, storageAdapter, auth, nil)
         reconciliationQueueSink = reconciliationQueue?.publisher.sink(
             receiveCompletion: onReceiveCompletion(receiveCompletion:),
             receiveValue: onReceive(receiveValue:))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -13,7 +13,7 @@ import Foundation
 //Used for testing:
 @available(iOS 13.0, *)
 typealias IncomingEventReconciliationQueueFactory =
-    ([Model.Type],
+    ([ModelSchema],
     APICategoryGraphQLBehavior,
     StorageEngineAdapter,
     AuthCategoryBehavior?,
@@ -23,8 +23,8 @@ typealias IncomingEventReconciliationQueueFactory =
 @available(iOS 13.0, *)
 final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue {
 
-    static let factory: IncomingEventReconciliationQueueFactory = { modelTypes, api, storageAdapter, auth, _ in
-        AWSIncomingEventReconciliationQueue(modelTypes: modelTypes,
+    static let factory: IncomingEventReconciliationQueueFactory = { modelSchemas, api, storageAdapter, auth, _ in
+        AWSIncomingEventReconciliationQueue(modelSchemas: modelSchemas,
                                             api: api,
                                             storageAdapter: storageAdapter,
                                             auth: auth,
@@ -42,7 +42,7 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
     private var reconciliationQueueConnectionStatus: [String: Bool]
     private var modelReconciliationQueueFactory: ModelReconciliationQueueFactory
 
-    init(modelTypes: [Model.Type],
+    init(modelSchemas: [ModelSchema],
          api: APICategoryGraphQLBehavior,
          storageAdapter: StorageEngineAdapter,
          auth: AuthCategoryBehavior? = nil,
@@ -52,14 +52,14 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
         self.reconciliationQueues = [:]
         self.reconciliationQueueConnectionStatus = [:]
         self.modelReconciliationQueueFactory = modelReconciliationQueueFactory ??
-            AWSModelReconciliationQueue.init(modelType:storageAdapter:api:auth:incomingSubscriptionEvents:)
+            AWSModelReconciliationQueue.init(modelSchema:storageAdapter:api:auth:incomingSubscriptionEvents:)
         //TODO: Add target for SyncEngine system to help prevent thread explosion and increase performance
         // https://github.com/aws-amplify/amplify-ios/issues/399
         self.connectionStatusSerialQueue
             = DispatchQueue(label: "com.amazonaws.DataStore.AWSIncomingEventReconciliationQueue")
-        for modelType in modelTypes {
-            let modelName = modelType.modelName
-            let queue = self.modelReconciliationQueueFactory(modelType, storageAdapter, api, auth, nil)
+        for modelSchema in modelSchemas {
+            let modelName = modelSchema.name
+            let queue = self.modelReconciliationQueueFactory(modelSchema, storageAdapter, api, auth, nil)
             guard reconciliationQueues[modelName] == nil else {
                 Amplify.DataStore.log
                     .warn("Duplicate model name found: \(modelName), not subscribing")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -22,9 +22,9 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
         return subscriptionEventSubject.eraseToAnyPublisher()
     }
 
-    init(modelType: Model.Type, api: APICategoryGraphQLBehavior, auth: AuthCategoryBehavior?) {
+    init(modelSchema: ModelSchema, api: APICategoryGraphQLBehavior, auth: AuthCategoryBehavior?) {
         self.subscriptionEventSubject = PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>()
-        self.asyncEvents = IncomingAsyncSubscriptionEventPublisher(modelType: modelType,
+        self.asyncEvents = IncomingAsyncSubscriptionEventPublisher(modelSchema: modelSchema,
                                                                    api: api,
                                                                    auth: auth)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -41,13 +41,13 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
 
     private let incomingSubscriptionEvents: PassthroughSubject<Event, DataStoreError>
 
-    init(modelType: Model.Type, api: APICategoryGraphQLBehavior, auth: AuthCategoryBehavior?) {
+    init(modelSchema: ModelSchema, api: APICategoryGraphQLBehavior, auth: AuthCategoryBehavior?) {
         self.onCreateConnected = false
         self.onUpdateConnected = false
         self.onDeleteConnected = false
         self.connectionStatusQueue = OperationQueue()
         connectionStatusQueue.name
-            = "com.amazonaws.Amplify.RemoteSyncEngine.\(modelType.modelName).IncomingAsyncSubscriptionEventPublisher"
+            = "com.amazonaws.Amplify.RemoteSyncEngine.\(modelSchema.name).IncomingAsyncSubscriptionEventPublisher"
         connectionStatusQueue.maxConcurrentOperationCount = 1
         connectionStatusQueue.isSuspended = false
 
@@ -57,7 +57,7 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
         let onCreateValueListener = onCreateValueListenerHandler(event:)
         self.onCreateValueListener = onCreateValueListener
         self.onCreateOperation = IncomingAsyncSubscriptionEventPublisher.apiSubscription(
-            for: modelType,
+            for: modelSchema,
             subscriptionType: .onCreate,
             api: api,
             auth: auth,
@@ -68,7 +68,7 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
         let onUpdateValueListener = onUpdateValueListenerHandler(event:)
         self.onUpdateValueListener = onUpdateValueListener
         self.onUpdateOperation = IncomingAsyncSubscriptionEventPublisher.apiSubscription(
-            for: modelType,
+            for: modelSchema,
             subscriptionType: .onUpdate,
             api: api,
             auth: auth,
@@ -79,7 +79,7 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
         let onDeleteValueListener = onDeleteValueListenerHandler(event:)
         self.onDeleteValueListener = onDeleteValueListener
         self.onDeleteOperation = IncomingAsyncSubscriptionEventPublisher.apiSubscription(
-            for: modelType,
+            for: modelSchema,
             subscriptionType: .onDelete,
             api: api,
             auth: auth,
@@ -147,7 +147,7 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
     }
 
     static func apiSubscription(
-        for modelType: Model.Type,
+        for modelSchema: ModelSchema,
         subscriptionType: GraphQLSubscriptionType,
         api: APICategoryGraphQLBehavior,
         auth: AuthCategoryBehavior?,
@@ -156,14 +156,14 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
     ) -> GraphQLSubscriptionOperation<Payload> {
 
         let request: GraphQLRequest<Payload>
-        if let auth = auth, modelType.schema.hasAuthenticationRules, let user = auth.getCurrentUser() {
+        if let auth = auth, modelSchema.hasAuthenticationRules, let user = auth.getCurrentUser() {
             // TODO: check model schema for identityClaim to figure out which is the ownerId field coming from
             // https://github.com/aws-amplify/amplify-ios/issues/485
-            request = GraphQLRequest<Payload>.subscription(to: modelType.schema,
+            request = GraphQLRequest<Payload>.subscription(to: modelSchema,
                                                            subscriptionType: subscriptionType,
                                                            ownerId: user.username)
         } else {
-            request = GraphQLRequest<Payload>.subscription(to: modelType.schema, subscriptionType: subscriptionType)
+            request = GraphQLRequest<Payload>.subscription(to: modelSchema, subscriptionType: subscriptionType)
         }
 
         let operation = api.subscribe(request: request,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -159,11 +159,11 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
         if let auth = auth, modelType.schema.hasAuthenticationRules, let user = auth.getCurrentUser() {
             // TODO: check model schema for identityClaim to figure out which is the ownerId field coming from
             // https://github.com/aws-amplify/amplify-ios/issues/485
-            request = GraphQLRequest<Payload>.subscription(to: modelType,
+            request = GraphQLRequest<Payload>.subscription(to: modelType.schema,
                                                            subscriptionType: subscriptionType,
                                                            ownerId: user.username)
         } else {
-            request = GraphQLRequest<Payload>.subscription(to: modelType, subscriptionType: subscriptionType)
+            request = GraphQLRequest<Payload>.subscription(to: modelType.schema, subscriptionType: subscriptionType)
         }
 
         let operation = api.subscribe(request: request,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -13,7 +13,7 @@ import Foundation
 //Used for testing:
 @available(iOS 13.0, *)
 typealias ModelReconciliationQueueFactory = (
-    Model.Type,
+    ModelSchema,
     StorageEngineAdapter,
     APICategoryGraphQLBehavior,
     AuthCategoryBehavior?,
@@ -71,32 +71,32 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
         return modelReconciliationQueueSubject.eraseToAnyPublisher()
     }
 
-    init(modelType: Model.Type,
+    init(modelSchema: ModelSchema,
          storageAdapter: StorageEngineAdapter?,
          api: APICategoryGraphQLBehavior,
          auth: AuthCategoryBehavior?,
          incomingSubscriptionEvents: IncomingSubscriptionEventPublisher? = nil) {
 
-        self.modelName = modelType.modelName
+        self.modelName = modelSchema.name
 
         self.storageAdapter = storageAdapter
 
         self.modelReconciliationQueueSubject = PassthroughSubject<ModelReconciliationQueueEvent, DataStoreError>()
 
         self.reconcileAndSaveQueue = OperationQueue()
-        reconcileAndSaveQueue.name = "com.amazonaws.DataStore.\(modelType).reconcile"
+        reconcileAndSaveQueue.name = "com.amazonaws.DataStore.\(modelName).reconcile"
         reconcileAndSaveQueue.maxConcurrentOperationCount = 1
         reconcileAndSaveQueue.underlyingQueue = DispatchQueue.global()
         reconcileAndSaveQueue.isSuspended = false
 
         self.incomingSubscriptionEventQueue = OperationQueue()
-        incomingSubscriptionEventQueue.name = "com.amazonaws.DataStore.\(modelType).remoteEvent"
+        incomingSubscriptionEventQueue.name = "com.amazonaws.DataStore.\(modelName).remoteEvent"
         incomingSubscriptionEventQueue.maxConcurrentOperationCount = 1
         incomingSubscriptionEventQueue.underlyingQueue = DispatchQueue.global()
         incomingSubscriptionEventQueue.isSuspended = true
 
         let resolvedIncomingSubscriptionEvents = incomingSubscriptionEvents ??
-            AWSIncomingSubscriptionEventPublisher(modelType: modelType, api: api, auth: auth)
+            AWSIncomingSubscriptionEventPublisher(modelSchema: modelSchema, api: api, auth: auth)
         self.incomingSubscriptionEvents = resolvedIncomingSubscriptionEvents
         self.reconcileAndLocalSaveOperationSinks = Set<AnyCancellable?>()
         self.incomingEventsSink = resolvedIncomingSubscriptionEvents

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -217,7 +217,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
             return
         }
 
-        storageAdapter.delete(untypedModelType: modelType, withId: remoteModel.model.id) { response in
+        storageAdapter.delete(untypedModelType: modelType, modelSchema: modelType.schema, withId: remoteModel.model.id) { response in
             switch response {
             case .failure(let dataStoreError):
                 let errorAction = Action.errored(dataStoreError)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
@@ -41,7 +41,7 @@ class SQLStatementTests: XCTestCase {
     /// - Then:
     ///   - check if the generated SQL statement is valid
     func testCreateTableFromSimpleModel() {
-        let statement = CreateTableStatement(modelType: Post.self)
+        let statement = CreateTableStatement(modelSchema: Post.schema)
         let expectedStatement = """
         create table if not exists Post (
           "id" text primary key not null,
@@ -65,7 +65,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid:
     ///     - contains a `foreign key` referencing `Post`
     func testCreateTableFromModelWithForeignKey() {
-        let statement = CreateTableStatement(modelType: Comment.self)
+        let statement = CreateTableStatement(modelSchema: Comment.schema)
         let expectedStatement = """
         create table if not exists Comment (
           "id" text primary key not null,
@@ -88,7 +88,7 @@ class SQLStatementTests: XCTestCase {
     ///     - contains a `foreign key` referencing `UserProfile`
     ///     - the foreign key column is `unique`
     func testCreateTableFromModelWithOneToOneForeignKey() {
-        let statement = CreateTableStatement(modelType: UserProfile.self)
+        let statement = CreateTableStatement(modelSchema: UserProfile.schema)
         let expectedStatement = """
         create table if not exists UserProfile (
           "id" text primary key not null,
@@ -109,7 +109,7 @@ class SQLStatementTests: XCTestCase {
     ///     - contains a `foreign key` referencing `Author`
     ///     - contains a `foreign key` referencing `Book`
     func testCreateTableFromManyToManyAssociationModel() {
-        let statement = CreateTableStatement(modelType: BookAuthor.self)
+        let statement = CreateTableStatement(modelSchema: BookAuthor.schema)
         let expectedStatement = """
         create table if not exists BookAuthor (
           "id" text primary key not null,
@@ -137,7 +137,7 @@ class SQLStatementTests: XCTestCase {
                         content: "content",
                         createdAt: .now(),
                         status: .draft)
-        let statement = InsertStatement(model: post)
+        let statement = InsertStatement(model: post, modelSchema: post.schema)
 
         let expectedStatement = """
         insert into Post ("id", "content", "createdAt", "draft", "rating", "status", "title", "updatedAt")
@@ -162,7 +162,7 @@ class SQLStatementTests: XCTestCase {
     func testInsertStatementFromModelWithForeignKey() {
         let post = Post(title: "title", content: "content", createdAt: .now())
         let comment = Comment(content: "comment", createdAt: .now(), post: post)
-        let statement = InsertStatement(model: comment)
+        let statement = InsertStatement(model: comment, modelSchema: comment.schema)
 
         let expectedStatement = """
         insert into Comment ("id", "content", "createdAt", "commentPostId")
@@ -185,7 +185,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the variables match the expected values
     func testUpdateStatementFromModel() {
         let post = Post(title: "title", content: "content", createdAt: .now())
-        let statement = UpdateStatement(model: post)
+        let statement = UpdateStatement(model: post, modelSchema: post.schema)
 
         let expectedStatement = """
         update Post
@@ -216,7 +216,7 @@ class SQLStatementTests: XCTestCase {
     func testUpdateStatementFromModelWithCondition() {
         let post = Post(title: "title", content: "content", createdAt: .now())
         let condition = Post.keys.content == "content2"
-        let statement = UpdateStatement(model: post, condition: condition)
+        let statement = UpdateStatement(model: post, modelSchema: post.schema, condition: condition)
 
         let expectedStatement = """
         update Post
@@ -249,7 +249,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the variables match the expected values
     func testDeleteStatementFromModel() {
         let id = UUID().uuidString
-        let statement = DeleteStatement(modelType: Post.self, withId: id)
+        let statement = DeleteStatement(modelSchema: Post.schema, withId: id)
 
         let expectedStatement = """
         delete from Post as root
@@ -270,7 +270,7 @@ class SQLStatementTests: XCTestCase {
     /// - Then:
     ///   - check if the generated SQL statement is valid
     func testSelectStatementFromModel() {
-        let statement = SelectStatement(from: Post.self)
+        let statement = SelectStatement(from: Post.schema)
         let expectedStatement = """
         select
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
@@ -291,7 +291,7 @@ class SQLStatementTests: XCTestCase {
     func testSelectStatementFromModelWithPredicate() {
         let post = Post.keys
         let predicate = post.draft == false && post.rating > 3
-        let statement = SelectStatement(from: Post.self, predicate: predicate)
+        let statement = SelectStatement(from: Post.schema, predicate: predicate)
         let expectedStatement = """
         select
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
@@ -316,7 +316,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if an inner join is added referencing `Post`
     func testSelectStatementFromModelWithJoin() {
-        let statement = SelectStatement(from: Comment.self)
+        let statement = SelectStatement(from: Comment.schema)
         let expectedStatement = """
         select
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
@@ -340,7 +340,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `limit` and `offset`
     func testSelectStatementWithPaginationInfo() {
-        let statement = SelectStatement(from: Post.self, predicate: nil, paginationInput: .page(2, limit: 20))
+        let statement = SelectStatement(from: Post.schema, predicate: nil, paginationInput: .page(2, limit: 20))
         let expectedStatement = """
         select
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
@@ -362,8 +362,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `order by` and `ascending`
     func testSelectStatementWithOneSort() {
-        let statement = SelectStatement(from: Post.self,
-                                        sort: .ascending(Post.keys.id))
+        let statement = SelectStatement(from: Post.schema, sort: .ascending(Post.keys.id))
         let expectedStatement = """
         select
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
@@ -383,7 +382,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `order by` and `ascending`
     func testSelectStatementWithTwoFieldsSort() {
-        let statement = SelectStatement(from: Post.self,
+        let statement = SelectStatement(from: Post.schema,
                                         sort: .by(.ascending(Post.keys.id),
                                                   .descending(Post.keys.createdAt)))
         let expectedStatement = """
@@ -405,7 +404,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `where` statement, `order by` and `ascending`
     func testSelectStatementWithPredicateAndSort() {
-        let statement = SelectStatement(from: Post.self,
+        let statement = SelectStatement(from: Post.schema,
                                         predicate: Post.keys.rating > 4,
                                         sort: .descending(Post.keys.id))
         let expectedStatement = """
@@ -430,7 +429,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `where` statement, `order by` and `ascending`
     func testSelectStatementWithSortAndPaginationInfo() {
-        let statement = SelectStatement(from: Post.self,
+        let statement = SelectStatement(from: Post.schema,
                                         sort: .descending(Post.keys.id),
                                         paginationInput: .page(0, limit: 5))
         let expectedStatement = """
@@ -455,7 +454,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `where` statement, `order by` and `ascending`
     func testSelectStatementWithPredicateAndSortAndPaginationInfo() {
-        let statement = SelectStatement(from: Post.self,
+        let statement = SelectStatement(from: Post.schema,
                                         predicate: Post.keys.rating > 4,
                                         sort: .descending(Post.keys.id),
                                         paginationInput: .page(0, limit: 5))
@@ -485,7 +484,7 @@ class SQLStatementTests: XCTestCase {
         let post = Post.keys
 
         let predicate = post.id != nil
-        let statement = ConditionStatement(modelType: Post.self, predicate: predicate)
+        let statement = ConditionStatement(modelSchema: Post.schema, predicate: predicate)
 
         XCTAssertEqual("""
           and "id" is not null
@@ -503,7 +502,7 @@ class SQLStatementTests: XCTestCase {
         let post = Post.keys
 
         let predicate = post.id != nil
-        let statement = ConditionStatement(modelType: Post.self, predicate: predicate, namespace: "root")
+        let statement = ConditionStatement(modelSchema: Post.schema, predicate: predicate, namespace: "root")
 
         XCTAssertEqual("""
           and "root"."id" is not null
@@ -521,7 +520,7 @@ class SQLStatementTests: XCTestCase {
         func assertPredicate(_ predicate: QueryPredicate,
                              matches sql: String,
                              bindings: [Binding?]? = nil) {
-            let statement = ConditionStatement(modelType: Post.self, predicate: predicate, namespace: "root")
+            let statement = ConditionStatement(modelSchema: Post.schema, predicate: predicate, namespace: "root")
             XCTAssertEqual(statement.stringValue, "  and \(sql)")
             if let bindings = bindings {
                 XCTAssertEqual(bindings.count, statement.variables.count)
@@ -570,7 +569,7 @@ class SQLStatementTests: XCTestCase {
             && post.updatedAt == nil
             && (post.content ~= "gelato" || post.title.beginsWith("ice cream"))
 
-        let statement = ConditionStatement(modelType: Post.self, predicate: predicate)
+        let statement = ConditionStatement(modelSchema: Post.schema, predicate: predicate)
 
         XCTAssertEqual("""
           and "id" is not null
@@ -610,7 +609,7 @@ class SQLStatementTests: XCTestCase {
             && post.updatedAt == nil
             && (post.content ~= "gelato" || post.title.beginsWith("ice cream"))
 
-        let statement = ConditionStatement(modelType: Post.self, predicate: predicate, namespace: "root")
+        let statement = ConditionStatement(modelSchema: Post.schema, predicate: predicate, namespace: "root")
 
         XCTAssertEqual("""
           and "root"."id" is not null

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
@@ -1,0 +1,110 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+import Foundation
+import SQLite
+
+class SQLiteStorageEngineAdapterJsonTests: XCTestCase {
+
+    var connection: Connection!
+    var storageEngine: StorageEngine!
+    var storageAdapter: SQLiteStorageEngineAdapter!
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        super.setUp()
+        sleep(2)
+        Amplify.reset()
+        Amplify.Logging.logLevel = .warn
+
+        let validAPIPluginKey = "MockAPICategoryPlugin"
+        let validAuthPluginKey = "MockAuthCategoryPlugin"
+        do {
+            connection = try Connection(.inMemory)
+            storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
+            try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
+
+            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
+                                                  dataStoreConfiguration: .default)
+            storageEngine = StorageEngine(storageAdapter: storageAdapter,
+                                          dataStoreConfiguration: .default,
+                                          syncEngine: syncEngine,
+                                          validAPIPluginKey: validAPIPluginKey,
+                                          validAuthPluginKey: validAuthPluginKey)
+        } catch {
+            XCTFail(String(describing: error))
+            return
+        }
+
+        let dataStorePublisher = DataStorePublisher()
+        let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestJsonModelRegistration(),
+                                                 storageEngine: storageEngine,
+                                                 dataStorePublisher: dataStorePublisher,
+                                                 validAPIPluginKey: validAPIPluginKey,
+                                                 validAuthPluginKey: validAuthPluginKey)
+
+        let dataStoreConfig = DataStoreCategoryConfiguration(plugins: [
+            "awsDataStorePlugin": true
+        ])
+        let amplifyConfig = AmplifyConfiguration(dataStore: dataStoreConfig)
+
+        do {
+
+            try Amplify.add(plugin: dataStorePlugin)
+            try Amplify.configure(amplifyConfig)
+        } catch {
+            XCTFail(String(describing: error))
+            return
+        }
+    }
+
+    /// - Given: a list a `Post` instance
+    /// - When:
+    ///   - the `save(post)` is called
+    /// - Then:
+    ///   - call `query(Post)` to check if the model was correctly inserted
+    func testInsertPost() {
+        let expectation = self.expectation(
+            description: "it should save and select a Post from the database")
+
+        // insert a post
+        let post = ["title": "title",
+                    "content": "content information"] as [String: JSONValue]
+        let model = DynamicModel(values: post)
+        storageAdapter.save(model, modelSchema: ModelRegistry.modelSchema(from: "Post")!) { saveResult in
+            switch saveResult {
+            case .success:
+                self.storageAdapter.query(
+                    DynamicModel.self,
+                    modelSchema: ModelRegistry.modelSchema(from: "Post")!) { queryResult in
+                        switch queryResult {
+                        case .success(let posts):
+                            XCTAssert(posts.count == 1)
+                            if let savedPost = posts.first {
+                                XCTAssert(model.id == savedPost.id)
+                            }
+                            expectation.fulfill()
+                        case .failure(let error):
+                            XCTFail(String(describing: error))
+                            expectation.fulfill()
+                        }
+                }
+            case .failure(let error):
+                XCTFail(String(describing: error))
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: 5)
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -27,7 +27,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
         storageAdapter.save(post) { saveResult in
             switch saveResult {
             case .success:
-                storageAdapter.query(Post.self) { queryResult in
+                self.storageAdapter.query(Post.self) { queryResult in
                     switch queryResult {
                     case .success(let posts):
                         XCTAssert(posts.count == 1)
@@ -68,7 +68,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             switch saveResult {
             case .success:
                 let predicate = Post.keys.title == post.title
-                storageAdapter.query(Post.self, predicate: predicate) { queryResult in
+                self.storageAdapter.query(Post.self, predicate: predicate) { queryResult in
                     switch queryResult {
                     case .success(let posts):
                         XCTAssertEqual(posts.count, 1)
@@ -126,7 +126,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             switch insertResult {
             case .success:
                 post.title = "title updated"
-                storageAdapter.save(post) { updateResult in
+                self.storageAdapter.save(post) { updateResult in
                     switch updateResult {
                     case .success:
                         checkSavedPost(id: post.id)
@@ -177,7 +177,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             case .success:
                 post.title = "title updated"
                 let condition = Post.keys.content == post.content
-                storageAdapter.save(post, condition: condition) { updateResult in
+                self.storageAdapter.save(post, condition: condition) { updateResult in
                     switch updateResult {
                     case .success:
                         checkSavedPost(id: post.id)
@@ -237,7 +237,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             case .success:
                 post.title = "title updated"
                 let condition = Post.keys.content == "content 2 does not match previous content"
-                storageAdapter.save(post, condition: condition) { updateResult in
+                self.storageAdapter.save(post, condition: condition) { updateResult in
                     switch updateResult {
                     case .success:
                         XCTFail("Update should not be successful")
@@ -274,11 +274,11 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             switch insertResult {
             case .success:
                 saveExpectation.fulfill()
-                storageAdapter.delete(Post.self, withId: post.id) {
+                self.storageAdapter.delete(Post.self, withId: post.id) {
                     switch $0 {
                     case .success:
                         deleteExpectation.fulfill()
-                        checkIfPostIsDeleted(id: post.id)
+                        self.checkIfPostIsDeleted(id: post.id)
                         queryExpectation.fulfill()
                     case .failure(let error):
                         XCTFail(error.errorDescription)
@@ -306,11 +306,11 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                 saveExpectation.fulfill()
                 let postKeys = Post.keys
                 let predicate = postKeys.createdAt.gt(dateTestStart)
-                storageAdapter.delete(Post.self, predicate: predicate) { result in
+                self.storageAdapter.delete(Post.self, predicate: predicate) { result in
                     switch result {
                     case .success:
                         deleteExpectation.fulfill()
-                        checkIfPostIsDeleted(id: post.id)
+                        self.checkIfPostIsDeleted(id: post.id)
                         queryExpectation.fulfill()
                     case .failure(let error):
                         XCTFail(error.errorDescription)
@@ -345,12 +345,12 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                     postsAdded.append(post.id)
                     if counter == maxCount - 1 {
                         saveExpectation.fulfill()
-                        storageAdapter.delete(Post.self, predicate: QueryPredicateConstant.all) { result in
+                        self.storageAdapter.delete(Post.self, predicate: QueryPredicateConstant.all) { result in
                             switch result {
                             case .success:
                                 deleteExpectation.fulfill()
                                 for postId in postsAdded {
-                                    checkIfPostIsDeleted(id: postId)
+                                    self.checkIfPostIsDeleted(id: postId)
                                 }
                                 queryExpectation.fulfill()
                             case .failure(let error):

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -274,7 +274,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             switch insertResult {
             case .success:
                 saveExpectation.fulfill()
-                self.storageAdapter.delete(Post.self, withId: post.id) {
+                self.storageAdapter.delete(Post.self, modelSchema: Post.schema, withId: post.id) {
                     switch $0 {
                     case .success:
                         deleteExpectation.fulfill()
@@ -306,7 +306,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                 saveExpectation.fulfill()
                 let postKeys = Post.keys
                 let predicate = postKeys.createdAt.gt(dateTestStart)
-                self.storageAdapter.delete(Post.self, predicate: predicate) { result in
+                self.storageAdapter.delete(Post.self, modelSchema: Post.schema, predicate: predicate) { result in
                     switch result {
                     case .success:
                         deleteExpectation.fulfill()
@@ -345,7 +345,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                     postsAdded.append(post.id)
                     if counter == maxCount - 1 {
                         saveExpectation.fulfill()
-                        self.storageAdapter.delete(Post.self, predicate: QueryPredicateConstant.all) { result in
+                        self.storageAdapter.delete(Post.self, modelSchema: Post.schema, predicate: QueryPredicateConstant.all) { result in
                             switch result {
                             case .success:
                                 deleteExpectation.fulfill()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -369,7 +369,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
 
     func checkIfPostIsDeleted(id: String) {
         do {
-            let exists = try storageAdapter.exists(Post.self, withId: id)
+            let exists = try storageAdapter.exists(Post.schema, withId: id)
             XCTAssertFalse(exists, "ID \(id) should not exist")
         } catch {
             XCTFail(String(describing: error))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SortByDependencyOrderTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SortByDependencyOrderTests.swift
@@ -29,59 +29,59 @@ class SortByDependencyOrderTests: XCTestCase {
         modelList.forEach { ModelRegistry.register(modelType: $0) }
     }
 
-    /// - Given: a list of `Model` types
+    /// - Given: a list of `ModelSchema` types
     /// - When:
     ///   - the list is not in the correct order: `[Comment, Post]`
     /// - Then:
     ///   - check if `sortByDependencyOrder()` sorts the list to `[Post, Comment]`
     func testModelDependencySortOrder() {
-        let models: [Model.Type] = [Comment.self, Post.self]
+        let modelSchemas: [ModelSchema] = [Comment.schema, Post.schema]
 
-        let sorted = models.sortByDependencyOrder()
+        let sorted = modelSchemas.sortByDependencyOrder()
 
-        let sortedModelNames = sorted.map { $0.modelName }
+        let sortedModelNames = sorted.map { $0.name }
         XCTAssertEqual(sortedModelNames, ["Post", "Comment"])
     }
 
-    /// - Given: A list of `Model` types
+    /// - Given: A list of `ModelSchema` types
     /// - When:
     ///    - not all models are connected: `[Comment, MockSynced, Post]`
     /// - Then:
     ///    - the sorted list should include unconnected models at the end
     func testModelDependencySortForUnconnectedModels() {
-        let models: [Model.Type] = [Comment.self, MockSynced.self, Post.self]
+        let modelSchemas: [ModelSchema] = [Comment.schema, MockSynced.schema, Post.schema]
 
-        let sorted = models.sortByDependencyOrder()
+        let sorted = modelSchemas.sortByDependencyOrder()
 
-        let sortedModelNames = sorted.map { $0.modelName }
+        let sortedModelNames = sorted.map { $0.name }
         XCTAssertEqual(sortedModelNames, ["Post", "Comment", "MockSynced"])
     }
 
-    /// - Given: a list of Model types
+    /// - Given: a list of `ModelSchema` types
     /// - When:
     ///    - the list includes members of two diffrently-connected dependency graphs
     /// - Then:
     ///    - the sorted list should include both graphs in order
     func testMultipleConnectedModels() {
-        let models: [Model.Type] = [Comment.self, UserProfile.self, Post.self, UserAccount.self]
+        let modelSchemas: [ModelSchema] = [Comment.schema, UserProfile.schema, Post.schema, UserAccount.schema]
 
-        let sorted = models.sortByDependencyOrder()
+        let sorted = modelSchemas.sortByDependencyOrder()
 
-        let sortedModelNames = sorted.map { $0.modelName }
+        let sortedModelNames = sorted.map { $0.name }
         XCTAssertEqual(sortedModelNames, ["Post", "Comment", "UserAccount", "UserProfile"])
     }
 
-    /// - Given: a list of Model types
+    /// - Given: a list of `ModelSchema` types
     /// - When:
     ///    - the list includes a many-to-many connection
     /// - Then:
     ///    - the sorted list should include both leaf models before the join model
     func testManyToManyConnections() {
-        let models: [Model.Type] = [Author.self, BookAuthor.self, Book.self]
+        let modelSchemas: [ModelSchema] = [Author.schema, BookAuthor.schema, Book.schema]
 
-        let sorted = models.sortByDependencyOrder()
+        let sorted = modelSchemas.sortByDependencyOrder()
 
-        let sortedModelNames = sorted.map { $0.modelName }
+        let sortedModelNames = sorted.map { $0.name }
         XCTAssertEqual(sortedModelNames, ["Author", "Book", "BookAuthor"])
     }
 
@@ -95,9 +95,11 @@ class SortByDependencyOrderTests: XCTestCase {
                                   "UserAccount", "UserProfile"]
 
         for _ in 0 ..< 10 {
-            let models = modelList.shuffled()
-            let sorted = models.sortByDependencyOrder()
-            let sortedModelNames = sorted.map { $0.modelName }
+            let modelSchemas = modelList.shuffled().map { (modelType) -> ModelSchema in
+                modelType.schema
+            }
+            let sorted = modelSchemas.sortByDependencyOrder()
+            let sortedModelNames = sorted.map { $0.name }
             XCTAssertEqual(sortedModelNames, expectedModelNames)
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/DynamicModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/DynamicModel.swift
@@ -1,0 +1,65 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+
+struct DynamicModel: Model, JSONValueHolder {
+
+    public let id: String
+    public let values: [String: JSONValue]
+
+    public init(id: String = UUID().uuidString, values: [String: JSONValue]) {
+        self.id = id
+        self.values = values
+    }
+
+    public init(from decoder: Decoder) throws {
+
+        print("DEncode \(decoder)")
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        values = try decoder.singleValueContainer().decode([String: JSONValue].self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        print("Encode")
+        var container = encoder.unkeyedContainer()
+        try container.encode(values)
+    }
+
+    public func jsonValue(for key: String) -> Any?? {
+        if key == "id" {
+            return id
+        }
+        switch values[key] {
+        case .some(.array(let deserializedValue)):
+            return deserializedValue
+        case .some(.boolean(let deserializedValue)):
+            return deserializedValue
+        case .some(.number(let deserializedValue)):
+            return deserializedValue
+        case .some(.object(let deserializedValue)):
+            return deserializedValue
+        case .some(.string(let deserializedValue)):
+            return deserializedValue
+        case .some(.null):
+            return .some(nil)
+        case .none:
+            return nil
+        }
+    }
+}
+
+extension DynamicModel {
+
+    public enum CodingKeys: String, ModelKey {
+        case id
+        case values
+    }
+
+    public static let keys = CodingKeys.self
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/SQLModelValueConverterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/SQLModelValueConverterTests.swift
@@ -55,7 +55,7 @@ class SQLModelValueConverterTests: BaseDataStoreTests {
         let example = exampleModel
 
         // convert model to SQLite Bindings
-        let bindings = example.sqlValues()
+        let bindings = example.sqlValues(modelSchema: example.schema)
 
         // columns are ordered, so check if the values are correct and in the right index
         XCTAssertEqual(bindings.count, ExampleWithEveryType.schema.columns.count)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
@@ -65,7 +65,7 @@ extension APICategoryDependencyTests {
 
         let connection = try Connection(.inMemory)
         storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-        try storageAdapter.setUp(models: StorageEngine.systemModels)
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
 
         let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
                                               dataStoreConfiguration: .default)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -234,7 +234,7 @@ class InitialSyncOperationTests: XCTestCase {
         apiPlugin.responders[.queryRequestListener] = responder
 
         let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
-        try storageAdapter.setUp(models: StorageEngine.systemModels + [MockSynced.self])
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas + [MockSynced.schema])
 
         let syncCallbackReceived = expectation(description: "Sync callback received, sync operation is complete")
         let reconciliationQueue = MockReconciliationQueue()
@@ -328,7 +328,7 @@ class InitialSyncOperationTests: XCTestCase {
         let startDateMilliseconds = (Int(Date().timeIntervalSince1970) - 100) * 1_000
 
         let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
-        try storageAdapter.setUp(models: StorageEngine.systemModels + [MockSynced.self])
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas + [MockSynced.schema])
 
         let syncMetadata = ModelSyncMetadata(id: MockSynced.modelName, lastSync: startDateMilliseconds)
         let syncMetadataSaved = expectation(description: "Sync metadata saved")
@@ -375,7 +375,7 @@ class InitialSyncOperationTests: XCTestCase {
         let startDateMilliSeconds = (Int(Date().timeIntervalSince1970) - 100) * 1_000
 
         let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
-        try storageAdapter.setUp(models: StorageEngine.systemModels + [MockSynced.self])
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas + [MockSynced.schema])
 
         let syncMetadata = ModelSyncMetadata(id: MockSynced.modelName, lastSync: startDateMilliSeconds)
         let syncMetadataSaved = expectation(description: "Sync metadata saved")
@@ -420,7 +420,7 @@ class InitialSyncOperationTests: XCTestCase {
 
     func testBaseQueryWithCustomSyncPageSize() throws {
         let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
-        try storageAdapter.setUp(models: StorageEngine.systemModels + [MockSynced.self])
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas + [MockSynced.schema])
 
         let apiWasQueried = expectation(description: "API was queried for a PaginatedList of AnyModel")
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { request, listener in

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -44,7 +44,7 @@ class InitialSyncOperationTests: XCTestCase {
 
         let reconciliationQueue = MockReconciliationQueue()
         let operation = InitialSyncOperation(
-            modelType: MockSynced.self,
+            modelSchema: MockSynced.schema,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
             storageAdapter: storageAdapter,
@@ -79,7 +79,7 @@ class InitialSyncOperationTests: XCTestCase {
 
         let reconciliationQueue = MockReconciliationQueue()
         let operation = InitialSyncOperation(
-            modelType: MockSynced.self,
+            modelSchema: MockSynced.schema,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
             storageAdapter: storageAdapter,
@@ -113,7 +113,7 @@ class InitialSyncOperationTests: XCTestCase {
         let reconciliationQueue = MockReconciliationQueue()
         let syncCallbackReceived = expectation(description: "Sync callback received, sync operation is complete")
         let operation = InitialSyncOperation(
-            modelType: MockSynced.self,
+            modelSchema: MockSynced.schema,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
             storageAdapter: storageAdapter,
@@ -155,7 +155,7 @@ class InitialSyncOperationTests: XCTestCase {
 
         let reconciliationQueue = MockReconciliationQueue()
         let operation = InitialSyncOperation(
-            modelType: MockSynced.self,
+            modelSchema: MockSynced.schema,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
             storageAdapter: storageAdapter,
@@ -204,7 +204,7 @@ class InitialSyncOperationTests: XCTestCase {
         }
 
         let operation = InitialSyncOperation(
-            modelType: MockSynced.self,
+            modelSchema: MockSynced.schema,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
             storageAdapter: storageAdapter,
@@ -239,7 +239,7 @@ class InitialSyncOperationTests: XCTestCase {
         let syncCallbackReceived = expectation(description: "Sync callback received, sync operation is complete")
         let reconciliationQueue = MockReconciliationQueue()
         let operation = InitialSyncOperation(
-            modelType: MockSynced.self,
+            modelSchema: MockSynced.schema,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
             storageAdapter: storageAdapter,
@@ -251,7 +251,7 @@ class InitialSyncOperationTests: XCTestCase {
 
         wait(for: [syncCallbackReceived], timeout: 1.0)
 
-        guard let syncMetadata = try storageAdapter.queryModelSyncMetadata(for: MockSynced.self) else {
+        guard let syncMetadata = try storageAdapter.queryModelSyncMetadata(for: MockSynced.schema) else {
             XCTFail("syncMetadata is nil")
             return
         }
@@ -298,7 +298,7 @@ class InitialSyncOperationTests: XCTestCase {
             XCTAssertNil(mutationEventOptional)
         })
         let operation = InitialSyncOperation(
-            modelType: MockSynced.self,
+            modelSchema: MockSynced.schema,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
             storageAdapter: storageAdapter,
@@ -359,7 +359,7 @@ class InitialSyncOperationTests: XCTestCase {
 
         let reconciliationQueue = MockReconciliationQueue()
         let operation = InitialSyncOperation(
-            modelType: MockSynced.self,
+            modelSchema: MockSynced.schema,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
             storageAdapter: storageAdapter,
@@ -407,7 +407,7 @@ class InitialSyncOperationTests: XCTestCase {
         let reconciliationQueue = MockReconciliationQueue()
         let configuration  = DataStoreConfiguration.custom(syncInterval: 60)
         let operation = InitialSyncOperation(
-            modelType: MockSynced.self,
+            modelSchema: MockSynced.schema,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
             storageAdapter: storageAdapter,
@@ -443,7 +443,7 @@ class InitialSyncOperationTests: XCTestCase {
         let reconciliationQueue = MockReconciliationQueue()
         let configuration  = DataStoreConfiguration.custom(syncPageSize: 10)
         let operation = InitialSyncOperation(
-            modelType: MockSynced.self,
+            modelSchema: MockSynced.schema,
             api: apiPlugin,
             reconciliationQueue: reconciliationQueue,
             storageAdapter: storageAdapter,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
@@ -30,7 +30,7 @@ class LocalSubscriptionTests: XCTestCase {
         do {
             let connection = try Connection(.inMemory)
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-            try storageAdapter.setUp(models: StorageEngine.systemModels)
+            try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
 
             let outgoingMutationQueue = NoOpMutationQueue()
             let mutationDatabaseAdapter = try AWSMutationDatabaseAdapter(storageAdapter: storageAdapter)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
@@ -35,7 +35,7 @@ class AWSMutationEventIngesterTests: XCTestCase {
         do {
             let connection = try Connection(.inMemory)
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-            try storageAdapter.setUp(models: StorageEngine.systemModels)
+            try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
 
             let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
                                                   dataStoreConfiguration: .default)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
@@ -40,7 +40,7 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
         do {
             let connection = try Connection(.inMemory)
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-            try storageAdapter.setUp(models: StorageEngine.systemModels)
+            try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
 
             let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
                                                   dataStoreConfiguration: .default)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -34,9 +34,9 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
 
         let modelReconciliationQueueFactory
-            = MockModelReconciliationQueue.init(modelType:storageAdapter:api:auth:incomingSubscriptionEvents:)
+            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:api:auth:incomingSubscriptionEvents:)
         let eventQueue = AWSIncomingEventReconciliationQueue(
-            modelTypes: [Post.self, Comment.self],
+            modelSchemas: [Post.schema, Comment.schema],
             api: apiPlugin,
             storageAdapter: storageAdapter,
             modelReconciliationQueueFactory: modelReconciliationQueueFactory)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
@@ -100,7 +100,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
                         //Assume AWSIncomingEventReconciliationQueue succeeds in establishing connections
                         DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
                             let request = GraphQLRequest<MutationSync<AnyModel>>
-                                .subscription(to: MockSynced.self, subscriptionType: .onUpdate)
+                                .subscription(to: MockSynced.schema, subscriptionType: .onUpdate)
                             let onUpdateListener: MutationSyncInProcessListener = { event in
                                 print("emptyListener")
                             }
@@ -201,7 +201,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
                         //Assume AWSIncomingEventReconciliationQueue succeeds in establishing connections
                         DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
                             let request = GraphQLRequest<MutationSync<AnyModel>>
-                                .subscription(to: MockSynced.self, subscriptionType: .onUpdate)
+                                .subscription(to: MockSynced.schema, subscriptionType: .onUpdate)
                             let onUpdateListener: MutationSyncInProcessListener = { event in
                                 switch event {
                                 case .data(.success(let mutationEvent)):

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -26,7 +26,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
             eventsNotSaved.fulfill()
         }
 
-        let queue = AWSModelReconciliationQueue(modelType: MockSynced.self,
+        let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
                                                 api: apiPlugin,
                                                 auth: authPlugin,
@@ -73,7 +73,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
             completion(.success(model))
         }
 
-        let queue = AWSModelReconciliationQueue(modelType: MockSynced.self,
+        let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
                                                 api: apiPlugin,
                                                 auth: authPlugin,
@@ -166,7 +166,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                 completion(.success(model))
         }
 
-        let queue = AWSModelReconciliationQueue(modelType: MockSynced.self,
+        let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
                                                 api: apiPlugin,
                                                 auth: authPlugin,
@@ -236,7 +236,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                 completion(.success(model))
         }
 
-        let queue = AWSModelReconciliationQueue(modelType: MockSynced.self,
+        let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
                                                 api: apiPlugin,
                                                 auth: authPlugin,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockModelReconciliatinQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockModelReconciliatinQueue.swift
@@ -16,20 +16,20 @@ class MockModelReconciliationQueue: ModelReconciliationQueue {
 
     public static var mockModelReconciliationQueues: [String: MockModelReconciliationQueue] = [:]
 
-    private let modelType: Model.Type
+    private let modelSchema: ModelSchema
     let modelReconciliationQueueSubject: PassthroughSubject<ModelReconciliationQueueEvent, DataStoreError>
     var publisher: AnyPublisher<ModelReconciliationQueueEvent, DataStoreError> {
         return modelReconciliationQueueSubject.eraseToAnyPublisher()
     }
 
-    init(modelType: Model.Type,
+    init(modelSchema: ModelSchema,
          storageAdapter: StorageEngineAdapter?,
          api: APICategoryGraphQLBehavior,
          auth: AuthCategoryBehavior?,
          incomingSubscriptionEvents: IncomingSubscriptionEventPublisher? = nil) {
         self.modelReconciliationQueueSubject = PassthroughSubject<ModelReconciliationQueueEvent, DataStoreError>()
-        self.modelType = modelType
-        MockModelReconciliationQueue.mockModelReconciliationQueues[modelType.modelName] = self
+        self.modelSchema = modelSchema
+        MockModelReconciliationQueue.mockModelReconciliationQueues[modelSchema.name] = self
     }
 
     func start() {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -192,7 +192,7 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
         return resultForQueryMutationSyncMetadata
     }
 
-    func queryModelSyncMetadata(for modelType: Model.Type) throws -> ModelSyncMetadata? {
+    func queryModelSyncMetadata(for modelSchema: ModelSchema) throws -> ModelSyncMetadata? {
         listenerForModelSyncMetadata?()
         return resultForQueryModelSyncMetadata
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -32,7 +32,7 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
         self.shouldReturnErrorOnDeleteMutation = false
     }
 
-    func setUp(models: [Model.Type]) throws {
+    func setUp(modelSchemas: [ModelSchema]) throws {
         XCTFail("Not expected to execute")
     }
 
@@ -183,7 +183,7 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
     func startSync() {
     }
 
-    func setUp(models: [Model.Type]) throws {
+    func setUp(modelSchemas: [ModelSchema]) throws {
     }
 
     func save<M: Model>(_ model: M, condition: QueryPredicate?, completion: @escaping DataStoreCallback<M>) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -99,7 +99,7 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
         return []
     }
 
-    func exists(_ modelType: Model.Type, withId id: Model.Identifier, predicate: QueryPredicate?) throws -> Bool {
+    func exists(_ modelSchema: ModelSchema, withId id: Model.Identifier, predicate: QueryPredicate?) throws -> Bool {
         XCTFail("Not expected to execute")
         return true
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -63,18 +63,21 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
     // MARK: - StorageEngineAdapter
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           withId id: Model.Identifier,
                           completion: DataStoreCallback<M?>) {
         XCTFail("Not expected to execute")
     }
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           predicate: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>) {
         XCTFail("Not expected to execute")
     }
 
     func delete(untypedModelType modelType: Model.Type,
+                modelSchema: ModelSchema,
                 withId id: String,
                 completion: (Result<Void, DataStoreError>) -> Void) {
         if let responder = responders[.deleteUntypedModel] as? DeleteUntypedModelCompletionResponder {
@@ -145,7 +148,7 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
 
     func save<M: Model>(_ model: M,
                         modelSchema: ModelSchema,
-                        where: QueryPredicate?,
+                        condition where: QueryPredicate?,
                         completion: @escaping DataStoreCallback<M>) {
         if let responder = responders[.saveModelCompletion] as? SaveModelCompletionResponder<M> {
             responder.callback((model, completion))
@@ -224,18 +227,20 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
 
     func save<M: Model>(_ model: M,
                         modelSchema: ModelSchema,
-                        where: QueryPredicate?,
+                        condition where: QueryPredicate?,
                         completion: @escaping DataStoreCallback<M>) {
         XCTFail("Not expected to execute")
     }
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           withId id: Model.Identifier,
                           completion: DataStoreCallback<M?>) {
         completion(.success(nil))
     }
 
     func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           predicate: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>) {
         XCTFail("Not expected to execute")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
@@ -33,7 +33,7 @@ class BaseDataStoreTests: XCTestCase {
         do {
             connection = try Connection(.inMemory)
             storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-            try storageAdapter.setUp(models: StorageEngine.systemModels)
+            try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
 
             let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
                                                   dataStoreConfiguration: .default)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
@@ -13,8 +13,8 @@ import Combine
 @testable import AWSDataStoreCategoryPlugin
 
 class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue {
-    static let factory: IncomingEventReconciliationQueueFactory = { modelTypes, api, storageAdapter, auth, _ in
-        MockAWSIncomingEventReconciliationQueue(modelTypes: modelTypes,
+    static let factory: IncomingEventReconciliationQueueFactory = { modelSchemas, api, storageAdapter, auth, _ in
+        MockAWSIncomingEventReconciliationQueue(modelSchemas: modelSchemas,
                                                 api: api,
                                                 storageAdapter: storageAdapter,
                                                 auth: auth)
@@ -25,7 +25,7 @@ class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue 
     }
 
     static var lastInstance: MockAWSIncomingEventReconciliationQueue?
-    init(modelTypes: [Model.Type],
+    init(modelSchemas: [ModelSchema],
          api: APICategoryGraphQLBehavior,
          storageAdapter: StorageEngineAdapter,
          auth: AuthCategoryBehavior?) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
@@ -27,3 +27,61 @@ struct TestModelRegistration: AmplifyModelRegistration {
     let version: String = "1"
 
 }
+
+struct TestJsonModelRegistration: AmplifyModelRegistration {
+
+    func registerModels(registry: ModelRegistry.Type) {
+
+        // Post
+        let id = ModelFieldDefinition.id("id").modelField
+        let title = ModelField(name: "title", type: .string, isRequired: true)
+        let content = ModelField(name: "content", type: .string, isRequired: true)
+        let updatedAt = ModelField(name: "updatedAt", type: .dateTime, isRequired: false)
+        let draft = ModelField(name: "draft", type: .bool, isRequired: false)
+        let rating = ModelField(name: "rating", type: .double, isRequired: false)
+        let comments = ModelField(name: "comments",
+                                  type: .collection(of: "Comment"),
+                                  isRequired: false,
+                                  association: .hasMany(associatedWith: "Comment.keys.post"))
+        let postSchema = ModelSchema(name: "Post",
+                                     pluralName: "Posts",
+                                     fields: [id.name: id,
+                                              title.name: title,
+                                              content.name: content,
+                                              updatedAt.name: updatedAt,
+                                              draft.name: draft,
+                                              rating.name: rating,
+                                              comments.name: comments])
+
+        ModelRegistry.register(modelName: postSchema.name,
+                               modelSchema: postSchema,
+                               modelType: DynamicModel.self) { (_, _) -> Model in
+                                DynamicModel(id: "", values: [:])
+        }
+
+        // Comment
+
+        let commentId = ModelFieldDefinition.id().modelField
+        let commentContent = ModelField(name: "content", type: .string, isRequired: true)
+        let commentCreatedAt = ModelField(name: "createdAt", type: .dateTime, isRequired: true)
+        let belongsTo = ModelField(name: "comment.post",
+                                   type: .model(name: "Post"),
+                                   isRequired: true,
+                                   association: .belongsTo(associatedWith: nil, targetName: "commentPostId"))
+        let commentSchema = ModelSchema(name: "Comment",
+                                        pluralName: "Comments",
+                                        fields: [
+                                            commentId.name: commentId,
+                                            commentContent.name: commentContent,
+                                            commentCreatedAt.name: commentCreatedAt,
+                                            belongsTo.name: belongsTo])
+        ModelRegistry.register(modelName: commentSchema.name,
+                               modelSchema: commentSchema,
+                               modelType: DynamicModel.self) { (_, _) -> Model in
+                                DynamicModel(id: "", values: [:])
+        }
+    }
+
+    let version: String = "1"
+
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
@@ -53,10 +53,8 @@ struct TestJsonModelRegistration: AmplifyModelRegistration {
                                               rating.name: rating,
                                               comments.name: comments])
 
-        ModelRegistry.register(modelName: postSchema.name,
-                               modelSchema: postSchema,
-                               modelType: DynamicModel.self) { (_, _) -> Model in
-                                DynamicModel(id: "", values: [:])
+        ModelRegistry.register(modelType: DynamicModel.self, modelSchema: postSchema) { (_, _) -> Model in
+            DynamicModel(id: "", values: [:])
         }
 
         // Comment
@@ -75,10 +73,9 @@ struct TestJsonModelRegistration: AmplifyModelRegistration {
                                             commentContent.name: commentContent,
                                             commentCreatedAt.name: commentCreatedAt,
                                             belongsTo.name: belongsTo])
-        ModelRegistry.register(modelName: commentSchema.name,
-                               modelSchema: commentSchema,
-                               modelType: DynamicModel.self) { (_, _) -> Model in
-                                DynamicModel(id: "", values: [:])
+        ModelRegistry.register(modelType: DynamicModel.self, modelSchema: commentSchema
+        ) { (_, _) -> Model in
+            DynamicModel(id: "", values: [:])
         }
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -72,7 +72,7 @@ class SyncEngineTestBase: XCTestCase {
         models.forEach { ModelRegistry.register(modelType: $0) }
         let connection = try Connection(.inMemory)
         storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
-        try storageAdapter.setUp(models: StorageEngine.systemModels + models)
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas + models.map { $0.schema })
     }
 
     /// Sets up a DataStorePlugin backed by the storageAdapter created in `setUpStorageAdapter()`, and an optional

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -85,6 +85,8 @@
 		A569484A6FBAE7EC7ADF3FD4 /* Pods_AWSDataStoreCategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A1D332BE6CF885805360B3D /* Pods_AWSDataStoreCategoryPlugin.framework */; };
 		B10BF4A52A1C9840C208C8A8 /* Pods_HostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 19AFF6D00CF3AF927BA90382 /* Pods_HostApp.framework */; };
 		B40EF02824BF68C900F2264C /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40EF02724BF68C900F2264C /* ConfigurationTests.swift */; };
+		B4D9B9E224DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D9B9E124DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift */; };
+		B4D9B9E424DF90CD0049484F /* DynamicModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D9B9E324DF90CD0049484F /* DynamicModel.swift */; };
 		B912D1B824296F1E0028F05C /* QueryPaginationInput+SQLite.swift in Sources */ = {isa = PBXBuildFile; fileRef = B912D1B724296F1E0028F05C /* QueryPaginationInput+SQLite.swift */; };
 		B912D1BA242984D10028F05C /* QueryPaginationInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B912D1B9242984D10028F05C /* QueryPaginationInputTests.swift */; };
 		B9334BA22433AF3E00C9F407 /* DataStoreConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9334BA12433AF3E00C9F407 /* DataStoreConfiguration.swift */; };
@@ -302,6 +304,8 @@
 		9D42A96449A4B73735566C07 /* Pods-AWSDataStoreCategoryPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSDataStoreCategoryPlugin/Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; sourceTree = "<group>"; };
 		9F987EC33AAD7C0904A598CA /* Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B40EF02724BF68C900F2264C /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
+		B4D9B9E124DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteStorageEngineAdapterJsonTests.swift; sourceTree = "<group>"; };
+		B4D9B9E324DF90CD0049484F /* DynamicModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicModel.swift; sourceTree = "<group>"; };
 		B912D1B724296F1E0028F05C /* QueryPaginationInput+SQLite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QueryPaginationInput+SQLite.swift"; sourceTree = "<group>"; };
 		B912D1B9242984D10028F05C /* QueryPaginationInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPaginationInputTests.swift; sourceTree = "<group>"; };
 		B9334BA12433AF3E00C9F407 /* DataStoreConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreConfiguration.swift; sourceTree = "<group>"; };
@@ -658,6 +662,7 @@
 				B996FC4623FF3C7C006D0F68 /* ExampleWithEveryType.swift */,
 				B996FC4823FF3E92006D0F68 /* ExampleWithEveryType+Schema.swift */,
 				B996FC4A23FF418C006D0F68 /* SQLModelValueConverterTests.swift */,
+				B4D9B9E324DF90CD0049484F /* DynamicModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -771,15 +776,16 @@
 		FAD2BDF423957F35006EB065 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				B40EF02724BF68C900F2264C /* ConfigurationTests.swift */,
 				B9FAA13F238C600A009414B4 /* ListTests.swift */,
 				B912D1B9242984D10028F05C /* QueryPaginationInputTests.swift */,
 				2149E5F0238869CF00873955 /* QueryPredicateTests.swift */,
 				FA4FF13B239B218000056633 /* SortByDependencyOrderTests.swift */,
+				B4D9B9E124DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift */,
 				2149E5F7238869CF00873955 /* SQLiteStorageEngineAdapterTests.swift */,
 				2149E5F6238869CF00873955 /* SQLStatementTests.swift */,
 				FA3841EC23889D8F0070AD5B /* StateMachineTests.swift */,
 				2129BE4923948A97006363A1 /* StorageAdapterMutationSyncTests.swift */,
-				B40EF02724BF68C900F2264C /* ConfigurationTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1564,6 +1570,7 @@
 				6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */,
 				FA4B8E962391C609009FC10F /* XCTest+AmplifyExtensions.swift in Sources */,
 				FAE4146C239AA40600CE94C2 /* MockSQLiteStorageEngineAdapter.swift in Sources */,
+				B4D9B9E424DF90CD0049484F /* DynamicModel.swift in Sources */,
 				B912D1BA242984D10028F05C /* QueryPaginationInputTests.swift in Sources */,
 				FA8D932F239EA5C4001ED336 /* NoOpInitialSyncOrchestrator.swift in Sources */,
 				FAABC225239B1B3500740F9F /* ModelReconciliationDeleteTests.swift in Sources */,
@@ -1587,6 +1594,7 @@
 				B9FAA142238C6082009414B4 /* BaseDataStoreTests.swift in Sources */,
 				6B52DC9624478E75007F5AD3 /* MockModelReconciliatinQueue.swift in Sources */,
 				FA4A955B239AD3F4008E876E /* Foundation+TestExtensions.swift in Sources */,
+				B4D9B9E224DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift in Sources */,
 				6B64027B23E38B9900001FD7 /* MockOutgoingMutationQueue.swift in Sources */,
 				2149E600238869CF00873955 /* SQLiteStorageEngineAdapterTests.swift in Sources */,
 				21B3AD27242BB58000C7E1DA /* ProcessMutationErrorFromCloudOperationTests.swift in Sources */,

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSDataStoreCategoryPlugin.xcscheme
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSDataStoreCategoryPlugin.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyTests/CategoryTests/DataStore/JSONValueHolderTest.swift
+++ b/AmplifyTests/CategoryTests/DataStore/JSONValueHolderTest.swift
@@ -1,0 +1,65 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import Amplify
+
+class JSONValueHolderTest: XCTestCase {
+
+    var jsonValueHodler = DynamicModel(values: ["id": 123,
+                                                "name": nil,
+                                                "comment": "here is a comment"])
+
+    func testJsonDoubleValue() {
+        guard let id = jsonValueHodler.jsonValue(for: "id") as? Double else {
+            XCTFail("Should cast to Double")
+            return
+        }
+        XCTAssertEqual(id, 123, "Returned value should match")
+    }
+
+    func testJsonStringValue() {
+        guard let comment = jsonValueHodler.jsonValue(for: "comment") as? String else {
+            XCTFail("Should cast to String")
+            return
+        }
+        XCTAssertEqual(comment, "here is a comment", "Returned value should match")
+    }
+
+    func testNilJsonValue() {
+        let name = jsonValueHodler.jsonValue(for: "name")
+        guard case .some(let value) = name else {
+            XCTFail("Should cast to an Optional value")
+            return
+        }
+        XCTAssertNil(value, "Returned value should be nil")
+    }
+}
+
+struct DynamicModel: JSONValueHolder {
+
+    let values: [String: JSONValue]
+
+    func jsonValue(for key: String) -> Any?? {
+        switch values[key] {
+        case .some(.array(let deserializedValue)):
+            return deserializedValue
+        case .some(.boolean(let deserializedValue)):
+            return deserializedValue
+        case .some(.number(let deserializedValue)):
+            return deserializedValue
+        case .some(.object(let deserializedValue)):
+            return deserializedValue
+        case .some(.string(let deserializedValue)):
+            return deserializedValue
+        case .some(.null):
+            return .some(nil)
+        case .none:
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Removing dependency on Model.Type in SyncEngine

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
