### PR TITLE
fix(API): support for auth api oidc provider

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -147,7 +147,6 @@
 		6BB7441023A9954900B0EB6C /* DispatchSource+MakeOneOff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB7440F23A9954900B0EB6C /* DispatchSource+MakeOneOff.swift */; };
 		6BBECD7123ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BBECD7023ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift */; };
 		6BBECD7423ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BBECD7323ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift */; };
-		6BD461F52537F4D100906831 /* APIAuthProviders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD461F42537F4D100906831 /* APIAuthProviders.swift */; };
 		6BEE0817253114FD00133961 /* AWSAuthServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE0816253114FD00133961 /* AWSAuthServiceTests.swift */; };
 		6BEE08192533CAA600133961 /* GraphQLRequestOwnerAndGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE08182533CAA600133961 /* GraphQLRequestOwnerAndGroupTests.swift */; };
 		6BEE081C2533CCFA00133961 /* OGCScenarioBPost+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE081A2533CCFA00133961 /* OGCScenarioBPost+Schema.swift */; };
@@ -872,7 +871,6 @@
 		6BB7440F23A9954900B0EB6C /* DispatchSource+MakeOneOff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchSource+MakeOneOff.swift"; sourceTree = "<group>"; };
 		6BBECD7023ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplifyAWSServiceConfiguration.swift; sourceTree = "<group>"; };
 		6BBECD7323ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplifyAWSServiceConfigurationTests.swift; sourceTree = "<group>"; };
-		6BD461F42537F4D100906831 /* APIAuthProviders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIAuthProviders.swift; sourceTree = "<group>"; };
 		6BEE0816253114FD00133961 /* AWSAuthServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAuthServiceTests.swift; sourceTree = "<group>"; };
 		6BEE08182533CAA600133961 /* GraphQLRequestOwnerAndGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRequestOwnerAndGroupTests.swift; sourceTree = "<group>"; };
 		6BEE081A2533CCFA00133961 /* OGCScenarioBPost+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OGCScenarioBPost+Schema.swift"; sourceTree = "<group>"; };
@@ -1775,7 +1773,6 @@
 		21C395B4245729F100597EA2 /* API */ = {
 			isa = PBXGroup;
 			children = (
-				6BD461F32537F4A700906831 /* AuthProvider */,
 				21C395B2245729EC00597EA2 /* AppSyncErrorType.swift */,
 			);
 			path = API;
@@ -2001,14 +1998,6 @@
 				6BBECD7323ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift */,
 			);
 			path = ServiceConfiguration;
-			sourceTree = "<group>";
-		};
-		6BD461F32537F4A700906831 /* AuthProvider */ = {
-			isa = PBXGroup;
-			children = (
-				6BD461F42537F4D100906831 /* APIAuthProviders.swift */,
-			);
-			path = AuthProvider;
 			sourceTree = "<group>";
 		};
 		6BEE0815253114E600133961 /* Auth */ = {
@@ -4106,7 +4095,6 @@
 				219A888523EB897700BBC5F2 /* GraphQLRequest+AnyModelWithSync.swift in Sources */,
 				219A88F123F3379900BBC5F2 /* GraphQLDocumentInput.swift in Sources */,
 				21AD424E249BF0E90016FE95 /* AnyModel+Subscript.swift in Sources */,
-				6BD461F52537F4D100906831 /* APIAuthProviders.swift in Sources */,
 				21420AA0237222A900FA140C /* AWSAuthorizationType.swift in Sources */,
 				B4EBEB64246204D000D06375 /* AuthAWSCredentialsProvider.swift in Sources */,
 				212CE6FC23E9E523007D8E71 /* SelectionSet.swift in Sources */,

--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -135,6 +135,9 @@
 		2CFB61C7E80D065C0A885A2F /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsTestCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5363CAF9EFAA822FED56808 /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsTestCommon.framework */; };
 		3263D332138415AF42E64FF7 /* Pods_AmplifyTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC7F1C368154B364CB74742 /* Pods_AmplifyTestApp.framework */; };
 		6B33896823AAACC900561E5B /* ReachabilityUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B33896723AAACC900561E5B /* ReachabilityUpdate.swift */; };
+		6B50C917253E2AD9007B16DD /* AmplifyAPICategory+AuthProviderBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B50C916253E2AD9007B16DD /* AmplifyAPICategory+AuthProviderBehavior.swift */; };
+		6B50C91A253E2B16007B16DD /* APIAuthProviders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B50C919253E2B16007B16DD /* APIAuthProviders.swift */; };
+		6B50C91C253E2B57007B16DD /* APICategoryAuthProviderBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B50C91B253E2B57007B16DD /* APICategoryAuthProviderBehavior.swift */; };
 		6B767FB723AC092800C683ED /* AmplifyAPICategory+ReachabilityBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B767FB623AC092800C683ED /* AmplifyAPICategory+ReachabilityBehavior.swift */; };
 		6B767FB923AC0A0D00C683ED /* APICategoryReachabilityBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B767FB823AC0A0D00C683ED /* APICategoryReachabilityBehavior.swift */; };
 		6B9F7C5225267E1500F1F71C /* MockAWSAuthUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9F7C5125267E1500F1F71C /* MockAWSAuthUser.swift */; };
@@ -144,6 +147,7 @@
 		6BB7441023A9954900B0EB6C /* DispatchSource+MakeOneOff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB7440F23A9954900B0EB6C /* DispatchSource+MakeOneOff.swift */; };
 		6BBECD7123ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BBECD7023ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift */; };
 		6BBECD7423ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BBECD7323ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift */; };
