### PR TITLE
fix(Predictions): Fix of PredicationPlugin unit tests

### DIFF
--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Mocks/Service/MockTextractBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Mocks/Service/MockTextractBehavior.swift
@@ -17,18 +17,18 @@ class MockTextractBehavior: AWSTextractBehavior {
     var error: Error?
 
     func analyzeDocument(request: AWSTextractAnalyzeDocumentRequest) -> AWSTask<AWSTextractAnalyzeDocumentResponse> {
-        if let finalResult = analyzeDocument {
-            return AWSTask(result: finalResult)
+        guard let finalError = error else {
+            return AWSTask(result: analyzeDocument)
         }
-        return AWSTask(error: error!)
+        return AWSTask(error: finalError)
     }
 
     func detectDocumentText(request: AWSTextractDetectDocumentTextRequest)
-        -> AWSTask<AWSTextractDetectDocumentTextResponse> {
-            if let finalResult = detectDocumentText {
-                return AWSTask(result: finalResult)
-            }
-            return AWSTask(error: error!)
+    -> AWSTask<AWSTextractDetectDocumentTextResponse> {
+        guard let finalError = error else {
+            return AWSTask(result: detectDocumentText)
+        }
+        return AWSTask(error: finalError)
     }
 
     func getTextract() -> AWSTextract {

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Mocks/Service/MockTranscribeStreamingBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Mocks/Service/MockTranscribeStreamingBehavior.swift
@@ -12,6 +12,8 @@ import AWSTranscribeStreaming
 
 class MockTranscribeBehavior: AWSTranscribeStreamingBehavior {
 
+    var delegate: AWSTranscribeStreamingClientDelegate?
+    var callbackQueue: DispatchQueue?
     var transcriptionResult: AWSTranscribeStreamingTranscriptResultStream?
     var error: Error?
 
@@ -26,14 +28,16 @@ class MockTranscribeBehavior: AWSTranscribeStreamingBehavior {
 
     public func setResult(result: AWSTranscribeStreamingTranscriptResultStream?) {
         transcriptionResult = result
+        error = nil
     }
 
     func startTranscriptionWSS(request: AWSTranscribeStreamingStartStreamTranscriptionRequest) {
-
+        delegate?.didReceiveEvent(transcriptionResult, decodingError: error)
     }
 
     func setDelegate(delegate: AWSTranscribeStreamingClientDelegate, callbackQueue: DispatchQueue) {
-
+        self.delegate = delegate
+        self.callbackQueue = callbackQueue
     }
 
     func send(data: Data, headers: [String: String]) {

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceComprehendTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceComprehendTests.swift
@@ -8,7 +8,6 @@
 import XCTest
 import AWSComprehend
 import Amplify
-import Foundation
 @testable import AWSPredictionsPlugin
 
 class PredictionsServiceComprehendTests: XCTestCase {

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceRekognitionTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceRekognitionTests.swift
@@ -78,6 +78,8 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyLabelsService() {
         setUpAmplify()
+
+        let resultReceived = expectation(description: "Transcription result should be returned")
         let mockResponse: AWSRekognitionDetectLabelsResponse = AWSRekognitionDetectLabelsResponse()
         mockResponse.labels = [AWSRekognitionLabel]()
 
@@ -94,10 +96,13 @@ class PredictionsServiceRekognitionTests: XCTestCase {
                 let labelResult = result as? IdentifyLabelsResult
                 let labels = IdentifyLabelsResultTransformers.processLabels(mockResponse.labels!)
                 XCTAssertEqual(labelResult?.labels, labels, "Labels should be the same")
+                resultReceived.fulfill()
             case .failed(let error):
                 XCTFail("Should not produce error: \(error)")
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether error is correctly propogated
@@ -110,6 +115,8 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyLabelsServiceWithError() {
         setUpAmplify()
+
+        let errorReceived = expectation(description: "Error should be returned")
         let mockError = NSError(domain: AWSRekognitionErrorDomain,
                                 code: AWSRekognitionErrorType.invalidImageFormat.rawValue,
                                 userInfo: [:])
@@ -122,8 +129,11 @@ class PredictionsServiceRekognitionTests: XCTestCase {
                 XCTFail("Should not produce result: \(result)")
             case .failed(let error):
                 XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether error is correctly propogated
@@ -136,8 +146,9 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyLabelsServiceWithNilResponse() {
         setUpAmplify()
-
         mockRekognition.setLabelsResponse(result: nil)
+
+        let errorReceived = expectation(description: "Error should be returned")
         let testBundle = Bundle(for: type(of: self))
         guard let url = testBundle.url(forResource: "testImageLabels", withExtension: "jpg") else {
             XCTFail("Unable to find image")
@@ -150,8 +161,11 @@ class PredictionsServiceRekognitionTests: XCTestCase {
                 XCTFail("Should not produce result: \(result)")
             case .failed(let error):
                 XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether we can make a successful rekognition call to identify moderation labels
@@ -164,6 +178,8 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyModerationLabelsService() {
         setUpAmplify()
+
+        let resultReceived = expectation(description: "Transcription result should be returned")
         let mockResponse: AWSRekognitionDetectModerationLabelsResponse = AWSRekognitionDetectModerationLabelsResponse()
         mockResponse.moderationLabels = [AWSRekognitionModerationLabel]()
 
@@ -182,10 +198,13 @@ class PredictionsServiceRekognitionTests: XCTestCase {
                 XCTAssertEqual(labelResult?.labels, labels, "Labels should be the same")
                 XCTAssertNotNil(labelResult?.unsafeContent,
                                 "unsafe content should have a boolean in it since we called moderation labels")
+                resultReceived.fulfill()
             case .failed(let error):
                 XCTFail("Should not produce error: \(error)")
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether error is prograted correctly when making a rekognition call to identify moderation labels
@@ -198,6 +217,8 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyModerationLabelsServiceWithError() {
         setUpAmplify()
+
+        let errorReceived = expectation(description: "Error should be returned")
         let mockError = NSError(domain: AWSRekognitionErrorDomain,
                                 code: AWSRekognitionErrorType.invalidImageFormat.rawValue,
                                 userInfo: [:])
@@ -207,11 +228,14 @@ class PredictionsServiceRekognitionTests: XCTestCase {
         predictionsService.detectLabels(image: url, type: .moderation) { event in
             switch event {
             case .completed(let result):
-                  XCTFail("Should not produce result: \(result)")
+                XCTFail("Should not produce result: \(result)")
             case .failed(let error):
                 XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether we can make a successful rekognition call to identify moderation labels but receive a nil response
@@ -224,8 +248,9 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyModerationLabelsServiceWithNilResponse() {
         setUpAmplify()
-
         mockRekognition.setModerationLabelsResponse(result: nil)
+
+        let errorReceived = expectation(description: "Error should be returned")
         let testBundle = Bundle(for: type(of: self))
         guard let url = testBundle.url(forResource: "testImageLabels", withExtension: "jpg") else {
             XCTFail("Unable to find image")
@@ -235,11 +260,14 @@ class PredictionsServiceRekognitionTests: XCTestCase {
         predictionsService.detectLabels(image: url, type: .moderation) { event in
             switch event {
             case .completed(let result):
-                  XCTFail("Should not produce result: \(result)")
+                XCTFail("Should not produce result: \(result)")
             case .failed(let error):
                 XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether we can make a successful rekognition call to identify all labels
@@ -252,6 +280,8 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyAllLabelsService() {
         setUpAmplify()
+
+        let resultReceived = expectation(description: "Transcription result should be returned")
         let mockLabelsResponse: AWSRekognitionDetectLabelsResponse = AWSRekognitionDetectLabelsResponse()
         mockLabelsResponse.labels = [AWSRekognitionLabel]()
 
@@ -274,10 +304,13 @@ class PredictionsServiceRekognitionTests: XCTestCase {
                 XCTAssertEqual(labelResult?.labels, labels, "Labels should be the same")
                 XCTAssertNotNil(labelResult?.unsafeContent,
                                 "unsafe content should have a boolean in it since we called all labels")
+                resultReceived.fulfill()
             case .failed(let error):
                 XCTFail("Should not produce error: \(error)")
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether error is prograted correctly when making a rekognition call to identify all labels
@@ -291,20 +324,27 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     func testIdentifyAllLabelsServiceWithNilResponse() {
         setUpAmplify()
         mockRekognition.setAllLabelsResponse(labelsResult: nil, moderationResult: nil)
+
         let testBundle = Bundle(for: type(of: self))
         guard let url = testBundle.url(forResource: "testImageLabels", withExtension: "jpg") else {
             XCTFail("Unable to find image")
             return
         }
 
+        let errorReceived = expectation(description: "Error should be returned")
+        errorReceived.expectedFulfillmentCount = 2
+
         predictionsService.detectLabels(image: url, type: .all) { event in
             switch event {
             case .completed(let result):
-                  XCTFail("Should not produce result: \(result)")
+                XCTFail("Should not produce result: \(result)")
             case .failed(let error):
                 XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether error is prograted correctly when making a rekognition call to identify all labels
@@ -317,20 +357,25 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyAllLabelsServiceWithError() {
         setUpAmplify()
+
         let mockError = NSError(domain: AWSRekognitionErrorDomain,
                                 code: AWSRekognitionErrorType.invalidImageFormat.rawValue,
                                 userInfo: [:])
         mockRekognition.setError(error: mockError)
         let url = URL(fileURLWithPath: "")
+        let errorReceived = expectation(description: "Error should be returned")
 
         predictionsService.detectLabels(image: url, type: .all) { event in
             switch event {
             case .completed(let result):
-                  XCTFail("Should not produce result: \(result)")
+                XCTFail("Should not produce result: \(result)")
             case .failed(let error):
                 XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether we can make a successfull rekognition call to identify entities
@@ -343,6 +388,7 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyEntitiesService() {
         setUpAmplify()
+
         let mockResponse: AWSRekognitionDetectFacesResponse = AWSRekognitionDetectFacesResponse()
         mockResponse.faceDetails = [AWSRekognitionFaceDetail]()
 
@@ -353,16 +399,21 @@ class PredictionsServiceRekognitionTests: XCTestCase {
             return
         }
 
+        let resultReceived = expectation(description: "Transcription result should be returned")
+
         predictionsService.detectEntities(image: url) { event in
             switch event {
             case .completed(let result):
                 let entitiesResult = result as? IdentifyEntitiesResult
                 let newFaces = IdentifyEntitiesResultTransformers.processFaces(mockResponse.faceDetails!)
                 XCTAssertEqual(entitiesResult?.entities.count, newFaces.count, "Faces count number should be the same")
+                resultReceived.fulfill()
             case .failed(let error):
                 XCTFail("Should not produce error: \(error)")
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether error is correctly propogated for detecting entities
@@ -375,11 +426,13 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyEntitiesServiceWithError() {
         setUpAmplify()
+
         let mockError = NSError(domain: AWSRekognitionErrorDomain,
                                 code: AWSRekognitionErrorType.invalidImageFormat.rawValue,
                                 userInfo: [:])
         mockRekognition.setError(error: mockError)
         let url = URL(fileURLWithPath: "")
+        let errorReceived = expectation(description: "Error should be returned")
 
         predictionsService.detectEntities(image: url) { event in
             switch event {
@@ -387,8 +440,11 @@ class PredictionsServiceRekognitionTests: XCTestCase {
                 XCTFail("Should not produce result: \(result)")
             case .failed(let error):
                 XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether error is correctly propogated for detecting entities when a nil response is received
@@ -402,11 +458,13 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     func testIdentifyEntitiesServiceWithNilResponse() {
         setUpAmplify()
         mockRekognition.setFacesResponse(result: nil)
+
         let testBundle = Bundle(for: type(of: self))
         guard let url = testBundle.url(forResource: "testImageEntities", withExtension: "jpg") else {
             XCTFail("Unable to find image")
             return
         }
+        let errorReceived = expectation(description: "Error should be returned")
 
         predictionsService.detectEntities(image: url) { event in
             switch event {
@@ -414,8 +472,11 @@ class PredictionsServiceRekognitionTests: XCTestCase {
                 XCTFail("Should not produce result: \(result)")
             case .failed(let error):
                 XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether we can make a successfull rekognition call to identify entities from a collection
@@ -428,6 +489,7 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyEntityMatchesService() {
         setUpAmplify(withCollection: true)
+
         let mockResponse: AWSRekognitionSearchFacesByImageResponse = AWSRekognitionSearchFacesByImageResponse()
         mockResponse.faceMatches = [AWSRekognitionFaceMatch]()
 
@@ -437,6 +499,7 @@ class PredictionsServiceRekognitionTests: XCTestCase {
             XCTFail("Unable to find image")
             return
         }
+        let resultReceived = expectation(description: "Transcription result should be returned")
 
         predictionsService.detectEntities(image: url) { event in
             switch event {
@@ -444,10 +507,13 @@ class PredictionsServiceRekognitionTests: XCTestCase {
                 let entitiesResult = result as? IdentifyEntityMatchesResult
                 let newFaces = IdentifyEntitiesResultTransformers.processCollectionFaces(mockResponse.faceMatches!)
                 XCTAssertEqual(entitiesResult?.entities.count, newFaces.count, "Faces count number should be the same")
+                resultReceived.fulfill()
             case .failed(let error):
                 XCTFail("Should not produce error: \(error)")
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether error is correctly propogated for entity matches
@@ -460,11 +526,13 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyEntityMatchesServiceWithError() {
         setUpAmplify(withCollection: true)
+
         let mockError = NSError(domain: AWSRekognitionErrorDomain,
                                 code: AWSRekognitionErrorType.invalidImageFormat.rawValue,
                                 userInfo: [:])
         mockRekognition.setError(error: mockError)
         let url = URL(fileURLWithPath: "")
+        let errorReceived = expectation(description: "Error should be returned")
 
         predictionsService.detectEntities(image: url) { event in
             switch event {
@@ -472,8 +540,11 @@ class PredictionsServiceRekognitionTests: XCTestCase {
                 XCTFail("Should not produce result: \(result)")
             case .failed(let error):
                 XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether error is correctly propogated for entity matches when request is nil
@@ -487,11 +558,13 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     func testIdentifyEntityMatchesServiceWithNilResponse() {
         setUpAmplify(withCollection: true)
         mockRekognition.setFacesFromCollection(result: nil)
+
         let testBundle = Bundle(for: type(of: self))
         guard let url = testBundle.url(forResource: "testImageEntities", withExtension: "jpg") else {
             XCTFail("Unable to find image")
             return
         }
+        let errorReceived = expectation(description: "Error should be returned")
 
         predictionsService.detectEntities(image: url) { event in
             switch event {
@@ -499,8 +572,11 @@ class PredictionsServiceRekognitionTests: XCTestCase {
                 XCTFail("Should not produce result: \(result)")
             case .failed(let error):
                 XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether we can make a successfull rekognition call to identify plain text
@@ -513,6 +589,7 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyPlainTextService() {
         setUpAmplify()
+
         let mockResponse: AWSRekognitionDetectTextResponse = AWSRekognitionDetectTextResponse()
         mockResponse.textDetections = [AWSRekognitionTextDetection]()
 
@@ -522,6 +599,7 @@ class PredictionsServiceRekognitionTests: XCTestCase {
             XCTFail("Unable to find image")
             return
         }
+        let resultReceived = expectation(description: "Transcription result should be returned")
 
         predictionsService.detectText(image: url, format: .plain) { event in
             switch event {
@@ -530,10 +608,13 @@ class PredictionsServiceRekognitionTests: XCTestCase {
                 let newText = IdentifyTextResultTransformers.processText(mockResponse.textDetections!)
                 XCTAssertEqual(textResult?.identifiedLines?.count,
                                newText.identifiedLines?.count, "Text line count number should be the same")
+                resultReceived.fulfill()
             case .failed(let error):
                 XCTFail("Should not produce error: \(error)")
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether error is correctly propogated for text matches
@@ -546,11 +627,13 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyPlainTextServiceWithError() {
         setUpAmplify()
+
         let mockError = NSError(domain: AWSRekognitionErrorDomain,
                                 code: AWSRekognitionErrorType.invalidImageFormat.rawValue,
                                 userInfo: [:])
         mockRekognition.setError(error: mockError)
         let url = URL(fileURLWithPath: "")
+        let errorReceived = expectation(description: "Error should be returned")
 
         predictionsService.detectText(image: url, format: .plain) { event in
             switch event {
@@ -558,8 +641,11 @@ class PredictionsServiceRekognitionTests: XCTestCase {
                 XCTFail("Should not produce result: \(result)")
             case .failed(let error):
                 XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether error is correctly propogated for text matches and receive a nil response
@@ -579,6 +665,7 @@ class PredictionsServiceRekognitionTests: XCTestCase {
             XCTFail("Unable to find image")
             return
         }
+        let errorReceived = expectation(description: "Error should be returned")
 
         predictionsService.detectText(image: url, format: .plain) { event in
             switch event {
@@ -586,7 +673,10 @@ class PredictionsServiceRekognitionTests: XCTestCase {
                 XCTFail("Should not produce result: \(result)")
             case .failed(let error):
                 XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 }

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceTranscribeTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceTranscribeTests.swift
@@ -36,10 +36,12 @@ class PredictionsServiceTranscribeTests: XCTestCase {
                                                        awsTextract: MockTextractBehavior(),
                                                        awsComprehend: MockComprehendBehavior(),
                                                        awsPolly: MockPollyBehavior(),
-                                                       awsTranscribeStreaming: MockTranscribeBehavior(),
+                                                       awsTranscribeStreaming: mockTranscribe,
                                                        nativeWebSocketProvider: nativeWebSocketProvider,
                                                        transcribeClientDelegate: clientDelegate,
                                                        configuration: mockConfiguration)
+
+            mockTranscribe.setDelegate(delegate: clientDelegate, callbackQueue: dispatchQueue)
 
             let testBundle = Bundle(for: type(of: self))
             guard let url = testBundle.url(forResource: "audio", withExtension: "wav") else {
@@ -62,6 +64,8 @@ class PredictionsServiceTranscribeTests: XCTestCase {
         resultStream.alternatives = [alternative]
         results.results = [resultStream]
         transcriptEvent.transcript = results
+        transcriptEvent.transcript?.results?.first?.isPartial = false
+        mockResponse.transcriptEvent = transcriptEvent
         return mockResponse
     }
 
@@ -74,16 +78,22 @@ class PredictionsServiceTranscribeTests: XCTestCase {
     ///    - I should get back a result
     ///
     func testTranscribeService() {
-         let transcription = "This is a test"
+        let mockResponse = createMockTranscribeResponse()
+        mockTranscribe.setResult(result: mockResponse)
+        let expectedTranscription = "This is a test"
+        let resultReceived = expectation(description: "Transcription result should be returned")
+
         predictionsService.transcribe(speechToText: audioFile, language: .usEnglish) { event in
             switch event {
             case .completed(let result):
-                XCTAssertEqual(result.transcription, transcription, "transcribed text should be the same")
+                XCTAssertEqual(result.transcription, expectedTranscription, "transcribed text should be the same")
+                resultReceived.fulfill()
             case .failed(let error):
                 XCTFail("Should not produce error: \(error)")
             }
-
         }
+
+        waitForExpectations(timeout: 1)
 
     }
 
@@ -101,15 +111,19 @@ class PredictionsServiceTranscribeTests: XCTestCase {
                                 userInfo: [:])
         mockTranscribe.setError(error: mockError)
 
+        let errorReceived = expectation(description: "Error should be returned")
+
         predictionsService.transcribe(speechToText: audioFile, language: .usEnglish) { event in
             switch event {
             case .completed(let result):
                 XCTFail("Should not produce result: \(result)")
             case .failed(let error):
                 XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
             }
-
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test if language from configuration is picked up
@@ -122,16 +136,16 @@ class PredictionsServiceTranscribeTests: XCTestCase {
     ///
     func testLanguageFromConfiguration() {
         let mockConfigurationJSON = """
-        {
-            "defaultRegion": "us-east-1",
-            "convert": {
-                "transcription": {
-                    "region": "us-east-1",
-                    "language": "en-US"
+            {
+                "defaultRegion": "us-east-1",
+                "convert": {
+                    "transcription": {
+                        "region": "us-east-1",
+                        "language": "en-US"
+                    }
                 }
             }
-        }
-        """.data(using: .utf8)!
+            """.data(using: .utf8)!
         do {
             let clientDelegate = NativeWSTranscribeStreamingClientDelegate()
             let dispatchQueue = DispatchQueue(label: "TranscribeStreamingTests")
@@ -149,21 +163,28 @@ class PredictionsServiceTranscribeTests: XCTestCase {
                                                        nativeWebSocketProvider: nativeWebSocketProvider,
                                                        transcribeClientDelegate: clientDelegate,
                                                        configuration: mockConfiguration)
+
+            mockTranscribe.setDelegate(delegate: clientDelegate, callbackQueue: dispatchQueue)
         } catch {
             XCTFail("Initialization of the service failed. \(error)")
         }
 
         let mockResponse = createMockTranscribeResponse()
         mockTranscribe.setResult(result: mockResponse)
+        let expectedTranscription = "This is a test"
+        let resultReceived = expectation(description: "Transcription result should be returned")
 
         predictionsService.transcribe(speechToText: audioFile, language: nil) {event in
             switch event {
             case .completed(let result):
-                XCTAssertEqual(result.transcription, "This is a test", "Transcribed text should be the same")
+                XCTAssertEqual(result.transcription, expectedTranscription, "Transcribed text should be the same")
+                resultReceived.fulfill()
             case .failed(let error):
                 XCTFail("Should not produce error: \(error)")
             }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test if the service returns nil, we get an error back
@@ -176,13 +197,19 @@ class PredictionsServiceTranscribeTests: XCTestCase {
     ///
     func testNilResult() {
         mockTranscribe.setResult(result: nil)
+
+        let errorReceived = expectation(description: "Error should be returned")
+
         predictionsService.transcribe(speechToText: audioFile, language: nil) {event in
             switch event {
             case .completed(let result):
-                 XCTFail("Should not produce result: \(result)")
+                XCTFail("Should not produce result: \(result)")
             case .failed(let error):
-                 XCTAssertNotNil(error, "Should produce an error")
-             }
+                XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
+            }
         }
+
+        waitForExpectations(timeout: 1)
     }
 }

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceTranscribeTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceTranscribeTests.swift
@@ -61,10 +61,10 @@ class PredictionsServiceTranscribeTests: XCTestCase {
         let resultStream = AWSTranscribeStreamingResult()!
         let alternative = AWSTranscribeStreamingAlternative()!
         alternative.transcript = str
+        resultStream.isPartial = false
         resultStream.alternatives = [alternative]
         results.results = [resultStream]
         transcriptEvent.transcript = results
-        transcriptEvent.transcript?.results?.first?.isPartial = false
         mockResponse.transcriptEvent = transcriptEvent
         return mockResponse
     }

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceTranslateTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceTranslateTests.swift
@@ -56,18 +56,23 @@ class PredictionsServiceTranslateTests: XCTestCase {
         mockResponse.translatedText = "translated text here"
         mockTranslate.setResult(result: mockResponse)
 
+        let resultReceived = expectation(description: "Transcription result should be returned")
+
         predictionsService.translateText(text: "Hello there",
                                          language: .english,
                                          targetLanguage: .italian) { event in
-                                            switch event {
-                                            case .completed(let result):
-                                                XCTAssertEqual(result.text,
-                                                               mockResponse.translatedText,
-                                                               "Translated text should be same")
-                                            case .failed(let error):
-                                                XCTFail("Should not produce error: \(error)")
-                                            }
+            switch event {
+            case .completed(let result):
+                XCTAssertEqual(result.text,
+                               mockResponse.translatedText,
+                               "Translated text should be same")
+                resultReceived.fulfill()
+            case .failed(let error):
+                XCTFail("Should not produce error: \(error)")
+            }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test whether error is correctly propogated
@@ -79,22 +84,26 @@ class PredictionsServiceTranslateTests: XCTestCase {
     ///    - I should get back a service error
     ///
     func testTranslateServiceWithError() {
-
         let mockError = NSError(domain: AWSTranslateErrorDomain,
                                 code: AWSTranslateErrorType.invalidRequest.rawValue,
                                 userInfo: [:])
         mockTranslate.setError(error: mockError)
 
+        let errorReceived = expectation(description: "Error should be returned")
+
         predictionsService.translateText(text: "",
                                          language: .english,
                                          targetLanguage: .italian) { event in
-                                            switch event {
-                                            case .completed(let result):
-                                                XCTFail("Should not produce result: \(result)")
-                                            case .failed(let error):
-                                                XCTAssertNotNil(error, "Should produce an error")
-                                            }
+            switch event {
+            case .completed(let result):
+                XCTFail("Should not produce result: \(result)")
+            case .failed(let error):
+                XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
+            }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test if language from configuration is picked up
@@ -144,18 +153,23 @@ class PredictionsServiceTranslateTests: XCTestCase {
         mockResponse.translatedText = "translated text here"
         mockTranslate.setResult(result: mockResponse)
 
+        let resultReceived = expectation(description: "Transcription result should be returned")
+
         predictionsService.translateText(text: "Hello there",
-                              language: nil,
-                              targetLanguage: nil) { event in
-                                switch event {
-                                case .completed(let result):
-                                    XCTAssertEqual(result.text,
-                                                   mockResponse.translatedText,
-                                                   "Translated text should be same")
-                                case .failed(let error):
-                                    XCTFail("Should not produce error: \(error)")
-                                }
+                                         language: nil,
+                                         targetLanguage: nil) { event in
+            switch event {
+            case .completed(let result):
+                XCTAssertEqual(result.text,
+                               mockResponse.translatedText,
+                               "Translated text should be same")
+                resultReceived.fulfill()
+            case .failed(let error):
+                XCTFail("Should not produce error: \(error)")
+            }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test if the source language is nil error is thrown
@@ -171,16 +185,21 @@ class PredictionsServiceTranslateTests: XCTestCase {
         mockResponse.translatedText = "translated text here"
         mockTranslate.setResult(result: mockResponse)
 
+        let errorReceived = expectation(description: "Error should be returned")
+
         predictionsService.translateText(text: "",
                                          language: nil,
                                          targetLanguage: .italian) { event in
-                                            switch event {
-                                            case .completed(let result):
-                                                XCTFail("Should not produce result: \(result)")
-                                            case .failed(let error):
-                                                XCTAssertNotNil(error, "Should produce an error")
-                                            }
+            switch event {
+            case .completed(let result):
+                XCTFail("Should not produce result: \(result)")
+            case .failed(let error):
+                XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
+            }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test if the target is nil and configuration is not set
@@ -196,16 +215,21 @@ class PredictionsServiceTranslateTests: XCTestCase {
         mockResponse.translatedText = "translated text here"
         mockTranslate.setResult(result: mockResponse)
 
+        let errorReceived = expectation(description: "Error should be returned")
+
         predictionsService.translateText(text: "",
                                          language: .english,
                                          targetLanguage: nil) { event in
-                                            switch event {
-                                            case .completed(let result):
-                                                XCTFail("Should not produce result: \(result)")
-                                            case .failed(let error):
-                                                XCTAssertNotNil(error, "Should produce an error")
-                                            }
+            switch event {
+            case .completed(let result):
+                XCTFail("Should not produce result: \(result)")
+            case .failed(let error):
+                XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
+            }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test if the service returns nil, we get an error back
@@ -218,16 +242,22 @@ class PredictionsServiceTranslateTests: XCTestCase {
     ///
     func testNilResult() {
         mockTranslate.setResult(result: nil)
+
+        let errorReceived = expectation(description: "Error should be returned")
+
         predictionsService.translateText(text: "",
                                          language: .english,
                                          targetLanguage: .spanish) { event in
-                                            switch event {
-                                            case .completed(let result):
-                                                XCTFail("Should not produce result: \(result)")
-                                            case .failed(let error):
-                                                XCTAssertNotNil(error, "Should produce an error")
-                                            }
+            switch event {
+            case .completed(let result):
+                XCTFail("Should not produce result: \(result)")
+            case .failed(let error):
+                XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
+            }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test if the service returns nil for translated text, we get an error back
@@ -241,16 +271,22 @@ class PredictionsServiceTranslateTests: XCTestCase {
     func testNilTranslatedTextResult() {
         let mockResponse = AWSTranslateTranslateTextResponse()!
         mockTranslate.setResult(result: mockResponse)
+
+        let errorReceived = expectation(description: "Error should be returned")
+
         predictionsService.translateText(text: "",
                                          language: .english,
                                          targetLanguage: .spanish) { event in
-                                            switch event {
-                                            case .completed(let result):
-                                                XCTFail("Should not produce result: \(result)")
-                                            case .failed(let error):
-                                                XCTAssertNotNil(error, "Should produce an error")
-                                            }
+            switch event {
+            case .completed(let result):
+                XCTFail("Should not produce result: \(result)")
+            case .failed(let error):
+                XCTAssertNotNil(error, "Should produce an error")
+                errorReceived.fulfill()
+            }
         }
+
+        waitForExpectations(timeout: 1)
     }
 
     /// Test if the target language is set
@@ -266,18 +302,23 @@ class PredictionsServiceTranslateTests: XCTestCase {
         mockResponse.translatedText = "translated text here"
         mockTranslate.setResult(result: mockResponse)
 
+        let resultReceived = expectation(description: "Transcription result should be returned")
+
         predictionsService.translateText(text: "Hello there",
                                          language: .english,
                                          targetLanguage: .malayalam) { event in
-                                            switch event {
-                                            case .completed(let result):
-                                                XCTAssertEqual(result.text,
-                                                               mockResponse.translatedText,
-                                                               "Translated text should be same")
-                                                 XCTAssertEqual(result.targetLanguage, .malayalam)
-                                            case .failed(let error):
-                                                XCTFail("Should not produce error: \(error)")
-                                            }
+            switch event {
+            case .completed(let result):
+                XCTAssertEqual(result.text,
+                               mockResponse.translatedText,
+                               "Translated text should be same")
+                XCTAssertEqual(result.targetLanguage, .malayalam)
+                resultReceived.fulfill()
+            case .failed(let error):
+                XCTFail("Should not produce error: \(error)")
+            }
         }
+
+        waitForExpectations(timeout: 1)
     }
 }


### PR DESCRIPTION
*Description of changes:*

This PR solved several issues I found in unit tests:

1. Added `Expectation`, `fullfil()` and `wait()` to every test
2. Avoid force unwrap of error, otherwise fails the tests: https://github.com/aws-amplify/amplify-ios/pull/903/files#r527990223
3. Properly set `AWSTranscribeStreamingClientDelegate` in MockTranscribeStreamingBehavior.swift: https://github.com/aws-amplify/amplify-ios/pull/903/files#diff-36fd00eb37548e02a87ce71ab27eaaf5b486a863f2350501c4059c62efc319a5R39-R40, otherwise, the checking in callback is never run.
4. PredictionsServiceTextractTests should conforms to `XCTestCase` instead of `XCTest` otherwise, all the tests are not going to run: https://github.com/aws-amplify/amplify-ios/pull/903/files#diff-9db6d14f94733eac54f7efb37e462e3872117c41f5caf6e47da3504b2a0bc1d6R15
5. Type of casting is incorrect: https://github.com/aws-amplify/amplify-ios/pull/903/files#diff-9db6d14f94733eac54f7efb37e462e3872117c41f5caf6e47da3504b2a0bc1d6R70

Minor things that got fixed:

1. Formatting.
2. Assert failure of several tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
