### PR TITLE
fix: Data race in AWSModelReconciliationQueue

### DIFF
--- a/Amplify.xcodeproj/xcshareddata/xcschemes/AWSPluginsCore.xcscheme
+++ b/Amplify.xcodeproj/xcshareddata/xcschemes/AWSPluginsCore.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSAPICategoryPlugin.xcscheme
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSAPICategoryPlugin.xcscheme
@@ -40,7 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/GraphQLWithIAMIntegrationTests.xcscheme
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/GraphQLWithIAMIntegrationTests.xcscheme
@@ -10,7 +10,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/GraphQLWithUserPoolIntegrationTests.xcscheme
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/GraphQLWithUserPoolIntegrationTests.xcscheme
@@ -10,7 +10,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/RESTWithIAMIntegrationTests.xcscheme
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/RESTWithIAMIntegrationTests.xcscheme
@@ -10,7 +10,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/RESTWithUserPoolIntegrationTests.xcscheme
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/RESTWithUserPoolIntegrationTests.xcscheme
@@ -10,7 +10,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/xcshareddata/xcschemes/AWSCognitoAuthPlugin.xcscheme
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/xcshareddata/xcschemes/AWSCognitoAuthPlugin.xcscheme
@@ -40,7 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
@@ -24,7 +24,7 @@ class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue 
         return incomingEventSubject.eraseToAnyPublisher()
     }
 
-    static var lastInstance: MockAWSIncomingEventReconciliationQueue?
+    static var lastInstance = AtomicValue<MockAWSIncomingEventReconciliationQueue?>(initialValue: nil)
     init(modelTypes: [Model.Type],
          api: APICategoryGraphQLBehavior,
          storageAdapter: StorageEngineAdapter,
@@ -34,7 +34,7 @@ class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue 
     }
 
     func updateLastInstance(instance: MockAWSIncomingEventReconciliationQueue) {
-        MockAWSIncomingEventReconciliationQueue.lastInstance = instance
+        MockAWSIncomingEventReconciliationQueue.lastInstance.set(instance)
     }
 
     func start() {
@@ -50,11 +50,11 @@ class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue 
     }
 
     static func mockSendCompletion(completion: Subscribers.Completion<DataStoreError>) {
-        lastInstance?.incomingEventSubject.send(completion: completion)
+        lastInstance.get()?.incomingEventSubject.send(completion: completion)
     }
 
     static func mockSend(event: IncomingEventReconciliationQueueEvent) {
-        lastInstance?.incomingEventSubject.send(event)
+        lastInstance.get()?.incomingEventSubject.send(event)
     }
 
     func cancel() {

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSDataStoreCategoryPlugin.xcscheme
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSDataStoreCategoryPlugin.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyPlugins/Predictions/PredictionsCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSPredictionsPlugin.xcscheme
+++ b/AmplifyPlugins/Predictions/PredictionsCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSPredictionsPlugin.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
       <CodeCoverageTargets>

--- a/AmplifyPlugins/Predictions/PredictionsCategoryPlugin.xcodeproj/xcshareddata/xcschemes/CoreMLPredictionsPlugin.xcscheme
+++ b/AmplifyPlugins/Predictions/PredictionsCategoryPlugin.xcodeproj/xcshareddata/xcschemes/CoreMLPredictionsPlugin.xcscheme
@@ -41,6 +41,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
       <CodeCoverageTargets>

--- a/AmplifyPlugins/Storage/StoragePlugin.xcodeproj/xcshareddata/xcschemes/AWSS3StoragePlugin.xcscheme
+++ b/AmplifyPlugins/Storage/StoragePlugin.xcodeproj/xcshareddata/xcschemes/AWSS3StoragePlugin.xcscheme
@@ -26,7 +26,19 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B478F5FA2374DBF400C4F92B"
+            BuildableName = "AWSS3StoragePlugin.framework"
+            BlueprintName = "AWSS3StoragePlugin"
+            ReferencedContainer = "container:StoragePlugin.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyTestCommon/Mocks/MessageReporter.swift
+++ b/AmplifyTestCommon/Mocks/MessageReporter.swift
@@ -5,12 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import Amplify
+
 class MessageReporter {
     /// Callbacks to be invoked
-    var listeners = [(String) -> Void]()
+    var listeners = AtomicValue<[(String) -> Void]>(initialValue: [])
 
     func notify(_ message: String = #function) {
-        listeners.forEach { $0(message) }
+        listeners.get().forEach { $0(message) }
     }
 
     init() {

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -24,7 +24,7 @@ class MockAPICategoryPlugin: MessageReporter, APICategoryPlugin {
 
     func reset(onComplete: @escaping BasicClosure) {
         notify("reset")
-        listeners = []
+        listeners.set([])
         onComplete()
     }
 


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-amplify/amplify-ios/issues/773

*Description of changes:*

- Wraps `reconcileAndLocalSaveOperationSinks` in an AtomicValue to protect from data races
- Fixes data races in test mocks
- Enable Thread Sanitizer throughout all tests
- Add code coverage for Storage plugin test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
