### PR TITLE
fix(datastore): Regression bug caused by changing the public enum value

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -295,6 +295,7 @@
 		B4A19DAD24101F7100DE2E55 /* AuthSignUpOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A19DAC24101F7100DE2E55 /* AuthSignUpOperation.swift */; };
 		B4ADE8F4241063820007E86C /* AuthCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4ADE8F3241063820007E86C /* AuthCategory.swift */; };
 		B4B1E0E524733687007F3261 /* AuthEventName.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B1E0E424733687007F3261 /* AuthEventName.swift */; };
+		B4B34C55255B725F00033033 /* ModelFieldAssociationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B34C54255B725F00033033 /* ModelFieldAssociationTests.swift */; };
 		B4B5CC812457B0690019C783 /* AuthFetchUserAttributesRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B5CC802457B0690019C783 /* AuthFetchUserAttributesRequest.swift */; };
 		B4B5CC872457B2470019C783 /* AuthUpdateUserAttributeRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B5CC862457B2470019C783 /* AuthUpdateUserAttributeRequest.swift */; };
 		B4B5CC8B2457B32D0019C783 /* AuthConfirmUserAttributeRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B5CC8A2457B32D0019C783 /* AuthConfirmUserAttributeRequest.swift */; };
@@ -1112,6 +1113,7 @@
 		B4A19DAC24101F7100DE2E55 /* AuthSignUpOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSignUpOperation.swift; sourceTree = "<group>"; };
 		B4ADE8F3241063820007E86C /* AuthCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCategory.swift; sourceTree = "<group>"; };
 		B4B1E0E424733687007F3261 /* AuthEventName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthEventName.swift; sourceTree = "<group>"; };
+		B4B34C54255B725F00033033 /* ModelFieldAssociationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFieldAssociationTests.swift; sourceTree = "<group>"; };
 		B4B5CC802457B0690019C783 /* AuthFetchUserAttributesRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFetchUserAttributesRequest.swift; sourceTree = "<group>"; };
 		B4B5CC862457B2470019C783 /* AuthUpdateUserAttributeRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthUpdateUserAttributeRequest.swift; sourceTree = "<group>"; };
 		B4B5CC8A2457B32D0019C783 /* AuthConfirmUserAttributeRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthConfirmUserAttributeRequest.swift; sourceTree = "<group>"; };
@@ -3396,11 +3398,12 @@
 			children = (
 				FAD3937923820CDB00463F5E /* DataStoreCategoryClientAPITests.swift */,
 				FAD3937C23820D0200463F5E /* DataStoreCategoryConfigurationTests.swift */,
+				B4944D51251C141200BF0BFE /* JSONValueHolderTest.swift */,
+				B4B34C54255B725F00033033 /* ModelFieldAssociationTests.swift */,
 				FAE414602399A6A500CE94C2 /* ModelRegistryTests.swift */,
 				B99EF4B423DB020C00D821BC /* TemporalComparableTests.swift */,
 				B9AF547D23F37DF20059E6C4 /* TemporalOperationTests.swift */,
 				B91A87A323D64B0F0049A12F /* TemporalTests.swift */,
-				B4944D51251C141200BF0BFE /* JSONValueHolderTest.swift */,
 			);
 			path = DataStore;
 			sourceTree = "<group>";
@@ -4796,6 +4799,7 @@
 				FACD264D2386E8F10068FBE6 /* JSONValue+KeyPathTests.swift in Sources */,
 				FA9FB782232AA26500C04D32 /* DefaultHubPluginCustomChannelTests.swift in Sources */,
 				FAC23567227A056600424678 /* APICategoryClientRESTTests.swift in Sources */,
