### PR TITLE
refactor(datastore): Replace usage of Model.Type from internal HubEvent

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestOwnerAndGroupTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestOwnerAndGroupTests.swift
@@ -28,7 +28,8 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
         let claims = ["username": "user1",
                       "sub": "123e4567-dead-beef-a456-426614174000",
                       "cognito:groups": ["Admins"]] as IdentityClaimsDictionary
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, claims)))
@@ -47,7 +48,7 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
           }
         }
         """
-        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType,
+        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType.schema,
                                                                       subscriptionType: .onCreate,
                                                                       claims: claims)
         XCTAssertEqual(document.stringValue, request.document)
@@ -61,7 +62,8 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
         let claims = ["username": "user1",
                       "sub": "123e4567-dead-beef-a456-426614174000",
                       "cognito:groups": ["Admins"]] as IdentityClaimsDictionary
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onUpdate))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onUpdate, claims)))
@@ -80,7 +82,7 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
           }
         }
         """
-        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType,
+        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType.schema,
                                                                       subscriptionType: .onUpdate,
                                                                       claims: claims)
         XCTAssertEqual(document.stringValue, request.document)
@@ -94,7 +96,8 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
         let claims = ["username": "user1",
                       "sub": "123e4567-dead-beef-a456-426614174000",
                       "cognito:groups": ["Admins"]] as IdentityClaimsDictionary
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onDelete))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onDelete, claims)))
@@ -113,7 +116,7 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
           }
         }
         """
-        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType,
+        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType.schema,
                                                                       subscriptionType: .onDelete,
                                                                       claims: claims)
         XCTAssertEqual(document.stringValue, request.document)
@@ -127,7 +130,8 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
         let claims = ["username": "user1",
                       "sub": "123e4567-dead-beef-a456-426614174000",
                       "cognito:groups": ["Admins", "GroupX"]] as IdentityClaimsDictionary
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, claims)))
@@ -146,7 +150,7 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
           }
         }
         """
-        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType,
+        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType.schema,
                                                                       subscriptionType: .onCreate,
                                                                       claims: claims)
         XCTAssertEqual(document.stringValue, request.document)
@@ -160,7 +164,8 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
         let claims = ["username": "user1",
                       "sub": "123e4567-dead-beef-a456-426614174000",
                       "cognito:groups": ["GroupX"]] as IdentityClaimsDictionary
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, claims)))
@@ -179,7 +184,7 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
           }
         }
         """
-        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType,
+        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType.schema,
                                                                       subscriptionType: .onCreate,
                                                                       claims: claims)
         XCTAssertEqual(document.stringValue, request.document)
@@ -201,7 +206,8 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
         let claims = ["username": "user1",
                       "sub": "123e4567-dead-beef-a456-426614174000",
                       "cognito:groups": ["GroupX"]] as IdentityClaimsDictionary
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onUpdate))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onUpdate, claims)))
@@ -220,7 +226,7 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
           }
         }
         """
-        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType,
+        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType.schema,
                                                                       subscriptionType: .onUpdate,
                                                                       claims: claims)
         XCTAssertEqual(document.stringValue, request.document)
@@ -242,7 +248,8 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
         let claims = ["username": "user1",
                       "sub": "123e4567-dead-beef-a456-426614174000",
                       "cognito:groups": ["GroupX"]] as IdentityClaimsDictionary
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onDelete))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onDelete, claims)))
@@ -261,7 +268,7 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
           }
         }
         """
-        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType,
+        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType.schema,
                                                                       subscriptionType: .onDelete,
                                                                       claims: claims)
         XCTAssertEqual(document.stringValue, request.document)
@@ -284,7 +291,8 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
                       "sub": "123e4567-dead-beef-a456-426614174000"] as IdentityClaimsDictionary
         //Specifically, leave this out:
         //                     "cognito:groups": ["GroupX"]]
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onDelete))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onDelete, claims)))
@@ -303,7 +311,7 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
           }
         }
         """
