### PR TITLE
fix: Designate SwiftUI a weak_framework in podspec

### DIFF
--- a/Amplify.podspec
+++ b/Amplify.podspec
@@ -28,6 +28,12 @@ Pod::Spec.new do |s|
   s.source_files = 'Amplify/**/*.swift'
   s.default_subspec = 'Default'
 
+  # There appears to be a bug in Xcode < 12 where SwiftUI isn't properly
+  # weak-linked even though system frameworks should be weak-linked by default.
+  # Explicitly weak link it here until we upgrade Amplify's platform support
+  # version to >= 13.0. https://github.com/aws-amplify/amplify-ios/issues/878
+  s.weak_frameworks = 'SwiftUI'
+
   s.subspec 'Default' do |default|
     default.preserve_path = 'AmplifyTools'
     default.script_phase = {

--- a/Amplify/DevMenu/DevMenuPresentationContextProvider.swift
+++ b/Amplify/DevMenu/DevMenuPresentationContextProvider.swift
@@ -9,6 +9,7 @@ import Foundation
 import UIKit
 
 /// A protocol which provides a UI context over which views can be presented
+@available(iOS 13.0, *)
 public protocol DevMenuPresentationContextProvider: AnyObject {
     func devMenuPresentationContext() -> UIWindow
 }

--- a/Amplify/DevMenu/Trigger/TriggerDelegate.swift
+++ b/Amplify/DevMenu/Trigger/TriggerDelegate.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Implement this protocol to get notified of the trigger events recognized by
-/// a  `TriggerRecognizer`
+/// a `TriggerRecognizer`
 public protocol TriggerDelegate: AnyObject {
     func onTrigger(triggerRecognizer: TriggerRecognizer)
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-ios/issues/878

*Description of changes:*

Explicitly notes SwiftUI as a `weak_framework` to work around what I'm assuming is an Xcode or CocoaPods bug where SwiftUI isn't properly weak-linked by Xcode the way other frameworks (such as Combine) are.

This change also adds an `@available` guard on the `DevMenuPresentationContextProvider` protocol, to ensure that calling apps using the DevMenu are properly guarding their own code with availability checks or a sufficiently high minimum deployment target.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
