### PR TITLE
fix(predictions): use string's unicode scalars view to compute indexes for Comprehend results

### DIFF
--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Comprehend.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Comprehend.swift
@@ -137,8 +137,8 @@ extension AWSPredictionsService: AWSComprehendServiceBehavior {
                 }
                 let beginOffSet = syntax.beginOffset?.intValue ?? 0
                 let endOffset = syntax.endOffset?.intValue ?? 0
-                let startIndex = text.index(text.startIndex, offsetBy: beginOffSet)
-                let endIndex = text.index(text.startIndex, offsetBy: endOffset)
+                let startIndex = text.unicodeScalars.index(text.startIndex, offsetBy: beginOffSet)
+                let endIndex = text.unicodeScalars.index(text.startIndex, offsetBy: endOffset)
                 let range = startIndex ..< endIndex
 
                 let score = comprehendPartOfSpeech.score?.floatValue
@@ -174,8 +174,8 @@ extension AWSPredictionsService: AWSComprehendServiceBehavior {
 
                 let beginOffSet = keyPhrase.beginOffset?.intValue ?? 0
                 let endOffset = keyPhrase.endOffset?.intValue ?? 0
-                let startIndex = text.index(text.startIndex, offsetBy: beginOffSet)
-                let endIndex = text.index(text.startIndex, offsetBy: endOffset)
+                let startIndex = text.unicodeScalars.index(text.startIndex, offsetBy: beginOffSet)
+                let endIndex = text.unicodeScalars.index(text.startIndex, offsetBy: endOffset)
                 let range = startIndex ..< endIndex
                 let amplifyKeyPhrase = KeyPhrase(text: keyPhrase.text ?? "",
                                                  range: range,
@@ -230,8 +230,8 @@ extension AWSPredictionsService: AWSComprehendServiceBehavior {
             for entity in entities {
                 let beginOffSet = entity.beginOffset?.intValue ?? 0
                 let endOffset = entity.endOffset?.intValue ?? 0
-                let startIndex = text.index(text.startIndex, offsetBy: beginOffSet)
-                let endIndex = text.index(text.startIndex, offsetBy: endOffset)
+                let startIndex = text.unicodeScalars.index(text.startIndex, offsetBy: beginOffSet)
+                let endIndex = text.unicodeScalars.index(text.startIndex, offsetBy: endOffset)
                 let range = startIndex ..< endIndex
                 let interpretEntity = EntityDetectionResult(type: entity.types.toAmplifyEntityType(),
                                                             targetText: entity.text ?? "",

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/InterpretBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/InterpretBasicIntegrationTests.swift
@@ -39,6 +39,50 @@ class InterpretBasicIntegrationTests: AWSPredictionsPluginTestBase {
         waitForExpectations(timeout: networkTimeout)
     }
 
+    /// Test if we can make successful calls to interpret when different input texts containing one or more emoji ZWJ (zero width joiner)/modifier
+    /// sequences.
+    ///
+    /// - Given: Configured Amplify with prediction added
+    /// - When:
+    ///    - I invoke interpret with text
+    /// - Then:
+    ///    - Should return no empty result
+    ///
+    func testInterpretTextWithEmojisWithMultipleUnicodeScalars() {
+        let inputTexts = [
+            """
+            👇🏾 is a modifier sequence combining 👇 Backhand Index Pointing Down and 🏾 Medium-Dark Skin
+            tone.
+            """,
+            """
+            “Here's to the crazy ones. The misfits. The rebels. The troublemakers 🏴‍☠️“.
+            A pirate flag is ZWJ sequence combining  🏴, Zero Width Joiner and ☠️.
+            """,
+            """
+            👩‍👩‍👧‍👧 family emojii is a ZWJ sequence combining:
+                👩 Woman, Zero Width Joiner,
+                👩 Woman, Zero Width Joiner,
+                👧 Girl, Zero Width Joiner
+                and a 👧 Girl.
+            """
+        ]
+
+        for text in inputTexts {
+            let interpretInvoked = expectation(description: "Interpret invoked")
+            let operation = Amplify.Predictions.interpret(text: text) { event in
+                switch event {
+                case .success(let result):
+                    interpretInvoked.fulfill()
+                    XCTAssertNotNil(result, "Result should contain value")
+                case .failure(let error):
+                    XCTFail("Should not receive error \(error) for text \(text)")
+                }
+            }
+            XCTAssertNotNil(operation)
+            waitForExpectations(timeout: networkTimeout)
+        }
+    }
+
     /// Test if we can make successful call to interpret
     ///
     /// - Given: Configured Amplify with prediction added


### PR DESCRIPTION
Amazon Comprehend returns an array of Entity https://docs.aws.amazon.com/comprehend/latest/dg/API_Entity.html .
Each entity has a _beginOffset_ and _endOffset_ properties, which are positions of each UTF-8 "code point" in the string.

A [code point](https://www.unicode.org/glossary/#code_point) is a value in the Unicode codespace, the range of integers from 0 to 10FFFF, not all code points are assigned to encoded chars.
We need to use Swift strings underlying scalar view to compute indexes correctly and avoid crashes at runtime.

fix #873 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