-        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType,
+        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType.schema,
                                                                       subscriptionType: .onDelete,
                                                                       claims: claims)
         XCTAssertEqual(document.stringValue, request.document)
@@ -325,7 +333,8 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
         let claims = ["username": "user1",
                       "sub": "123e4567-dead-beef-a456-426614174000",
                       "cognito:groups": ["Admins"]] as IdentityClaimsDictionary
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, claims)))
@@ -344,7 +353,7 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
           }
         }
         """
-        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType,
+        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType.schema,
                                                                       subscriptionType: .onCreate,
                                                                       claims: claims)
         XCTAssertEqual(document.stringValue, request.document)
@@ -358,7 +367,8 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
         let claims = ["username": "user1",
                       "sub": "123e4567-dead-beef-a456-426614174000",
                       "cognito:groups": ["Admins", "GroupX"]] as IdentityClaimsDictionary
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .subscription)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
+                                                               operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, claims)))
@@ -377,7 +387,9 @@ class GraphQLRequestOwnerAndGroupTests: XCTestCase {
           }
         }
         """
-        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType, subscriptionType: .onCreate, claims: claims)
+        let request = GraphQLRequest<MutationSyncResult>.subscription(to: modelType.schema,
+                                                                      subscriptionType: .onCreate,
+                                                                      claims: claims)
         XCTAssertEqual(document.stringValue, request.document)
         XCTAssertEqual(documentStringValue, request.document)
         XCTAssert(request.responseType == MutationSyncResult.self)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+SyncRequirement.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+SyncRequirement.swift
@@ -55,13 +55,14 @@ extension StorageEngine {
         }
 
         if containsAuthEnabledSyncableModels,
