### PR TITLE
chore: Update source branch of ci-support repo

### DIFF
--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-release_actions', git: 'https://github.com/aws-amplify/amplify-ci-support', branch: 'master', glob: 'src/fastlane/release_actions/*.gemspec'
+gem 'fastlane-plugin-release_actions', git: 'https://github.com/aws-amplify/amplify-ci-support', branch: 'main', glob: 'src/fastlane/release_actions/*.gemspec'


### PR DESCRIPTION
*Description of changes:*

Default branch of https://github.com/aws-amplify/amplify-ci-support is now `main`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