+		6BD461F52537F4D100906831 /* APIAuthProviders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD461F42537F4D100906831 /* APIAuthProviders.swift */; };
 		6BEE0817253114FD00133961 /* AWSAuthServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE0816253114FD00133961 /* AWSAuthServiceTests.swift */; };
 		6BEE08192533CAA600133961 /* GraphQLRequestOwnerAndGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE08182533CAA600133961 /* GraphQLRequestOwnerAndGroupTests.swift */; };
 		6BEE081C2533CCFA00133961 /* OGCScenarioBPost+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE081A2533CCFA00133961 /* OGCScenarioBPost+Schema.swift */; };
@@ -855,6 +859,9 @@
 		687B09E9348F8D29979A2404 /* Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests/Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6AF0E4775809F0866F9C44D9 /* Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig"; path = "Target Support Files/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6B33896723AAACC900561E5B /* ReachabilityUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReachabilityUpdate.swift; sourceTree = "<group>"; };
+		6B50C916253E2AD9007B16DD /* AmplifyAPICategory+AuthProviderBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AmplifyAPICategory+AuthProviderBehavior.swift"; sourceTree = "<group>"; };
+		6B50C919253E2B16007B16DD /* APIAuthProviders.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIAuthProviders.swift; sourceTree = "<group>"; };
+		6B50C91B253E2B57007B16DD /* APICategoryAuthProviderBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APICategoryAuthProviderBehavior.swift; sourceTree = "<group>"; };
 		6B767FB623AC092800C683ED /* AmplifyAPICategory+ReachabilityBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AmplifyAPICategory+ReachabilityBehavior.swift"; sourceTree = "<group>"; };
 		6B767FB823AC0A0D00C683ED /* APICategoryReachabilityBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICategoryReachabilityBehavior.swift; sourceTree = "<group>"; };
 		6B9F7C5125267E1500F1F71C /* MockAWSAuthUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSAuthUser.swift; sourceTree = "<group>"; };
@@ -865,6 +872,7 @@
 		6BB7440F23A9954900B0EB6C /* DispatchSource+MakeOneOff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchSource+MakeOneOff.swift"; sourceTree = "<group>"; };
 		6BBECD7023ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplifyAWSServiceConfiguration.swift; sourceTree = "<group>"; };
 		6BBECD7323ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplifyAWSServiceConfigurationTests.swift; sourceTree = "<group>"; };
+		6BD461F42537F4D100906831 /* APIAuthProviders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIAuthProviders.swift; sourceTree = "<group>"; };
 		6BEE0816253114FD00133961 /* AWSAuthServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAuthServiceTests.swift; sourceTree = "<group>"; };
 		6BEE08182533CAA600133961 /* GraphQLRequestOwnerAndGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRequestOwnerAndGroupTests.swift; sourceTree = "<group>"; };
 		6BEE081A2533CCFA00133961 /* OGCScenarioBPost+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OGCScenarioBPost+Schema.swift"; sourceTree = "<group>"; };
@@ -1767,6 +1775,7 @@
 		21C395B4245729F100597EA2 /* API */ = {
 			isa = PBXGroup;
 			children = (
+				6BD461F32537F4A700906831 /* AuthProvider */,
 				21C395B2245729EC00597EA2 /* AppSyncErrorType.swift */,
 			);
 			path = API;
@@ -1969,6 +1978,14 @@
 			path = Reachability;
 			sourceTree = "<group>";
 		};