+				B4B34C55255B725F00033033 /* ModelFieldAssociationTests.swift in Sources */,
 				219A88EF23F3358F00BBC5F2 /* TreeTests.swift in Sources */,
 				FACA35EB2326B217000E74F6 /* AmplifyConfigurationInitializationTests.swift in Sources */,
 				FAD3937A23820CDB00463F5E /* DataStoreCategoryClientAPITests.swift in Sources */,

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/Model+Schema.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/Model+Schema.swift
@@ -40,7 +40,7 @@ extension Model {
     ///   - attributes: model attributes (aka "directives" or "annotations")
     ///   - define: the closure used to define the model attributes and fields
     /// - Returns: a valid `ModelSchema` instance
-    /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+    /// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used directly
     ///   by host applications. The behavior of this may change without warning.
     public static func defineSchema(name: String? = nil,
                                     attributes: ModelAttribute...,
@@ -51,7 +51,7 @@ extension Model {
         return definition.build()
     }
 
-    /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+    /// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used directly
     ///   by host applications. The behavior of this may change without warning.
     public static func rule(allow: AuthStrategy,
                             ownerField: String? = nil,

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
@@ -87,14 +87,26 @@ import Foundation
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
 public enum ModelAssociation {
-    case hasMany(associatedWith: String?)
-    case hasOne(associatedWith: String?)
-    case belongsTo(associatedWith: String?, targetName: String?)
+    case hasMany(associatedFieldName: String?)
+    case hasOne(associatedFieldName: String?)
+    case belongsTo(associatedFieldName: String?, targetName: String?)
 
-    public static let belongsTo: ModelAssociation = .belongsTo(associatedWith: nil, targetName: nil)
+    public static let belongsTo: ModelAssociation = .belongsTo(associatedFieldName: nil, targetName: nil)
 
     public static func belongsTo(targetName: String? = nil) -> ModelAssociation {
-        return .belongsTo(associatedWith: nil, targetName: nil)
+        return .belongsTo(associatedFieldName: nil, targetName: nil)
+    }
+
+    public static func hasMany(associatedWith: CodingKey?) -> ModelAssociation {
+        return .hasMany(associatedFieldName: associatedWith?.stringValue)
+    }
+
+    public static func hasOne(associatedWith: CodingKey?) -> ModelAssociation {
+        return .hasOne(associatedFieldName: associatedWith?.stringValue)
+    }
+
+    public static func belongsTo(associatedWith: CodingKey?, targetName: String?) -> ModelAssociation {
+        return .belongsTo(associatedFieldName: associatedWith?.stringValue, targetName: targetName)
     }
 
 }

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -31,7 +31,7 @@ public enum ModelFieldType {
     }
 
     public static func collection(of type: Model.Type) -> ModelFieldType {
-        return .collection(of: type.modelName)
+        .collection(of: type.modelName)
     }
 
     public var isArray: Bool {

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Defines the type of a `Model` field.
-/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
 public enum ModelFieldType {
 
@@ -89,7 +89,7 @@ public enum ModelFieldType {
     }
 }
 
-/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
 public enum ModelFieldNullability {
     case optional
@@ -105,7 +105,7 @@ public enum ModelFieldNullability {
     }
 }
 
-/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
 public struct ModelSchemaDefinition {
 
@@ -146,7 +146,7 @@ public struct ModelSchemaDefinition {
     }
 }
 
-/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
 public enum ModelFieldDefinition {
 

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -27,7 +27,7 @@ public enum ModelFieldType {
     case collection(of: ModelName)
 
     public static func model(type: Model.Type) -> ModelFieldType {
-        return .model(name: type.modelName)
+        .model(name: type.modelName)
     }
 
     public static func collection(of type: Model.Type) -> ModelFieldType {

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -26,6 +26,14 @@ public enum ModelFieldType {
     case model(name: ModelName)
     case collection(of: ModelName)
 
+    public static func model(type: Model.Type) -> ModelFieldType {
+        return .model(name: type.modelName)
+    }
+
+    public static func collection(of type: Model.Type) -> ModelFieldType {
+        return .collection(of: type.modelName)
+    }
+
     public var isArray: Bool {
         switch self {
         case .collection, .embeddedCollection:
@@ -72,7 +80,7 @@ public enum ModelFieldType {
             return .enum(type: enumType)
         }
         if let modelType = type as? Model.Type {
-            return .model(name: modelType.modelName)
+            return .model(type: modelType)
         }
         if let embeddedType = type as? Codable.Type {
             return .embedded(type: embeddedType, schema: nil)
@@ -195,8 +203,8 @@ public enum ModelFieldDefinition {
                                associatedWith associatedKey: CodingKey) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
-                      ofType: .collection(of: type.modelName),
-                      association: .hasMany(associatedWith: associatedKey.stringValue))
+                      ofType: .collection(of: type),
+                      association: .hasMany(associatedWith: associatedKey))
     }
 
     public static func hasOne(_ key: CodingKey,
@@ -205,8 +213,8 @@ public enum ModelFieldDefinition {
                               associatedWith associatedKey: CodingKey) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
-                      ofType: .model(name: type.modelName),
-                      association: .hasOne(associatedWith: associatedKey.stringValue))
+                      ofType: .model(type: type),
+                      association: .hasOne(associatedWith: associatedKey))
     }
 
     public static func belongsTo(_ key: CodingKey,
@@ -216,8 +224,8 @@ public enum ModelFieldDefinition {
                                  targetName: String? = nil) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
-                      ofType: .model(name: type.modelName),
-                      association: .belongsTo(associatedWith: associatedKey?.stringValue, targetName: targetName))
+                      ofType: .model(type: type),
+                      association: .belongsTo(associatedWith: associatedKey, targetName: targetName))
     }
 
     public var modelField: ModelField {

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
 public enum ModelAttribute {
 
@@ -16,13 +16,13 @@ public enum ModelAttribute {
     case isSystem
 }
 
-/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
 public enum ModelFieldAttribute {
     case primaryKey
 }
 
-/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
 public struct ModelField {
 
@@ -55,15 +55,15 @@ public struct ModelField {
     }
 }
 
-/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
 public typealias ModelFields = [String: ModelField]
 
-/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
 public typealias ModelName = String
 
-/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
 public struct ModelSchema {
 

--- a/AmplifyPlugins/API/Podfile.lock
+++ b/AmplifyPlugins/API/Podfile.lock
@@ -40,7 +40,7 @@ PODS:
   - ReachabilitySwift (5.0.0)
   - Starscream (3.1.1)
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.40.3)
+  - SwiftLint (0.41.0)
 
 DEPENDENCIES:
   - Amplify (from `../../`)
@@ -108,7 +108,7 @@ SPEC CHECKSUMS:
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
+  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
 
 PODFILE CHECKSUM: 31880f143dde88382b42400953bbeb67ca4f2ae3
 

--- a/AmplifyPlugins/Analytics/Podfile.lock
+++ b/AmplifyPlugins/Analytics/Podfile.lock
@@ -38,7 +38,7 @@ PODS:
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.40.3)
+  - SwiftLint (0.41.0)
 
 DEPENDENCIES:
   - Amplify (from `../../`)
@@ -100,7 +100,7 @@ SPEC CHECKSUMS:
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
+  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
 
 PODFILE CHECKSUM: 48d1574dddce5cef7bdb7b05b06fc588ee22956e
 

--- a/AmplifyPlugins/Auth/Podfile.lock
+++ b/AmplifyPlugins/Auth/Podfile.lock
@@ -29,7 +29,7 @@ PODS:
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.40.3)
+  - SwiftLint (0.41.0)
 
 DEPENDENCIES:
   - Amplify (from `../../`)
@@ -85,7 +85,7 @@ SPEC CHECKSUMS:
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
+  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
 
 PODFILE CHECKSUM: 371cf67fe35ebb5167d0880bad12b01618a0fb0e
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -76,7 +76,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
 
     public static func subscription(to modelType: Model.Type,
                                     subscriptionType: GraphQLSubscriptionType) -> GraphQLRequest<MutationSyncResult> {
-        return subscription(to: modelType.schema, subscriptionType: subscriptionType)
+        subscription(to: modelType.schema, subscriptionType: subscriptionType)
     }
 
     public static func subscription(to modelType: Model.Type,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -82,7 +82,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
     public static func subscription(to modelType: Model.Type,
                                     subscriptionType: GraphQLSubscriptionType,
                                     claims: IdentityClaimsDictionary) -> GraphQLRequest<MutationSyncResult> {
-        return subscription(to: modelType.schema, subscriptionType: subscriptionType, claims: claims)
+        subscription(to: modelType.schema, subscriptionType: subscriptionType, claims: claims)
     }
 
     public static func syncQuery(modelType: Model.Type,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -90,7 +90,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                  limit: Int?,
                                  nextToken: String?,
                                  lastSync: Int?) -> GraphQLRequest<SyncQueryResult> {
-        return syncQuery(modelSchema: modelType.schema,
+        syncQuery(modelSchema: modelType.schema,
                          where: predicate,
                          limit: limit,
                          nextToken: nextToken,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -71,7 +71,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
     public static func updateMutation(of model: Model,
                                       where filter: GraphQLFilter?,
                                       version: Int?) -> GraphQLRequest<MutationSyncResult> {
-        return updateMutation(of: model, modelSchema: model.schema, where: filter, version: version)
+        updateMutation(of: model, modelSchema: model.schema, where: filter, version: version)
     }
 
     public static func subscription(to modelType: Model.Type,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -65,7 +65,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
     }
 
     public static func createMutation(of model: Model, version: Int?) -> GraphQLRequest<MutationSyncResult> {
-        return createMutation(of: model, modelSchema: model.schema, version: version)
+        createMutation(of: model, modelSchema: model.schema, version: version)
     }
 
     public static func updateMutation(of model: Model,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -64,32 +64,25 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                                    decodePath: document.name)
     }
 
-    public static func createMutation(of model: Model,
-                                      version: Int?) -> GraphQLRequest<MutationSyncResult> {
+    public static func createMutation(of model: Model, version: Int?) -> GraphQLRequest<MutationSyncResult> {
         return createMutation(of: model, modelSchema: model.schema, version: version)
     }
 
     public static func updateMutation(of model: Model,
                                       where filter: GraphQLFilter?,
                                       version: Int?) -> GraphQLRequest<MutationSyncResult> {
-        return updateMutation(of: model,
-                              modelSchema: model.schema,
-                              where: filter,
-                              version: version)
+        return updateMutation(of: model, modelSchema: model.schema, where: filter, version: version)
     }
 
     public static func subscription(to modelType: Model.Type,
                                     subscriptionType: GraphQLSubscriptionType) -> GraphQLRequest<MutationSyncResult> {
-
         return subscription(to: modelType.schema, subscriptionType: subscriptionType)
     }
 
     public static func subscription(to modelType: Model.Type,
                                     subscriptionType: GraphQLSubscriptionType,
                                     claims: IdentityClaimsDictionary) -> GraphQLRequest<MutationSyncResult> {
-        return subscription(to: modelType.schema,
-                            subscriptionType: subscriptionType,
-                            claims: claims)
+        return subscription(to: modelType.schema, subscriptionType: subscriptionType, claims: claims)
     }
 
     public static func syncQuery(modelType: Model.Type,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -65,6 +65,46 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
     }
 
     public static func createMutation(of model: Model,
+                                      version: Int?) -> GraphQLRequest<MutationSyncResult> {
+        return createMutation(of: model, modelSchema: model.schema, version: version)
+    }
+
+    public static func updateMutation(of model: Model,
+                                      where filter: GraphQLFilter?,
+                                      version: Int?) -> GraphQLRequest<MutationSyncResult> {
+        return updateMutation(of: model,
+                              modelSchema: model.schema,
+                              where: filter,
+                              version: version)
+    }
+
+    public static func subscription(to modelType: Model.Type,
+                                    subscriptionType: GraphQLSubscriptionType) -> GraphQLRequest<MutationSyncResult> {
+
+        return subscription(to: modelType.schema, subscriptionType: subscriptionType)
+    }
+
+    public static func subscription(to modelType: Model.Type,
+                                    subscriptionType: GraphQLSubscriptionType,
+                                    claims: IdentityClaimsDictionary) -> GraphQLRequest<MutationSyncResult> {
+        return subscription(to: modelType.schema,
+                            subscriptionType: subscriptionType,
+                            claims: claims)
+    }
+
+    public static func syncQuery(modelType: Model.Type,
+                                 where predicate: QueryPredicate?,
+                                 limit: Int?,
+                                 nextToken: String?,
+                                 lastSync: Int?) -> GraphQLRequest<SyncQueryResult> {
+        return syncQuery(modelSchema: modelType.schema,
+                         where: predicate,
+                         limit: limit,
+                         nextToken: nextToken,
+                         lastSync: lastSync)
+    }
+
+    public static func createMutation(of model: Model,
                                       modelSchema: ModelSchema,
                                       version: Int? = nil) -> GraphQLRequest<MutationSyncResult> {
         createOrUpdateMutation(of: model, modelSchema: modelSchema, type: .create, version: version)

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
@@ -150,6 +150,12 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
     }
 
     public static func mutation<M: Model>(of model: M,
+                                          where predicate: QueryPredicate? = nil,
+                                          type: GraphQLMutationType) -> GraphQLRequest<M> {
+        return mutation(of: model, modelSchema: model.schema, where: predicate, type: type)
+    }
+
+    public static func mutation<M: Model>(of model: M,
                                           modelSchema: ModelSchema,
                                           where predicate: QueryPredicate? = nil,
                                           type: GraphQLMutationType) -> GraphQLRequest<M> {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
@@ -152,7 +152,7 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
     public static func mutation<M: Model>(of model: M,
                                           where predicate: QueryPredicate? = nil,
                                           type: GraphQLMutationType) -> GraphQLRequest<M> {
-        return mutation(of: model, modelSchema: model.schema, where: predicate, type: type)
+        mutation(of: model, modelSchema: model.schema, where: predicate, type: type)
     }
 
     public static func mutation<M: Model>(of model: M,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -28,13 +28,13 @@ extension Model {
 
             let name = field.graphQLName
             let fieldOptionalValue: Any??
-            
+
             if let jsonModel = self as? JSONValueHolder {
                 fieldOptionalValue = jsonModel.jsonValue(for: field.name, modelSchema: modelSchema) ?? nil
             } else {
                 fieldOptionalValue = self[field.name] ?? nil
             }
-            
+
             // Since the returned value is Any?? we need to do the following:
             // - `guard` to make sure the field name exists on the model
             // - `guard` to ensure the returned value isn't nil

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
@@ -160,10 +160,10 @@ extension Array where Element == ModelSchema {
                 let associatedModelSchemas = schema.sortedFields
                     .filter { $0.isForeignKey }
                     .map { (schema) -> ModelSchema in
-                        guard let associatedSchema = ModelRegistry.modelSchema(from: schema.requiredAssociatedModel)
+                        guard let associatedSchema = ModelRegistry.modelSchema(from: schema.requiredAssociatedModelName)
                         else {
                             preconditionFailure("""
-                            Could not retrieve schema for the model \(schema.requiredAssociatedModel), verify that
+                            Could not retrieve schema for the model \(schema.requiredAssociatedModelName), verify that
                             datastore is initialized.
                             """)
                         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
@@ -49,7 +49,7 @@ struct CreateTableStatement: SQLStatement {
 
         for (index, foreignKey) in foreignKeys.enumerated() {
             statement += "  foreign key(\"\(foreignKey.sqlName)\") "
-            let associatedModel = foreignKey.requiredAssociatedModel
+            let associatedModel = foreignKey.requiredAssociatedModelName
             guard let schema = ModelRegistry.modelSchema(from: associatedModel) else {
                 preconditionFailure("""
                 Could not retrieve schema for the model \(associatedModel), verify that datastore is initialized.

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Select.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Select.swift
@@ -93,7 +93,7 @@ struct SelectStatementMetadata {
 
         func visitAssociations(node: ModelSchema, namespace: String = "root") {
             for foreignKey in node.foreignKeys {
-                let associatedModelName = foreignKey.requiredAssociatedModel
+                let associatedModelName = foreignKey.requiredAssociatedModelName
 
                 guard let associatedSchema = ModelRegistry.modelSchema(from: associatedModelName) else {
                     preconditionFailure("""

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -127,6 +127,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
                         "Save failed due to condition did not match existing model instance.",
                         "The save will continue to fail until the model instance is updated.")
                         completion(.failure(causedBy: dataStoreError))
+
                         return
                     }
                 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
@@ -44,7 +44,7 @@ struct TestJsonModelRegistration: AmplifyModelRegistration {
         let comments = ModelField(name: "comments",
                                   type: .collection(of: "Comment"),
                                   isRequired: false,
-                                  association: .hasMany(associatedWith: "post"))
+                                  association: .hasMany(associatedFieldName: "post"))
         let postSchema = ModelSchema(name: "Post",
                                      pluralName: "Posts",
                                      fields: [id.name: id,

--- a/AmplifyPlugins/DataStore/Podfile.lock
+++ b/AmplifyPlugins/DataStore/Podfile.lock
@@ -48,7 +48,7 @@ PODS:
   - SQLite.swift/standard (0.12.2)
   - Starscream (3.1.1)
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.40.3)
+  - SwiftLint (0.41.0)
 
 DEPENDENCIES:
   - Amplify (from `../../`)
@@ -118,7 +118,7 @@ SPEC CHECKSUMS:
   SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
   Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
+  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
 
 PODFILE CHECKSUM: 04860e414d616b67d24ed3346a60700f427764b9
 

--- a/AmplifyPlugins/Predictions/Podfile.lock
+++ b/AmplifyPlugins/Predictions/Podfile.lock
@@ -48,7 +48,7 @@ PODS:
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.40.3)
+  - SwiftLint (0.41.0)
 
 DEPENDENCIES:
   - Amplify (from `../../`)
@@ -125,7 +125,7 @@ SPEC CHECKSUMS:
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
+  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
 
 PODFILE CHECKSUM: 65cca76c6059f8ccc8628936971fb9e4b035fb10
 

--- a/AmplifyPlugins/Storage/Podfile.lock
+++ b/AmplifyPlugins/Storage/Podfile.lock
@@ -38,7 +38,7 @@ PODS:
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.40.3)
+  - SwiftLint (0.41.0)
 
 DEPENDENCIES:
   - Amplify (from `../../`)
@@ -100,7 +100,7 @@ SPEC CHECKSUMS:
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
+  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
 
 PODFILE CHECKSUM: 23c3028505a2f56c001d01c66c1622dff6f8dd8e
 

--- a/AmplifyTests/CategoryTests/DataStore/ModelFieldAssociationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/ModelFieldAssociationTests.swift
@@ -1,0 +1,94 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+@testable import AmplifyTestCommon
+
+class ModelFieldAssociationTests: XCTestCase {
+
+    override func setUp() {
+        ModelRegistry.register(modelType: Post.self)
+        ModelRegistry.register(modelType: Comment.self)
+    }
+
+    func testBelongsToWithCodingKeys() {
+        let belongsTo = ModelAssociation.belongsTo(associatedWith: Comment.keys.post, targetName: "postID")
+        guard case .belongsTo(let fieldName, let target) = belongsTo else {
+            XCTFail("Should create belongsTo association")
+            return
+        }
+        XCTAssertEqual(fieldName, Comment.keys.post.stringValue)
+        XCTAssertEqual(target, "postID")
+    }
+
+    func testHasManyWithCodingKeys() {
+        let hasMany = ModelAssociation.hasMany(associatedWith: Comment.keys.post)
+        guard case .hasMany(let fieldName) = hasMany else {
+            XCTFail("Should create hasMany association")
+            return
+        }
+        XCTAssertEqual(fieldName, Comment.keys.post.stringValue)
+    }
+
+    func testHasOneWithCodingKeys() {
+        let hasOne = ModelAssociation.hasOne(associatedWith: Comment.keys.post)
+        guard case .hasOne(let fieldName) = hasOne else {
+            XCTFail("Should create hasOne association")
+            return
+        }
+        XCTAssertEqual(fieldName, Comment.keys.post.stringValue)
+    }
+
+    func testBelongsToWithTargetName() {
+        let belongsTo = ModelAssociation.belongsTo(targetName: "postID")
+        guard case .belongsTo(let fieldName, let target) = belongsTo else {
+            XCTFail("Should create belongsTo association")
+            return
+        }
+        XCTAssertNil(fieldName)
+        XCTAssertNil(target)
+    }
+
+    func testModelFieldWithBelongsToAssociation() {
+        let belongsTo = ModelAssociation.belongsTo(associatedWith: nil, targetName: "commentPostId")
+        let field = ModelField.init(name: "post",
+                                    type: .model(type: Post.self),
+                                    association: belongsTo)
+
+        XCTAssertEqual("Post", field.associatedModelName)
+        XCTAssertTrue(field.hasAssociation)
+        XCTAssertTrue(field.isAssociationOwner)
+    }
+
+    func testModelFieldWithHasManyAssociation() {
+        let hasMany = ModelAssociation.hasMany(associatedWith: Comment.keys.post)
+        let field = ModelField.init(name: "comments",
+                                    type: .collection(of: Comment.self),
+                                    isArray: true,
+                                    association: hasMany)
+
+        XCTAssertEqual("Comment", field.associatedModelName)
+        XCTAssertTrue(field.hasAssociation)
+        XCTAssertFalse(field.isAssociationOwner)
+        XCTAssertNotNil(field.associatedField)
+    }
+
+    func testModelFieldWithHasOneAssociation() {
+        let hasOne = ModelAssociation.hasOne(associatedWith: Comment.keys.post)
+        let field = ModelField.init(name: "comment",
+                                    type: .model(type: Comment.self),
+                                    association: hasOne)
+
+        XCTAssertEqual("Comment", field.associatedModelName)
+        XCTAssertTrue(field.hasAssociation)
+        XCTAssertFalse(field.isAssociationOwner)
+        XCTAssertTrue(field.isOneToOne)
+        XCTAssertNotNil(field.associatedField)
+    }
+
+}

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,7 +15,7 @@ PODS:
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.40.3)
+  - SwiftLint (0.41.0)
 
 DEPENDENCIES:
   - AWSMobileClient (~> 2.18.0)
@@ -59,7 +59,7 @@ SPEC CHECKSUMS:
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
+  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
 
 PODFILE CHECKSUM: a2acde35ab1bc6b80b362106cfda70905a6a840f
 


### PR DESCRIPTION
*Issue:* https://github.com/aws-amplify/amplify-ios/issues/882
*Description of changes:*  Regression bug caused by changing the public enum value

- Added static functions inside enum to match the previous enum cases to make it backward compatible.
- Unit tests for the changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
