### PR TITLE
chore: Target code coverage to only library modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
           command: xcodebuild test -workspace Amplify.xcworkspace -scheme Amplify -sdk iphonesimulator -destination "${destination}" | tee "artifacts/test-Amplify.log" | xcpretty --simple --color --report junit
       - run:
           name: Upload coverage report to Codecov
-          command: bash ~/amplify-ios/build-support/codecov.sh -F $CIRCLE_JOB -J 'Amplify' # From https://codecov.io/bash 
+          command: bash ~/amplify-ios/build-support/codecov.sh -F $CIRCLE_JOB -J 'Amplify'
       - store_test_results:
           path: build/reports
       - upload_artifacts
@@ -163,7 +163,7 @@ jobs:
           command: xcodebuild test -workspace << parameters.workspace >>.xcworkspace -scheme << parameters.scheme >> -sdk iphonesimulator -destination "${destination}" | tee "artifacts/test-<< parameters.scheme >>.log" | xcpretty --simple --color --report junit
       - run:
           name: Upload << parameters.path >> coverage report to Codecov
-          command: bash ~/amplify-ios/build-support/codecov.sh -F << parameters.path >>_plugin_unit_test -J '<< parameters.scheme >>' # From https://codecov.io/bash 
+          command: bash ~/amplify-ios/build-support/codecov.sh -F << parameters.path >>_plugin_unit_test -J '<< parameters.scheme >>'
       - store_test_results:
           path: build/reports
       - upload_artifacts

--- a/Amplify.xcodeproj/xcshareddata/xcschemes/AWSPluginsCore.xcscheme
+++ b/Amplify.xcodeproj/xcshareddata/xcschemes/AWSPluginsCore.xcscheme
@@ -27,7 +27,18 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      enableThreadSanitizer = "YES">
+      enableThreadSanitizer = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA131AA92360FE070008381C"
+            BuildableName = "AWSPluginsCore.framework"
+            BlueprintName = "AWSPluginsCore"
+            ReferencedContainer = "container:Amplify.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Amplify.xcodeproj/xcshareddata/xcschemes/Amplify.xcscheme
+++ b/Amplify.xcodeproj/xcshareddata/xcschemes/Amplify.xcscheme
@@ -47,13 +47,6 @@
             BlueprintName = "Amplify"
             ReferencedContainer = "container:Amplify.xcodeproj">
          </BuildableReference>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "21265DA32307389A004CCE39"
-            BuildableName = "AWSS3StoragePlugin.framework"
-            BlueprintName = "AWSS3StoragePlugin"
-            ReferencedContainer = "container:Amplify.xcodeproj">
-         </BuildableReference>
       </CodeCoverageTargets>
       <Testables>
          <TestableReference

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSAPICategoryPlugin.xcscheme
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSAPICategoryPlugin.xcscheme
@@ -41,8 +41,18 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
-      enableThreadSanitizer = "YES">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B478F5FA2374DBF400C4F92B"
+            BuildableName = "AWSAPICategoryPlugin.framework"
+            BlueprintName = "AWSAPICategoryPlugin"
+            ReferencedContainer = "container:APICategoryPlugin.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyPlugins/Analytics/AnalyticsCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSPinpointAnalyticsPlugin.xcscheme
+++ b/AmplifyPlugins/Analytics/AnalyticsCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSPinpointAnalyticsPlugin.xcscheme
@@ -27,7 +27,17 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B478F5FA2374DBF400C4F92B"
+            BuildableName = "AWSPinpointAnalyticsPlugin.framework"
+            BlueprintName = "AWSPinpointAnalyticsPlugin"
+            ReferencedContainer = "container:AnalyticsCategoryPlugin.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/xcshareddata/xcschemes/AWSCognitoAuthPlugin.xcscheme
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/xcshareddata/xcschemes/AWSCognitoAuthPlugin.xcscheme
@@ -41,8 +41,18 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
-      enableThreadSanitizer = "YES">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B43DC7442410572400D40275"
+            BuildableName = "AWSCognitoAuthPlugin.framework"
+            BlueprintName = "AWSCognitoAuthPlugin"
+            ReferencedContainer = "container:AWSCognitoAuthPlugin.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/ReadyEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/ReadyEventEmitterTests.swift
@@ -43,7 +43,7 @@ class ReadyEventEmitterTests: XCTestCase {
         remoteSyncTopicPublisher.send(.syncStarted)
         let syncQueriesReadyEventPayload = HubPayload(eventName: HubPayload.EventName.DataStore.syncQueriesReady)
         Amplify.Hub.dispatch(to: .dataStore, payload: syncQueriesReadyEventPayload)
-        
+
         wait(for: [readyReceived], timeout: 1)
         readyEventSink?.cancel()
     }

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSDataStoreCategoryPlugin.xcscheme
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSDataStoreCategoryPlugin.xcscheme
@@ -27,8 +27,18 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
-      enableThreadSanitizer = "YES">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2149E59A238867E100873955"
+            BuildableName = "AWSDataStoreCategoryPlugin.framework"
+            BlueprintName = "AWSDataStoreCategoryPlugin"
+            ReferencedContainer = "container:DataStoreCategoryPlugin.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyPlugins/Predictions/PredictionsCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSPredictionsPlugin.xcscheme
+++ b/AmplifyPlugins/Predictions/PredictionsCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSPredictionsPlugin.xcscheme
@@ -28,7 +28,8 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       enableThreadSanitizer = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/AmplifyPlugins/Predictions/PredictionsCategoryPlugin.xcodeproj/xcshareddata/xcschemes/CoreMLPredictionsPlugin.xcscheme
+++ b/AmplifyPlugins/Predictions/PredictionsCategoryPlugin.xcodeproj/xcshareddata/xcschemes/CoreMLPredictionsPlugin.xcscheme
@@ -42,7 +42,8 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       enableThreadSanitizer = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/AmplifyPlugins/Storage/StoragePlugin.xcodeproj/xcshareddata/xcschemes/AWSS3StoragePlugin.xcscheme
+++ b/AmplifyPlugins/Storage/StoragePlugin.xcodeproj/xcshareddata/xcschemes/AWSS3StoragePlugin.xcscheme
@@ -27,8 +27,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES"
       enableThreadSanitizer = "YES"
+      codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
       <CodeCoverageTargets>
          <BuildableReference


### PR DESCRIPTION
Previous configuration reported code coverage for the Test modules as well as
the library modules themselves. This change removes test targets from the
report.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
