### PR TITLE
fix(api): make sure collections are not in the gql input - fixes #828

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -19,6 +19,13 @@ extension Model {
         var input: GraphQLInput = [:]
         schema.fields.forEach {
             let field = $0.value
+
+            // TODO how to handle associations of type "many" (i.e. cascade save)?
+            // This is not supported right now and might be added as a future feature
+            if case .collection = field.type {
+                return
+            }
+
             let name = field.graphQLName
             let fieldValue = self[field.name] ?? nil
 
@@ -45,10 +52,6 @@ extension Model {
                     fieldName = targetName ?? fieldName
                 }
                 input[fieldName] = (value as? Model)?.id
-            case .collection:
-                // TODO how to handle associations of type "many" (i.e. cascade save)?
-                // This is not supported right now and might be added as a future feature
-                break
             case .embedded, .embeddedCollection:
                 if let encodable = value as? Encodable {
                     let jsonEncoder = JSONEncoder(dateEncodingStrategy: ModelDateFormatting.encodingStrategy)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLUpdateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLUpdateMutationTests.swift
@@ -67,6 +67,7 @@ class GraphQLUpdateMutationTests: XCTestCase {
         }
         XCTAssert(input["title"] as? String == post.title)
         XCTAssert(input["content"] as? String == post.content)
+        XCTAssertFalse(input.keys.contains("comments"))
     }
 
     /// - Given: a `Model` instance
@@ -119,5 +120,6 @@ class GraphQLUpdateMutationTests: XCTestCase {
         XCTAssert(input["title"] as? String == post.title)
         XCTAssert(input["content"] as? String == post.content)
         XCTAssert(input["_version"] as? Int == 5)
+        XCTAssertFalse(input.keys.contains("comments"))
     }
 }


### PR DESCRIPTION
*Issue #, if available:* #828 

**Notes:**

In some scenarios the fields of type `.collection` were not being
correctly excluded from the `input` of the `GraphQLRequest`.

This change makes sure the fields of type `.collection` are not added to
the input variable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
