### PR TITLE
refactor(datastore): Removed dependency of Model.Type in Initial sync

### DIFF
--- a/Amplify/Categories/DataStore/Subscribe/MutationEvent.swift
+++ b/Amplify/Categories/DataStore/Subscribe/MutationEvent.swift
@@ -53,6 +53,21 @@ public struct MutationEvent: Model {
 
     }
 
+    @available(*, deprecated, message: """
+    Init method without ModelSchema is deprecated, use the other init methods.
+    """)
+    public init<M: Model>(model: M,
+                          mutationType: MutationType,
+                          version: Int? = nil,
+                          graphQLFilterJSON: String? = nil) throws {
+        try self.init(model: model,
+                      modelSchema: model.schema,
+                      mutationType: mutationType,
+                      version: version,
+                      graphQLFilterJSON: graphQLFilterJSON)
+
+    }
+
     public func decodeModel() throws -> Model {
         let model = try ModelRegistry.decode(modelName: modelName, from: json)
         return model

--- a/Amplify/Categories/DataStore/Subscribe/MutationEvent.swift
+++ b/Amplify/Categories/DataStore/Subscribe/MutationEvent.swift
@@ -54,7 +54,8 @@ public struct MutationEvent: Model {
     }
 
     @available(*, deprecated, message: """
-    Init method without ModelSchema is deprecated, use the other init methods.
+    Initializing from a model without a ModelSchema is deprecated.
+    Use init(model:modelSchema:mutationType:version:graphQLFilterJSON:) instead.
     """)
     public init<M: Model>(model: M,
                           mutationType: MutationType,

--- a/Amplify/Categories/DataStore/Subscribe/MutationEvent.swift
+++ b/Amplify/Categories/DataStore/Subscribe/MutationEvent.swift
@@ -39,13 +39,13 @@ public struct MutationEvent: Model {
     }
 
     public init<M: Model>(model: M,
+                          modelSchema: ModelSchema,
                           mutationType: MutationType,
                           version: Int? = nil,
                           graphQLFilterJSON: String? = nil) throws {
-        let modelType = type(of: model)
         let json = try model.toJSON()
         self.init(modelId: model.id,
-                  modelName: modelType.schema.name,
+                  modelName: modelSchema.name,
                   json: json,
                   mutationType: mutationType,
                   version: version,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -134,7 +134,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
                 }
 
                 let statement = UpdateStatement(model: model,
-                                                modelSchema: modelType.schema,
+                                                modelSchema: modelSchema,
                                                 condition: condition)
                 _ = try connection.prepare(statement.stringValue).run(statement.variables)
             }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
@@ -12,20 +12,28 @@ extension SQLiteStorageEngineAdapter {
 
     func save(untypedModel: Model, completion: DataStoreCallback<Model>) {
         do {
-            guard let modelType = ModelRegistry.modelType(from: untypedModel.modelName) else {
-                let error = DataStoreError.invalidModelName(untypedModel.modelName)
+            let modelName: ModelName
+            if let jsonModel = untypedModel as? JSONValueHolder,
+               let modelNameFromJson = jsonModel.jsonValue(for: "__typename") as? String {
+                modelName = modelNameFromJson
+            } else {
+                modelName = untypedModel.modelName
+            }
+
+            guard let modelSchema = ModelRegistry.modelSchema(from: modelName) else {
+                let error = DataStoreError.invalidModelName(modelName)
                 throw error
             }
 
-            let shouldUpdate = try exists(modelType.schema, withId: untypedModel.id)
+            let shouldUpdate = try exists(modelSchema, withId: untypedModel.id)
 
             // TODO serialize result and create a new instance of the model
             // (some columns might be auto-generated after DB insert/update)
             if shouldUpdate {
-                let statement = UpdateStatement(model: untypedModel, modelSchema: untypedModel.schema)
+                let statement = UpdateStatement(model: untypedModel, modelSchema: modelSchema)
                 _ = try connection.prepare(statement.stringValue).run(statement.variables)
             } else {
-                let statement = InsertStatement(model: untypedModel, modelSchema: untypedModel.schema)
+                let statement = InsertStatement(model: untypedModel, modelSchema: modelSchema)
                 _ = try connection.prepare(statement.stringValue).run(statement.variables)
             }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -158,7 +158,7 @@ final class InitialSyncOperation: AsynchronousOperation {
         recordsReceived += UInt(items.count)
 
         for item in items {
-            reconciliationQueue.offer(item)
+            reconciliationQueue.offer(item, modelSchema: modelSchema)
         }
 
         if let nextToken = syncQueryResult.nextToken, recordsReceived < syncMaxRecords {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -38,8 +38,8 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
     }
 
     private let connectionStatusSerialQueue: DispatchQueue
-    private var reconciliationQueues: [String: ModelReconciliationQueue]
-    private var reconciliationQueueConnectionStatus: [String: Bool]
+    private var reconciliationQueues: [ModelName: ModelReconciliationQueue]
+    private var reconciliationQueueConnectionStatus: [ModelName: Bool]
     private var modelReconciliationQueueFactory: ModelReconciliationQueueFactory
 
     init(modelSchemas: [ModelSchema],
@@ -82,8 +82,8 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
         eventReconciliationQueueTopic.send(.paused)
     }
 
-    func offer(_ remoteModel: MutationSync<AnyModel>) {
-        guard let queue = reconciliationQueues[remoteModel.model.modelName] else {
+    func offer(_ remoteModel: MutationSync<AnyModel>, modelSchema: ModelSchema) {
+        guard let queue = reconciliationQueues[modelSchema.name] else {
             // TODO: Error handling
             return
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
@@ -24,6 +24,6 @@ enum IncomingEventReconciliationQueueEvent {
 protocol IncomingEventReconciliationQueue: class, Cancellable {
     func start()
     func pause()
-    func offer(_ remoteModel: MutationSync<AnyModel>)
+    func offer(_ remoteModel: MutationSync<AnyModel>, modelSchema: ModelSchema)
     var publisher: AnyPublisher<IncomingEventReconciliationQueueEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationDatabaseAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationDatabaseAdapterTests.swift
@@ -29,8 +29,12 @@ class AWSMutationDatabaseAdapterTests: XCTestCase {
     }
 
     func test_replaceLocal_localCreateCandidateUpdate() throws {
-        let localCreate = try MutationEvent(model: model1, mutationType: MutationEvent.MutationType.create)
-        let candidateUpdate = try MutationEvent(model: model1, mutationType: MutationEvent.MutationType.update)
+        let localCreate = try MutationEvent(model: model1,
+                                            modelSchema: model1.schema,
+                                            mutationType: MutationEvent.MutationType.create)
+        let candidateUpdate = try MutationEvent(model: model1,
+                                                modelSchema: model1.schema,
+                                                mutationType: MutationEvent.MutationType.update)
 
         let disposition = databaseAdapter.disposition(for: candidateUpdate, given: [localCreate])
 
@@ -38,10 +42,13 @@ class AWSMutationDatabaseAdapterTests: XCTestCase {
     }
 
     func test_saveCandidate_CanadidateUpdateWithCondition() throws {
-        let anyLocal = try MutationEvent(model: model1, mutationType: MutationEvent.MutationType.create)
+        let anyLocal = try MutationEvent(model: model1,
+                                         modelSchema: model1.schema,
+                                         mutationType: MutationEvent.MutationType.create)
         let queryPredicate = post.title == model1.title
         let graphQLFilterJSON = try GraphQLFilterConverter.toJSON(queryPredicate)
         let candidateUpdate = try MutationEvent(model: model1,
+                                                modelSchema: model1.schema,
                                                 mutationType: MutationEvent.MutationType.update,
                                                 graphQLFilterJSON: graphQLFilterJSON)
 
@@ -50,10 +57,13 @@ class AWSMutationDatabaseAdapterTests: XCTestCase {
     }
 
     func test_saveCandidate_CanadidateDeleteWithCondition() throws {
-        let anyLocal = try MutationEvent(model: model1, mutationType: MutationEvent.MutationType.create)
+        let anyLocal = try MutationEvent(model: model1,
+                                         modelSchema: model1.schema,
+                                         mutationType: MutationEvent.MutationType.create)
         let queryPredicate = post.title == model1.title
         let graphQLFilterJSON = try GraphQLFilterConverter.toJSON(queryPredicate)
         let candidateUpdate = try MutationEvent(model: model1,
+                                                modelSchema: model1.schema,
                                                 mutationType: MutationEvent.MutationType.delete,
                                                 graphQLFilterJSON: graphQLFilterJSON)
 
@@ -62,8 +72,12 @@ class AWSMutationDatabaseAdapterTests: XCTestCase {
     }
 
     func test_replaceLocal_BothUpdate() throws {
-        let localCreate = try MutationEvent(model: model1, mutationType: MutationEvent.MutationType.update)
-        let candidateUpdate = try MutationEvent(model: model1, mutationType: MutationEvent.MutationType.update)
+        let localCreate = try MutationEvent(model: model1,
+                                            modelSchema: model1.schema,
+                                            mutationType: MutationEvent.MutationType.update)
+        let candidateUpdate = try MutationEvent(model: model1,
+                                                modelSchema: model1.schema,
+                                                mutationType: MutationEvent.MutationType.update)
 
         let disposition = databaseAdapter.disposition(for: candidateUpdate, given: [localCreate])
 
@@ -71,8 +85,12 @@ class AWSMutationDatabaseAdapterTests: XCTestCase {
     }
 
     func test_replaceLocal_localUpdateCandidateDelete() throws {
-        let localCreate = try MutationEvent(model: model1, mutationType: MutationEvent.MutationType.update)
-        let candidateUpdate = try MutationEvent(model: model1, mutationType: MutationEvent.MutationType.delete)
+        let localCreate = try MutationEvent(model: model1,
+                                            modelSchema: model1.schema,
+                                            mutationType: MutationEvent.MutationType.update)
+        let candidateUpdate = try MutationEvent(model: model1,
+                                                modelSchema: model1.schema,
+                                                mutationType: MutationEvent.MutationType.delete)
 
         let disposition = databaseAdapter.disposition(for: candidateUpdate, given: [localCreate])
 
@@ -80,8 +98,12 @@ class AWSMutationDatabaseAdapterTests: XCTestCase {
     }
 
     func test_replaceLocal_BothDelete() throws {
-        let localCreate = try MutationEvent(model: model1, mutationType: MutationEvent.MutationType.delete)
-        let candidateUpdate = try MutationEvent(model: model1, mutationType: MutationEvent.MutationType.delete)
+        let localCreate = try MutationEvent(model: model1,
+                                            modelSchema: model1.schema,
+                                            mutationType: MutationEvent.MutationType.delete)
+        let candidateUpdate = try MutationEvent(model: model1,
+                                                modelSchema: model1.schema,
+                                                mutationType: MutationEvent.MutationType.delete)
 
         let disposition = databaseAdapter.disposition(for: candidateUpdate, given: [localCreate])
 
@@ -89,8 +111,12 @@ class AWSMutationDatabaseAdapterTests: XCTestCase {
     }
 
     func test_dropCandidate_localCreateCandidateDelete() throws {
-        let localCreate = try MutationEvent(model: model1, mutationType: MutationEvent.MutationType.create)
-        let candidateUpdate = try MutationEvent(model: model1, mutationType: MutationEvent.MutationType.delete)
+        let localCreate = try MutationEvent(model: model1,
+                                            modelSchema: model1.schema,
+                                            mutationType: MutationEvent.MutationType.create)
+        let candidateUpdate = try MutationEvent(model: model1,
+                                                modelSchema: model1.schema,
+                                                mutationType: MutationEvent.MutationType.delete)
 
         let disposition = databaseAdapter.disposition(for: candidateUpdate, given: [localCreate])
 
@@ -98,8 +124,12 @@ class AWSMutationDatabaseAdapterTests: XCTestCase {
     }
 
     func test_dropCandidateWithError_localItemExistsAlreadyCandidateCreates() throws {
-        let localCreate = try MutationEvent(model: model1, mutationType: MutationEvent.MutationType.create)
-        let candidateUpdate = try MutationEvent(model: model1, mutationType: MutationEvent.MutationType.create)
+        let localCreate = try MutationEvent(model: model1,
+                                            modelSchema: model1.schema,
+                                            mutationType: MutationEvent.MutationType.create)
+        let candidateUpdate = try MutationEvent(model: model1,
+                                                modelSchema: model1.schema,
+                                                mutationType: MutationEvent.MutationType.create)
 
         let disposition = databaseAdapter.disposition(for: candidateUpdate, given: [localCreate])
 
@@ -107,8 +137,12 @@ class AWSMutationDatabaseAdapterTests: XCTestCase {
     }
 
     func test_dropCandidateWithError_updateMutationForItemMarkedDeleted() throws {
-        let localCreate = try MutationEvent(model: model1, mutationType: MutationEvent.MutationType.delete)
-        let candidateUpdate = try MutationEvent(model: model1, mutationType: MutationEvent.MutationType.update)
+        let localCreate = try MutationEvent(model: model1,
+                                            modelSchema: model1.schema,
+                                            mutationType: MutationEvent.MutationType.delete)
+        let candidateUpdate = try MutationEvent(model: model1,
+                                                modelSchema: model1.schema,
+                                                mutationType: MutationEvent.MutationType.update)
 
         let disposition = databaseAdapter.disposition(for: candidateUpdate, given: [localCreate])
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
@@ -146,6 +146,7 @@ class OutgoingMutationQueueMockStateTest: XCTestCase {
                         content: "content",
                         createdAt: .now())
         let futureResult = try MutationEvent(model: post,
+                                             modelSchema: post.schema,
                                              mutationType: .create)
         eventSource.pushMutationEvent(futureResult: .success(futureResult))
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -40,7 +40,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     ///    - `DataStoreErrorHandler` is called
     func testProcessMutationErrorFromCloudOperationSuccessForAuthErroor() throws {
         let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: localPost, mutationType: .update)
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .update)
         let authError = AuthError.signedOut("User is not authenticated", "Authenticate user", nil)
         let apiError = APIError.operationError("not signed in", "Sign In User", authError)
         let expectCompletion = expectation(description: "Expect to complete error processing")
@@ -92,7 +92,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     func testProcessMutationErrorFromCloudOperationSuccessForUnknownError() throws {
         let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
         let remotePost = Post(id: localPost.id, title: "remoteTitle", content: "remoteContent", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: localPost, mutationType: .delete)
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .delete)
         guard let graphQLResponseError = try getGraphQLResponseError(withRemote: remotePost,
                                                                      deleted: true,
                                                                      version: 1,
@@ -122,7 +122,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     func testProcessMutationErrorFromCloudOperationSuccessForMissingErrorType() throws {
         let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
         let remotePost = Post(id: localPost.id, title: "remoteTitle", content: "remoteContent", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: localPost, mutationType: .delete)
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .delete)
         guard let graphQLResponseError = try getGraphQLResponseError(withRemote: remotePost,
                                                                      deleted: true,
                                                                      version: 1,
@@ -163,7 +163,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             expectCompletion.fulfill()
         }
         let post1 = Post(title: "post1", content: "content1", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: post1, mutationType: .create)
+        let mutationEvent = try MutationEvent(model: post1, modelSchema: post1.schema, mutationType: .create)
         let graphQLError = GraphQLError(message: "conditional request failed",
                                         locations: nil,
                                         path: nil,
@@ -191,7 +191,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     ///    - Unexpected scenario, there should never be an conflict unhandled error without error.data
     func testConflictUnhandledReturnsErrorForMissingRemoteModel() throws {
         let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: localPost, mutationType: .create)
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .create)
         let graphQLError = GraphQLError(message: "conflict unhandled",
                                         extensions: ["errorType": .string(AppSyncErrorType.conflictUnhandled.rawValue)])
         let graphQLResponseError = GraphQLResponseError<MutationSync<AnyModel>>.error([graphQLError])
@@ -225,7 +225,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     ///    - Unexpected scenario, there should never get a conflict for create mutations
     func testConflictUnhandledReturnsErrorForCreateMutation() throws {
         let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: localPost, mutationType: .create)
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .create)
         let remotePost = Post(title: "remoteTitle", content: "remoteContent", createdAt: .now())
         guard let graphQLResponseError = try getGraphQLResponseError(withRemote: remotePost,
                                                                      deleted: false,
@@ -264,7 +264,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     func testConflictUnhandledForDeleteMutationAndDeletedRemoteModel() throws {
         let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
         let remotePost = Post(id: localPost.id, title: "remoteTitle", content: "remoteContent", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: localPost, mutationType: .delete)
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .delete)
         guard let graphQLResponseError = try getGraphQLResponseError(withRemote: remotePost,
                                                                      deleted: true,
                                                                      version: 1) else {
@@ -298,7 +298,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     func testConflictUnhandledForDeleteMutationAndUpdatedRemoteModelReturnsRetryLocal() throws {
         let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
         let remotePost = Post(id: localPost.id, title: "remoteTitle", content: "remoteContent", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: localPost, mutationType: .delete)
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .delete)
         guard let graphQLResponseError = try getGraphQLResponseError(withRemote: remotePost,
                                                                      deleted: false,
                                                                      version: 2) else {
@@ -375,7 +375,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     func testConflictUnhandledForDeleteMutationAndUpdatedRemoteModelReturnsRetryModel() throws {
         let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
         let remotePost = Post(id: localPost.id, title: "remoteTitle", content: "remoteContent", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: localPost, mutationType: .delete)
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .delete)
         guard let graphQLResponseError = try getGraphQLResponseError(withRemote: remotePost,
                                                                      deleted: false,
                                                                      version: 2) else {
@@ -453,7 +453,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     func testConflictUnhandledForDeleteMutationAndUpdatedRemoteModelReturnsApplyRemote() throws {
         let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
         let remotePost = Post(id: localPost.id, title: "remoteTitle", content: "remoteContent", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: localPost, mutationType: .delete)
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .delete)
         guard let graphQLResponseError = try getGraphQLResponseError(withRemote: remotePost,
                                                                      deleted: false,
                                                                      version: 2) else {
@@ -523,7 +523,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     func testConflictUnhandledForUpdateMutationAndDeletedRemoteModel() throws {
         let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
         let remotePost = Post(id: localPost.id, title: "remoteTitle", content: "remoteContent", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: localPost, mutationType: .update)
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .update)
         guard let graphQLResponseError = try getGraphQLResponseError(withRemote: remotePost,
                                                                      deleted: true,
                                                                      version: 2) else {
@@ -588,7 +588,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     func testConflictUnhandledUpdateMutationAndUpdatedRemoteReturnsApplyRemote() throws {
         let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
         let remotePost = Post(id: localPost.id, title: "remoteTitle", content: "remoteContent", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: localPost, mutationType: .update)
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .update)
         guard let graphQLResponseError = try getGraphQLResponseError(withRemote: remotePost,
                                                                      deleted: false,
                                                                      version: 2) else {
@@ -672,7 +672,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     func testConflictUnhandledUpdateMutationAndUpdatedRemoteReturnsRetryLocal() throws {
         let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
         let remotePost = Post(id: localPost.id, title: "remoteTitle", content: "remoteContent", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: localPost, mutationType: .update)
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .update)
         guard let graphQLResponseError = try getGraphQLResponseError(withRemote: remotePost,
                                                                      deleted: false,
                                                                      version: 2) else {
@@ -747,7 +747,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     func testConflictUnhandledUpdateMutationAndUpdatedRemoteReturnsRetryModel() throws {
         let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
         let remotePost = Post(id: localPost.id, title: "remoteTitle", content: "remoteContent", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: localPost, mutationType: .update)
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .update)
         guard let graphQLResponseError = try getGraphQLResponseError(withRemote: remotePost,
                                                                      deleted: false,
                                                                      version: 2) else {
@@ -824,7 +824,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     func testConflictUnhandledSyncToCloudReturnsError() throws {
         let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
         let remotePost = Post(id: localPost.id, title: "remoteTitle", content: "remoteContent", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: localPost, mutationType: .update)
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .update)
         guard let graphQLResponseError = try getGraphQLResponseError(withRemote: remotePost,
                                                                      deleted: false,
                                                                      version: 2) else {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
@@ -40,7 +40,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         let expectSecondCallToAPIMutate = expectation(description: "Second call to API.mutate")
 
         let post1 = Post(title: "post1", content: "content1", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: post1, mutationType: .create)
+        let mutationEvent = try MutationEvent(model: post1, modelSchema: post1.schema, mutationType: .create)
 
         var listenerFromFirstRequestOptional: GraphQLOperation<MutationSync<AnyModel>>.ResultListener?
         var listenerFromSecondRequestOptional: GraphQLOperation<MutationSync<AnyModel>>.ResultListener?
@@ -111,7 +111,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         let expectFirstCallToAPIMutate = expectation(description: "First call to API.mutate")
         let expectSecondCallToAPIMutate = expectation(description: "Second call to API.mutate")
         let post1 = Post(title: "post1", content: "content1", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: post1, mutationType: .create)
+        let mutationEvent = try MutationEvent(model: post1, modelSchema: post1.schema, mutationType: .create)
 
         var listenerFromFirstRequestOptional: GraphQLOperation<MutationSync<AnyModel>>.ResultListener?
         var listenerFromSecondRequestOptional: GraphQLOperation<MutationSync<AnyModel>>.ResultListener?
@@ -181,7 +181,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         let expectMutationRequestFailed = expectation(description: "Expect to fail mutation request")
         let expectFirstCallToAPIMutate = expectation(description: "First call to API.mutate")
         let post1 = Post(title: "post1", content: "content1", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: post1, mutationType: .create)
+        let mutationEvent = try MutationEvent(model: post1, modelSchema: post1.schema, mutationType: .create)
 
         var listenerFromFirstRequestOptional: GraphQLOperation<MutationSync<AnyModel>>.ResultListener?
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
@@ -45,7 +45,7 @@ class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue 
         incomingEventSubject.send(.paused)
     }
 
-    func offer(_ remoteModel: MutationSync<AnyModel>) {
+    func offer(_ remoteModel: MutationSync<AnyModel>, modelSchema: ModelSchema) {
         //no-op for mock
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
@@ -21,7 +21,7 @@ final class MockReconciliationQueue: MessageReporter, IncomingEventReconciliatio
         notify()
     }
 
-    func offer(_ remoteModel: MutationSync<AnyModel>) {
+    func offer(_ remoteModel: MutationSync<AnyModel>, modelSchema: ModelSchema) {
         notify("offer(_:) remoteModel: \(remoteModel)")
     }
 


### PR DESCRIPTION
- Removed dependency of Model.Type in Initial sync. Uses `__typename` to figure out the model name for the untyped model in save
- Mutation event takes a modelSchema now to identity the modelName.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
