### PR TITLE
refactor(datastore): Support for non codingkey based sort

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -88,7 +88,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
         query(modelType,
               modelSchema: modelType.schema,
               where: predicate,
-              sort: sortInput?.covertToSortDescriptor(),
+              sort: sortInput?.asSortDescriptors(),
               paginate: paginationInput,
               completion: completion)
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -88,7 +88,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
         query(modelType,
               modelSchema: modelType.schema,
               where: predicate,
-              sort: sortInput,
+              sort: sortInput?.covertToSortDescriptor(),
               paginate: paginationInput,
               completion: completion)
     }
@@ -96,7 +96,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     public func query<M: Model>(_ modelType: M.Type,
                                 modelSchema: ModelSchema,
                                 where predicate: QueryPredicate? = nil,
-                                sort sortInput: QuerySortInput? = nil,
+                                sort sortInput: [QuerySortDescriptor]? = nil,
                                 paginate paginationInput: QueryPaginationInput? = nil,
                                 completion: DataStoreCallback<[M]>) {
         reinitStorageEngineIfNeeded()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
@@ -31,14 +31,14 @@ protocol ModelStorageBehavior {
 
     func query<M: Model>(_ modelType: M.Type,
                          predicate: QueryPredicate?,
-                         sort: QuerySortInput?,
+                         sort: [QuerySortDescriptor]?,
                          paginationInput: QueryPaginationInput?,
                          completion: DataStoreCallback<[M]>)
 
     func query<M: Model>(_ modelType: M.Type,
                          modelSchema: ModelSchema,
                          predicate: QueryPredicate?,
-                         sort: QuerySortInput?,
+                         sort: [QuerySortDescriptor]?,
                          paginationInput: QueryPaginationInput?,
                          completion: DataStoreCallback<[M]>)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QuerySort+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QuerySort+SQLite.swift
@@ -30,7 +30,7 @@ extension QuerySortBy {
 
 extension QuerySortInput {
 
-    func covertToSortDescriptor() -> [QuerySortDescriptor]? {
+    func asSortDescriptors() -> [QuerySortDescriptor]? {
         return inputs.map { QuerySortDescriptor(fieldName: $0.fieldName, order: $0.fieldOrder) }
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QuerySort+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QuerySort+SQLite.swift
@@ -10,6 +10,7 @@ import Foundation
 import SQLite
 
 extension QuerySortBy {
+
     var fieldName: String {
         switch self {
         case .ascending(let key), .descending(let key):
@@ -17,30 +18,19 @@ extension QuerySortBy {
         }
     }
 
-    var fieldOrder: String {
+    var fieldOrder: QuerySortOrder {
         switch self {
         case .ascending:
-            return "asc"
+            return QuerySortOrder.ascending
         case .descending:
-            return "desc"
+            return QuerySortOrder.descending
         }
     }
 }
 
 extension QuerySortInput {
-    func sortStatement(namespace: String) -> String {
-        let sqlResult = inputs
-            .map { QuerySortInput.columnFor(field: $0.fieldName,
-                                            order: $0.fieldOrder,
-                                            namespace: namespace) }
 
-        return sqlResult.joined(separator: ", ")
-    }
-
-    static func columnFor(field: String,
-                          order: String,
-                          namespace: String) -> String {
-        return namespace.quoted() + "." + field.quoted() + " " + order
-
+    func covertToSortDescriptor() -> [QuerySortDescriptor]? {
+        return inputs.map { QuerySortDescriptor(fieldName: $0.fieldName, order: $0.fieldOrder) }
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QuerySortDescriptor.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QuerySortDescriptor.swift
@@ -1,0 +1,48 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// Struct used by the Datastore plugin to decide on how to order a query.
+public struct QuerySortDescriptor {
+
+    /// String representation of the CodingKey value of the field to be sorted.
+    ///
+    /// fieldName for a field createdBy inside Post model can be retreived by `Post.keys.createdBy.stringValue`.
+    let fieldName: String
+
+    /// Sorting order for the field
+    let order: QuerySortOrder
+}
+
+public enum QuerySortOrder: String {
+
+    case ascending = "asc"
+
+    case descending = "desc"
+}
+
+extension Array where Element == QuerySortDescriptor {
+
+    /// Generates the sorting part of the sql statement.
+    ///
+    /// For a sort description of ascending on `Post.createdAt` will return the string `"\"root\".\"createdAt\" asc"`
+    /// where `root` is the namespace.
+    func sortStatement(namespace: String) -> String {
+        let sqlResult = map { Array.columnFor(field: $0.fieldName,
+                                              order: $0.order.rawValue,
+                                              namespace: namespace) }
+        return sqlResult.joined(separator: ", ")
+    }
+
+    static func columnFor(field: String,
+                          order: String,
+                          namespace: String) -> String {
+        return namespace.quoted() + "." + field.quoted() + " " + order
+
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Select.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Select.swift
@@ -21,7 +21,7 @@ struct SelectStatementMetadata {
 
     static func metadata(from modelSchema: ModelSchema,
                          predicate: QueryPredicate? = nil,
-                         sort: QuerySortInput? = nil,
+                         sort: [QuerySortDescriptor]? = nil,
                          paginationInput: QueryPaginationInput? = nil) -> SelectStatementMetadata {
         let rootNamespace = "root"
         let fields = modelSchema.columns
@@ -57,7 +57,7 @@ struct SelectStatementMetadata {
             """
         }
 
-        if let sort = sort, !sort.inputs.isEmpty {
+        if let sort = sort, !sort.isEmpty {
             sql = """
             \(sql)
             order by \(sort.sortStatement(namespace: rootNamespace))
@@ -141,7 +141,7 @@ struct SelectStatement: SQLStatement {
 
     init(from modelSchema: ModelSchema,
          predicate: QueryPredicate? = nil,
-         sort: QuerySortInput? = nil,
+         sort: [QuerySortDescriptor]? = nil,
          paginationInput: QueryPaginationInput? = nil) {
         self.modelSchema = modelSchema
         self.metadata = .metadata(from: modelSchema,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -198,7 +198,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
 
     func query<M: Model>(_ modelType: M.Type,
                          predicate: QueryPredicate? = nil,
-                         sort: QuerySortInput? = nil,
+                         sort: [QuerySortDescriptor]? = nil,
                          paginationInput: QueryPaginationInput? = nil,
                          completion: DataStoreCallback<[M]>) {
         query(modelType,
@@ -212,7 +212,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
     func query<M: Model>(_ modelType: M.Type,
                          modelSchema: ModelSchema,
                          predicate: QueryPredicate? = nil,
-                         sort: QuerySortInput? = nil,
+                         sort: [QuerySortDescriptor]? = nil,
                          paginationInput: QueryPaginationInput? = nil,
                          completion: DataStoreCallback<[M]>) {
         do {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -352,7 +352,7 @@ final class StorageEngine: StorageEngineBehavior {
     func query<M: Model>(_ modelType: M.Type,
                          modelSchema: ModelSchema,
                          predicate: QueryPredicate?,
-                         sort: QuerySortInput?,
+                         sort: [QuerySortDescriptor]?,
                          paginationInput: QueryPaginationInput?,
                          completion: (DataStoreResult<[M]>) -> Void) {
         return storageAdapter.query(modelType,
@@ -365,7 +365,7 @@ final class StorageEngine: StorageEngineBehavior {
 
     func query<M: Model>(_ modelType: M.Type,
                          predicate: QueryPredicate? = nil,
-                         sort: QuerySortInput? = nil,
+                         sort: [QuerySortDescriptor]? = nil,
                          paginationInput: QueryPaginationInput? = nil,
                          completion: DataStoreCallback<[M]>) {
         query(modelType,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventSource.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventSource.swift
@@ -20,10 +20,10 @@ extension AWSMutationDatabaseAdapter: MutationEventSource {
 
         let fields = MutationEvent.keys
         let predicate = fields.inProcess == false || fields.inProcess == nil
-
+        let sort = QuerySortDescriptor(fieldName: MutationEvent.keys.createdAt.stringValue, order: .ascending)
         storageAdapter.query(MutationEvent.self,
                              predicate: predicate,
-                             sort: .ascending(MutationEvent.keys.createdAt),
+                             sort: [sort],
                              paginationInput: nil) { result in
                                 switch result {
                                 case .failure(let dataStoreError):

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventClearState.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventClearState.swift
@@ -18,10 +18,10 @@ final class MutationEventClearState {
     func clearStateOutgoingMutations(completion: @escaping BasicClosure) {
         let fields = MutationEvent.keys
         let predicate = fields.inProcess == true
-
+        let sort = QuerySortDescriptor(fieldName: fields.createdAt.stringValue, order: .ascending)
         storageAdapter.query(MutationEvent.self,
                              predicate: predicate,
-                             sort: .ascending(fields.createdAt),
+                             sort: [sort],
                              paginationInput: nil) { result in
                                 switch result {
                                 case .failure(let dataStoreError):

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Query.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Query.swift
@@ -13,10 +13,10 @@ extension MutationEvent {
                                       completion: DataStoreCallback<[MutationEvent]>) {
         let fields = MutationEvent.keys
         let predicate = fields.modelId == modelId && (fields.inProcess == false || fields.inProcess == nil)
-
+        let sort = QuerySortDescriptor(fieldName: fields.createdAt.stringValue, order: .ascending)
         storageAdapter.query(MutationEvent.self,
                              predicate: predicate,
-                             sort: .ascending(fields.createdAt),
+                             sort: [sort],
                              paginationInput: nil) { completion($0) }
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
@@ -362,7 +362,8 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `order by` and `ascending`
     func testSelectStatementWithOneSort() {
-        let statement = SelectStatement(from: Post.schema, sort: .ascending(Post.keys.id))
+        let ascSort = QuerySortDescriptor(fieldName: Post.keys.id.stringValue, order: .ascending)
+        let statement = SelectStatement(from: Post.schema, sort: [ascSort])
         let expectedStatement = """
         select
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
@@ -382,9 +383,10 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `order by` and `ascending`
     func testSelectStatementWithTwoFieldsSort() {
+        let ascSort = QuerySortDescriptor(fieldName: Post.keys.id.stringValue, order: .ascending)
+        let dscSort = QuerySortDescriptor(fieldName: Post.keys.createdAt.stringValue, order: .descending)
         let statement = SelectStatement(from: Post.schema,
-                                        sort: .by(.ascending(Post.keys.id),
-                                                  .descending(Post.keys.createdAt)))
+                                        sort: [ascSort, dscSort])
         let expectedStatement = """
         select
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
@@ -404,9 +406,10 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `where` statement, `order by` and `ascending`
     func testSelectStatementWithPredicateAndSort() {
+        let sort = QuerySortDescriptor(fieldName: Post.keys.id.stringValue, order: .descending)
         let statement = SelectStatement(from: Post.schema,
                                         predicate: Post.keys.rating > 4,
-                                        sort: .descending(Post.keys.id))
+                                        sort: [sort])
         let expectedStatement = """
         select
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
@@ -429,8 +432,9 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `where` statement, `order by` and `ascending`
     func testSelectStatementWithSortAndPaginationInfo() {
+        let sort = QuerySortDescriptor(fieldName: Post.keys.id.stringValue, order: .descending)
         let statement = SelectStatement(from: Post.schema,
-                                        sort: .descending(Post.keys.id),
+                                        sort: [sort],
                                         paginationInput: .page(0, limit: 5))
         let expectedStatement = """
         select
@@ -454,9 +458,10 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the statement contains the correct `where` statement, `order by` and `ascending`
     func testSelectStatementWithPredicateAndSortAndPaginationInfo() {
+        let sort = QuerySortDescriptor(fieldName: Post.keys.id.stringValue, order: .descending)
         let statement = SelectStatement(from: Post.schema,
                                         predicate: Post.keys.rating > 4,
-                                        sort: .descending(Post.keys.id),
+                                        sort: [sort],
                                         paginationInput: .page(0, limit: 5))
         let expectedStatement = """
         select

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -108,7 +108,7 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
     func query<M: Model>(_ modelType: M.Type,
                          modelSchema: ModelSchema,
                          predicate: QueryPredicate?,
-                         sort: QuerySortInput?,
+                         sort: [QuerySortDescriptor]?,
                          paginationInput: QueryPaginationInput?,
                          completion: (DataStoreResult<[M]>) -> Void) {
         XCTFail("Not expected to execute")
@@ -167,7 +167,7 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
 
     func query<M: Model>(_ modelType: M.Type,
                          predicate: QueryPredicate?,
-                         sort: QuerySortInput?,
+                         sort: [QuerySortDescriptor]?,
                          paginationInput: QueryPaginationInput?,
                          completion: DataStoreCallback<[M]>) {
         if let responder = responders[.queryModelTypePredicate]
@@ -248,7 +248,7 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
 
     func query<M: Model>(_ modelType: M.Type,
                          predicate: QueryPredicate?,
-                         sort: QuerySortInput?,
+                         sort: [QuerySortDescriptor]?,
                          paginationInput: QueryPaginationInput?,
                          completion: DataStoreCallback<[M]>) {
         //TODO: Find way to mock this
@@ -257,7 +257,7 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
     func query<M: Model>(_ modelType: M.Type,
                          modelSchema: ModelSchema,
                          predicate: QueryPredicate?,
-                         sort: QuerySortInput?,
+                         sort: [QuerySortDescriptor]?,
                          paginationInput: QueryPaginationInput?,
                          completion: (DataStoreResult<[M]>) -> Void) {
         //TODO: Find way to mock this

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		A569484A6FBAE7EC7ADF3FD4 /* Pods_AWSDataStoreCategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A1D332BE6CF885805360B3D /* Pods_AWSDataStoreCategoryPlugin.framework */; };
 		B10BF4A52A1C9840C208C8A8 /* Pods_HostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 19AFF6D00CF3AF927BA90382 /* Pods_HostApp.framework */; };
 		B40EF02824BF68C900F2264C /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40EF02724BF68C900F2264C /* ConfigurationTests.swift */; };
+		B47532F02540DF640032098E /* QuerySortDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47532EF2540DF640032098E /* QuerySortDescriptor.swift */; };
 		B4D9B9E224DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D9B9E124DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift */; };
 		B4D9B9E424DF90CD0049484F /* DynamicModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D9B9E324DF90CD0049484F /* DynamicModel.swift */; };
 		B912D1B824296F1E0028F05C /* QueryPaginationInput+SQLite.swift in Sources */ = {isa = PBXBuildFile; fileRef = B912D1B724296F1E0028F05C /* QueryPaginationInput+SQLite.swift */; };
@@ -304,6 +305,7 @@
 		9D42A96449A4B73735566C07 /* Pods-AWSDataStoreCategoryPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSDataStoreCategoryPlugin/Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; sourceTree = "<group>"; };
 		9F987EC33AAD7C0904A598CA /* Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B40EF02724BF68C900F2264C /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
+		B47532EF2540DF640032098E /* QuerySortDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuerySortDescriptor.swift; sourceTree = "<group>"; };
 		B4D9B9E124DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteStorageEngineAdapterJsonTests.swift; sourceTree = "<group>"; };
 		B4D9B9E324DF90CD0049484F /* DynamicModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicModel.swift; sourceTree = "<group>"; };
 		B912D1B724296F1E0028F05C /* QueryPaginationInput+SQLite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QueryPaginationInput+SQLite.swift"; sourceTree = "<group>"; };
@@ -527,6 +529,7 @@
 				B912D1B724296F1E0028F05C /* QueryPaginationInput+SQLite.swift */,
 				2149E5B42388684F00873955 /* QueryPredicate+SQLite.swift */,
 				D8D900A3249DB599004042E7 /* QuerySort+SQLite.swift */,
+				B47532EF2540DF640032098E /* QuerySortDescriptor.swift */,
 				2149E5AC2388684F00873955 /* SQLStatement.swift */,
 				2149E5B62388684F00873955 /* SQLStatement+Condition.swift */,
 				2149E5B22388684F00873955 /* SQLStatement+CreateTable.swift */,
@@ -1495,6 +1498,7 @@
 				2149E5C52388684F00873955 /* StorageEngineBehavior.swift in Sources */,
 				FAF7CECF238C93A50095547B /* RemoteSyncEngineBehavior.swift in Sources */,
 				2149E5CF2388684F00873955 /* SQLStatement+Delete.swift in Sources */,
+				B47532F02540DF640032098E /* QuerySortDescriptor.swift in Sources */,
 				2149E5C92388684F00873955 /* SQLStatement+Insert.swift in Sources */,
 				2149E5D42388684F00873955 /* DataStorePublisher.swift in Sources */,
 				FA3841E723889D340070AD5B /* ReconcileAndLocalSaveOperation.swift in Sources */,


### PR DESCRIPTION
*Description of changes:* Give support for AWSDatastorePlugin to accept non Coding key based sort input. The public api can be accessed via escape hatch

```swift
public func query<M: Model>(_ modelType: M.Type,
                                modelSchema: ModelSchema,
                                where predicate: QueryPredicate? = nil,
                                sort sortInput: [QuerySortDescriptor]? = nil,
                                paginate paginationInput: QueryPaginationInput? = nil,
                                completion: DataStoreCallback<[M]>)
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
