### PR TITLE
fix(DataStore): Nested query predicates are not stored properly

### DIFF
--- a/Amplify/Categories/DataStore/Query/QueryPredicate.swift
+++ b/Amplify/Categories/DataStore/Query/QueryPredicate.swift
@@ -45,9 +45,7 @@ public class QueryPredicateGroup: QueryPredicate {
             predicates.append(predicate)
             return self
         }
-        let group = QueryPredicateGroup(type: .and, predicates: [predicate])
-        predicates.append(group)
-        return self
+        return QueryPredicateGroup(type: .and, predicates: [self, predicate])
     }
 
     public func or(_ predicate: QueryPredicate) -> QueryPredicateGroup {
@@ -55,9 +53,7 @@ public class QueryPredicateGroup: QueryPredicate {
             predicates.append(predicate)
             return self
         }
-        let group = QueryPredicateGroup(type: .or, predicates: [predicate])
-        predicates.append(group)
-        return self
+        return QueryPredicateGroup(type: .or, predicates: [self, predicate])
     }
 
     public static func && (lhs: QueryPredicateGroup, rhs: QueryPredicate) -> QueryPredicateGroup {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/QueryPredicateGraphQLTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/QueryPredicateGraphQLTests.swift
@@ -151,6 +151,70 @@ class QueryPredicateGraphQLTests: XCTestCase {
         XCTAssertEqual(result, expected)
     }
 
+    func testPredicateWithNestedAndOperator() throws {
+        let post = Post.keys
+        let predicate = (post.title.beginsWith("Title") && post.content.contains("content")) || post.id.eq("id")
+        let expected = """
+        {
+          "or" : [
+            {
+              "and" : [
+                {
+                  "title" : {
+                    "beginsWith" : "Title"
+                  }
+                },
+                {
+                  "content" : {
+                    "contains" : "content"
+                  }
+                }
+              ]
+            },
+            {
+              "id" : {
+                "eq" : "id"
+              }
+            }
+          ]
+        }
+        """
+        let result = try GraphQLFilterConverter.toJSON(predicate, options: [.prettyPrinted])
+        XCTAssertEqual(result, expected)
+    }
+
+    func testPredicateWithNestedOrOperator() throws {
+        let post = Post.keys
+        let predicate = (post.title.beginsWith("Title") || post.content.contains("content")) && post.id.eq("id")
+        let expected = """
+        {
+          "and" : [
+            {
+              "or" : [
+                {
+                  "title" : {
+                    "beginsWith" : "Title"
+                  }
+                },
+                {
+                  "content" : {
+                    "contains" : "content"
+                  }
+                }
+              ]
+            },
+            {
+              "id" : {
+                "eq" : "id"
+              }
+            }
+          ]
+        }
+        """
+        let result = try GraphQLFilterConverter.toJSON(predicate, options: [.prettyPrinted])
+        XCTAssertEqual(result, expected)
+    }
+
     func testJSONSerializationAndDeserialization() throws {
         let post = Post.keys
         let predicate = post.id.eq("id") && post.title.beginsWith("Title")


### PR DESCRIPTION
For Reference, android code:
https://github.com/aws-amplify/amplify-android/blame/12ec8e9819228f63bd677a0431a5ab191f79d9e1/core/src/main/java/com/amplifyframework/core/model/query/predicate/QueryPredicateGroup.java#L77

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
