### PR TITLE
add github workflow action to handle stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-label: 'closing soon'
-        exempt-issue-labels: 'pending triage,follow up'
+        exempt-issue-labels: 'pending investigation,pending triage,follow up,feature request,enhancement'
         stale-issue-message: 'This issue is stale because it has been open 14 days with no activity. Please, provide an update or this will be automatically closed in 7 days.'
         close-issue-message: 'This issue is being automatically closed due to inactivity. If you believe this was closed by mistake, provide an update and re-open it.'
         days-before-stale: 14

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-label: 'closing soon'
+        exempt-issue-labels: 'pending triage,follow up'
+        stale-issue-message: 'This issue is stale because it has been open 14 days with no activity. Please, provide an update or this will be automatically closed in 7 days.'
+        close-issue-message: 'This issue is being automatically closed due to inactivity. If you believe this was closed by mistake, provide an update and re-open it.'
+        days-before-stale: 14
+        days-before-close: 7


### PR DESCRIPTION
*Description of changes:* this PR adds a GitHub Action workflow to automatically handle stale issues. It leverages the official https://github.com/actions/stale 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
