### PR TITLE
fix(auth): Dismiss UI first before sending callback for HostedUI

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -145,35 +145,33 @@ extension AuthenticationProviderAdapter {
         }
 
         parentViewController?.present(navController, animated: false, completion: {
-
+            
             self.awsMobileClient.showSignIn(navigationController: navController,
                                             signInUIOptions: SignInUIOptions(),
                                             hostedUIOptions: hostedUIOptions) { [weak self] state, error in
-                                                defer {
-                                                    DispatchQueue.main.async {
-                                                        navController.dismiss(animated: false)
-                                                    }
-                                                }
-                                                guard let self = self else { return }
-
-                                                if let error = error {
-                                                    let authError = self.convertSignUIErrorToAuthError(error)
-                                                    completionHandler(.failure(authError))
-                                                    return
-                                                }
-
-                                                guard let state = state, state == .signedIn else {
-
-                                                    let error = AuthError.unknown("""
-                                                    signInWithWebUI did not produce a valid result.
-                                                    """)
-                                                    completionHandler(.failure(error))
-                                                    return
-                                                }
-                                                let authResult = AuthSignInResult(nextStep: .done)
-                                                completionHandler(.success(authResult))
+                
+                DispatchQueue.main.async {
+                    navController.dismiss(animated: false) {
+                        guard let self = self else { return }
+                        
+                        if let error = error {
+                            let authError = self.convertSignUIErrorToAuthError(error)
+                            completionHandler(.failure(authError))
+                            return
+                        }
+                        
+                        guard let state = state, state == .signedIn else {
+                            
+                            let error = AuthError.unknown("signInWithWebUI did not produce a valid result.")
+                            completionHandler(.failure(error))
+                            return
+                        }
+                        let authResult = AuthSignInResult(nextStep: .done)
+                        completionHandler(.success(authResult))
+                    }
+                }
             }
-
+            
         })
     }
 

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -145,23 +145,23 @@ extension AuthenticationProviderAdapter {
         }
 
         parentViewController?.present(navController, animated: false, completion: {
-            
+
             self.awsMobileClient.showSignIn(navigationController: navController,
                                             signInUIOptions: SignInUIOptions(),
                                             hostedUIOptions: hostedUIOptions) { [weak self] state, error in
-                
+
                 DispatchQueue.main.async {
                     navController.dismiss(animated: false) {
                         guard let self = self else { return }
-                        
+
                         if let error = error {
                             let authError = self.convertSignUIErrorToAuthError(error)
                             completionHandler(.failure(authError))
                             return
                         }
-                        
+
                         guard let state = state, state == .signedIn else {
-                            
+
                             let error = AuthError.unknown("signInWithWebUI did not produce a valid result.")
                             completionHandler(.failure(error))
                             return
@@ -171,7 +171,7 @@ extension AuthenticationProviderAdapter {
                     }
                 }
             }
-            
+
         })
     }
 


### PR DESCRIPTION
*Issue:* #809 

*Description of changes:* Fix an issue where the UI was dismissed after the callback was completed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
