### PR TITLE
fix(Core): use groupClaim in @auth rule for oidc

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -147,6 +147,8 @@
 		6BB7441023A9954900B0EB6C /* DispatchSource+MakeOneOff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB7440F23A9954900B0EB6C /* DispatchSource+MakeOneOff.swift */; };
 		6BBECD7123ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BBECD7023ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift */; };
 		6BBECD7423ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BBECD7323ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift */; };
+		6BDF15B62541262000B5BE69 /* ModelWithOwnerAuthAndGroupWithGroupClaim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDF15B52541262000B5BE69 /* ModelWithOwnerAuthAndGroupWithGroupClaim.swift */; };
+		6BDF15B825412DE600B5BE69 /* ModelWithOwnerAuthAndMultiGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDF15B725412DE600B5BE69 /* ModelWithOwnerAuthAndMultiGroup.swift */; };
 		6BEE0817253114FD00133961 /* AWSAuthServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE0816253114FD00133961 /* AWSAuthServiceTests.swift */; };
 		6BEE08192533CAA600133961 /* GraphQLRequestOwnerAndGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE08182533CAA600133961 /* GraphQLRequestOwnerAndGroupTests.swift */; };
 		6BEE081C2533CCFA00133961 /* OGCScenarioBPost+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE081A2533CCFA00133961 /* OGCScenarioBPost+Schema.swift */; };
@@ -871,6 +873,8 @@
 		6BB7440F23A9954900B0EB6C /* DispatchSource+MakeOneOff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchSource+MakeOneOff.swift"; sourceTree = "<group>"; };
 		6BBECD7023ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplifyAWSServiceConfiguration.swift; sourceTree = "<group>"; };
 		6BBECD7323ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplifyAWSServiceConfigurationTests.swift; sourceTree = "<group>"; };
+		6BDF15B52541262000B5BE69 /* ModelWithOwnerAuthAndGroupWithGroupClaim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelWithOwnerAuthAndGroupWithGroupClaim.swift; sourceTree = "<group>"; };
+		6BDF15B725412DE600B5BE69 /* ModelWithOwnerAuthAndMultiGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelWithOwnerAuthAndMultiGroup.swift; sourceTree = "<group>"; };
 		6BEE0816253114FD00133961 /* AWSAuthServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAuthServiceTests.swift; sourceTree = "<group>"; };
 		6BEE08182533CAA600133961 /* GraphQLRequestOwnerAndGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRequestOwnerAndGroupTests.swift; sourceTree = "<group>"; };
 		6BEE081A2533CCFA00133961 /* OGCScenarioBPost+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OGCScenarioBPost+Schema.swift"; sourceTree = "<group>"; };
@@ -1740,6 +1744,8 @@
 				21A3FDAE24630D7F00E76120 /* ModelWithOwnerFieldAuthRuleTests.swift */,
 				21A3FDB32463C49F00E76120 /* ModelReadUpdateAuthRuleTests.swift */,
 				21A3FDB52464590600E76120 /* ModelMultipleOwnerAuthRuleTests.swift */,
+				6BDF15B52541262000B5BE69 /* ModelWithOwnerAuthAndGroupWithGroupClaim.swift */,
+				6BDF15B725412DE600B5BE69 /* ModelWithOwnerAuthAndMultiGroup.swift */,
 			);
 			path = AuthRuleDecorator;
 			sourceTree = "<group>";
@@ -4154,6 +4160,7 @@
 				2129BE48239489AC006363A1 /* MutationSyncMetadataTests.swift in Sources */,
 				216E45F1248E971E0035E3CE /* GraphQLRequestNonModelTests.swift in Sources */,
 				21A3FDAF24630D7F00E76120 /* ModelWithOwnerFieldAuthRuleTests.swift in Sources */,
+				6BDF15B825412DE600B5BE69 /* ModelWithOwnerAuthAndMultiGroup.swift in Sources */,
 				2183A56823EA4A8E00232880 /* GraphQLDeleteMutationTests.swift in Sources */,
 				21A3FDB42463C49F00E76120 /* ModelReadUpdateAuthRuleTests.swift in Sources */,
 				2183A56323EA4A7800232880 /* GraphQLSubscriptionTests.swift in Sources */,
