### PR TITLE
refactor(datastore): Fix sync and local save to use non modeltype

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -18,9 +18,11 @@ protocol ModelSyncGraphQLRequestFactory {
     static func query(modelName: String, byId id: String) -> GraphQLRequest<MutationSyncResult?>
 
     static func createMutation(of model: Model,
+                               modelSchema: ModelSchema,
                                version: Int?) -> GraphQLRequest<MutationSyncResult>
 
     static func updateMutation(of model: Model,
+                               modelSchema: ModelSchema,
                                where filter: GraphQLFilter?,
                                version: Int?) -> GraphQLRequest<MutationSyncResult>
 
@@ -63,14 +65,16 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
     }
 
     public static func createMutation(of model: Model,
+                                      modelSchema: ModelSchema,
                                       version: Int? = nil) -> GraphQLRequest<MutationSyncResult> {
-        createOrUpdateMutation(of: model, type: .create, version: version)
+        createOrUpdateMutation(of: model, modelSchema: modelSchema, type: .create, version: version)
     }
 
     public static func updateMutation(of model: Model,
+                                      modelSchema: ModelSchema,
                                       where filter: GraphQLFilter? = nil,
                                       version: Int? = nil) -> GraphQLRequest<MutationSyncResult> {
-        createOrUpdateMutation(of: model, where: filter, type: .update, version: version)
+        createOrUpdateMutation(of: model, modelSchema: modelSchema, where: filter, type: .update, version: version)
     }
 
     public static func deleteMutation(modelName: String,
@@ -150,10 +154,11 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
     // MARK: Private methods
 
     private static func createOrUpdateMutation(of model: Model,
+                                               modelSchema: ModelSchema,
                                                where filter: GraphQLFilter? = nil,
                                                type: GraphQLMutationType,
                                                version: Int? = nil) -> GraphQLRequest<MutationSyncResult> {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: model.modelName,
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: modelSchema.name,
                                                                operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: type))
         documentBuilder.add(decorator: ModelDecorator(model: model))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
@@ -93,6 +93,7 @@ extension Model {
                case let .model(modelName) = field.type,
                let modelSchema = ModelRegistry.modelSchema(from: modelName) {
 
+                // Check if it is a Model or json object.
                 if let value = value as? Model {
                     let associatedModel: Model.Type = type(of: value)
                     return value[associatedModel.schema.primaryKey.name] as? String

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -22,7 +22,6 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
                      databaseName: String = "database",
                      userDefaults: UserDefaults = UserDefaults.standard) throws {
         var dbFilePath = SQLiteStorageEngineAdapter.getDbFilePath(databaseName: databaseName)
-
         try SQLiteStorageEngineAdapter.clearIfNewVersion(version: version,
                                                          dbFilePath: dbFilePath)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
@@ -189,7 +189,14 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
                                                                                 version: latestVersion)
                 self.makeAPIRequest(request)
             case .retry(let model):
+                guard let modelSchema = ModelRegistry.modelSchema(from: self.mutationEvent.modelName) else {
+                    preconditionFailure("""
+                    Could not retrieve schema for the model \(self.mutationEvent.modelName), verify that datastore is
+                    initialized.
+                    """)
+                }
                 let request = GraphQLRequest<MutationSyncResult>.updateMutation(of: model,
+                                                                                modelSchema: modelSchema,
                                                                                 version: latestVersion)
                 self.makeAPIRequest(request)
             }
@@ -210,11 +217,25 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
             case .applyRemote:
                 self.saveCreateOrUpdateMutation(remoteModel: remoteModel)
             case .retryLocal:
+                guard let modelSchema = ModelRegistry.modelSchema(from: self.mutationEvent.modelName) else {
+                    preconditionFailure("""
+                    Could not retrieve schema for the model \(self.mutationEvent.modelName), verify that datastore is
+                    initialized.
+                    """)
+                }
                 let request = GraphQLRequest<MutationSyncResult>.updateMutation(of: localModel,
+                                                                                modelSchema: modelSchema,
                                                                                 version: latestVersion)
                 self.makeAPIRequest(request)
             case .retry(let model):
+                guard let modelSchema = ModelRegistry.modelSchema(from: self.mutationEvent.modelName) else {
+                    preconditionFailure("""
+                    Could not retrieve schema for the model \(self.mutationEvent.modelName), verify that datastore is
+                    initialized.
+                    """)
+                }
                 let request = GraphQLRequest<MutationSyncResult>.updateMutation(of: model,
+                                                                                modelSchema: modelSchema,
                                                                                 version: latestVersion)
                 self.makeAPIRequest(request)
             }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
