### PR TITLE
fix(amplify): change reset method

### DIFF
--- a/Amplify/Core/Configuration/Internal/Amplify+Reset.swift
+++ b/Amplify/Core/Configuration/Internal/Amplify+Reset.swift
@@ -37,7 +37,7 @@ extension Amplify {
             case .predictions:
                 reset(Predictions, in: group) { group.leave() }
             case .hub, .logging:
-                // should be waited until other finish resetting
+                // Hub and Logging should be reset after all other categories
                 break
             }
         }

--- a/Amplify/Core/Configuration/Internal/Amplify+Reset.swift
+++ b/Amplify/Core/Configuration/Internal/Amplify+Reset.swift
@@ -22,12 +22,7 @@ extension Amplify {
 
         let group = DispatchGroup()
 
-        let manuallyResetCategories = [CategoryType.logging, .hub]
-        let remainingCategories = CategoryType.allCases.filter {
-            !manuallyResetCategories.contains($0)
-        }
-
-        for categoryType in remainingCategories {
+        for categoryType in CategoryType.allCases {
             switch categoryType {
             case .analytics:
                 reset(Analytics, in: group) { group.leave() }
@@ -42,17 +37,19 @@ extension Amplify {
             case .predictions:
                 reset(Predictions, in: group) { group.leave() }
             case .hub, .logging:
-                // Will be reset at last
+                // should be waited until other finish resetting
                 break
             }
         }
 
-        for categoryType in manuallyResetCategories {
+        group.wait()
+
+        for categoryType in CategoryType.allCases {
             switch categoryType {
-            case .logging:
-                reset(Logging, in: group) { group.leave() }
             case .hub:
                 reset(Hub, in: group) { group.leave() }
+            case .logging:
+                reset(Logging, in: group) { group.leave() }
             default:
                 break
             }

--- a/Amplify/Core/Configuration/Internal/Amplify+Reset.swift
+++ b/Amplify/Core/Configuration/Internal/Amplify+Reset.swift
@@ -23,7 +23,9 @@ extension Amplify {
         let group = DispatchGroup()
 
         let manuallyResetCategories = [CategoryType.logging, .hub]
-        let remainingCategories = CategoryType.allCases.filter { !manuallyResetCategories.contains($0) }
+        let remainingCategories = CategoryType.allCases.filter {
+            !manuallyResetCategories.contains($0)
+        }
 
         for categoryType in remainingCategories {
             switch categoryType {
@@ -40,13 +42,20 @@ extension Amplify {
             case .predictions:
                 reset(Predictions, in: group) { group.leave() }
             case .hub, .logging:
-                // Need to be reset at the last
+                // Will be reset at last
                 break
             }
         }
 
         for categoryType in manuallyResetCategories {
-            reset(categoryType, in: group) { group.leave() }
+            switch categoryType {
+            case .logging:
+                reset(Logging, in: group) { group.leave() }
+            case .hub:
+                reset(Hub, in: group) { group.leave() }
+            default:
+                break
+            }
         }
 
         if #available(iOS 13.0.0, *) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
@@ -111,10 +111,10 @@ class SyncEventEmitterTests: XCTestCase {
 
         var modelSyncedEventPayloads = [ModelSyncedEvent]()
         let expectedModelSyncedEventPayloads: [ModelSyncedEvent]
-            = [ModelSyncedEvent(modelName: "Post",
+            = [ModelSyncedEvent(modelName: "Comment",
                                 isFullSync: true, isDeltaSync: false,
                                 added: 0, updated: 0, deleted: 0),
-               ModelSyncedEvent(modelName: "Comment",
+               ModelSyncedEvent(modelName: "Post",
                                 isFullSync: true, isDeltaSync: false,
                                 added: 0, updated: 0, deleted: 0)]
         let listener = Amplify.Hub.publisher(for: .dataStore).sink { payload in
@@ -126,6 +126,9 @@ class SyncEventEmitterTests: XCTestCase {
                 }
                 modelSyncedEventPayloads.append(modelSyncedEventPayload)
                 if modelSyncedEventPayloads.count == 2 {
+                    modelSyncedEventPayloads.sort {
+                        $0.modelName < $1.modelName
+                    }
                     XCTAssertEqual(modelSyncedEventPayloads[0], expectedModelSyncedEventPayloads[0])
                     XCTAssertEqual(modelSyncedEventPayloads[1], expectedModelSyncedEventPayloads[1])
                     modelSyncedReceived.fulfill()
@@ -200,12 +203,12 @@ class SyncEventEmitterTests: XCTestCase {
         let commentMutationEvent = try MutationEvent(untypedModel: testComment, mutationType: .delete)
 
         let expectedModelSyncedEventPayloads: [ModelSyncedEvent]
-            = [ModelSyncedEvent(modelName: "Post",
+            = [ModelSyncedEvent(modelName: "Comment",
                                 isFullSync: true, isDeltaSync: false,
-                                added: 1, updated: 0, deleted: 0),
-               ModelSyncedEvent(modelName: "Comment",
+                                added: 0, updated: 0, deleted: 1),
+               ModelSyncedEvent(modelName: "Post",
                                 isFullSync: true, isDeltaSync: false,
-                                added: 0, updated: 0, deleted: 1)]
+                                added: 1, updated: 0, deleted: 0)]
         var modelSyncedEventPayloads = [ModelSyncedEvent]()
         let listener = Amplify.Hub.publisher(for: .dataStore).sink { payload in
             switch payload.eventName {
@@ -217,6 +220,9 @@ class SyncEventEmitterTests: XCTestCase {
                 modelSyncedEventPayloads.append(modelSyncedEventPayload)
 
                 if modelSyncedEventPayloads.count == 2 {
+                    modelSyncedEventPayloads.sort {
+                        $0.modelName < $1.modelName
+                    }
                     XCTAssertTrue(modelSyncedEventPayloads[0] == expectedModelSyncedEventPayloads[0])
                     XCTAssertTrue(modelSyncedEventPayloads[1] == expectedModelSyncedEventPayloads[1])
                     modelSyncedReceived.fulfill()


### PR DESCRIPTION
*Description of changes:*

The existing implementation of `Amplify.reset()` is to call `reset()` on every Categories and put them in global `DispatchGroup` which might cause a race condition. For example, during the `DataStore` reset process, it depends on `Hub` to dispatch some event, but at that point, `Hub` might already been reset and cause a precondition failure on https://github.com/aws-amplify/amplify-ios/blob/main/Amplify/Categories/Hub/HubCategory.swift#L44

The change I made is:
`reset()` on `logging` and `hub` categories should be called when other categories finish resetting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
