### PR TITLE
feat(datastore): selective sync on initial sync & incoming subscription models

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/DataStoreConfiguration.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/DataStoreConfiguration.swift
@@ -63,16 +63,20 @@ public struct DataStoreConfiguration {
     /// The page size of each sync execution
     public let syncPageSize: UInt
 
+    public let syncExpressions: [DataStoreSyncExpression]
+
     init(errorHandler: @escaping DataStoreErrorHandler,
          conflictHandler: @escaping DataStoreConflictHandler,
          syncInterval: TimeInterval,
          syncMaxRecords: UInt,
-         syncPageSize: UInt) {
+         syncPageSize: UInt,
+         syncExpressions: [DataStoreSyncExpression]) {
         self.errorHandler = errorHandler
         self.conflictHandler = conflictHandler
         self.syncInterval = syncInterval
         self.syncMaxRecords = syncMaxRecords
         self.syncPageSize = syncPageSize
+        self.syncExpressions = syncExpressions
     }
 
 }
@@ -101,13 +105,15 @@ extension DataStoreConfiguration {
         },
         syncInterval: TimeInterval = DataStoreConfiguration.defaultSyncInterval,
         syncMaxRecords: UInt = DataStoreConfiguration.defaultSyncMaxRecords,
-        syncPageSize: UInt = DataStoreConfiguration.defaultSyncPageSize
+        syncPageSize: UInt = DataStoreConfiguration.defaultSyncPageSize,
+        syncExpressions: [DataStoreSyncExpression] = []
     ) -> DataStoreConfiguration {
         return DataStoreConfiguration(errorHandler: errorHandler,
                                       conflictHandler: conflictHandler,
                                       syncInterval: syncInterval,
                                       syncMaxRecords: syncMaxRecords,
-                                      syncPageSize: syncPageSize)
+                                      syncPageSize: syncPageSize,
+                                      syncExpressions: syncExpressions)
     }
 
     /// The default configuration.

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/DataStoreSyncExpression.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/DataStoreSyncExpression.swift
@@ -1,0 +1,21 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Amplify
+
+public typealias QueryPredicateResolver = () -> QueryPredicate
+
+public struct DataStoreSyncExpression {
+    let modelType: Model.Type
+    let modelPredicate: QueryPredicateResolver
+
+    static public func syncExpression(_ modelType: Model.Type,
+                                      where predicate: @escaping QueryPredicateResolver) -> DataStoreSyncExpression {
+        return DataStoreSyncExpression(modelType: modelType, modelPredicate: predicate)
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/DataStoreSyncExpression.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/DataStoreSyncExpression.swift
@@ -11,11 +11,11 @@ import Amplify
 public typealias QueryPredicateResolver = () -> QueryPredicate
 
 public struct DataStoreSyncExpression {
-    let modelType: Model.Type
+    let modelSchema: ModelSchema
     let modelPredicate: QueryPredicateResolver
 
-    static public func syncExpression(_ modelType: Model.Type,
+    static public func syncExpression(_ modelSchema: ModelSchema,
                                       where predicate: @escaping QueryPredicateResolver) -> DataStoreSyncExpression {
-        return DataStoreSyncExpression(modelType: modelType, modelPredicate: predicate)
+        return DataStoreSyncExpression(modelSchema: modelSchema, modelPredicate: predicate)
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/DataStoreSyncExpression.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/DataStoreSyncExpression.swift
@@ -16,6 +16,6 @@ public struct DataStoreSyncExpression {
 
     static public func syncExpression(_ modelSchema: ModelSchema,
                                       where predicate: @escaping QueryPredicateResolver) -> DataStoreSyncExpression {
-        return DataStoreSyncExpression(modelSchema: modelSchema, modelPredicate: predicate)
+        DataStoreSyncExpression(modelSchema: modelSchema, modelPredicate: predicate)
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -117,9 +117,9 @@ final class InitialSyncOperation: AsynchronousOperation {
         }
         let minSyncPageSize = Int(min(syncMaxRecords - recordsReceived, syncPageSize))
         let limit = minSyncPageSize < 0 ? Int(syncPageSize) : minSyncPageSize
-        let syncExpression = dataStoreConfiguration.syncExpressions.first(where: {
+        let syncExpression = dataStoreConfiguration.syncExpressions.first {
             $0.modelSchema.name == modelSchema.name
-        })
+        }
         let queryPredicate = syncExpression?.modelPredicate()
         let request = GraphQLRequest<SyncQueryResult>.syncQuery(modelSchema: modelSchema,
                                                                 where: queryPredicate,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -118,7 +118,7 @@ final class InitialSyncOperation: AsynchronousOperation {
         let minSyncPageSize = Int(min(syncMaxRecords - recordsReceived, syncPageSize))
         let limit = minSyncPageSize < 0 ? Int(syncPageSize) : minSyncPageSize
         let syncExpression = dataStoreConfiguration.syncExpressions.first(where: {
-                                                                            $0.modelType.schema.name == modelSchema.name
+            $0.modelSchema.name == modelSchema.name
         })
         let queryPredicate = syncExpression?.modelPredicate()
         let request = GraphQLRequest<SyncQueryResult>.syncQuery(modelSchema: modelSchema,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -117,7 +117,12 @@ final class InitialSyncOperation: AsynchronousOperation {
         }
         let minSyncPageSize = Int(min(syncMaxRecords - recordsReceived, syncPageSize))
         let limit = minSyncPageSize < 0 ? Int(syncPageSize) : minSyncPageSize
+        let syncExpression = dataStoreConfiguration.syncExpressions.first(where: {
+                                                                            $0.modelType.schema.name == modelSchema.name
+        })
+        let queryPredicate = syncExpression?.modelPredicate()
         let request = GraphQLRequest<SyncQueryResult>.syncQuery(modelSchema: modelSchema,
+                                                                where: queryPredicate,
                                                                 limit: limit,
                                                                 nextToken: nextToken,
                                                                 lastSync: lastSyncTime)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -77,7 +77,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
             OutgoingMutationQueue(storageAdapter: storageAdapter, dataStoreConfiguration: dataStoreConfiguration)
 
         let reconciliationQueueFactory = reconciliationQueueFactory ??
-            AWSIncomingEventReconciliationQueue.init(modelSchemas:api:storageAdapter:configuration:auth:modelReconciliationQueueFactory:)
+            AWSIncomingEventReconciliationQueue.init(modelSchemas:api:storageAdapter:syncExpressions:auth:modelReconciliationQueueFactory:)
 
         let initialSyncOrchestratorFactory = initialSyncOrchestratorFactory ??
             AWSInitialSyncOrchestrator.init(dataStoreConfiguration:api:reconciliationQueue:storageAdapter:)
@@ -262,7 +262,12 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
                                          storageAdapter: StorageEngineAdapter) {
         log.debug(#function)
         let syncableModelSchemas = ModelRegistry.modelSchemas.filter { $0.isSyncable }
-        reconciliationQueue = reconciliationQueueFactory(syncableModelSchemas, api, storageAdapter, dataStoreConfiguration, auth, nil)
+        reconciliationQueue = reconciliationQueueFactory(syncableModelSchemas,
+                                                         api,
+                                                         storageAdapter,
+                                                         dataStoreConfiguration.syncExpressions,
+                                                         auth,
+                                                         nil)
         reconciliationQueueSink = reconciliationQueue?.publisher.sink(
             receiveCompletion: onReceiveCompletion(receiveCompletion:),
             receiveValue: onReceive(receiveValue:))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -77,7 +77,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
             OutgoingMutationQueue(storageAdapter: storageAdapter, dataStoreConfiguration: dataStoreConfiguration)
 
         let reconciliationQueueFactory = reconciliationQueueFactory ??
-            AWSIncomingEventReconciliationQueue.init(modelSchemas:api:storageAdapter:auth:modelReconciliationQueueFactory:)
+            AWSIncomingEventReconciliationQueue.init(modelSchemas:api:storageAdapter:configuration:auth:modelReconciliationQueueFactory:)
 
         let initialSyncOrchestratorFactory = initialSyncOrchestratorFactory ??
             AWSInitialSyncOrchestrator.init(dataStoreConfiguration:api:reconciliationQueue:storageAdapter:)
@@ -262,7 +262,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
                                          storageAdapter: StorageEngineAdapter) {
         log.debug(#function)
         let syncableModelSchemas = ModelRegistry.modelSchemas.filter { $0.isSyncable }
-        reconciliationQueue = reconciliationQueueFactory(syncableModelSchemas, api, storageAdapter, auth, nil)
+        reconciliationQueue = reconciliationQueueFactory(syncableModelSchemas, api, storageAdapter, dataStoreConfiguration, auth, nil)
         reconciliationQueueSink = reconciliationQueue?.publisher.sink(
             receiveCompletion: onReceiveCompletion(receiveCompletion:),
             receiveValue: onReceive(receiveValue:))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -16,7 +16,7 @@ typealias IncomingEventReconciliationQueueFactory =
     ([ModelSchema],
     APICategoryGraphQLBehavior,
     StorageEngineAdapter,
-    DataStoreConfiguration,
+    [DataStoreSyncExpression],
     AuthCategoryBehavior?,
     ModelReconciliationQueueFactory?
 ) -> IncomingEventReconciliationQueue
@@ -24,11 +24,11 @@ typealias IncomingEventReconciliationQueueFactory =
 @available(iOS 13.0, *)
 final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue {
 
-    static let factory: IncomingEventReconciliationQueueFactory = { modelSchemas, api, storageAdapter, config, auth, _ in
+    static let factory: IncomingEventReconciliationQueueFactory = { modelSchemas, api, storageAdapter, syncExpressions, auth, _ in
         AWSIncomingEventReconciliationQueue(modelSchemas: modelSchemas,
                                             api: api,
                                             storageAdapter: storageAdapter,
-                                            configuration: config,
+                                            syncExpressions: syncExpressions,
                                             auth: auth,
                                             modelReconciliationQueueFactory: nil)
     }
@@ -51,7 +51,7 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
     init(modelSchemas: [ModelSchema],
          api: APICategoryGraphQLBehavior,
          storageAdapter: StorageEngineAdapter,
-         configuration: DataStoreConfiguration,
+         syncExpressions: [DataStoreSyncExpression],
          auth: AuthCategoryBehavior? = nil,
          modelReconciliationQueueFactory: ModelReconciliationQueueFactory? = nil) {
         self.modelReconciliationQueueSinks = [:]
@@ -66,7 +66,7 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
             = DispatchQueue(label: "com.amazonaws.DataStore.AWSIncomingEventReconciliationQueue")
         for modelSchema in modelSchemas {
             let modelName = modelSchema.name
-            let syncExpression = configuration.syncExpressions.first(where: {
+            let syncExpression = syncExpressions.first(where: {
                 $0.modelSchema.name == modelName
             })
             let modelPredicate = syncExpression?.modelPredicate() ?? nil

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -24,12 +24,12 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
 
     init(modelSchema: ModelSchema,
          api: APICategoryGraphQLBehavior,
-         configuration: DataStoreConfiguration,
+         modelPredicate: QueryPredicate?,
          auth: AuthCategoryBehavior?) {
         self.subscriptionEventSubject = PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>()
         self.asyncEvents = IncomingAsyncSubscriptionEventPublisher(modelSchema: modelSchema,
                                                                    api: api,
-                                                                   configuration: configuration,
+                                                                   modelPredicate: modelPredicate,
                                                                    auth: auth)
 
         let mapper = IncomingAsyncSubscriptionEventToAnyModelMapper()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -22,10 +22,14 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
         return subscriptionEventSubject.eraseToAnyPublisher()
     }
 
-    init(modelSchema: ModelSchema, api: APICategoryGraphQLBehavior, auth: AuthCategoryBehavior?) {
+    init(modelSchema: ModelSchema,
+         api: APICategoryGraphQLBehavior,
+         configuration: DataStoreConfiguration,
+         auth: AuthCategoryBehavior?) {
         self.subscriptionEventSubject = PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>()
         self.asyncEvents = IncomingAsyncSubscriptionEventPublisher(modelSchema: modelSchema,
                                                                    api: api,
+                                                                   configuration: configuration,
                                                                    auth: auth)
 
         let mapper = IncomingAsyncSubscriptionEventToAnyModelMapper()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -42,7 +42,10 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
     private let incomingSubscriptionEvents: PassthroughSubject<Event, DataStoreError>
     private let awsAuthService: AWSAuthServiceBehavior
 
-    init(modelSchema: ModelSchema, api: APICategoryGraphQLBehavior, auth: AuthCategoryBehavior?,
+    init(modelSchema: ModelSchema,
+         api: APICategoryGraphQLBehavior,
+         configuration: DataStoreConfiguration,
+         auth: AuthCategoryBehavior?,
          awsAuthService: AWSAuthServiceBehavior? = nil) {
         self.onCreateConnected = false
         self.onUpdateConnected = false

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -44,7 +44,7 @@ final class IncomingAsyncSubscriptionEventPublisher: Cancellable {
 
     init(modelSchema: ModelSchema,
          api: APICategoryGraphQLBehavior,
-         configuration: DataStoreConfiguration,
+         modelPredicate: QueryPredicate?,
          auth: AuthCategoryBehavior?,
          awsAuthService: AWSAuthServiceBehavior? = nil) {
         self.onCreateConnected = false

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -15,6 +15,7 @@ import Foundation
 typealias ModelReconciliationQueueFactory = (
     ModelSchema,
     StorageEngineAdapter,
+    DataStoreConfiguration,
     APICategoryGraphQLBehavior,
     AuthCategoryBehavior?,
     IncomingSubscriptionEventPublisher?
@@ -73,6 +74,7 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
 
     init(modelSchema: ModelSchema,
          storageAdapter: StorageEngineAdapter?,
+         configuration: DataStoreConfiguration,
          api: APICategoryGraphQLBehavior,
          auth: AuthCategoryBehavior?,
          incomingSubscriptionEvents: IncomingSubscriptionEventPublisher? = nil) {
@@ -96,7 +98,7 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
         incomingSubscriptionEventQueue.isSuspended = true
 
         let resolvedIncomingSubscriptionEvents = incomingSubscriptionEvents ??
-            AWSIncomingSubscriptionEventPublisher(modelSchema: modelSchema, api: api, auth: auth)
+            AWSIncomingSubscriptionEventPublisher(modelSchema: modelSchema, api: api, configuration: configuration, auth: auth)
         self.incomingSubscriptionEvents = resolvedIncomingSubscriptionEvents
         self.reconcileAndLocalSaveOperationSinks = AtomicValue(initialValue: Set<AnyCancellable?>())
         self.incomingEventsSink = resolvedIncomingSubscriptionEvents

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -162,7 +162,6 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
         case .mutationEvent(let remoteModel):
             if let predicate = modelPredicate {
                 guard predicate.evaluate(target: remoteModel.model.instance) else {
-                    print("AWSModelReconciliationQueue: filtering out:\(remoteModel.model.instance)")
                     return
                 }
             }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -647,4 +647,88 @@ class InitialSyncOperationTests: XCTestCase {
         waitForExpectations(timeout: 1)
         sink.cancel()
     }
+
+    func testBaseQueryWithSyncExpression() throws {
+        let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas + [MockSynced.schema])
+
+        let apiWasQueried = expectation(description: "API was queried with sync expression")
+        let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { request, listener in
+            XCTAssertEqual(request.document, """
+            query SyncMockSynceds($filter: ModelMockSyncedFilterInput, $limit: Int) {
+              syncMockSynceds(filter: $filter, limit: $limit) {
+                items {
+                  id
+                  __typename
+                  _version
+                  _deleted
+                  _lastChangedAt
+                }
+                nextToken
+                startedAt
+              }
+            }
+            """)
+            guard let filter = request.variables?["filter"] as? [String: Any?] else {
+                XCTFail("Unable to get filter")
+                return nil
+            }
+            guard let key = filter["id"] as? [String: Any?] else {
+                XCTFail("Unable to get id from filter")
+                return nil
+            }
+            guard let value = key["eq"] as? String else {
+                XCTFail("Unable to get eq from key")
+                return nil
+            }
+            XCTAssertEqual(value, "id-123")
+
+            let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: nil)
+            let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
+            listener?(event)
+            apiWasQueried.fulfill()
+            return nil
+        }
+
+        let apiPlugin = MockAPICategoryPlugin()
+        apiPlugin.responders[.queryRequestListener] = responder
+
+        let reconciliationQueue = MockReconciliationQueue()
+        let syncExpression = DataStoreSyncExpression.syncExpression(MockSynced.schema, where: {
+            MockSynced.keys.id == "id-123"
+        })
+        let configuration  = DataStoreConfiguration.custom(syncPageSize: 10, syncExpressions: [syncExpression])
+        let operation = InitialSyncOperation(
+            modelSchema: MockSynced.schema,
+            api: apiPlugin,
+            reconciliationQueue: reconciliationQueue,
+            storageAdapter: storageAdapter,
+            dataStoreConfiguration: configuration)
+
+        let syncStartedReceived = expectation(description: "Sync started received, sync operation started")
+        let syncCompletionReceived = expectation(description: "Sync completion received, sync operation is complete")
+        let finishedReceived = expectation(description: "InitialSyncOperation finishe offering items")
+        let sink = operation
+            .publisher
+            .sink(receiveCompletion: { _ in
+                syncCompletionReceived.fulfill()
+            }, receiveValue: { value in
+                switch value {
+                case .started(modelName: let modelName, syncType: let syncType):
+                    XCTAssertEqual(modelName, "MockSynced")
+                    XCTAssertEqual(syncType, .fullSync)
+                    syncStartedReceived.fulfill()
+                case .finished(modelName: let modelName):
+                    XCTAssertEqual(modelName, "MockSynced")
+                    finishedReceived.fulfill()
+                default:
+                    break
+                }
+            })
+
+        operation.main()
+
+        waitForExpectations(timeout: 1)
+        sink.cancel()
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
@@ -70,6 +70,7 @@ class SyncEventEmitterTests: XCTestCase {
         reconciliationQueue = MockAWSIncomingEventReconciliationQueue(modelSchemas: [Post.schema],
                                                                       api: nil,
                                                                       storageAdapter: nil,
+                                                                      syncExpressions: [],
                                                                       auth: nil)
 
         initialSyncOrchestrator = MockAWSInitialSyncOrchestrator(dataStoreConfiguration: .default,
@@ -146,6 +147,7 @@ class SyncEventEmitterTests: XCTestCase {
         reconciliationQueue = MockAWSIncomingEventReconciliationQueue(modelSchemas: syncableModelSchemas,
                                                                       api: nil,
                                                                       storageAdapter: nil,
+                                                                      syncExpressions: [],
                                                                       auth: nil)
 
         initialSyncOrchestrator = MockAWSInitialSyncOrchestrator(dataStoreConfiguration: .default,
@@ -240,6 +242,7 @@ class SyncEventEmitterTests: XCTestCase {
         reconciliationQueue = MockAWSIncomingEventReconciliationQueue(modelSchemas: syncableModelSchemas,
                                                                       api: nil,
                                                                       storageAdapter: nil,
+                                                                      syncExpressions: [],
                                                                       auth: nil)
 
         initialSyncOrchestrator = MockAWSInitialSyncOrchestrator(dataStoreConfiguration: .default,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -40,11 +40,12 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
 
         let modelReconciliationQueueFactory
-            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:api:auth:incomingSubscriptionEvents:)
+            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:configuration:api:auth:incomingSubscriptionEvents:)
         let eventQueue = AWSIncomingEventReconciliationQueue(
             modelSchemas: [Post.schema, Comment.schema],
             api: apiPlugin,
             storageAdapter: storageAdapter,
+            configuration: .default,
             modelReconciliationQueueFactory: modelReconciliationQueueFactory)
         eventQueue.start()
 
@@ -77,11 +78,12 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     func testSubscriptionFailedWithSingleModelUnauthorizedError() {
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
         let modelReconciliationQueueFactory
-            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:api:auth:incomingSubscriptionEvents:)
+            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:configuration:api:auth:incomingSubscriptionEvents:)
         let eventQueue = AWSIncomingEventReconciliationQueue(
             modelSchemas: [Post.schema],
             api: apiPlugin,
             storageAdapter: storageAdapter,
+            configuration: .default,
             modelReconciliationQueueFactory: modelReconciliationQueueFactory)
         eventQueue.start()
 
@@ -114,11 +116,12 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     func testSubscriptionFailedWithMultipleModels() {
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
         let modelReconciliationQueueFactory
-            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:api:auth:incomingSubscriptionEvents:)
+            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:configuration:api:auth:incomingSubscriptionEvents:)
         let eventQueue = AWSIncomingEventReconciliationQueue(
             modelSchemas: [Post.schema, Comment.schema],
             api: apiPlugin,
             storageAdapter: storageAdapter,
+            configuration: .default,
             modelReconciliationQueueFactory: modelReconciliationQueueFactory)
         eventQueue.start()
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -45,7 +45,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             modelSchemas: [Post.schema, Comment.schema],
             api: apiPlugin,
             storageAdapter: storageAdapter,
-            configuration: .default,
+            syncExpressions: [],
             modelReconciliationQueueFactory: modelReconciliationQueueFactory)
         eventQueue.start()
 
@@ -83,7 +83,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             modelSchemas: [Post.schema],
             api: apiPlugin,
             storageAdapter: storageAdapter,
-            configuration: .default,
+            syncExpressions: [],
             modelReconciliationQueueFactory: modelReconciliationQueueFactory)
         eventQueue.start()
 
@@ -121,7 +121,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             modelSchemas: [Post.schema, Comment.schema],
             api: apiPlugin,
             storageAdapter: storageAdapter,
-            configuration: .default,
+            syncExpressions: [],
             modelReconciliationQueueFactory: modelReconciliationQueueFactory)
         eventQueue.start()
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -40,7 +40,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
 
         let modelReconciliationQueueFactory
-            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:configuration:api:auth:incomingSubscriptionEvents:)
+            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:api:modelPredicate:auth:incomingSubscriptionEvents:)
         let eventQueue = AWSIncomingEventReconciliationQueue(
             modelSchemas: [Post.schema, Comment.schema],
             api: apiPlugin,
@@ -78,7 +78,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     func testSubscriptionFailedWithSingleModelUnauthorizedError() {
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
         let modelReconciliationQueueFactory
-            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:configuration:api:auth:incomingSubscriptionEvents:)
+            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:api:modelPredicate:auth:incomingSubscriptionEvents:)
         let eventQueue = AWSIncomingEventReconciliationQueue(
             modelSchemas: [Post.schema],
             api: apiPlugin,
@@ -116,7 +116,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     func testSubscriptionFailedWithMultipleModels() {
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
         let modelReconciliationQueueFactory
-            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:configuration:api:auth:incomingSubscriptionEvents:)
+            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:api:modelPredicate:auth:incomingSubscriptionEvents:)
         let eventQueue = AWSIncomingEventReconciliationQueue(
             modelSchemas: [Post.schema, Comment.schema],
             api: apiPlugin,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -28,8 +28,8 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
-                                                configuration: configuration,
                                                 api: apiPlugin,
+                                                modelPredicate: modelPredicate,
                                                 auth: authPlugin,
                                                 incomingSubscriptionEvents: subscriptionEventsPublisher)
 
@@ -76,8 +76,8 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
-                                                configuration: configuration,
                                                 api: apiPlugin,
+                                                modelPredicate: modelPredicate,
                                                 auth: authPlugin,
                                                 incomingSubscriptionEvents: subscriptionEventsPublisher)
 
@@ -146,11 +146,10 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
         let syncExpression = DataStoreSyncExpression.syncExpression(MockSynced.schema, where: {
             MockSynced.keys.id == "id-1" || MockSynced.keys.id == "id-3"
         })
-        let configWithSyncExpression = DataStoreConfiguration.custom(syncExpressions: [syncExpression])
         let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
-                                                configuration: configWithSyncExpression,
                                                 api: apiPlugin,
+                                                modelPredicate: syncExpression.modelPredicate(),
                                                 auth: authPlugin,
                                                 incomingSubscriptionEvents: subscriptionEventsPublisher)
 
@@ -240,8 +239,8 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
-                                                configuration: configuration,
                                                 api: apiPlugin,
+                                                modelPredicate: modelPredicate,
                                                 auth: authPlugin,
                                                 incomingSubscriptionEvents: subscriptionEventsPublisher)
         for iteration in 1 ... 3 {
@@ -311,8 +310,8 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
-                                                configuration: configuration,
                                                 api: apiPlugin,
+                                                modelPredicate: modelPredicate,
                                                 auth: authPlugin,
                                                 incomingSubscriptionEvents: subscriptionEventsPublisher)
         for iteration in 1 ... 2 {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -121,6 +121,76 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
             eventsSentViaPublisher3], timeout: 2.0)
     }
 
+    /// - Given: An AWSModelReconciliationQueue that has been buffering events with a selective sync configuration
+    /// - When:
+    ///    - I `start()` the queue
+    /// - Then:
+    ///    - It processes buffered events in order, that evaluate true against the predicate
+    func testProcessesEventsWithSelectiveSync() throws {
+        let event1Saved = expectation(description: "Event 1 saved")
+        let event3Saved = expectation(description: "Event 3 saved")
+        storageAdapter.responders[.saveUntypedModel] = SaveUntypedModelResponder { model, completion in
+            switch model.id {
+            case "id-1":
+                event1Saved.fulfill()
+            case "id-2":
+                XCTFail("id-2 should not be saved to be saved")
+            case "id-3":
+                event3Saved.fulfill()
+            default:
+                break
+            }
+
+            completion(.success(model))
+        }
+        let syncExpression = DataStoreSyncExpression.syncExpression(MockSynced.schema, where: {
+            MockSynced.keys.id == "id-1" || MockSynced.keys.id == "id-3"
+        })
+        let configWithSyncExpression = DataStoreConfiguration.custom(syncExpressions: [syncExpression])
+        let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
+                                                storageAdapter: storageAdapter,
+                                                configuration: configWithSyncExpression,
+                                                api: apiPlugin,
+                                                auth: authPlugin,
+                                                incomingSubscriptionEvents: subscriptionEventsPublisher)
+
+        for iteration in 1 ... 3 {
+            let model = try MockSynced(id: "id-\(iteration)").eraseToAnyModel()
+            let syncMetadata = MutationSyncMetadata(id: model.id,
+                                                    deleted: false,
+                                                    lastChangedAt: Date().unixSeconds,
+                                                    version: 1)
+            let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
+            subscriptionEventsSubject.send(.mutationEvent(mutationSync))
+        }
+
+        let eventsSentViaPublisher1 = expectation(description: "id-1 sent via publisher")
+        let eventsSentViaPublisher3 = expectation(description: "id-3 sent via publisher")
+        let queueSink = queue.publisher.sink(receiveCompletion: { _ in
+            XCTFail("Not expecting a call to completion")
+        }, receiveValue: { event in
+            if case let .mutationEvent(mutationEvent) = event {
+                switch mutationEvent.modelId {
+                case "id-1":
+                    eventsSentViaPublisher1.fulfill()
+                case "id-2":
+                    XCTFail("id-2 should not be saved to be saved")
+                case "id-3":
+                    eventsSentViaPublisher3.fulfill()
+                default:
+                    XCTFail("Not expecting a call to default")
+                }
+            }
+        })
+
+        queue.start()
+
+        wait(for: [event1Saved,
+                   event3Saved], timeout: 5.0, enforceOrder: true)
+        wait(for: [eventsSentViaPublisher1,
+                   eventsSentViaPublisher3], timeout: 2.0)
+    }
+
     /// - Given: An AWSModelReconciliationQueue that has been buffering events
     /// - When:
     ///    - I `start()` the queue

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -28,6 +28,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
+                                                configuration: configuration,
                                                 api: apiPlugin,
                                                 auth: authPlugin,
                                                 incomingSubscriptionEvents: subscriptionEventsPublisher)
@@ -75,6 +76,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
+                                                configuration: configuration,
                                                 api: apiPlugin,
                                                 auth: authPlugin,
                                                 incomingSubscriptionEvents: subscriptionEventsPublisher)
@@ -168,6 +170,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
+                                                configuration: configuration,
                                                 api: apiPlugin,
                                                 auth: authPlugin,
                                                 incomingSubscriptionEvents: subscriptionEventsPublisher)
@@ -238,6 +241,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
+                                                configuration: configuration,
                                                 api: apiPlugin,
                                                 auth: authPlugin,
                                                 incomingSubscriptionEvents: subscriptionEventsPublisher)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockModelReconciliatinQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockModelReconciliatinQueue.swift
@@ -24,6 +24,7 @@ class MockModelReconciliationQueue: ModelReconciliationQueue {
 
     init(modelSchema: ModelSchema,
          storageAdapter: StorageEngineAdapter?,
+         configuration: DataStoreConfiguration,
          api: APICategoryGraphQLBehavior,
          auth: AuthCategoryBehavior?,
          incomingSubscriptionEvents: IncomingSubscriptionEventPublisher? = nil) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockModelReconciliationQueue.swift
@@ -24,8 +24,8 @@ class MockModelReconciliationQueue: ModelReconciliationQueue {
 
     init(modelSchema: ModelSchema,
          storageAdapter: StorageEngineAdapter?,
-         configuration: DataStoreConfiguration,
          api: APICategoryGraphQLBehavior,
+         modelPredicate: QueryPredicate?,
          auth: AuthCategoryBehavior?,
          incomingSubscriptionEvents: IncomingSubscriptionEventPublisher? = nil) {
         self.modelReconciliationQueueSubject = PassthroughSubject<ModelReconciliationQueueEvent, DataStoreError>()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/ReconciliationQueueTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/ReconciliationQueueTestBase.swift
@@ -20,6 +20,7 @@ class ReconciliationQueueTestBase: XCTestCase {
     var storageAdapter: MockSQLiteStorageEngineAdapter!
     var subscriptionEventsPublisher: MockIncomingSubscriptionEventPublisher!
     var subscriptionEventsSubject: PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>!
+    var configuration: DataStoreConfiguration!
 
     override func setUp() {
         ModelRegistry.register(modelType: MockSynced.self)
@@ -30,6 +31,7 @@ class ReconciliationQueueTestBase: XCTestCase {
         storageAdapter = MockSQLiteStorageEngineAdapter()
         subscriptionEventsPublisher = MockIncomingSubscriptionEventPublisher()
         subscriptionEventsSubject = subscriptionEventsPublisher.subject
+        configuration = .default
     }
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/ReconciliationQueueTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/ReconciliationQueueTestBase.swift
@@ -20,7 +20,7 @@ class ReconciliationQueueTestBase: XCTestCase {
     var storageAdapter: MockSQLiteStorageEngineAdapter!
     var subscriptionEventsPublisher: MockIncomingSubscriptionEventPublisher!
     var subscriptionEventsSubject: PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>!
-    var configuration: DataStoreConfiguration!
+    var modelPredicate: QueryPredicate?
 
     override func setUp() {
         ModelRegistry.register(modelType: MockSynced.self)
@@ -31,7 +31,6 @@ class ReconciliationQueueTestBase: XCTestCase {
         storageAdapter = MockSQLiteStorageEngineAdapter()
         subscriptionEventsPublisher = MockIncomingSubscriptionEventPublisher()
         subscriptionEventsSubject = subscriptionEventsPublisher.subject
-        configuration = .default
     }
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
@@ -13,10 +13,11 @@ import Combine
 @testable import AWSDataStoreCategoryPlugin
 
 class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue {
-    static let factory: IncomingEventReconciliationQueueFactory = { modelSchemas, api, storageAdapter, auth, _ in
+    static let factory: IncomingEventReconciliationQueueFactory = { modelSchemas, api, storageAdapter, config, auth, _ in
         MockAWSIncomingEventReconciliationQueue(modelSchemas: modelSchemas,
                                                 api: api,
                                                 storageAdapter: storageAdapter,
+                                                configuration: config,
                                                 auth: auth)
     }
     let incomingEventSubject: PassthroughSubject<IncomingEventReconciliationQueueEvent, DataStoreError>
@@ -28,6 +29,7 @@ class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue 
     init(modelSchemas: [ModelSchema],
          api: APICategoryGraphQLBehavior?,
          storageAdapter: StorageEngineAdapter?,
+         configuration: DataStoreConfiguration? = nil,
          auth: AuthCategoryBehavior?) {
         self.incomingEventSubject = PassthroughSubject<IncomingEventReconciliationQueueEvent, DataStoreError>()
         updateLastInstance(instance: self)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
@@ -13,11 +13,11 @@ import Combine
 @testable import AWSDataStoreCategoryPlugin
 
 class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue {
-    static let factory: IncomingEventReconciliationQueueFactory = { modelSchemas, api, storageAdapter, config, auth, _ in
+    static let factory: IncomingEventReconciliationQueueFactory = { modelSchemas, api, storageAdapter, syncExpressions, auth, _ in
         MockAWSIncomingEventReconciliationQueue(modelSchemas: modelSchemas,
                                                 api: api,
                                                 storageAdapter: storageAdapter,
-                                                configuration: config,
+                                                syncExpressions: syncExpressions,
                                                 auth: auth)
     }
     let incomingEventSubject: PassthroughSubject<IncomingEventReconciliationQueueEvent, DataStoreError>
@@ -29,7 +29,7 @@ class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue 
     init(modelSchemas: [ModelSchema],
          api: APICategoryGraphQLBehavior?,
          storageAdapter: StorageEngineAdapter?,
-         configuration: DataStoreConfiguration? = nil,
+         syncExpressions: [DataStoreSyncExpression],
          auth: AuthCategoryBehavior?) {
         self.incomingEventSubject = PassthroughSubject<IncomingEventReconciliationQueueEvent, DataStoreError>()
         updateLastInstance(instance: self)

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		6B64027923E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B64027823E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift */; };
 		6B64027B23E38B9900001FD7 /* MockOutgoingMutationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */; };
 		6B91DEBF238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */; };
+		6BB01630255B1B4D00190897 /* DataStoreSyncExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB0162F255B1B4D00190897 /* DataStoreSyncExpression.swift */; };
 		6BB93F07244BA44B00ED1FC3 /* MutationEventClearState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB93F06244BA44B00ED1FC3 /* MutationEventClearState.swift */; };
 		6BB93F09244BA8ED00ED1FC3 /* MutationEventClearStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB93F08244BA8ED00ED1FC3 /* MutationEventClearStateTests.swift */; };
 		6BC4FDA823A899180027D20C /* RequestRetryablePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC4FDA723A899180027D20C /* RequestRetryablePolicyTests.swift */; };
@@ -306,6 +307,7 @@
 		6B64027823E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSIncomingEventReconciliationQueue.swift; sourceTree = "<group>"; };
 		6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOutgoingMutationQueue.swift; sourceTree = "<group>"; };
 		6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcileAndLocalSaveOperationTests.swift; sourceTree = "<group>"; };
+		6BB0162F255B1B4D00190897 /* DataStoreSyncExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreSyncExpression.swift; sourceTree = "<group>"; };
 		6BB93F06244BA44B00ED1FC3 /* MutationEventClearState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEventClearState.swift; sourceTree = "<group>"; };
 		6BB93F08244BA8ED00ED1FC3 /* MutationEventClearStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEventClearStateTests.swift; sourceTree = "<group>"; };
 		6BC4FDA723A899180027D20C /* RequestRetryablePolicyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestRetryablePolicyTests.swift; sourceTree = "<group>"; };
@@ -519,6 +521,7 @@
 				FA5D4CEE238AFCBC00D2F54A /* AWSDataStorePlugin+DataStoreSubscribeBehavior.swift */,
 				FA5D4CEC238AFC4D00D2F54A /* AWSDataStorePlugin+DefaultLogger.swift */,
 				B9334BA12433AF3E00C9F407 /* DataStoreConfiguration.swift */,
+				6BB0162F255B1B4D00190897 /* DataStoreSyncExpression.swift */,
 				2149E5C32388684F00873955 /* Info.plist */,
 				2149E5A72388684F00873955 /* Storage */,
 				2149E5B82388684F00873955 /* Subscribe */,
@@ -1516,6 +1519,7 @@
 				2149E5D12388684F00873955 /* StorageEngineAdapter+SQLite.swift in Sources */,
 				FA5D4CED238AFC4D00D2F54A /* AWSDataStorePlugin+DefaultLogger.swift in Sources */,
 				2149E5CA2388684F00873955 /* ModelSchema+SQLite.swift in Sources */,
+				6BB01630255B1B4D00190897 /* DataStoreSyncExpression.swift in Sources */,
 				2149E5CD2388684F00873955 /* SQLStatement+Update.swift in Sources */,
 				FAF7CEC9238C6A940095547B /* SyncMutationToCloudOperation.swift in Sources */,
 				FA8F4D1E2395AF7600861D91 /* DataStoreError+Plugin.swift in Sources */,

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -70,7 +70,7 @@
 		6B4E3DF42397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E3DF32397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift */; };
 		6B4E3DF62397327E00AD962B /* MockStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E3DF52397327E00AD962B /* MockStateMachine.swift */; };
 		6B52DC94244784FC007F5AD3 /* AWSIncomingEventReconciliationQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B52DC93244784FC007F5AD3 /* AWSIncomingEventReconciliationQueueTests.swift */; };
-		6B52DC9624478E75007F5AD3 /* MockModelReconciliatinQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B52DC9524478E75007F5AD3 /* MockModelReconciliatinQueue.swift */; };
+		6B52DC9624478E75007F5AD3 /* MockModelReconciliationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B52DC9524478E75007F5AD3 /* MockModelReconciliationQueue.swift */; };
 		6B64027923E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B64027823E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift */; };
 		6B64027B23E38B9900001FD7 /* MockOutgoingMutationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */; };
 		6B91DEBF238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */; };
@@ -303,7 +303,7 @@
 		6B4E3DF32397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingMutationQueueTestsWithMockStateMachine.swift; sourceTree = "<group>"; };
 		6B4E3DF52397327E00AD962B /* MockStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStateMachine.swift; sourceTree = "<group>"; };
 		6B52DC93244784FC007F5AD3 /* AWSIncomingEventReconciliationQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSIncomingEventReconciliationQueueTests.swift; sourceTree = "<group>"; };
-		6B52DC9524478E75007F5AD3 /* MockModelReconciliatinQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockModelReconciliatinQueue.swift; sourceTree = "<group>"; };
+		6B52DC9524478E75007F5AD3 /* MockModelReconciliationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockModelReconciliationQueue.swift; sourceTree = "<group>"; };
 		6B64027823E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSIncomingEventReconciliationQueue.swift; sourceTree = "<group>"; };
 		6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOutgoingMutationQueue.swift; sourceTree = "<group>"; };
 		6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcileAndLocalSaveOperationTests.swift; sourceTree = "<group>"; };
@@ -890,7 +890,7 @@
 				FAE4146B239AA40600CE94C2 /* MockSQLiteStorageEngineAdapter.swift */,
 				FA4A955C239AD810008E876E /* MockSQLiteStorageEngineAdapterResponders.swift */,
 				FAABC226239B1B9100740F9F /* ReconciliationQueueTestBase.swift */,
-				6B52DC9524478E75007F5AD3 /* MockModelReconciliatinQueue.swift */,
+				6B52DC9524478E75007F5AD3 /* MockModelReconciliationQueue.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -1640,7 +1640,7 @@
 				B4B3794B2551CF87007781D6 /* QuerySortDescriptorTests.swift in Sources */,
 				2149E5FE238869CF00873955 /* RemoteSyncAPIInvocationTests.swift in Sources */,
 				B9FAA142238C6082009414B4 /* BaseDataStoreTests.swift in Sources */,
-				6B52DC9624478E75007F5AD3 /* MockModelReconciliatinQueue.swift in Sources */,
+				6B52DC9624478E75007F5AD3 /* MockModelReconciliationQueue.swift in Sources */,
 				FA4A955B239AD3F4008E876E /* Foundation+TestExtensions.swift in Sources */,
 				B4D9B9E224DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift in Sources */,
 				6B64027B23E38B9900001FD7 /* MockOutgoingMutationQueue.swift in Sources */,


### PR DESCRIPTION
Smoke tested with a basic case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
