### PR TITLE
fix(DataStore): failed subscriptions lead to instability in sync engine

### DIFF
--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Reachability/NetworkReachabilityNotifier.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Reachability/NetworkReachabilityNotifier.swift
@@ -15,6 +15,7 @@ class NetworkReachabilityNotifier {
     private var reachability: NetworkReachabilityProviding?
     private var allowsCellularAccess = true
 
+    // This is a CurrentValueSubject.  Please do not change this unless you talk to wooj2@ or palpatim@ before changing this.
     let reachabilityPublisher = CurrentValueSubject<ReachabilityUpdate, Never>(ReachabilityUpdate(isOnline: false))
     var publisher: AnyPublisher<ReachabilityUpdate, Never> {
         return reachabilityPublisher.eraseToAnyPublisher()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/MutationRetryNotifier.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/MutationRetryNotifier.swift
@@ -22,10 +22,10 @@ final class MutationRetryNotifier {
          retryMutationCallback: @escaping BasicClosure) {
         self.retryMutationCallback = retryMutationCallback
 
-        networkReachabilityPublisher?.subscribe(self)
-
         let deadline = DispatchTime.now() + advice.retryInterval
         scheduleTimer(at: deadline)
+
+        networkReachabilityPublisher?.dropFirst().subscribe(self)
     }
 
     deinit {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
@@ -20,13 +20,13 @@ class SyncMutationToCloudOperationTests: XCTestCase {
     let secondsInADay = 60 * 60 * 24
     var mockAPIPlugin: MockAPICategoryPlugin!
 
-    var reachabilityPublisher: PassthroughSubject<ReachabilityUpdate, Never>!
+    var reachabilityPublisher: CurrentValueSubject<ReachabilityUpdate, Never>!
     var publisher: AnyPublisher<ReachabilityUpdate, Never> {
         return reachabilityPublisher.eraseToAnyPublisher()
     }
 
     override func setUp() {
-        reachabilityPublisher = PassthroughSubject<ReachabilityUpdate, Never>()
+        reachabilityPublisher = CurrentValueSubject<ReachabilityUpdate, Never>(ReachabilityUpdate(isOnline: false))
         tryOrFail {
             try setUpWithAPI()
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