@@ -108,12 +108,27 @@ class SyncMutationToCloudOperation: Operation {
                                                                             version: mutationEvent.version)
             case .update:
                 let model = try mutationEvent.decodeModel()
+                guard let modelSchema = ModelRegistry.modelSchema(from: mutationEvent.modelName) else {
+                    preconditionFailure("""
+                    Could not retrieve schema for the model \(mutationEvent.modelName), verify that datastore is
+                    initialized.
+                    """)
+                }
                 request = GraphQLRequest<MutationSyncResult>.updateMutation(of: model,
+                                                                            modelSchema: modelSchema,
                                                                             where: graphQLFilter,
                                                                             version: mutationEvent.version)
             case .create:
                 let model = try mutationEvent.decodeModel()
-                request = GraphQLRequest<MutationSyncResult>.createMutation(of: model, version: mutationEvent.version)
+                guard let modelSchema = ModelRegistry.modelSchema(from: mutationEvent.modelName) else {
+                    preconditionFailure("""
+                    Could not retrieve schema for the model \(mutationEvent.modelName), verify that datastore is
+                    initialized.
+                    """)
+                }
+                request = GraphQLRequest<MutationSyncResult>.createMutation(of: model,
+                                                                            modelSchema: modelSchema,
+                                                                            version: mutationEvent.version)
             }
         } catch {
             let apiError = APIError.unknown("Couldn't decode model", "", error)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -61,7 +61,7 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
     /// is always active.
     private let reconcileAndSaveQueue: OperationQueue
 
-    private let modelName: String
+    private let modelSchema: ModelSchema
 
     private var incomingEventsSink: AnyCancellable?
     private var reconcileAndLocalSaveOperationSinks: AtomicValue<Set<AnyCancellable?>>
@@ -77,20 +77,20 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
          auth: AuthCategoryBehavior?,
          incomingSubscriptionEvents: IncomingSubscriptionEventPublisher? = nil) {
 
-        self.modelName = modelSchema.name
+        self.modelSchema = modelSchema
 
         self.storageAdapter = storageAdapter
 
         self.modelReconciliationQueueSubject = PassthroughSubject<ModelReconciliationQueueEvent, DataStoreError>()
 
         self.reconcileAndSaveQueue = OperationQueue()
-        reconcileAndSaveQueue.name = "com.amazonaws.DataStore.\(modelName).reconcile"
+        reconcileAndSaveQueue.name = "com.amazonaws.DataStore.\(modelSchema.name).reconcile"
         reconcileAndSaveQueue.maxConcurrentOperationCount = 1
         reconcileAndSaveQueue.underlyingQueue = DispatchQueue.global()
         reconcileAndSaveQueue.isSuspended = false
 
         self.incomingSubscriptionEventQueue = OperationQueue()
-        incomingSubscriptionEventQueue.name = "com.amazonaws.DataStore.\(modelName).remoteEvent"
+        incomingSubscriptionEventQueue.name = "com.amazonaws.DataStore.\(modelSchema.name).remoteEvent"
         incomingSubscriptionEventQueue.maxConcurrentOperationCount = 1
         incomingSubscriptionEventQueue.underlyingQueue = DispatchQueue.global()
         incomingSubscriptionEventQueue.isSuspended = true
@@ -131,7 +131,8 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
     }
 
     func enqueue(_ remoteModel: MutationSync<AnyModel>) {
-        let reconcileOp = ReconcileAndLocalSaveOperation(remoteModel: remoteModel,
+        let reconcileOp = ReconcileAndLocalSaveOperation(modelSchema: modelSchema,
+                                                         remoteModel: remoteModel,
                                                          storageAdapter: storageAdapter)
         var reconcileAndLocalSaveOperationSink: AnyCancellable?
 
@@ -154,7 +155,7 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
                 self.enqueue(remoteModel)
             })
         case .connectionConnected:
-            modelReconciliationQueueSubject.send(.connected(modelName))
+            modelReconciliationQueueSubject.send(.connected(modelSchema.name))
         }
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -50,7 +50,8 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         stateMachine = MockStateMachine(initialState: .waiting,
                                         resolver: ReconcileAndLocalSaveOperation.Resolver.resolve(currentState:action:))
 
-        operation = ReconcileAndLocalSaveOperation(remoteModel: anyPostMutationSync,
+        operation = ReconcileAndLocalSaveOperation(modelSchema: anyPostMutationSync.model.schema,
+                                                   remoteModel: anyPostMutationSync,
                                                    storageAdapter: storageAdapter,
                                                    stateMachine: stateMachine)
     }


### PR DESCRIPTION
*Description of changes:*

- Updated sync operations to make use of model schema
- Fixed local save to use id from the associated model for json type.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