+		6B50C918253E2AEF007B16DD /* AuthProvider */ = {
+			isa = PBXGroup;
+			children = (
+				6B50C919253E2B16007B16DD /* APIAuthProviders.swift */,
+			);
+			path = AuthProvider;
+			sourceTree = "<group>";
+		};
 		6BBECD6F23ADA7C100C8DFBE /* ServiceConfiguration */ = {
 			isa = PBXGroup;
 			children = (
@@ -1984,6 +2001,14 @@
 				6BBECD7323ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift */,
 			);
 			path = ServiceConfiguration;
+			sourceTree = "<group>";
+		};
+		6BD461F32537F4A700906831 /* AuthProvider */ = {
+			isa = PBXGroup;
+			children = (
+				6BD461F42537F4D100906831 /* APIAuthProviders.swift */,
+			);
+			path = AuthProvider;
 			sourceTree = "<group>";
 		};
 		6BEE0815253114E600133961 /* Auth */ = {
@@ -2705,12 +2730,14 @@
 		FA6BC879235F5CDB0001A882 /* ClientBehavior */ = {
 			isa = PBXGroup;
 			children = (
+				6B50C916253E2AD9007B16DD /* AmplifyAPICategory+AuthProviderBehavior.swift */,
 				FAC428A1235F80000000F221 /* AmplifyAPICategory+GraphQLBehavior.swift */,
 				FA249EEA24C5FE66009B3CE8 /* AmplifyAPICategory+GraphQLBehavior+Combine.swift */,
 				FAC428A3235F802A0000F221 /* AmplifyAPICategory+InterceptorBehavior.swift */,
 				6B767FB623AC092800C683ED /* AmplifyAPICategory+ReachabilityBehavior.swift */,
 				FAC4289F235F7F980000F221 /* AmplifyAPICategory+RESTBehavior.swift */,
 				FA249EE824C5FE39009B3CE8 /* AmplifyAPICategory+RESTBehavior+Combine.swift */,
+				6B50C91B253E2B57007B16DD /* APICategoryAuthProviderBehavior.swift */,
 				FAC234FC227A053D00424678 /* APICategoryBehavior.swift */,
 				FA6BC87A235F5D240001A882 /* APICategoryGraphQLBehavior.swift */,
 				FA6BC87E235F5DAE0001A882 /* APICategoryInterceptorBehavior.swift */,
@@ -2879,6 +2906,7 @@
 				FA6BC86C235F5AE30001A882 /* APICategory+HubPayloadEventName.swift */,
 				FA09B9462322CBA7000E064D /* APICategoryConfiguration.swift */,
 				FAC234FD227A053D00424678 /* APICategoryPlugin.swift */,
+				6B50C918253E2AEF007B16DD /* AuthProvider */,
 				FA6BC879235F5CDB0001A882 /* ClientBehavior */,
 				FA6BC870235F5BA00001A882 /* Error */,
 				FAA9FC3C23620CED0012638A /* Interceptor */,
@@ -4078,6 +4106,7 @@
 				219A888523EB897700BBC5F2 /* GraphQLRequest+AnyModelWithSync.swift in Sources */,
 				219A88F123F3379900BBC5F2 /* GraphQLDocumentInput.swift in Sources */,
 				21AD424E249BF0E90016FE95 /* AnyModel+Subscript.swift in Sources */,
+				6BD461F52537F4D100906831 /* APIAuthProviders.swift in Sources */,
 				21420AA0237222A900FA140C /* AWSAuthorizationType.swift in Sources */,
 				B4EBEB64246204D000D06375 /* AuthAWSCredentialsProvider.swift in Sources */,
 				212CE6FC23E9E523007D8E71 /* SelectionSet.swift in Sources */,
@@ -4376,6 +4405,7 @@
 				95DAAB89237F13B70028544F /* IdentifyEntityMatchesResult.swift in Sources */,
 				FAC428A2235F80000000F221 /* AmplifyAPICategory+GraphQLBehavior.swift in Sources */,
 				95DAAB37237E63370028544F /* Attribute.swift in Sources */,
+				6B50C91C253E2B57007B16DD /* APICategoryAuthProviderBehavior.swift in Sources */,
 				95DAAB2D237E63370028544F /* EmotionType.swift in Sources */,
 				B4BD6B392370932300A1F0A7 /* PredictionsIdentifyRequest.swift in Sources */,
 				21409C5B2384C57D000A53C9 /* GraphQLQueryType.swift in Sources */,
@@ -4443,6 +4473,7 @@
 				B493E6A42453A32C00D9E521 /* AuthSocialWebUISignInOperation.swift in Sources */,
 				FA09B9492322CBD5000E064D /* HubCategoryConfiguration.swift in Sources */,
 				B9FAA1252388BE48009414B4 /* List+Model.swift in Sources */,
+				6B50C917253E2AD9007B16DD /* AmplifyAPICategory+AuthProviderBehavior.swift in Sources */,
 				FA5704CB245F58C600392C19 /* AmplifyOperation+Hub.swift in Sources */,
 				FAC0A2B222B4402000B50912 /* StorageCategory+ClientBehavior.swift in Sources */,
 				B9FAA1272388BE91009414B4 /* List+LazyLoad.swift in Sources */,
@@ -4498,6 +4529,7 @@
 				B9FB05F82383740D00DE1FD4 /* DataStoreStatement.swift in Sources */,
 				FAC23527227A053D00424678 /* LoggingCategoryClientBehavior.swift in Sources */,
 				FA09B92B2321A10E000E064D /* AnalyticsCategory+CategoryConfigurable.swift in Sources */,
+				6B50C91A253E2B16007B16DD /* APIAuthProviders.swift in Sources */,
 				2144226E234BDE23009357F7 /* StorageUploadFileOperation.swift in Sources */,
 				21FFF9A2230C9731005878EA /* StorageListResult.swift in Sources */,
 				B92E03B42367CE7A006CEB8D /* DataStoreCategory+Configurable.swift in Sources */,

--- a/Amplify/Categories/API/AuthProvider/APIAuthProviders.swift
+++ b/Amplify/Categories/API/AuthProvider/APIAuthProviders.swift
@@ -1,0 +1,17 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public protocol APIAuthProviders {
+    func oidcAuthProvider() -> AmplifyOIDCAuthProvider?
+
+}
+
+public protocol AmplifyOIDCAuthProvider {
+    func getLatestAuthToken() -> Result<String, Error>
+}

--- a/Amplify/Categories/API/ClientBehavior/APICategoryAuthProviderBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategoryAuthProviderBehavior.swift
@@ -1,0 +1,12 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public protocol APICategoryAuthProviderBehavior {
+    func apiAuthProviders() -> APIAuthProviders?
+}

--- a/Amplify/Categories/API/ClientBehavior/APICategoryBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategoryBehavior.swift
@@ -10,4 +10,5 @@ public typealias APICategoryBehavior =
     APICategoryRESTBehavior &
     APICategoryGraphQLBehavior &
     APICategoryInterceptorBehavior &
-    APICategoryReachabilityBehavior
+    APICategoryReachabilityBehavior &
+    APICategoryAuthProviderBehavior

--- a/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+AuthProviderBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+AuthProviderBehavior.swift
@@ -1,0 +1,14 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension AmplifyAPICategory: APICategoryAuthProviderBehavior {
+    public func apiAuthProviders() -> APIAuthProviders? {
+        return plugin.apiAuthProviders()
+    }
+}

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
@@ -94,6 +94,9 @@
 		6B33896E23AABEEE00561E5B /* MockReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B33896D23AABEEE00561E5B /* MockReachability.swift */; };
 		6B33897023AABF1800561E5B /* NetworkReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B33896F23AABF1800561E5B /* NetworkReachability.swift */; };
 		6B33897223AAD94800561E5B /* AWSAPIPlugin+Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B33897123AAD94800561E5B /* AWSAPIPlugin+Reachability.swift */; };