@@ -4166,6 +4173,7 @@
 				6BBECD7423ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift in Sources */,
 				6B9F7C5225267E1500F1F71C /* MockAWSAuthUser.swift in Sources */,
 				21AD425A249C0D910016FE95 /* AnyModelTester.swift in Sources */,
+				6BDF15B62541262000B5BE69 /* ModelWithOwnerAuthAndGroupWithGroupClaim.swift in Sources */,
 				2129BE3C2394828B006363A1 /* GraphQLRequestModelTests.swift in Sources */,
 				2183A56523EA4A8400232880 /* GraphQLListQueryTests.swift in Sources */,
 				6BEE08192533CAA600133961 /* GraphQLRequestOwnerAndGroupTests.swift in Sources */,

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerAuthAndGroupWithGroupClaim.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerAuthAndGroupWithGroupClaim.swift
@@ -1,0 +1,186 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSPluginsCore
+
+/*
+ type OIDCGroupPost
+   @model
+   @auth(
+     rules: [
+       { allow: owner, provider: oidc, identityClaim: "sub"},
+       { allow: groups, provider: oidc, groups: ["Admins"],
+                                    groupClaim: "https://myapp.com/claims/groups"}
+     ]
+   ) {
+   id: ID!
+   title: String!
+   owner: String
+ }
+ */
+
+public struct OIDCGroupPost: Model {
+  public let id: String
+  public var title: String
+  public var owner: String?
+
+  public init(id: String = UUID().uuidString,
+              title: String,
+              owner: String? = nil) {
+      self.id = id
+      self.title = title
+      self.owner = owner
+  }
+
+    // MARK: - CodingKeys
+     public enum CodingKeys: String, ModelKey {
+      case id
+      case title
+      case owner
+    }
+
+    public static let keys = CodingKeys.self
+    public static let schema = defineSchema { model in
+      let oIDCGroupPost = OIDCGroupPost.keys
+
+      model.authRules = [
+        rule(allow: .owner,
+             ownerField: "owner",
+             identityClaim: "sub",
+             operations: [.create, .update, .delete, .read]),
+        rule(allow: .groups,
+             groupClaim: "https://myapp.com/claims/groups",
+             groups: ["Admins"],
+             operations: [.create, .update, .delete, .read])
+      ]
+
+      model.pluralName = "OIDCGroupPosts"
+
+      model.fields(
+        .id(),
+        .field(oIDCGroupPost.title, is: .required, ofType: .string),
+        .field(oIDCGroupPost.owner, is: .optional, ofType: .string)
+      )
+      }
+}
+
+class ModelWithOwnerAuthAndGroupWithGroupClaim: XCTestCase {
+    override func setUp() {
+        ModelRegistry.register(modelType: OIDCGroupPost.self)
+    }
+
+    override func tearDown() {
+        ModelRegistry.reset()
+    }
+
+    func testOnCreateSubscription_NoGroupInfoPassed() {
+        let claims = ["username": "user1",
+                      "sub": "123e4567-dead-beef-a456-426614174000"] as IdentityClaimsDictionary
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: OIDCGroupPost.self,
+                                                               operationType: .subscription)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
+        documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, claims)))
+        let document = documentBuilder.build()
+        let expectedQueryDocument = """
+        subscription OnCreateOIDCGroupPost($owner: String!) {
+          onCreateOIDCGroupPost(owner: $owner) {
+            id
+            owner
+            title
+            __typename
+          }
+        }
+        """
+        XCTAssertEqual(document.name, "onCreateOIDCGroupPost")
+        XCTAssertEqual(document.stringValue, expectedQueryDocument)
+        guard let variables = document.variables else {
+            XCTFail("The document doesn't contain variables")
+            return
+        }
+        XCTAssertEqual(variables["owner"] as? String, "123e4567-dead-beef-a456-426614174000")
+    }
+
+    func testOnCreateSubscription_InAdminsGroup() {
+        let claims = ["username": "user1",
+                      "sub": "123e4567-dead-beef-a456-426614174000",
+                      "https://myapp.com/claims/groups": ["Admins"]] as IdentityClaimsDictionary
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: OIDCGroupPost.self,
+                                                               operationType: .subscription)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
+        documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, claims)))
+        let document = documentBuilder.build()
+        let expectedQueryDocument = """
+        subscription OnCreateOIDCGroupPost {
+          onCreateOIDCGroupPost {
+            id
+            owner
+            title
+            __typename
+          }
+        }
+        """
+        XCTAssertEqual(document.name, "onCreateOIDCGroupPost")
+        XCTAssertEqual(document.stringValue, expectedQueryDocument)
+        XCTAssert(document.variables.isEmpty)
+    }
+
+    func testOnCreateSubscription_InAdminsGroupAndAnother() {
+        let claims = ["username": "user1",
+                      "sub": "123e4567-dead-beef-a456-426614174000",
+                      "https://myapp.com/claims/groups": ["Admins", "Users"]] as IdentityClaimsDictionary
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: OIDCGroupPost.self,
+                                                               operationType: .subscription)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
+        documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, claims)))
+        let document = documentBuilder.build()
+        let expectedQueryDocument = """
+        subscription OnCreateOIDCGroupPost {
+          onCreateOIDCGroupPost {
+            id
+            owner
+            title
+            __typename
+          }
+        }
+        """
+        XCTAssertEqual(document.name, "onCreateOIDCGroupPost")
+        XCTAssertEqual(document.stringValue, expectedQueryDocument)
+        XCTAssert(document.variables.isEmpty)
+    }
+
+    func testOnCreateSubscription_NotInAdminsGroup() {
+        let claims = ["username": "user1",
+                      "sub": "123e4567-dead-beef-a456-426614174000",
+                      "https://myapp.com/claims/groups": ["Users"]] as IdentityClaimsDictionary
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: OIDCGroupPost.self,
+                                                               operationType: .subscription)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
+        documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, claims)))
+        let document = documentBuilder.build()
+        let expectedQueryDocument = """
+        subscription OnCreateOIDCGroupPost($owner: String!) {
+          onCreateOIDCGroupPost(owner: $owner) {
+            id
+            owner
+            title
+            __typename
+          }
+        }
+        """
+        XCTAssertEqual(document.name, "onCreateOIDCGroupPost")
+        XCTAssertEqual(document.stringValue, expectedQueryDocument)
+        guard let variables = document.variables else {
+            XCTFail("The document doesn't contain variables")
+            return
+        }
+        XCTAssertEqual(variables["owner"] as? String, "123e4567-dead-beef-a456-426614174000")
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerAuthAndMultiGroup.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerAuthAndMultiGroup.swift
@@ -1,0 +1,251 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSPluginsCore
+
+/*
+ type OIDCMultiGroupPost
+   @model
+   @auth(
+     rules: [
+    { allow: owner, provider: oidc, identityClaim: "sub"},
+    { allow: groups, provider: oidc, groups: ["Admins"],
+                                   groupClaim: "https://myapp.com/claims/groups"},
+    { allow: groups, provider: oidc, groups: ["Moderators", "Editors"],
+                                   groupClaim: "https://differentapp.com/claims/groups"}
+     ]
+   ) {
+   id: ID!
+   title: String!
+   owner: String
+ }
+ */
+
+public struct OIDCMultiGroupPost: Model {
+    public let id: String
+    public var title: String
+    public var owner: String?
+
+    public init(id: String = UUID().uuidString,
+                title: String,
+                owner: String? = nil) {
+        self.id = id
+        self.title = title
+        self.owner = owner
+    }
+
+    public enum CodingKeys: String, ModelKey {
+        case id
+        case title
+        case owner
+    }
+
+    public static let keys = CodingKeys.self
+
+    public static let schema = defineSchema { model in
+        let oIDCMultiGroupPost = OIDCMultiGroupPost.keys
+
+        model.authRules = [
+            rule(allow: .owner,
+                 ownerField: "owner",
+                 identityClaim: "sub",
+                 operations: [.create, .update, .delete, .read]),
+            rule(allow: .groups,
+                 groupClaim: "https://myapp.com/claims/groups",
+                 groups: ["Admins"],
+                 operations: [.create, .update, .delete, .read]),
+            rule(allow: .groups,
+                 groupClaim: "https://differentapp.com/claims/groups",
+                 groups: ["Moderators", "Editors"],
+                 operations: [.create, .update, .delete, .read])
+        ]
+        model.pluralName = "OIDCMultiGroupPosts"
+        model.fields(
+            .id(),
+            .field(oIDCMultiGroupPost.title, is: .required, ofType: .string),
+            .field(oIDCMultiGroupPost.owner, is: .optional, ofType: .string)
+        )
+    }
+}
+
+class ModelWithOwnerAuthAndMultiGroup: XCTestCase {
+    override func setUp() {
+        ModelRegistry.register(modelType: OIDCMultiGroupPost.self)
+    }
+
+    override func tearDown() {
+        ModelRegistry.reset()
+    }
+
+    func testOnCreateSubscription_NoGroupInfoPassed() {
+        let claims = ["username": "user1",
+                      "sub": "123e4567-dead-beef-a456-426614174000"] as IdentityClaimsDictionary
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: OIDCMultiGroupPost.self,
+                                                               operationType: .subscription)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
+        documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, claims)))
+        let document = documentBuilder.build()
+        let expectedQueryDocument = """
+        subscription OnCreateOIDCMultiGroupPost($owner: String!) {
+          onCreateOIDCMultiGroupPost(owner: $owner) {
+            id
+            owner
+            title
+            __typename
+          }
+        }
+        """
+        XCTAssertEqual(document.name, "onCreateOIDCMultiGroupPost")
+        XCTAssertEqual(document.stringValue, expectedQueryDocument)
+        guard let variables = document.variables else {
+            XCTFail("The document doesn't contain variables")
+            return
+        }
+        XCTAssertEqual(variables["owner"] as? String,
+                       "123e4567-dead-beef-a456-426614174000",
+                       "owner should exist since there were no groups present in the claims to match the schema")
+    }
+
+    func testOnCreateSubscription_InDifferentAppWithModerators() {
+        let claims = ["username": "user1",
+                      "sub": "123e4567-dead-beef-a456-426614174000",
+                      "https://differentapp.com/claims/groups": ["Moderators"]] as IdentityClaimsDictionary
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: OIDCMultiGroupPost.self,
+                                                               operationType: .subscription)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
+        documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, claims)))
+        let document = documentBuilder.build()
+        let expectedQueryDocument = """
+        subscription OnCreateOIDCMultiGroupPost {
+          onCreateOIDCMultiGroupPost {
+            id
+            owner
+            title
+            __typename
+          }
+        }
+        """
+        XCTAssertEqual(document.name, "onCreateOIDCMultiGroupPost")
+        XCTAssertEqual(document.stringValue, expectedQueryDocument)
+        XCTAssertTrue(document.variables.isEmpty,
+                      "variables should be empty since claim group value matches the auth rule schema")
+    }
+
+    func testOnCreateSubscription_InDifferentAppWithModeratorsAndEditors() {
+        let claims = ["username": "user1",
+                      "sub": "123e4567-dead-beef-a456-426614174000",
+                      "https://differentapp.com/claims/groups": ["Moderators", "Editors"]] as IdentityClaimsDictionary
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: OIDCMultiGroupPost.self,
+                                                               operationType: .subscription)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
+        documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, claims)))
+        let document = documentBuilder.build()
+        let expectedQueryDocument = """
+        subscription OnCreateOIDCMultiGroupPost {
+          onCreateOIDCMultiGroupPost {
+            id
+            owner
+            title
+            __typename
+          }
+        }
+        """
+        XCTAssertEqual(document.name, "onCreateOIDCMultiGroupPost")
+        XCTAssertEqual(document.stringValue, expectedQueryDocument)
+        XCTAssertTrue(document.variables.isEmpty,
+                      "variables should be empty since claim group value matches the auth rule schema")
+    }
+
+    func testOnCreateSubscription_InDifferentAppWithAdminsFromMyApp() {
+        let claims = ["username": "user1",
+                      "sub": "123e4567-dead-beef-a456-426614174000",
+                      "https://myapp.com/claims/groups": ["Admins"]] as IdentityClaimsDictionary
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: OIDCMultiGroupPost.self,
+                                                               operationType: .subscription)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
+        documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, claims)))
+        let document = documentBuilder.build()
+        let expectedQueryDocument = """
+        subscription OnCreateOIDCMultiGroupPost {
+          onCreateOIDCMultiGroupPost {
+            id
+            owner
+            title
+            __typename
+          }
+        }
+        """
+        XCTAssertEqual(document.name, "onCreateOIDCMultiGroupPost")
+        XCTAssertEqual(document.stringValue, expectedQueryDocument)
+        XCTAssertTrue(document.variables.isEmpty,
+                      "variables should be empty since claim group value matches the auth rule schema")
+    }
+
+    func testOnCreateSubscription_InAdminsGroupInDifferentClaim() {
+        let claims = ["username": "user1",
+                      "sub": "123e4567-dead-beef-a456-426614174000",
+                      "https://differentapp.com/claims/groups": ["Admins"]] as IdentityClaimsDictionary
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: OIDCMultiGroupPost.self,
+                                                               operationType: .subscription)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
+        documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, claims)))
+        let document = documentBuilder.build()
+        let expectedQueryDocument = """
+        subscription OnCreateOIDCMultiGroupPost($owner: String!) {
+          onCreateOIDCMultiGroupPost(owner: $owner) {
+            id
+            owner
+            title
+            __typename
+          }
+        }
+        """
+        XCTAssertEqual(document.name, "onCreateOIDCMultiGroupPost")
+        XCTAssertEqual(document.stringValue, expectedQueryDocument)
+        guard let variables = document.variables else {
+            XCTFail("The document doesn't contain variables")
+            return
+        }
+        XCTAssertEqual(variables["owner"] as? String,
+                       "123e4567-dead-beef-a456-426614174000",
+                       "owner should exist since `Admins` is part of myapp.com, not differntapp.com")
+    }
+
+    func testOnCreateSubscription_InGroupButNotInSchema() {
+        let claims = ["username": "user1",
+                      "sub": "123e4567-dead-beef-a456-426614174000",
+                      "https://differentapp.com/claims/groups": ["Users"]] as IdentityClaimsDictionary
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: OIDCMultiGroupPost.self,
+                                                               operationType: .subscription)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
+        documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, claims)))
+        let document = documentBuilder.build()
+        let expectedQueryDocument = """
+        subscription OnCreateOIDCMultiGroupPost($owner: String!) {
+          onCreateOIDCMultiGroupPost(owner: $owner) {
+            id
+            owner
+            title
+            __typename
+          }
+        }
+        """
+        XCTAssertEqual(document.name, "onCreateOIDCMultiGroupPost")
+        XCTAssertEqual(document.stringValue, expectedQueryDocument)
+        guard let variables = document.variables else {
+            XCTFail("The document doesn't contain variables")
+            return
+        }
+        XCTAssertEqual(variables["owner"] as? String,
+                       "123e4567-dead-beef-a456-426614174000",
+                       "owner should exist since `Users` is not part of differentapp.com")
+    }
+}


