### PR TITLE
fix: auth category should throw AuthError instead of PredictionsError

### DIFF
--- a/Amplify/Categories/Auth/AuthCategory.swift
+++ b/Amplify/Categories/Auth/AuthCategory.swift
@@ -51,7 +51,7 @@ final public class AuthCategory: Category {
         let key = plugin.key
         guard !key.isEmpty else {
             let pluginDescription = String(describing: plugin)
-            let error = PredictionsError.configuration("Plugin \(pluginDescription) has an empty `key`.",
+            let error = AuthError.configuration("Plugin \(pluginDescription) has an empty `key`.",
                 "Set the `key` property for \(String(describing: plugin))")
             throw error
         }

--- a/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
@@ -181,6 +181,12 @@ class MockSecondAuthCategoryPlugin: MockAuthCategoryPlugin {
     }
 }
 
+class MockAuthCategoryPluginWithoutKey: MockAuthCategoryPlugin {
+    override var key: String {
+        return ""
+    }
+}
+
 class MockAuthChangePasswordOperation: AmplifyOperation<AuthChangePasswordRequest, Void, AuthError>,
 AuthChangePasswordOperation {
 

--- a/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
@@ -392,4 +392,18 @@ class AuthCategoryConfigurationTests: XCTestCase {
         waitForExpectations(timeout: 0.1)
     }
 
+    /// Test that Amplify throws an `AuthError` if it encounters a plugin without a key
+    ///
+    /// - Given: Unconfigured Amplify Framework
+    /// - When:
+    ///     - I add an Auth plugin without a key
+    /// - Then:
+    ///     - An `AuthError` is thrown
+    ///
+    func testThrowsPluginWithoutKey() {
+        let plugin = MockAuthCategoryPluginWithoutKey()
+        XCTAssertThrowsError(try Amplify.add(plugin: plugin)) { error in
+            XCTAssertNotNil(error as? AuthError)
+        }
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/aws-amplify/amplify-ios/issues/829

*Description of changes:*
When adding an Auth plugin using `Amplify.add(plugin:)`, if the plugin does not have a key a `PredictionsError` will be thrown. Since this is the `AuthCategory` I would expect an `AuthError` to be thrown. This code changes the error to an `AuthError` and adds a new unit test to verify (1) that an error is thrown and (2) that the error is an `AuthError`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