+		6B382B452538E53700906593 /* AWSAPIPlugin+AuthProviderBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B382B442538E53700906593 /* AWSAPIPlugin+AuthProviderBehavior.swift */; };
+		6BD4620625380EA200906831 /* OIDCAuthProviderWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD4620525380EA200906831 /* OIDCAuthProviderWrapper.swift */; };
+		6BD462082538102500906831 /* AuthTokenProviderWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD462072538102500906831 /* AuthTokenProviderWrapper.swift */; };
 		7632AD8A252E1E10009B5BC9 /* AppSyncJSONValue+toJSONValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7632AD89252E1E10009B5BC9 /* AppSyncJSONValue+toJSONValue.swift */; };
 		9B13EA5E48896E8B38883633 /* Pods_HostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 930DD773E0FB4047393CA2AD /* Pods_HostApp.framework */; };
 		A04815BCD5F9181C8AEDEF43 /* Pods_AWSAPICategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 881AB4B98B48235DEC7754C2 /* Pods_AWSAPICategoryPlugin.framework */; };
@@ -385,6 +388,9 @@
 		6B33896D23AABEEE00561E5B /* MockReachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockReachability.swift; sourceTree = "<group>"; };
 		6B33896F23AABF1800561E5B /* NetworkReachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachability.swift; sourceTree = "<group>"; };
 		6B33897123AAD94800561E5B /* AWSAPIPlugin+Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSAPIPlugin+Reachability.swift"; sourceTree = "<group>"; };
+		6B382B442538E53700906593 /* AWSAPIPlugin+AuthProviderBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSAPIPlugin+AuthProviderBehavior.swift"; sourceTree = "<group>"; };
+		6BD4620525380EA200906831 /* OIDCAuthProviderWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OIDCAuthProviderWrapper.swift; sourceTree = "<group>"; };
+		6BD462072538102500906831 /* AuthTokenProviderWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTokenProviderWrapper.swift; sourceTree = "<group>"; };
 		6DD6386039136045F18D44AC /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithUserPoolIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithUserPoolIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74EDB7008F5342ED4B38C9CA /* Pods_HostApp_AWSAPICategoryPluginIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSAPICategoryPluginIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7632AD89252E1E10009B5BC9 /* AppSyncJSONValue+toJSONValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSyncJSONValue+toJSONValue.swift"; sourceTree = "<group>"; };
@@ -726,6 +732,7 @@
 			isa = PBXGroup;
 			children = (
 				21D5286624169E74005186BA /* IAMAuthInterceptor.swift */,
+				6BD4620525380EA200906831 /* OIDCAuthProviderWrapper.swift */,
 			);
 			path = SubscriptionInterceptor;
 			sourceTree = "<group>";