### PR DESCRIPTION
Updated the algorithm to support multiple read restricted group based rules.  For example, if given the following schema:
```
 type OIDCMultiGroupPost
   @model
   @auth(
     rules: [
    { allow: owner, provider: oidc, identityClaim: "sub"},
    { allow: groups, provider: oidc, groups: ["Admins"],
                                   groupClaim: "https://myapp.com/claims/groups"},
    { allow: groups, provider: oidc, groups: ["Moderators", "Editors"],
                                   groupClaim: "https://differentapp.com/claims/groups"}
     ]
   ) {
   id: ID!
   title: String!
   owner: String
 }
```

The following examples of OIDC tokens with the following claims, will result in a subscription document that does not filter on the owner (since the user is part of at least one of the groups of a claim that was specified in the schema)
```
Example 1:
["username": "user1",
 "sub": "123e4567-dead-beef-a456-426614174000",
 "https://myapp.com/claims/groups": ["Admins"]]

Example 2:
["username": "user1",
 "sub": "123e4567-dead-beef-a456-426614174000",
 "https://differentapp.com/claims/groups": ["Moderators"]]

Example 3:
["username": "user1",
 "sub": "123e4567-dead-beef-a456-426614174000",
 "https://differentapp.com/claims/groups": ["Moderators", "Editors"]]
```
On the other hand, the following examples of OIDC tokens with the following claims, will result in a subscription document that will filter on the owner (since the user is NOT part of any of the groups of a claim that was specified in the schema)
```
Example 4:
["username": "user1",
 "sub": "123e4567-dead-beef-a456-426614174000"]

Example 5:
["username": "user1",
 "sub": "123e4567-dead-beef-a456-426614174000",
 "https://differentapp.com/claims/groups": ["Admins"]]

Example 6:
["username": "user1",
 "sub": "123e4567-dead-beef-a456-426614174000",
 "https://differentapp.com/claims/groups": ["Users"]]
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
