### PR TITLE
chore: Fix data race in MockStateMachine

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockStateMachine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockStateMachine.swift
@@ -6,20 +6,21 @@
 //
 
 import Foundation
+import Amplify
 @testable import AWSDataStoreCategoryPlugin
 
 class MockStateMachine<S, A>: StateMachine<S, A> {
     typealias ExpectActionCriteria = (_ action: A) -> Void
-    var expectActionCriteriaQueue: [ExpectActionCriteria]
+    var expectActionCriteriaQueue: AtomicValue<[ExpectActionCriteria]>
 
     override init(initialState: S, resolver: @escaping Reducer) {
-        self.expectActionCriteriaQueue = []
+        self.expectActionCriteriaQueue = AtomicValue(initialValue: [])
         super.init(initialState: initialState, resolver: resolver)
     }
     override func notify(action: A) {
-        if let expectActionCriteria = expectActionCriteriaQueue.first {
+        if let expectActionCriteria = expectActionCriteriaQueue.get().first {
             expectActionCriteria(action)
-            expectActionCriteriaQueue.removeFirst(1)
+            expectActionCriteriaQueue.with { $0.removeFirst(1) }
         }
     }
     func pushExpectActionCriteria(expectActionCriteria: @escaping ExpectActionCriteria) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes sporadic data races in MockStateMachine that [we are seeing](https://app.circleci.com/pipelines/github/aws-amplify/amplify-ios/1963/workflows/75662a04-24c0-4c24-a1c5-7d50e0dd862a/jobs/16663) now that we have enabled Thread Sanitizer:

```
==================
WARNING: ThreadSanitizer: Swift access race (pid=4622)
  Modifying access of Swift variable at 0x7b18000459b8 by main thread:
    #0 MockStateMachine.expectActionCriteriaQueue.modify <compiler-generated> (AWSDataStoreCategoryPluginTests:x86_64+0x1ec7bd)
    #1 MockStateMachine.pushExpectActionCriteria(expectActionCriteria:) MockStateMachine.swift:26 (AWSDataStoreCategoryPluginTests:x86_64+0x1ed445)
    #2 OutgoingMutationQueueMockStateTest.testRequestingEvent_subscriptionSetup() OutgoingMutationQueueTestsWithMockStateMachine.swift:87 (AWSDataStoreCategoryPluginTests:x86_64+0x17180d)
    #3 @objc OutgoingMutationQueueMockStateTest.testRequestingEvent_subscriptionSetup() <compiler-generated> (AWSDataStoreCategoryPluginTests:x86_64+0x173497)
    #4 __invoking___ <null>:2 (CoreFoundation:x86_64+0x11792b)

  Previous modifying access of Swift variable at 0x7b18000459b8 by thread T5:
    #0 MockStateMachine.expectActionCriteriaQueue.modify <compiler-generated> (AWSDataStoreCategoryPluginTests:x86_64+0x1ec7bd)
    #1 MockStateMachine.notify(action:) MockStateMachine.swift:22 (AWSDataStoreCategoryPluginTests:x86_64+0x1ed081)
    #2 OutgoingMutationQueue.receive(subscription:) OutgoingMutationQueue.swift:334 (AWSDataStoreCategoryPlugin:x86_64+0xe0306)
    #3 protocol witness for Subscriber.receive(subscription:) in conformance OutgoingMutationQueue <compiler-generated> (AWSDataStoreCategoryPlugin:x86_64+0xe0a66)
    #4 AWSMutationEventPublisher.receive<A>(subscriber:) AWSMutationEventPublisher.swift:32 (AWSDataStoreCategoryPlugin:x86_64+0x703aa)
    #5 protocol witness for Publisher.receive<A>(subscriber:) in conformance AWSMutationEventPublisher <compiler-generated> (AWSDataStoreCategoryPlugin:x86_64+0x71c16)
    #6 PublisherBox.receive<A>(subscriber:) <null>:2 (Combine:x86_64+0xa42f0)
    #7 partial apply for closure #1 in OutgoingMutationQueue.start(api:mutationEventPublisher:) <compiler-generated> (AWSDataStoreCategoryPlugin:x86_64+0xe1f39)
    #8 closure #1 in OutgoingMutationQueue.queryMutationEventsFromStorage(onComplete:) OutgoingMutationQueue.swift:278 (AWSDataStoreCategoryPlugin:x86_64+0xdf416)
    #9 partial apply for closure #1 in OutgoingMutationQueue.queryMutationEventsFromStorage(onComplete:) <compiler-generated> (AWSDataStoreCategoryPlugin:x86_64+0xe16b4)
    #10 MockSQLiteStorageEngineAdapter.query<A>(_:predicate:sort:paginationInput:completion:) MockSQLiteStorageEngineAdapter.swift:146 (AWSDataStoreCategoryPluginTests:x86_64+0xbf619)
    #11 protocol witness for StorageEngineAdapter.query<A>(_:predicate:sort:paginationInput:completion:) in conformance MockSQLiteStorageEngineAdapter <compiler-generated> (AWSDataStoreCategoryPluginTests:x86_64+0xc1176)
    #12 OutgoingMutationQueue.queryMutationEventsFromStorage(onComplete:) OutgoingMutationQueue.swift:268 (AWSDataStoreCategoryPlugin:x86_64+0xdacab)
    #13 OutgoingMutationQueue.start(api:mutationEventPublisher:) OutgoingMutationQueue.swift:142 (AWSDataStoreCategoryPlugin:x86_64+0xd9bd1)
    #14 OutgoingMutationQueue.respond(to:) OutgoingMutationQueue.swift:107 (AWSDataStoreCategoryPlugin:x86_64+0xd894b)
    #15 closure #1 in closure #1 in OutgoingMutationQueue.init(_:storageAdapter:dataStoreConfiguration:) OutgoingMutationQueue.swift:69 (AWSDataStoreCategoryPlugin:x86_64+0xd8639)
    #16 partial apply for closure #1 in closure #1 in OutgoingMutationQueue.init(_:storageAdapter:dataStoreConfiguration:) <compiler-generated> (AWSDataStoreCategoryPlugin:x86_64+0xe1da8)
    #17 thunk for @escaping @callee_guaranteed () -> () <compiler-generated> (AWSDataStoreCategoryPlugin:x86_64+0x8c73)
    #18 __tsan::invoke_and_release_block(void*) <null>:2 (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x70f1b)
    #19 _dispatch_client_callout <null>:2 (libdispatch.dylib:x86_64+0x3533)

  Location is heap block of size 96 at 0x7b1800045960 allocated by main thread:
    #0 __sanitizer_mz_malloc <null>:2 (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x4f2fa)
    #1 _malloc_zone_malloc <null>:2 (libsystem_malloc.dylib:x86_64+0x12a0f)
    #2 OutgoingMutationQueueMockStateTest.setUp() OutgoingMutationQueueTestsWithMockStateMachine.swift:31 (AWSDataStoreCategoryPluginTests:x86_64+0x16dee8)
    #3 @objc OutgoingMutationQueueMockStateTest.setUp() <compiler-generated> (AWSDataStoreCategoryPluginTests:x86_64+0x16ee64)
    #4 __70-[XCTestCase _shouldContinueAfterPerformingSetUpSequenceWithSelector:]_block_invoke_2 <null>:2 (XCTest:x86_64+0x2ac3f)

  Thread T5 (tid=82450, running) is a GCD worker thread

SUMMARY: ThreadSanitizer: Swift access race <compiler-generated> in MockStateMachine.expectActionCriteriaQueue.modify
==================
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