-            let apiCategoryAuthProviderBehavior = api as? APICategoryAuthProviderFactoryBehavior,
-            apiCategoryAuthProviderBehavior.apiAuthProviderFactory().oidcAuthProvider() != nil {
+           let apiCategoryAuthProviderBehavior = api as? APICategoryAuthProviderFactoryBehavior,
+           apiCategoryAuthProviderBehavior.apiAuthProviderFactory().oidcAuthProvider() != nil {
             if tryGetAuthPlugin() != nil {
-                log.warn("""
-Detected OIDC Auth Provider & Auth Plugin Category available.
-This is not a supported use case.
-""")
+                log.warn(
+                    """
+                    Detected OIDC Auth Provider & Auth Plugin Category available.
+                    This is not a supported use case.
+                    """)
             }
             return false
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -57,7 +57,7 @@ final class InitialSyncOperation: AsynchronousOperation {
         log.info("Beginning sync for \(modelSchema.name)")
         let lastSyncTime = getLastSyncTime()
         let syncType: SyncType = lastSyncTime == nil ? .fullSync : .deltaSync
-        initialSyncOperationTopic.send(.started(modelType: modelType, syncType: syncType))
+        initialSyncOperationTopic.send(.started(modelName: modelSchema.name, syncType: syncType))
         query(lastSyncTime: lastSyncTime)
     }
 
@@ -172,7 +172,7 @@ final class InitialSyncOperation: AsynchronousOperation {
                 self.query(lastSyncTime: lastSyncTime, nextToken: nextToken)
             }
         } else {
-            initialSyncOperationTopic.send(.finished(modelType: modelType))
+            initialSyncOperationTopic.send(.finished(modelName: modelSchema.name))
             updateModelSyncMetadata(lastSyncTime: syncQueryResult.startedAt)
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperationEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperationEvent.swift
@@ -11,13 +11,15 @@ import AWSPluginsCore
 enum InitialSyncOperationEvent {
     /// Published at the start of sync query (full or delta) for a particular Model
     /// Used by `SyncEventEmitter` and `ModelSyncedEmitted`
-    case started(modelType: Model.Type, syncType: SyncType)
+    case started(modelName: ModelName, syncType: SyncType)
+
     /// Published when a remote model is enqueued for local store reconcillation.
     /// Used by `ModelSyncedEventEmitter` for record counting.
     case enqueued(MutationSync<AnyModel>)
+
     /// Published when the sync operation has completed and all remote models have been enqueued for reconcillation.
     /// Used by `ModelSyncedEventEmitter` to determine when to send `ModelSyncedEvent`
-    case finished(modelType: Model.Type)
+    case finished(modelName: ModelName)
 }
 
 enum SyncType {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/SyncEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/SyncEventEmitter.swift
@@ -18,15 +18,14 @@ final class SyncEventEmitter {
          reconciliationQueue: IncomingEventReconciliationQueue?) {
         self.modelSyncedEventEmitters = [String: ModelSyncedEventEmitter]()
 
-        let syncableModels = ModelRegistry.models
-            .filter { $0.schema.isSyncable }
+        let syncableModelSchemas = ModelRegistry.modelSchemas.filter { $0.isSyncable }
 
         var publishers = [AnyPublisher<Never, Never>]()
-        for syncableModel in syncableModels {
-            let modelSyncedEventEmitter = ModelSyncedEventEmitter(modelType: syncableModel,
+        for syncableModelSchema in syncableModelSchemas {
+            let modelSyncedEventEmitter = ModelSyncedEventEmitter(modelSchema: syncableModelSchema,
                                                                   initialSyncOrchestrator: initialSyncOrchestrator,
                                                                   reconciliationQueue: reconciliationQueue)
-            modelSyncedEventEmitters[syncableModel.modelName] = modelSyncedEventEmitter
+            modelSyncedEventEmitters[syncableModelSchema.name] = modelSyncedEventEmitter
             publishers.append(modelSyncedEventEmitter.publisher)
         }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -159,7 +159,7 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
                 self.enqueue(remoteModel)
             })
         case .connectionConnected:
-            modelReconciliationQueueSubject.send(.connected(modelSchema.name))
+            modelReconciliationQueueSubject.send(.connected(modelName: modelSchema.name))
         }
     }
 
@@ -171,7 +171,7 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
         case .failure(let dataStoreError):
             if case let .api(error, _) = dataStoreError,
                case let APIError.operationError(_, _, underlyingError) = error, isUnauthorizedError(underlyingError) {
-                modelReconciliationQueueSubject.send(.disconnected(modelName: modelName, reason: .unauthorized))
+                modelReconciliationQueueSubject.send(.disconnected(modelName: modelSchema.name, reason: .unauthorized))
                 return
             }
             log.error("receiveCompletion: error: \(dataStoreError)")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -61,12 +61,12 @@ class InitialSyncOperationTests: XCTestCase {
                 syncCompletionReceived.fulfill()
             }, receiveValue: { value in
                 switch value {
-                case .started(modelType: let modelType, syncType: let syncType):
-                    XCTAssertEqual(modelType.modelName, "MockSynced")
+                case .started(modelName: let modelName, syncType: let syncType):
+                    XCTAssertEqual(modelName, "MockSynced")
                     XCTAssertEqual(syncType, .fullSync)
                     syncStartedReceived.fulfill()
-                case .finished(modelType: let modelType):
-                    XCTAssertEqual(modelType.modelName, "MockSynced")
+                case .finished(modelName: let modelName):
+                    XCTAssertEqual(modelName, "MockSynced")
                     finishedReceived.fulfill()
                 default:
                     break
@@ -118,12 +118,12 @@ class InitialSyncOperationTests: XCTestCase {
                 syncCompletionReceived.fulfill()
             }, receiveValue: { value in
                 switch value {
-                case .started(modelType: let modelType, syncType: let syncType):
-                    XCTAssertEqual(modelType.modelName, "MockSynced")
+                case .started(modelName: let modelName, syncType: let syncType):
+                    XCTAssertEqual(modelName, "MockSynced")
                     XCTAssertEqual(syncType, .fullSync)
                     syncStartedReceived.fulfill()
-                case .finished(modelType: let modelType):
-                    XCTAssertEqual(modelType.modelName, "MockSynced")
+                case .finished(modelName: let modelName):
+                    XCTAssertEqual(modelName, "MockSynced")
                     finishedReceived.fulfill()
                 default:
                     break
@@ -170,8 +170,8 @@ class InitialSyncOperationTests: XCTestCase {
             syncCompletionReceived.fulfill()
         }, receiveValue: { value in
             switch value {
-            case .finished(modelType: let modelType):
-                XCTAssertEqual(modelType.modelName, "MockSynced")
+            case .finished(modelName: let modelName):
+                XCTAssertEqual(modelName, "MockSynced")
                 finishedReceived.fulfill()
             default:
                 break
@@ -225,8 +225,8 @@ class InitialSyncOperationTests: XCTestCase {
             syncCompletionReceived.fulfill()
         }, receiveValue: { value in
             switch value {
-            case .finished(modelType: let modelType):
-                XCTAssertEqual(modelType.modelName, "MockSynced")
+            case .finished(modelName: let modelName):
+                XCTAssertEqual(modelName, "MockSynced")
                 finishedReceived.fulfill()
             default:
                 break
@@ -293,15 +293,15 @@ class InitialSyncOperationTests: XCTestCase {
                 syncCompletionReceived.fulfill()
             }, receiveValue: { value in
                 switch value {
-                case .started(modelType: let modelType, syncType: let syncType):
-                    XCTAssertEqual(modelType.modelName, "MockSynced")
+                case .started(modelName: let modelName, syncType: let syncType):
+                    XCTAssertEqual(modelName, "MockSynced")
                     XCTAssertEqual(syncType, .fullSync)
                     syncStartedReceived.fulfill()
                 case .enqueued(let returnedValue):
                     XCTAssertTrue(returnedValue.syncMetadata == mutationSync.syncMetadata)
                     offeredValueReceived.fulfill()
-                case .finished(modelType: let modelType):
-                    XCTAssertEqual(modelType.modelName, "MockSynced")
+                case .finished(modelName: let modelName):
+                    XCTAssertEqual(modelName, "MockSynced")
                     finishedReceived.fulfill()
                 }
             })
@@ -350,12 +350,12 @@ class InitialSyncOperationTests: XCTestCase {
                 syncCompletionReceived.fulfill()
             }, receiveValue: { value in
                 switch value {
-                case .started(modelType: let modelType, syncType: let syncType):
-                    XCTAssertEqual(modelType.modelName, "MockSynced")
+                case .started(modelName: let modelName, syncType: let syncType):
+                    XCTAssertEqual(modelName, "MockSynced")
                     XCTAssertEqual(syncType, .fullSync)
                     syncStartedReceived.fulfill()
-                case .finished(modelType: let modelType):
-                    XCTAssertEqual(modelType.modelName, "MockSynced")
+                case .finished(modelName: let modelName):
+                    XCTAssertEqual(modelName, "MockSynced")
                     finishedReceived.fulfill()
                 default:
                     break
@@ -430,8 +430,8 @@ class InitialSyncOperationTests: XCTestCase {
             }
         }, receiveValue: { value in
             switch value {
-            case .started(modelType: let modelType, syncType: let syncType):
-                XCTAssertEqual(modelType.modelName, "MockSynced")
+            case .started(modelName: let modelName, syncType: let syncType):
+                XCTAssertEqual(modelName, "MockSynced")
                 XCTAssertEqual(syncType, .fullSync)
                 syncStartedReceived.fulfill()
             default:
@@ -502,12 +502,12 @@ class InitialSyncOperationTests: XCTestCase {
                 syncCompletionReceived.fulfill()
             }, receiveValue: { value in
                 switch value {
-                case .started(modelType: let modelType, syncType: let syncType):
-                    XCTAssertEqual(modelType.modelName, "MockSynced")
+                case .started(modelName: let modelName, syncType: let syncType):
+                    XCTAssertEqual(modelName, "MockSynced")
                     XCTAssertEqual(syncType, .deltaSync)
                     syncStartedReceived.fulfill()
-                case .finished(modelType: let modelType):
-                    XCTAssertEqual(modelType.modelName, "MockSynced")
+                case .finished(modelName: let modelName):
+                    XCTAssertEqual(modelName, "MockSynced")
                     finishedReceived.fulfill()
                 default:
                     break
@@ -572,12 +572,12 @@ class InitialSyncOperationTests: XCTestCase {
                 syncCompletionReceived.fulfill()
             }, receiveValue: { value in
                 switch value {
-                case .started(modelType: let modelType, syncType: let syncType):
-                    XCTAssertEqual(modelType.modelName, "MockSynced")
+                case .started(modelName: let modelName, syncType: let syncType):
+                    XCTAssertEqual(modelName, "MockSynced")
                     XCTAssertEqual(syncType, .fullSync)
                     syncStartedReceived.fulfill()
-                case .finished(modelType: let modelType):
-                    XCTAssertEqual(modelType.modelName, "MockSynced")
+                case .finished(modelName: let modelName):
+                    XCTAssertEqual(modelName, "MockSynced")
                     finishedReceived.fulfill()
                 default:
                     break
@@ -630,12 +630,12 @@ class InitialSyncOperationTests: XCTestCase {
                 syncCompletionReceived.fulfill()
             }, receiveValue: { value in
                 switch value {
-                case .started(modelType: let modelType, syncType: let syncType):
-                    XCTAssertEqual(modelType.modelName, "MockSynced")
+                case .started(modelName: let modelName, syncType: let syncType):
+                    XCTAssertEqual(modelName, "MockSynced")
                     XCTAssertEqual(syncType, .fullSync)
                     syncStartedReceived.fulfill()
-                case .finished(modelType: let modelType):
-                    XCTAssertEqual(modelType.modelName, "MockSynced")
+                case .finished(modelName: let modelName):
+                    XCTAssertEqual(modelName, "MockSynced")
                     finishedReceived.fulfill()
                 default:
                     break

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/ReadyEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/ReadyEventEmitterTests.swift
@@ -43,7 +43,7 @@ class ReadyEventEmitterTests: XCTestCase {
         remoteSyncTopicPublisher.send(.syncStarted)
         let syncQueriesReadyEventPayload = HubPayload(eventName: HubPayload.EventName.DataStore.syncQueriesReady)
         Amplify.Hub.dispatch(to: .dataStore, payload: syncQueriesReadyEventPayload)
-        
+
         wait(for: [readyReceived], timeout: 1)
         readyEventSink?.cancel()
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
@@ -67,7 +67,7 @@ class SyncEventEmitterTests: XCTestCase {
             }
         }
 
-        reconciliationQueue = MockAWSIncomingEventReconciliationQueue(modelTypes: [Post.self],
+        reconciliationQueue = MockAWSIncomingEventReconciliationQueue(modelSchemas: [Post.schema],
                                                                       api: nil,
                                                                       storageAdapter: nil,
                                                                       auth: nil)
@@ -80,9 +80,10 @@ class SyncEventEmitterTests: XCTestCase {
         syncEventEmitter = SyncEventEmitter(initialSyncOrchestrator: initialSyncOrchestrator,
                                             reconciliationQueue: reconciliationQueue)
 
-        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.started(modelType: Post.self, syncType: .fullSync))
+        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.started(modelName: Post.modelName,
+                                                                            syncType: .fullSync))
         initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.enqueued(anyPostMutationSync))
-        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.finished(modelType: Post.self))
+        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.finished(modelName: Post.modelName))
 
         reconciliationQueue?.incomingEventSubject.send(.mutationEventApplied(postMutationEvent))
 
@@ -137,9 +138,9 @@ class SyncEventEmitterTests: XCTestCase {
             }
         }
 
-        let syncableModelTypes = ModelRegistry.models.filter { $0.schema.isSyncable }
+        let syncableModelSchemas = ModelRegistry.modelSchemas.filter { $0.isSyncable }
 
-        reconciliationQueue = MockAWSIncomingEventReconciliationQueue(modelTypes: syncableModelTypes,
+        reconciliationQueue = MockAWSIncomingEventReconciliationQueue(modelSchemas: syncableModelSchemas,
                                                                       api: nil,
                                                                       storageAdapter: nil,
                                                                       auth: nil)
@@ -152,11 +153,11 @@ class SyncEventEmitterTests: XCTestCase {
         syncEventEmitter = SyncEventEmitter(initialSyncOrchestrator: initialSyncOrchestrator,
                                             reconciliationQueue: reconciliationQueue)
 
-        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.started(modelType: Post.self, syncType: .fullSync))
-        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.finished(modelType: Post.self))
+        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.started(modelName: Post.modelName, syncType: .fullSync))
+        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.finished(modelName: Post.modelName))
 
-        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.started(modelType: Comment.self, syncType: .fullSync))
-        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.finished(modelType: Comment.self))
+        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.started(modelName: Comment.modelName, syncType: .fullSync))
+        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.finished(modelName: Comment.modelName))
 
         waitForExpectations(timeout: 1)
         syncEventEmitter = nil
@@ -228,9 +229,9 @@ class SyncEventEmitterTests: XCTestCase {
             }
         }
 
-        let syncableModelTypes = ModelRegistry.models.filter { $0.schema.isSyncable }
+        let syncableModelSchemas = ModelRegistry.modelSchemas.filter { $0.isSyncable }
 
-        reconciliationQueue = MockAWSIncomingEventReconciliationQueue(modelTypes: syncableModelTypes,
+        reconciliationQueue = MockAWSIncomingEventReconciliationQueue(modelSchemas: syncableModelSchemas,
                                                                       api: nil,
                                                                       storageAdapter: nil,
                                                                       auth: nil)
@@ -243,13 +244,15 @@ class SyncEventEmitterTests: XCTestCase {
         syncEventEmitter = SyncEventEmitter(initialSyncOrchestrator: initialSyncOrchestrator,
                                             reconciliationQueue: reconciliationQueue)
 
-        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.started(modelType: Post.self, syncType: .fullSync))
+        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.started(modelName: Post.modelName,
+                                                                            syncType: .fullSync))
         initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.enqueued(anyPostMutationSync))
-        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.finished(modelType: Post.self))
+        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.finished(modelName: Post.modelName))
 
-        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.started(modelType: Comment.self, syncType: .fullSync))
+        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.started(modelName: Comment.modelName,
+                                                                            syncType: .fullSync))
         initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.enqueued(anyCommentMutationSync))
-        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.finished(modelType: Comment.self))
+        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.finished(modelName: Comment.modelName))
 
         reconciliationQueue?.incomingEventSubject.send(.mutationEventApplied(postMutationEvent))
         reconciliationQueue?.incomingEventSubject.send(.mutationEventApplied(commentMutationEvent))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -77,9 +77,9 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     func testSubscriptionFailedWithSingleModelUnauthorizedError() {
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
         let modelReconciliationQueueFactory
-            = MockModelReconciliationQueue.init(modelType:storageAdapter:api:auth:incomingSubscriptionEvents:)
+            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:api:auth:incomingSubscriptionEvents:)
         let eventQueue = AWSIncomingEventReconciliationQueue(
-            modelTypes: [Post.self],
+            modelSchemas: [Post.schema],
             api: apiPlugin,
             storageAdapter: storageAdapter,
             modelReconciliationQueueFactory: modelReconciliationQueueFactory)
@@ -114,9 +114,9 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     func testSubscriptionFailedWithMultipleModels() {
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
         let modelReconciliationQueueFactory
-            = MockModelReconciliationQueue.init(modelType:storageAdapter:api:auth:incomingSubscriptionEvents:)
+            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:api:auth:incomingSubscriptionEvents:)
         let eventQueue = AWSIncomingEventReconciliationQueue(
-            modelTypes: [Post.self, Comment.self],
+            modelSchemas: [Post.schema, Comment.schema],
             api: apiPlugin,
             storageAdapter: storageAdapter,
             modelReconciliationQueueFactory: modelReconciliationQueueFactory)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
