### PR TITLE
chore: Use NSLock instead of DispatchQueue to protect Atomics

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -2,3 +2,4 @@ case slave = "den"
 amazon-textract-code-samples/master/src-csharp
 aws-amplify/amplify-ci-support', branch: 'master'
 branch: master
+build-support/codecov.sh

--- a/Amplify/Core/Support/AtomicDictionary.swift
+++ b/Amplify/Core/Support/AtomicDictionary.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 final class AtomicDictionary<Key: Hashable, Value> {
-    let queue = DispatchQueue(label: "com.amazonaws.AtomicDictionary", target: DispatchQueue.global())
+    let lock = NSLock()
 
     private var value: [Key: Value]
 
@@ -17,48 +17,62 @@ final class AtomicDictionary<Key: Hashable, Value> {
     }
 
     var count: Int {
-        queue.sync {
-            value.count
+        lock.lock()
+        defer {
+            lock.unlock()
         }
+        return value.count
     }
 
     var keys: [Key] {
-        queue.sync {
-            Array(value.keys)
+        lock.lock()
+        defer {
+            lock.unlock()
         }
+        return Array(value.keys)
     }
 
     var values: [Value] {
-        return queue.sync {
-            Array(value.values)
+        lock.lock()
+        defer {
+            lock.unlock()
         }
+        return Array(value.values)
     }
 
     // MARK: - Functions
 
     func getValue(forKey key: Key) -> Value? {
-        queue.sync {
-            value[key]
+        lock.lock()
+        defer {
+            lock.unlock()
         }
+        return value[key]
     }
 
     func removeAll() {
-        queue.sync {
-            value = [:]
+        lock.lock()
+        defer {
+            lock.unlock()
         }
+        value = [:]
     }
 
     @discardableResult
     func removeValue(forKey key: Key) -> Value? {
-        queue.sync {
-            value.removeValue(forKey: key)
+        lock.lock()
+        defer {
+            lock.unlock()
         }
+        return value.removeValue(forKey: key)
     }
 
     func set(value: Value, forKey key: Key) {
-        queue.sync {
-            self.value[key] = value
+        lock.lock()
+        defer {
+            lock.unlock()
         }
+        self.value[key] = value
     }
 
 }

--- a/Amplify/Core/Support/AtomicValue+Bool.swift
+++ b/Amplify/Core/Support/AtomicValue+Bool.swift
@@ -16,10 +16,12 @@ extension AtomicValue where Value == Bool {
     /// print(atomicBool.get()) // prints "false"
     /// ```
     public func getAndToggle() -> Value {
-        queue.sync {
-            let oldValue = value
-            value.toggle()
-            return oldValue
+        lock.lock()
+        defer {
+            lock.unlock()
         }
+        let oldValue = value
+        value.toggle()
+        return oldValue
     }
 }

--- a/Amplify/Core/Support/AtomicValue+Numeric.swift
+++ b/Amplify/Core/Support/AtomicValue+Numeric.swift
@@ -8,17 +8,21 @@
 extension AtomicValue where Value: Numeric {
     /// Increments the current value by `amount` and returns the incremented value
     public func increment(by amount: Value = 1) -> Value {
-        return queue.sync {
-            value += amount
-            return value
+        lock.lock()
+        defer {
+            lock.unlock()
         }
+        value += amount
+        return value
     }
 
     /// Decrements the current value by `amount` and returns the decremented value
     public func decrement(by amount: Value = 1) -> Value {
-        return queue.sync {
-            value -= amount
-            return value
+        lock.lock()
+        defer {
+            lock.unlock()
         }
+        value -= amount
+        return value
     }
 }

--- a/Amplify/Core/Support/AtomicValue+RangeReplaceableCollection.swift
+++ b/Amplify/Core/Support/AtomicValue+RangeReplaceableCollection.swift
@@ -7,26 +7,34 @@
 
 extension AtomicValue where Value: RangeReplaceableCollection {
     public func append(_ newElement: Value.Element) {
-        queue.sync {
-            value.append(newElement)
+        lock.lock()
+        defer {
+            lock.unlock()
         }
+        value.append(newElement)
     }
 
     public func append<S>(contentsOf sequence: S) where S: Sequence, S.Element == Value.Element {
-        queue.sync {
-            value.append(contentsOf: sequence)
+        lock.lock()
+        defer {
+            lock.unlock()
         }
+        value.append(contentsOf: sequence)
     }
 
     public func removeFirst() -> Value.Element {
-        queue.sync {
-            value.removeFirst()
+        lock.lock()
+        defer {
+            lock.unlock()
         }
+        return value.removeFirst()
     }
 
     public subscript(_ key: Value.Index) -> Value.Element {
-        queue.sync {
-            value[key]
+        lock.lock()
+        defer {
+            lock.unlock()
         }
+        return value[key]
     }
 }

--- a/AmplifyTests/CoreTests/AtomicDictionaryTests.swift
+++ b/AmplifyTests/CoreTests/AtomicDictionaryTests.swift
@@ -10,6 +10,15 @@ import XCTest
 
 class AtomicDictionaryTests: XCTestCase {
 
+    func testPerformance() {
+        let atomicDictionary = AtomicDictionary(initialValue: [Int: Int]())
+        measure {
+            DispatchQueue.concurrentPerform(iterations: 10_000) { iteration in
+                atomicDictionary.set(value: iteration, forKey: iteration)
+            }
+        }
+    }
+
     /// Given: An AtomicDictionary
     /// When:
     /// - I `get` a nonexistent key

--- a/AmplifyTests/CoreTests/AtomicValueTests.swift
+++ b/AmplifyTests/CoreTests/AtomicValueTests.swift
@@ -11,11 +11,20 @@ import XCTest
 // These tests must be run with ThreadSanitizer enabled
 class AtomicValueTests: XCTestCase {
 
+    func testPerformance() {
+        let atomicInt = AtomicValue(initialValue: 0)
+        measure {
+            DispatchQueue.concurrentPerform(iterations: 10_000) { _ in
+                _ = atomicInt.increment()
+            }
+        }
+    }
+
     func testSimpleSet() {
         let atomicInt = AtomicValue(initialValue: -1)
 
         DispatchQueue.concurrentPerform(iterations: 10_000) { iteration in
-            _ = atomicInt.set(iteration)
+            atomicInt.set(iteration)
         }
 
         XCTAssertNotEqual(atomicInt.get(), -1)


### PR DESCRIPTION
*Description of changes:*

My initial implementation of AtomicValue was naively based on a `DispatchQueue` to protect access to the internal value and protect against data races. However, that could result in thread explosions (since not specifying a `target` for the private queue defaults to the global "overcommit" queue), and will require needless context switches. This change refactors `AtomicValue` and `AtomicDictionary` to use an `NSLock` instead of a `DispatchQueue` to protect against data races. As evidenced by the new performance test, this increases performance by about 50% over the previous implementation. It's not likely to make much of a change in our customer apps, since we don't typically have super-high volume use cases for our Atomics, but reducing thread usage is a win regardless.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
