### PR TITLE
fix(datastore): keep DataStore sync engine running even if model subscriptions fail

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -43,7 +43,7 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
     private var modelReconciliationQueueFactory: ModelReconciliationQueueFactory
     
     private var isInitialized: Bool {
-        self.reconciliationQueueConnectionStatus.count == self.reconciliationQueues.count
+        reconciliationQueueConnectionStatus.count == reconciliationQueues.count
     }
 
     init(modelTypes: [Model.Type],
@@ -121,6 +121,7 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
         case .disconnected(modelName: let modelName, reason: .unauthorized):
             connectionStatusSerialQueue.async {
                 self.reconciliationQueues[modelName]?.cancel()
+                self.modelReconciliationQueueSinks[modelName]?.cancel()
                 self.reconciliationQueueConnectionStatus[modelName] = false
                 if self.isInitialized {
                     self.eventReconciliationQueueTopic.send(.initialized)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -39,7 +39,7 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
 
     private let connectionStatusSerialQueue: DispatchQueue
     private var reconciliationQueues: [String: ModelReconciliationQueue]
-    private var reconciliationQueueConnectionStatus: [String: Bool]
+    private var reconciliationQueueConnectionStatus: [String: ModelConnectionStatus]
     private var modelReconciliationQueueFactory: ModelReconciliationQueueFactory
 
     init(modelTypes: [Model.Type],
@@ -107,9 +107,9 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
         switch receiveValue {
         case .mutationEvent(let event):
             eventReconciliationQueueTopic.send(.mutationEvent(event))
-        case .connected(let modelName):
+        case .connectionUpdated(let modelName, let status):
             connectionStatusSerialQueue.async {
-                self.reconciliationQueueConnectionStatus[modelName] = true
+                self.reconciliationQueueConnectionStatus[modelName] = status
                 if self.reconciliationQueueConnectionStatus.count == self.reconciliationQueues.count {
                     self.eventReconciliationQueueTopic.send(.initialized)
                 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -37,11 +37,6 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
     }
 
     private func onReceiveCompletion(receiveCompletion: Subscribers.Completion<DataStoreError>) {
-        if case let .failure(.api(error, _)) = receiveCompletion,
-           case let APIError.operationError(_, _, underlyingError) = error, isAuthError(underlyingError) {
-            subscriptionEventSubject.send(.connectionDisconnected(reason: .unauthorized))
-            return
-        }
         subscriptionEventSubject.send(completion: receiveCompletion)
     }
 
@@ -60,29 +55,6 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
         asyncEvents.cancel()
         mapper?.cancel()
         mapper = nil
-    }
-}
-
-// MARK: Auth errors handling
-@available(iOS 13.0, *)
-extension AWSIncomingSubscriptionEventPublisher {
-    private typealias ResponseType = MutationSync<AnyModel>
-    private func graphqlErrors(from error: GraphQLResponseError<ResponseType>?) -> [GraphQLError]? {
-        if case let .error(errors) = error {
-            return errors
-        }
-        return nil
-    }
-
-    private func isAuthError(_ error: Error?) -> Bool {
-        if let responseError = error as? GraphQLResponseError<ResponseType>,
-           let graphQLError = graphqlErrors(from: responseError)?.first,
-           let extensions = graphQLError.extensions,
-           case let .string(errorTypeValue) = extensions["errorType"],
-           case .unauthorized = AppSyncErrorType(errorTypeValue) {
-            return true
-        }
-        return false
     }
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
@@ -9,8 +9,13 @@ import Amplify
 import AWSPluginsCore
 import Combine
 
+enum ConnectionFailedReason {
+    case unauthorized
+}
+
 enum IncomingSubscriptionEventPublisherEvent {
     case connectionConnected
+    case connectionDisconnected(reason: ConnectionFailedReason)
     case mutationEvent(MutationSync<AnyModel>)
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
@@ -9,13 +9,8 @@ import Amplify
 import AWSPluginsCore
 import Combine
 
-enum ConnectionFailedReason {
-    case unauthorized
-}
-
 enum IncomingSubscriptionEventPublisherEvent {
     case connectionConnected
-    case connectionDisconnected(reason: ConnectionFailedReason)
     case mutationEvent(MutationSync<AnyModel>)
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -153,11 +153,8 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
             incomingSubscriptionEventQueue.addOperation(CancelAwareBlockOperation {
                 self.enqueue(remoteModel)
             })
-        case .connectionDisconnected(reason: .unauthorized):
-            modelReconciliationQueueSubject.send(.connectionUpdated(modelName, .disconnected))
-
         case .connectionConnected:
-            modelReconciliationQueueSubject.send(.connectionUpdated(modelName, .connected))
+            modelReconciliationQueueSubject.send(.connected(modelName: modelName))
         }
     }
 
@@ -167,6 +164,11 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
             log.info("receivedCompletion: finished")
             modelReconciliationQueueSubject.send(completion: .finished)
         case .failure(let dataStoreError):
+            if case let .api(error, _) = dataStoreError,
+               case let APIError.operationError(_, _, underlyingError) = error, isUnauthorizedError(underlyingError) {
+                modelReconciliationQueueSubject.send(.disconnected(modelName: modelName, reason: .unauthorized))
+                return
+            }
             log.error("receiveCompletion: error: \(dataStoreError)")
             modelReconciliationQueueSubject.send(completion: .failure(dataStoreError))
         }
@@ -176,6 +178,7 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
 @available(iOS 13.0, *)
 extension AWSModelReconciliationQueue: DefaultLogger { }
 
+// MARK: Resettable
 @available(iOS 13.0, *)
 extension AWSModelReconciliationQueue: Resettable {
 
@@ -210,4 +213,27 @@ extension AWSModelReconciliationQueue: Resettable {
         onComplete()
     }
 
+}
+
+// MARK: Auth errors handling
+@available(iOS 13.0, *)
+extension AWSModelReconciliationQueue {
+    private typealias ResponseType = MutationSync<AnyModel>
+    private func graphqlErrors(from error: GraphQLResponseError<ResponseType>?) -> [GraphQLError]? {
+        if case let .error(errors) = error {
+            return errors
+        }
+        return nil
+    }
+
+    private func isUnauthorizedError(_ error: Error?) -> Bool {
+        if let responseError = error as? GraphQLResponseError<ResponseType>,
+           let graphQLError = graphqlErrors(from: responseError)?.first,
+           let extensions = graphQLError.extensions,
+           case let .string(errorTypeValue) = extensions["errorType"],
+           case .unauthorized = AppSyncErrorType(errorTypeValue) {
+            return true
+        }
+        return false
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -153,8 +153,11 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
             incomingSubscriptionEventQueue.addOperation(CancelAwareBlockOperation {
                 self.enqueue(remoteModel)
             })
+        case .connectionDisconnected(reason: .unauthorized):
+            modelReconciliationQueueSubject.send(.connectionUpdated(modelName, .disconnected))
+
         case .connectionConnected:
-            modelReconciliationQueueSubject.send(.connected(modelName))
+            modelReconciliationQueueSubject.send(.connectionUpdated(modelName, .connected))
         }
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
@@ -9,15 +9,15 @@ import Amplify
 import AWSPluginsCore
 import Combine
 
-enum ModelConnectionStatus {
-    case connected
-    case disconnected
+enum ModelConnectionDisconnectedReason {
+    case unauthorized
 }
 
 enum ModelReconciliationQueueEvent {
     case started
     case paused
-    case connectionUpdated(String, ModelConnectionStatus)
+    case connected(modelName: String)
+    case disconnected(modelName: String, reason: ModelConnectionDisconnectedReason)
     case mutationEvent(MutationEvent)
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
@@ -9,10 +9,15 @@ import Amplify
 import AWSPluginsCore
 import Combine
 
+enum ModelConnectionStatus {
+    case connected
+    case disconnected
+}
+
 enum ModelReconciliationQueueEvent {
     case started
     case paused
-    case connected(String)
+    case connectionUpdated(String, ModelConnectionStatus)
     case mutationEvent(MutationEvent)
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -63,7 +63,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
         let reconciliationQueues = MockModelReconciliationQueue.mockModelReconciliationQueues
         for (queueName, queue) in reconciliationQueues {
             let cancellableOperation = CancelAwareBlockOperation {
-                queue.modelReconciliationQueueSubject.send(.connected(queueName))
+                queue.modelReconciliationQueueSubject.send(.connectionUpdated(queueName, .connected))
             }
             operationQueue.addOperation(cancellableOperation)
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -25,6 +25,12 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
 
         apiPlugin = MockAPICategoryPlugin()
 
+        operationQueue = OperationQueue()
+        operationQueue.name = "com.amazonaws.DataStore.UnitTestQueue"
+        operationQueue.maxConcurrentOperationCount = 2
+        operationQueue.underlyingQueue = DispatchQueue.global()
+        operationQueue.isSuspended = true
+
     }
     var operationQueue: OperationQueue!
 
@@ -50,20 +56,14 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             case .initialized:
                 expectInitialized.fulfill()
             default:
-                XCTFail("Should not expect any other state")
+                XCTFail("Should not expect any other state, received: \(event)")
             }
         })
-
-        operationQueue = OperationQueue()
-        operationQueue.name = "com.amazonaws.DataStore.UnitTestQueue"
-        operationQueue.maxConcurrentOperationCount = 2
-        operationQueue.underlyingQueue = DispatchQueue.global()
-        operationQueue.isSuspended = true
 
         let reconciliationQueues = MockModelReconciliationQueue.mockModelReconciliationQueues
         for (queueName, queue) in reconciliationQueues {
             let cancellableOperation = CancelAwareBlockOperation {
-                queue.modelReconciliationQueueSubject.send(.connectionUpdated(queueName, .connected))
+                queue.modelReconciliationQueueSubject.send(.connected(modelName: queueName))
             }
             operationQueue.addOperation(cancellableOperation)
         }
@@ -71,6 +71,81 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
         waitForExpectations(timeout: 2)
 
         // Take action on the sink to prevent compiler warnings about unused variables.
+        sink.cancel()
+    }
+
+    func testSubscriptionFailedWithSingleModelUnauthorizedError() {
+        let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
+        let modelReconciliationQueueFactory
+            = MockModelReconciliationQueue.init(modelType:storageAdapter:api:auth:incomingSubscriptionEvents:)
+        let eventQueue = AWSIncomingEventReconciliationQueue(
+            modelTypes: [Post.self],
+            api: apiPlugin,
+            storageAdapter: storageAdapter,
+            modelReconciliationQueueFactory: modelReconciliationQueueFactory)
+        eventQueue.start()
+
+        let sink = eventQueue.publisher.sink(receiveCompletion: { _ in
+            XCTFail("Not expecting this to call")
+        }, receiveValue: { event  in
+            switch event {
+            case .initialized:
+                expectInitialized.fulfill()
+            default:
+                XCTFail("Should not expect any other state, received: \(event)")
+            }
+        })
+
+        let reconciliationQueues = MockModelReconciliationQueue.mockModelReconciliationQueues
+        for (queueName, queue) in reconciliationQueues {
+            let cancellableOperation = CancelAwareBlockOperation {
+                queue.modelReconciliationQueueSubject.send(.disconnected(modelName: queueName, reason: .unauthorized))
+            }
+            operationQueue.addOperation(cancellableOperation)
+        }
+        operationQueue.isSuspended = false
+        waitForExpectations(timeout: 2)
+
+        sink.cancel()
+    }
+
+    // This test case tests that initialized event is received even if only one
+    // model subscriptions out of two failed - Post subscription will fail but Comment will succeed
+    func testSubscriptionFailedWithMultipleModels() {
+        let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
+        let modelReconciliationQueueFactory
+            = MockModelReconciliationQueue.init(modelType:storageAdapter:api:auth:incomingSubscriptionEvents:)
+        let eventQueue = AWSIncomingEventReconciliationQueue(
+            modelTypes: [Post.self, Comment.self],
+            api: apiPlugin,
+            storageAdapter: storageAdapter,
+            modelReconciliationQueueFactory: modelReconciliationQueueFactory)
+        eventQueue.start()
+
+        let sink = eventQueue.publisher.sink(receiveCompletion: { _ in
+            XCTFail("Not expecting this to call")
+        }, receiveValue: { event  in
+            switch event {
+            case .initialized:
+                expectInitialized.fulfill()
+            default:
+                XCTFail("Should not expect any other state, received: \(event)")
+            }
+        })
+
+        let reconciliationQueues = MockModelReconciliationQueue.mockModelReconciliationQueues
+        for (queueName, queue) in reconciliationQueues {
+            let cancellableOperation = CancelAwareBlockOperation {
+                let event: ModelReconciliationQueueEvent = queueName == Post.modelName ?
+                    .disconnected(modelName: queueName, reason: .unauthorized) :
+                    .connected(modelName: queueName)
+                queue.modelReconciliationQueueSubject.send(event)
+            }
+            operationQueue.addOperation(cancellableOperation)
+        }
+        operationQueue.isSuspended = false
+        waitForExpectations(timeout: 2)
+
         sink.cancel()
     }
 }


### PR DESCRIPTION
Keep DataStore sync engine running even if model subscriptions fail