### PR TITLE
fix: replace fastlane warn method

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -112,7 +112,7 @@ platform :ios do
           pod_push(path: pod[:spec], allow_warnings: true, synchronous: true)
         rescue StandardError => e
           raise e unless e.message =~ /Unable to accept duplicate entry/i
-          UI.warn("Version already exists. Ignoring")
+          UI.important("Version already exists. Ignoring")
         end
       end
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The error is
```
[22:27:44]: Unknown method 'warn', supported [:crash!, :not_implemented, :important, :shell_error!, :success, :build_failure!, :confirm, :command, :verbose, :abort_with_message!, :test_failure!, :deprecated, :error, :interactive?, :password, :input, :select, :header, :user_error!, :message, :command_output, :content_error]

```
ref https://docs.fastlane.tools/advanced/actions/#interacting-with-the-user


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