@@ -734,6 +741,7 @@
 			isa = PBXGroup;
 			children = (
 				21D7A09A237B54D90057D00D /* AWSAPIPlugin.swift */,
+				6B382B442538E53700906593 /* AWSAPIPlugin+AuthProviderBehavior.swift */,
 				21D7A098237B54D90057D00D /* AWSAPIPlugin+Configure.swift */,
 				21D7A0B1237B54D90057D00D /* AWSAPIPlugin+GraphQLBehavior.swift */,
 				21D7A099237B54D90057D00D /* AWSAPIPlugin+InterceptorBehavior.swift */,
@@ -852,6 +860,7 @@
 			isa = PBXGroup;
 			children = (
 				21D7A0D5237B54D90057D00D /* APIKeyURLRequestInterceptor.swift */,
+				6BD462072538102500906831 /* AuthTokenProviderWrapper.swift */,
 				21D7A0D6237B54D90057D00D /* IAMURLRequestInterceptor.swift */,
 				21D7A0D4237B54D90057D00D /* UserPoolRequestInterceptor.swift */,
 			);
@@ -2154,6 +2163,7 @@
 				21D7A0FB237B54D90057D00D /* AWSAPIPlugin+GraphQLBehavior.swift in Sources */,
 				21D7A0E7237B54D90057D00D /* AWSAPIPlugin+Resettable.swift in Sources */,
 				21D7A115237B54D90057D00D /* AWSAPIPlugin+RESTBehavior.swift in Sources */,
+				6BD4620625380EA200906831 /* OIDCAuthProviderWrapper.swift in Sources */,
 				21D7A0EA237B54D90057D00D /* AWSAPIPlugin.swift in Sources */,
 				21D7A0E2237B54D90057D00D /* AWSAPIOperation+APIOperation.swift in Sources */,
 				6B2E465823AAA69C0066EDCE /* NetworkReachabilityNotifier.swift in Sources */,
@@ -2164,6 +2174,7 @@
 				21D7A0E0237B54D90057D00D /* AWSGraphQLSubscriptionOperation.swift in Sources */,
 				21D7A10B237B54D90057D00D /* AWSAppSyncGraphQLResponse.swift in Sources */,
 				2129BE3E239486D2006363A1 /* AnyModel+JSONInit.swift in Sources */,
+				6BD462082538102500906831 /* AuthTokenProviderWrapper.swift in Sources */,
 				214BD3B223FB5C4C0059A286 /* SubscriptionConnectionFactory.swift in Sources */,
 				21D7A0E4237B54D90057D00D /* APIOperation.swift in Sources */,
 				21D7A11A237B54D90057D00D /* AWSAPICategoryPluginError.swift in Sources */,
@@ -2189,6 +2200,7 @@
 				21409C4F2384BA7E000A53C9 /* APIOperationResponse.swift in Sources */,
 				217856B72381F19400A30D19 /* AWSAPICategoryPluginEndpointType.swift in Sources */,
 				21D7A0E9237B54D90057D00D /* AWSAPIPlugin+InterceptorBehavior.swift in Sources */,
+				6B382B452538E53700906593 /* AWSAPIPlugin+AuthProviderBehavior.swift in Sources */,
 				6B33897023AABF1800561E5B /* NetworkReachability.swift in Sources */,
 				21D7A0FE237B54D90057D00D /* URLSessionDataTaskBehavior.swift in Sources */,
 				21D7A0E5237B54D90057D00D /* AWSAPICategoryPluginConfiguration.swift in Sources */,

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+AuthProviderBehavior.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+AuthProviderBehavior.swift
@@ -1,0 +1,15 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Foundation
+
+extension AWSAPIPlugin {
+    public func apiAuthProviders() -> APIAuthProviders? {
+        return authProviders
+    }
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Configure.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Configure.swift
@@ -31,8 +31,8 @@ public extension AWSAPIPlugin {
             )
         }
 
-        let dependencies = try ConfigurationDependencies(configurationValues: jsonValue)
-
+        let dependencies = try ConfigurationDependencies(configurationValues: jsonValue,
+                                                         apiAuthProviders: authProviders)
         configure(using: dependencies)
 
         log.info("Configure finished")
@@ -52,6 +52,7 @@ extension AWSAPIPlugin {
 
         init(
             configurationValues: JSONValue,
+            apiAuthProviders: APIAuthProviders? = nil,
             authService: AWSAuthServiceBehavior? = nil,
             subscriptionConnectionFactory: SubscriptionConnectionFactory? = nil
         ) throws {
@@ -60,6 +61,7 @@ extension AWSAPIPlugin {
 
             let pluginConfig = try AWSAPICategoryPluginConfiguration(
                 jsonValue: configurationValues,
+                apiAuthProviders: apiAuthProviders,
                 authService: authService
             )
 

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+GraphQLBehavior.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+GraphQLBehavior.swift
@@ -50,6 +50,7 @@ public extension AWSAPIPlugin {
                 pluginConfig: pluginConfig,
                 subscriptionConnectionFactory: subscriptionConnectionFactory,
                 authService: authService,
+                apiAuthProviders: authProviders,
                 inProcessListener: valueListener,
                 resultListener: completionListener)
             queue.addOperation(operation)

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin.swift
@@ -41,6 +41,8 @@ final public class AWSAPIPlugin: NSObject, APICategoryPlugin {
     /// to work around @available for use on stored properties
     var iReachabilityMap: [String: Any]?
 
+    var authProviders: APIAuthProviders?
+
     @available(iOS 13.0, *)
     var reachabilityMap: [String: NetworkReachabilityNotifier] {
         get {
@@ -56,11 +58,12 @@ final public class AWSAPIPlugin: NSObject, APICategoryPlugin {
 
     public init(
         modelRegistration: AmplifyModelRegistration? = nil,
-        sessionFactory: URLSessionBehaviorFactory? = nil
+        sessionFactory: URLSessionBehaviorFactory? = nil,
+        apiAuthProviders: APIAuthProviders? = nil
     ) {
         self.mapper = OperationTaskMapper()
         self.queue = OperationQueue()
-
+        self.authProviders =  apiAuthProviders
         super.init()
 
         modelRegistration?.registerModels(registry: ModelRegistry.self)

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginConfiguration+EndpointConfig.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginConfiguration+EndpointConfig.swift
@@ -27,7 +27,7 @@ public extension AWSAPICategoryPluginConfiguration {
 
         public init(name: String,
                     jsonValue: JSONValue,
-                    apiAuthProviders: APIAuthProviders?,
+                    apiAuthProviders: APIAuthProviders? = nil,
                     authService: AWSAuthServiceBehavior? = nil) throws {
 
             guard case .object(let endpointJSON) = jsonValue else {
@@ -58,7 +58,7 @@ public extension AWSAPICategoryPluginConfiguration {
              authorizationType: AWSAuthorizationType,
              authorizationConfiguration: AWSAuthorizationConfiguration,
              endpointType: AWSAPICategoryPluginEndpointType,
-             apiAuthProviders: APIAuthProviders?,
+             apiAuthProviders: APIAuthProviders? = nil,
              authService: AWSAuthServiceBehavior? = nil) throws {
             self.name = name
             self.baseURL = baseURL

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginConfiguration+EndpointConfig.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginConfiguration+EndpointConfig.swift
@@ -25,7 +25,10 @@ public extension AWSAPICategoryPluginConfiguration {
         // https://github.com/aws-amplify/amplify-ios/issues/73
         var interceptors = [URLRequestInterceptor]()
 
-        public init(name: String, jsonValue: JSONValue, authService: AWSAuthServiceBehavior? = nil) throws {
+        public init(name: String,
+                    jsonValue: JSONValue,
+                    apiAuthProviders: APIAuthProviders?,
+                    authService: AWSAuthServiceBehavior? = nil) throws {
 
             guard case .object(let endpointJSON) = jsonValue else {
                 throw PluginError.pluginConfigurationError(
@@ -45,6 +48,7 @@ public extension AWSAPICategoryPluginConfiguration {
                           authorizationType: EndpointConfig.getAuthorizationType(from: endpointJSON),
                           authorizationConfiguration: EndpointConfig.getAuthorizationConfiguration(from: endpointJSON),
                           endpointType: EndpointConfig.getEndpointType(from: endpointJSON),
+                          apiAuthProviders: apiAuthProviders,
                           authService: authService)
         }
 
@@ -54,6 +58,7 @@ public extension AWSAPICategoryPluginConfiguration {
              authorizationType: AWSAuthorizationType,
              authorizationConfiguration: AWSAuthorizationConfiguration,
              endpointType: AWSAPICategoryPluginEndpointType,
+             apiAuthProviders: APIAuthProviders?,
              authService: AWSAuthServiceBehavior? = nil) throws {
             self.name = name
             self.baseURL = baseURL
@@ -61,7 +66,7 @@ public extension AWSAPICategoryPluginConfiguration {
             self.authorizationType = authorizationType
             self.authorizationConfiguration = authorizationConfiguration
             self.endpointType = endpointType
-            try addInterceptors(authService: authService)
+            try addInterceptors(authService: authService, apiAuthProviders: apiAuthProviders)
         }
 
         public mutating func addInterceptor(interceptor: URLRequestInterceptor) {
@@ -71,7 +76,8 @@ public extension AWSAPICategoryPluginConfiguration {
         // MARK: Private
 
         /// Adds auto-discovered interceptors. Currently only works for authorization interceptors
-        private mutating func addInterceptors(authService: AWSAuthServiceBehavior? = nil) throws {
+        private mutating func addInterceptors(authService: AWSAuthServiceBehavior? = nil,
+                                              apiAuthProviders: APIAuthProviders?) throws {
             switch authorizationConfiguration {
             case .none:
                 // No interceptors needed
@@ -99,7 +105,12 @@ public extension AWSAPICategoryPluginConfiguration {
                 let interceptor = UserPoolURLRequestInterceptor(userPoolTokenProvider: provider)
                 addInterceptor(interceptor: interceptor)
             case .openIDConnect:
-                break
+                guard let oidcAuthProvider = apiAuthProviders?.oidcAuthProvider() else {
+                    return
+                }
+                let wrappedAuthProvider = AuthTokenProviderWrapper(oidcAuthProvider: oidcAuthProvider)
+                let interceptor = UserPoolURLRequestInterceptor(userPoolTokenProvider: wrappedAuthProvider)
+                addInterceptor(interceptor: interceptor)
             }
         }
 

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginConfiguration.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginConfiguration.swift
@@ -16,7 +16,9 @@ public struct AWSAPICategoryPluginConfiguration {
         self.endpoints = endpoints
     }
 
-    init(jsonValue: JSONValue, authService: AWSAuthServiceBehavior) throws {
+    init(jsonValue: JSONValue,
+         apiAuthProviders: APIAuthProviders?,
+         authService: AWSAuthServiceBehavior) throws {
         guard case .object(let config) = jsonValue else {
             throw PluginError.pluginConfigurationError(
                 "Could not cast incoming configuration to a JSONValue `.object`",
@@ -30,12 +32,14 @@ public struct AWSAPICategoryPluginConfiguration {
         }
 
         let endpoints = try AWSAPICategoryPluginConfiguration.endpointsFromConfig(config: config,
-                                                                           authService: authService)
+                                                                                  apiAuthProviders: apiAuthProviders,
+                                                                                  authService: authService)
         self.init(endpoints: endpoints)
     }
 
     private static func endpointsFromConfig(
         config: [String: JSONValue],
+        apiAuthProviders: APIAuthProviders?,
         authService: AWSAuthServiceBehavior
     ) throws -> [String: EndpointConfig] {
         var endpoints = [String: EndpointConfig]()
@@ -44,6 +48,7 @@ public struct AWSAPICategoryPluginConfiguration {
             let name = key
             let endpointConfig = try EndpointConfig(name: name,
                                                     jsonValue: jsonValue,
+                                                    apiAuthProviders: apiAuthProviders,
                                                     authService: authService)
             endpoints[name] = endpointConfig
         }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
@@ -1,0 +1,32 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import AWSPluginsCore
+import Foundation
+
+class AuthTokenProviderWrapper: AuthTokenProvider {
+
+    let oidcAuthProvider: AmplifyOIDCAuthProvider
+
+    init(oidcAuthProvider: AmplifyOIDCAuthProvider) {
+        self.oidcAuthProvider = oidcAuthProvider
+    }
+
+    func getToken() -> Result<String, AuthError> {
+        let result = oidcAuthProvider.getLatestAuthToken()
+        switch result {
+        case .success(let result):
+            return .success(result)
+        case .failure(let error):
+            return .failure(AuthError.service("Unable to get latest auth token",
+                                              "",
+                                              error))
+        }
+    }
+
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/OIDCAuthProviderWrapper.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/OIDCAuthProviderWrapper.swift
@@ -1,0 +1,23 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Foundation
+import AppSyncRealTimeClient
+
+class OIDCAuthProviderWrapper: OIDCAuthProvider {
+
+    let oidcAuthProvider: AmplifyOIDCAuthProvider
+
+    public init(oidcAuthProvider: AmplifyOIDCAuthProvider) {
+        self.oidcAuthProvider = oidcAuthProvider
+    }
+
+    func getLatestAuthToken() -> Result<String, Error> {
+        return oidcAuthProvider.getLatestAuthToken()
+    }
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLSubscriptionOperation.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLSubscriptionOperation.swift
@@ -19,17 +19,20 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
 
     var subscriptionConnection: SubscriptionConnection?
     var subscriptionItem: SubscriptionItem?
+    var apiAuthProviders: APIAuthProviders?
 
     init(request: GraphQLOperationRequest<R>,
          pluginConfig: AWSAPICategoryPluginConfiguration,
          subscriptionConnectionFactory: SubscriptionConnectionFactory,
          authService: AWSAuthServiceBehavior,
+         apiAuthProviders: APIAuthProviders? = nil,
          inProcessListener: AWSGraphQLSubscriptionOperation.InProcessListener?,
          resultListener: AWSGraphQLSubscriptionOperation.ResultListener?) {
 
         self.pluginConfig = pluginConfig
         self.subscriptionConnectionFactory = subscriptionConnectionFactory
         self.authService = authService
+        self.apiAuthProviders = apiAuthProviders
 
         super.init(categoryType: .api,
                    eventName: HubPayload.EventName.API.subscribe,
@@ -84,8 +87,10 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
 
         // Retrieve the subscription connection
         do {
-            subscriptionConnection = try subscriptionConnectionFactory.getOrCreateConnection(for: endpointConfig,
-                                                                                             authService: authService)
+            subscriptionConnection = try subscriptionConnectionFactory
+                .getOrCreateConnection(for: endpointConfig,
+                                       authService: authService,
+                                       apiAuthProviders: apiAuthProviders)
         } catch {
             let error = APIError.operationError("Unable to get connection for api \(endpointConfig.name)", "", error)
             dispatch(result: .failure(error))

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift
@@ -9,7 +9,7 @@ import Foundation
 import AWSPluginsCore
 import AppSyncRealTimeClient
 
-class AWSOIDCAuthProvider: AppSyncRealTimeClient.OIDCAuthProvider {
+class AWSOIDCAuthProvider: OIDCAuthProvider {
 
     var authService: AWSAuthServiceBehavior
 

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift
@@ -9,7 +9,7 @@ import Foundation
 import AWSPluginsCore
 import AppSyncRealTimeClient
 
-class AWSOIDCAuthProvider: OIDCAuthProvider {
+class AWSOIDCAuthProvider: AppSyncRealTimeClient.OIDCAuthProvider {
 
     var authService: AWSAuthServiceBehavior
 

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSSubscriptionConnectionFactory.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSSubscriptionConnectionFactory.swift
@@ -19,13 +19,15 @@ class AWSSubscriptionConnectionFactory: SubscriptionConnectionFactory {
     var apiToConnectionProvider: [String: ConnectionProvider] = [:]
 
     func getOrCreateConnection(for endpointConfig: AWSAPICategoryPluginConfiguration.EndpointConfig,
-                               authService: AWSAuthServiceBehavior) throws -> SubscriptionConnection {
+                               authService: AWSAuthServiceBehavior,
+                               apiAuthProviders: APIAuthProviders?) throws -> SubscriptionConnection {
         return try concurrencyQueue.sync {
             let apiName = endpointConfig.name
 
             let url = endpointConfig.baseURL
             let authInterceptor = try getInterceptor(for: endpointConfig.authorizationConfiguration,
-                                                     authService: authService)
+                                                     authService: authService,
+                                                     apiAuthProviders: apiAuthProviders)
 
             // create or retrieve the connection provider. If creating, add interceptors onto the provider.
             let connectionProvider = apiToConnectionProvider[apiName] ??
@@ -44,7 +46,8 @@ class AWSSubscriptionConnectionFactory: SubscriptionConnectionFactory {
     // MARK: Private methods
 
     private func getInterceptor(for authorizationConfiguration: AWSAuthorizationConfiguration,
-                                authService: AWSAuthServiceBehavior) throws -> AuthInterceptor {
+                                authService: AWSAuthServiceBehavior,
+                                apiAuthProviders: APIAuthProviders?) throws -> AuthInterceptor {
         let authInterceptor: AuthInterceptor
 
         switch authorizationConfiguration {
@@ -57,9 +60,13 @@ class AWSSubscriptionConnectionFactory: SubscriptionConnectionFactory {
             authInterceptor = IAMAuthInterceptor(authService.getCredentialsProvider(),
                                                  region: awsIAMConfiguration.region)
         case .openIDConnect:
-            // TODO: retrieve OIDC Token Provider from somewhere else that the developer added.
-            let tokenProvider = AWSOIDCAuthProvider(authService: authService)
-            authInterceptor = OIDCAuthInterceptor(tokenProvider)
+            guard let oidcAuthProvider = apiAuthProviders?.oidcAuthProvider() else {
+                throw APIError.invalidConfiguration("Using openIDConnect requires passing in an APIAuthProvider with an OIDC AuthProvider",
+                                                    "When instantiating AWSAPIPlugin pass in an instance of APIAuthProvider",
+                                                    nil)
+            }
+            let wrappedProvider = OIDCAuthProviderWrapper(oidcAuthProvider: oidcAuthProvider)
+            authInterceptor = OIDCAuthInterceptor(wrappedProvider)
         case .none:
             throw APIError.unknown("Cannot create AppSync subscription for none auth mode", "")
         }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/SubscriptionConnectionFactory.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/SubscriptionConnectionFactory.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import Amplify
 import AWSPluginsCore
 import AppSyncRealTimeClient
 
@@ -13,5 +14,6 @@ protocol SubscriptionConnectionFactory {
 
     /// Get connection based on the connection type
     func getOrCreateConnection(for endpointConfig: AWSAPICategoryPluginConfiguration.EndpointConfig,
-                               authService: AWSAuthServiceBehavior) throws -> SubscriptionConnection
+                               authService: AWSAuthServiceBehavior,
+                               apiAuthProviders: APIAuthProviders?) throws -> SubscriptionConnection
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Mocks/MockSubscription.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Mocks/MockSubscription.swift
@@ -25,7 +25,8 @@ struct MockSubscriptionConnectionFactory: SubscriptionConnectionFactory {
 
     func getOrCreateConnection(
         for endpointConfig: AWSAPICategoryPluginConfiguration.EndpointConfig,
-        authService: AWSAuthServiceBehavior
+        authService: AWSAuthServiceBehavior,
+        apiAuthProviders: APIAuthProviders?
     ) throws -> SubscriptionConnection {
         try onGetOrCreateConnection(endpointConfig, authService)
     }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -49,6 +49,9 @@ public class AWSAuthService: AWSAuthServiceBehavior {
         guard tokenSplit.count > 2 else {
             return .failure(.validation("", "Token is not valid base64 encoded string.", "", nil))
         }
+
+        //Add ability to do URL decoding
+        //https://stackoverflow.com/questions/40915607/how-can-i-decode-jwt-json-web-token-token-in-swift
         let claims = tokenSplit[1]
             .replacingOccurrences(of: "-", with: "+")
             .replacingOccurrences(of: "_", with: "/")

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -50,11 +50,13 @@ public class AWSAuthService: AWSAuthServiceBehavior {
             return .failure(.validation("", "Token is not valid base64 encoded string.", "", nil))
         }
         let claims = tokenSplit[1]
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
 
         let paddedLength = claims.count + (4 - (claims.count % 4)) % 4
         //JWT is not padded with =, pad it if necessary
         let updatedClaims = claims.padding(toLength: paddedLength, withPad: "=", startingAt: 0)
-        let encodedData = Data.init(base64Encoded: updatedClaims, options: .ignoreUnknownCharacters)
+        let encodedData = Data(base64Encoded: updatedClaims, options: .ignoreUnknownCharacters)
 
         guard let claimsData = encodedData else {
             return .failure(

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+SyncRequirement.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+SyncRequirement.swift
@@ -18,7 +18,7 @@ extension StorageEngine {
             return
         }
 
-        let authPluginRequired = requiresAuthPlugin()
+        let authPluginRequired = requiresAuthPlugin(api: api)
 
         guard authPluginRequired else {
             syncEngine?.start(api: api, auth: nil)
@@ -49,9 +49,15 @@ extension StorageEngine {
         }
     }
 
-    private func requiresAuthPlugin() -> Bool {
+    private func requiresAuthPlugin(api: APICategoryGraphQLBehavior?) -> Bool {
         let containsAuthEnabledSyncableModels = ModelRegistry.models.contains {
             $0.schema.isSyncable && $0.schema.hasAuthenticationRules
+        }
+
+        if containsAuthEnabledSyncableModels,
+            let apiCategoryAuthProviderBehavior = api as? APICategoryAuthProviderBehavior,
+            apiCategoryAuthProviderBehavior.apiAuthProviders()?.oidcAuthProvider() != nil {
+            return false
         }
 
         return containsAuthEnabledSyncableModels

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -41,7 +41,7 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
     private var reconciliationQueues: [String: ModelReconciliationQueue]
     private var reconciliationQueueConnectionStatus: [String: Bool]
     private var modelReconciliationQueueFactory: ModelReconciliationQueueFactory
-    
+
     private var isInitialized: Bool {
         reconciliationQueueConnectionStatus.count == reconciliationQueues.count
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -41,7 +41,7 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
     private var reconciliationQueues: [String: ModelReconciliationQueue]
     private var reconciliationQueueConnectionStatus: [String: Bool]
     private var modelReconciliationQueueFactory: ModelReconciliationQueueFactory
-
+    
     private var isInitialized: Bool {
         reconciliationQueueConnectionStatus.count == reconciliationQueues.count
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -164,9 +164,17 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
 
         let request: GraphQLRequest<Payload>
         if modelType.schema.hasAuthenticationRules,
+            let _ = auth,
             case .success(let tokenString) = awsAuthService.getToken(),
             case .success(let claims) = awsAuthService.getTokenClaims(tokenString: tokenString) {
 
+            request = GraphQLRequest<Payload>.subscription(to: modelType,
+                                                           subscriptionType: subscriptionType,
+                                                           claims: claims)
+        } else if modelType.schema.hasAuthenticationRules,
+            let oidcAuthProvider = hasOIDCAuthProviderAvailable(api: api),
+            case .success(let tokenString) = oidcAuthProvider.getLatestAuthToken(),
+            case .success(let claims) = awsAuthService.getTokenClaims(tokenString: tokenString) {
             request = GraphQLRequest<Payload>.subscription(to: modelType,
                                                            subscriptionType: subscriptionType,
                                                            claims: claims)
@@ -178,6 +186,15 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
                                       valueListener: valueListener,
                                       completionListener: completionListener)
         return operation
+    }
+
+    static func hasOIDCAuthProviderAvailable(api: APICategoryGraphQLBehavior) -> AmplifyOIDCAuthProvider? {
+        if let apiPlugin = api as? APICategoryAuthProviderBehavior,
+            let apiAuthProviders = apiPlugin.apiAuthProviders(),
+            let oidcAuthProvider = apiAuthProviders.oidcAuthProvider() {
+            return oidcAuthProvider
+        }
+        return nil
     }
 
     func subscribe<S: Subscriber>(subscriber: S) where S.Input == Event, S.Failure == DataStoreError {

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -190,6 +190,10 @@ class MockAPICategoryPlugin: MessageReporter, APICategoryPlugin {
     func add(interceptor: URLRequestInterceptor, for apiName: String) {
         notify("addInterceptor")
     }
+
+    func apiAuthProviders() -> APIAuthProviders? {
+        return nil
+    }
 }
 
 class MockSecondAPICategoryPlugin: MockAPICategoryPlugin {


### PR DESCRIPTION
This PR adds apiAuthProviders.

To use this feature, customers would create an instance of their own custom AuthProviders and pass it into the API Plugin.
```
...
            let apiAuthProviders = MyAPIAuthProviders()
            try Amplify.add(plugin: AWSAPIPlugin(apiAuthProviders: apiAuthProviders))
            try Amplify.configure()
....
```

Customers would essentially be responsible for
1: writing their own `APIAuthProviders`
```
class MyAPIAuthProviders: APIAuthProviders {
    let myOIDCAuthProvider = MyOIDCAuthProvider()
    
    func oidcAuthProvider() -> AmplifyOIDCAuthProvider? {
        return myOIDCAuthProvider
    }
}
```

2: writing their own implementation of the specific `AmplifyOIDCAuthProvider` they want to use


```
class MyOIDCAuthProvider : AmplifyOIDCAuthProvider {

    func getLatestAuthToken() -> Swift.Result<String, Error> {
        let semaphore = DispatchSemaphore(value: 1)

        semaphore.wait()
        var idTokenOptional: String?

        credentialsManager.credentials { error, credentials in
            guard error == nil, let credentials = credentials else {
                semaphore.signal()
                return
            }
            idTokenOptional = credentials.idToken
            semaphore.signal()
        }
        guard let idToken = idTokenOptional else {
            return .failure(APIError.unknown("no credentials", "nope", nil))
        }
        return .success(idToken)
    }
}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
