### PR TITLE
fix: move AWSServiceConfiguration Platform extension

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		21420AA0237222A900FA140C /* AWSAuthorizationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21420A8D237222A900FA140C /* AWSAuthorizationType.swift */; };
 		2144226C234BDD9B009357F7 /* StorageUploadFileRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2144226B234BDD9B009357F7 /* StorageUploadFileRequest.swift */; };
 		2144226E234BDE23009357F7 /* StorageUploadFileOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2144226D234BDE23009357F7 /* StorageUploadFileOperation.swift */; };
+		214C6226253A414E0041E96D /* AmplifyAWSServiceConfiguration+Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214C6225253A414E0041E96D /* AmplifyAWSServiceConfiguration+Platform.swift */; };
 		214F49772486D8A200DA616C /* UserFollowers+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49712486D8A100DA616C /* UserFollowers+Schema.swift */; };
 		214F49782486D8A200DA616C /* UserFollowing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49722486D8A200DA616C /* UserFollowing.swift */; };
 		214F49792486D8A200DA616C /* UserFollowing+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49732486D8A200DA616C /* UserFollowing+Schema.swift */; };
@@ -750,6 +751,7 @@
 		21420A8D237222A900FA140C /* AWSAuthorizationType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSAuthorizationType.swift; sourceTree = "<group>"; };
 		2144226B234BDD9B009357F7 /* StorageUploadFileRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageUploadFileRequest.swift; sourceTree = "<group>"; };
 		2144226D234BDE23009357F7 /* StorageUploadFileOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageUploadFileOperation.swift; sourceTree = "<group>"; };
+		214C6225253A414E0041E96D /* AmplifyAWSServiceConfiguration+Platform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AmplifyAWSServiceConfiguration+Platform.swift"; sourceTree = "<group>"; };
 		214F49712486D8A100DA616C /* UserFollowers+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserFollowers+Schema.swift"; sourceTree = "<group>"; };
 		214F49722486D8A200DA616C /* UserFollowing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserFollowing.swift; sourceTree = "<group>"; };
 		214F49732486D8A200DA616C /* UserFollowing+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserFollowing+Schema.swift"; sourceTree = "<group>"; };
@@ -1971,6 +1973,7 @@
 			isa = PBXGroup;
 			children = (
 				6BBECD7023ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift */,
+				214C6225253A414E0041E96D /* AmplifyAWSServiceConfiguration+Platform.swift */,
 			);
 			path = ServiceConfiguration;
 			sourceTree = "<group>";
@@ -4090,6 +4093,7 @@
 				21420A92237222A900FA140C /* OIDCConfiguration.swift in Sources */,
 				21420A95237222A900FA140C /* AWSAuthServiceBehavior.swift in Sources */,
 				21420A98237222A900FA140C /* AuthTokenProvider.swift in Sources */,
+				214C6226253A414E0041E96D /* AmplifyAWSServiceConfiguration+Platform.swift in Sources */,
 				21420A91237222A900FA140C /* AWSAuthorizationConfiguration.swift in Sources */,
 				212CE70F23E9E991007D8E71 /* ModelDecorator.swift in Sources */,
 				21420A97237222A900FA140C /* IAMCredentialProvider.swift in Sources */,

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration+Platform.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration+Platform.swift
@@ -1,0 +1,27 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension AmplifyAWSServiceConfiguration {
+
+    static var platformMapping: [Platform: String] = [:]
+
+    public static func addUserAgentPlatform(_ platform: Platform, version: String) {
+        platformMapping[platform] = version
+    }
+
+    public enum Platform: String {
+        case flutter = "amplify-flutter"
+    }
+
+    static func platformInformation() -> String {
+        var platformTokens = platformMapping.map { "\($0.rawValue)/\($1)" }
+        platformTokens.append("amplify-iOS/\(version)")
+        return platformTokens.joined(separator: " ")
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -42,22 +42,3 @@ public class AmplifyAWSServiceConfiguration: AWSServiceConfiguration {
         super.init(region: regionType, credentialsProvider: nil)
     }
 }
-
-extension AmplifyAWSServiceConfiguration {
-
-    static var platformMapping: [Platform: String] = [:]
-
-    public static func addUserAgentPlatform(_ platform: Platform, version: String) {
-        platformMapping[platform] = version
-    }
-
-    public enum Platform: String {
-        case flutter = "amplify-flutter"
-    }
-
-    static func platformInformation() -> String {
-        var platformTokens = platformMapping.map { "\($0.rawValue)/\($1)" }
-        platformTokens.append("amplify-iOS/\(version)")
-        return platformTokens.joined(separator: " ")
-    }
-}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the fast lane script, there are one-off's that bump the version
```
 set_key_value(file: "AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift", key: "version", value: version)
```

the problem was the version parameter was being picked up and replaced the type with the version number:
https://github.com/aws-amplify/amplify-ios/commit/3b431c8eec094d1f29a4bacdd15a42001183a316#r43315436

And so, this code change is to move that extension over to it's own file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
