### PR TITLE
chore(DataStore): Ability to evaluate QueryPredicate on Model instances

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -135,18 +135,32 @@
 		2CFB61C7E80D065C0A885A2F /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsTestCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5363CAF9EFAA822FED56808 /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsTestCommon.framework */; };
 		3263D332138415AF42E64FF7 /* Pods_AmplifyTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC7F1C368154B364CB74742 /* Pods_AmplifyTestApp.framework */; };
 		6B33896823AAACC900561E5B /* ReachabilityUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B33896723AAACC900561E5B /* ReachabilityUpdate.swift */; };
+		6B5087BD2565E5AD000AB673 /* QueryPredicateEvaluateGeneratedDoubleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5087BC2565E5AD000AB673 /* QueryPredicateEvaluateGeneratedDoubleTests.swift */; };
+		6B5087C125662DC3000AB673 /* QueryPredicateEvaluateGeneratedDoubleIntTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5087C025662DC3000AB673 /* QueryPredicateEvaluateGeneratedDoubleIntTests.swift */; };
+		6B5087C3256630DB000AB673 /* QueryPredicateEvaluateGeneratedIntTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5087C2256630DB000AB673 /* QueryPredicateEvaluateGeneratedIntTests.swift */; };
+		6B5087C5256632D3000AB673 /* QueryPredicateEvaluateGeneratedStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5087C4256632D3000AB673 /* QueryPredicateEvaluateGeneratedStringTests.swift */; };
+		6B5087C7256638EA000AB673 /* QueryPredicateEvaluateGeneratedDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5087C6256638EA000AB673 /* QueryPredicateEvaluateGeneratedDateTests.swift */; };
+		6B5087C92566F0FF000AB673 /* QueryPredicateEvaluateGeneratedIntDoubleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5087C82566F0FF000AB673 /* QueryPredicateEvaluateGeneratedIntDoubleTests.swift */; };
+		6B5087CB2566F70F000AB673 /* QueryPredicateEvaluateGeneratedDateTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5087CA2566F70F000AB673 /* QueryPredicateEvaluateGeneratedDateTimeTests.swift */; };
+		6B5087CD25673AC8000AB673 /* QueryPredicateEvaluateGeneratedTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5087CC25673AC8000AB673 /* QueryPredicateEvaluateGeneratedTimeTests.swift */; };
+		6B5087CF25674F99000AB673 /* QueryPredicateEvaluateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5087CE25674F99000AB673 /* QueryPredicateEvaluateTests.swift */; };
 		6B50C917253E2AD9007B16DD /* AmplifyAPICategory+AuthProviderFactoryBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B50C916253E2AD9007B16DD /* AmplifyAPICategory+AuthProviderFactoryBehavior.swift */; };
 		6B50C91A253E2B16007B16DD /* APIAuthProviderFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B50C919253E2B16007B16DD /* APIAuthProviderFactory.swift */; };
 		6B50C91C253E2B57007B16DD /* APICategoryAuthProviderFactoryBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B50C91B253E2B57007B16DD /* APICategoryAuthProviderFactoryBehavior.swift */; };
+		6B5979CB2565D18B0038C3E2 /* QueryPredicateEvaluateGeneratedBoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5979CA2565D18B0038C3E2 /* QueryPredicateEvaluateGeneratedBoolTests.swift */; };
+		6B597A0A2565D3E50038C3E2 /* QPredGen+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B597A082565D3E40038C3E2 /* QPredGen+Schema.swift */; };
+		6B597A0B2565D3E50038C3E2 /* QPredGen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B597A092565D3E50038C3E2 /* QPredGen.swift */; };
 		6B767FB723AC092800C683ED /* AmplifyAPICategory+ReachabilityBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B767FB623AC092800C683ED /* AmplifyAPICategory+ReachabilityBehavior.swift */; };
 		6B767FB923AC0A0D00C683ED /* APICategoryReachabilityBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B767FB823AC0A0D00C683ED /* APICategoryReachabilityBehavior.swift */; };
 		6B9F7C5225267E1500F1F71C /* MockAWSAuthUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9F7C5125267E1500F1F71C /* MockAWSAuthUser.swift */; };
 		6B9F7C552526864800F1F71C /* ScenarioATest6Post+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9F7C532526864800F1F71C /* ScenarioATest6Post+Schema.swift */; };
 		6B9F7C562526864800F1F71C /* ScenarioATest6Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9F7C542526864800F1F71C /* ScenarioATest6Post.swift */; };
 		6B9F7C59252687CC00F1F71C /* GraphQLRequestAuthIdentityClaimTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9F7C572526875A00F1F71C /* GraphQLRequestAuthIdentityClaimTests.swift */; };
+		6BAF4F38256893B900A811BA /* QueryPredicateEvaluateGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BAF4F37256893B900A811BA /* QueryPredicateEvaluateGenerator.swift */; };
 		6BB7441023A9954900B0EB6C /* DispatchSource+MakeOneOff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB7440F23A9954900B0EB6C /* DispatchSource+MakeOneOff.swift */; };
 		6BBECD7123ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BBECD7023ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift */; };
 		6BBECD7423ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BBECD7323ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift */; };
+		6BDD6320256353F0008D70DF /* Evaluable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDD631F256353F0008D70DF /* Evaluable.swift */; };
 		6BDF15B62541262000B5BE69 /* ModelWithOwnerAuthAndGroupWithGroupClaim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDF15B52541262000B5BE69 /* ModelWithOwnerAuthAndGroupWithGroupClaim.swift */; };
 		6BDF15B825412DE600B5BE69 /* ModelWithOwnerAuthAndMultiGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDF15B725412DE600B5BE69 /* ModelWithOwnerAuthAndMultiGroup.swift */; };
 		6BEE0817253114FD00133961 /* AWSAuthServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE0816253114FD00133961 /* AWSAuthServiceTests.swift */; };
@@ -907,9 +921,21 @@
 		687B09E9348F8D29979A2404 /* Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests/Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6AF0E4775809F0866F9C44D9 /* Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig"; path = "Target Support Files/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6B33896723AAACC900561E5B /* ReachabilityUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReachabilityUpdate.swift; sourceTree = "<group>"; };
+		6B5087BC2565E5AD000AB673 /* QueryPredicateEvaluateGeneratedDoubleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPredicateEvaluateGeneratedDoubleTests.swift; sourceTree = "<group>"; };
+		6B5087C025662DC3000AB673 /* QueryPredicateEvaluateGeneratedDoubleIntTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPredicateEvaluateGeneratedDoubleIntTests.swift; sourceTree = "<group>"; };
+		6B5087C2256630DB000AB673 /* QueryPredicateEvaluateGeneratedIntTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPredicateEvaluateGeneratedIntTests.swift; sourceTree = "<group>"; };
+		6B5087C4256632D3000AB673 /* QueryPredicateEvaluateGeneratedStringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPredicateEvaluateGeneratedStringTests.swift; sourceTree = "<group>"; };
+		6B5087C6256638EA000AB673 /* QueryPredicateEvaluateGeneratedDateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPredicateEvaluateGeneratedDateTests.swift; sourceTree = "<group>"; };
+		6B5087C82566F0FF000AB673 /* QueryPredicateEvaluateGeneratedIntDoubleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPredicateEvaluateGeneratedIntDoubleTests.swift; sourceTree = "<group>"; };
+		6B5087CA2566F70F000AB673 /* QueryPredicateEvaluateGeneratedDateTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPredicateEvaluateGeneratedDateTimeTests.swift; sourceTree = "<group>"; };
+		6B5087CC25673AC8000AB673 /* QueryPredicateEvaluateGeneratedTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPredicateEvaluateGeneratedTimeTests.swift; sourceTree = "<group>"; };
+		6B5087CE25674F99000AB673 /* QueryPredicateEvaluateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPredicateEvaluateTests.swift; sourceTree = "<group>"; };
 		6B50C916253E2AD9007B16DD /* AmplifyAPICategory+AuthProviderFactoryBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AmplifyAPICategory+AuthProviderFactoryBehavior.swift"; sourceTree = "<group>"; };
 		6B50C919253E2B16007B16DD /* APIAuthProviderFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIAuthProviderFactory.swift; sourceTree = "<group>"; };
 		6B50C91B253E2B57007B16DD /* APICategoryAuthProviderFactoryBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APICategoryAuthProviderFactoryBehavior.swift; sourceTree = "<group>"; };
+		6B5979CA2565D18B0038C3E2 /* QueryPredicateEvaluateGeneratedBoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPredicateEvaluateGeneratedBoolTests.swift; sourceTree = "<group>"; };
+		6B597A082565D3E40038C3E2 /* QPredGen+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "QPredGen+Schema.swift"; sourceTree = "<group>"; };
+		6B597A092565D3E50038C3E2 /* QPredGen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QPredGen.swift; sourceTree = "<group>"; };
 		6B767FB623AC092800C683ED /* AmplifyAPICategory+ReachabilityBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AmplifyAPICategory+ReachabilityBehavior.swift"; sourceTree = "<group>"; };
 		6B767FB823AC0A0D00C683ED /* APICategoryReachabilityBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICategoryReachabilityBehavior.swift; sourceTree = "<group>"; };
 		6B9F7C5125267E1500F1F71C /* MockAWSAuthUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSAuthUser.swift; sourceTree = "<group>"; };
@@ -917,9 +943,11 @@
 		6B9F7C542526864800F1F71C /* ScenarioATest6Post.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScenarioATest6Post.swift; sourceTree = "<group>"; };
 		6B9F7C572526875A00F1F71C /* GraphQLRequestAuthIdentityClaimTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRequestAuthIdentityClaimTests.swift; sourceTree = "<group>"; };
 		6BAC32194A15ACB56F07DC87 /* Pods-AWSS3StoragePlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSS3StoragePlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSS3StoragePlugin/Pods-AWSS3StoragePlugin.debug.xcconfig"; sourceTree = "<group>"; };
+		6BAF4F37256893B900A811BA /* QueryPredicateEvaluateGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPredicateEvaluateGenerator.swift; sourceTree = "<group>"; };
 		6BB7440F23A9954900B0EB6C /* DispatchSource+MakeOneOff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchSource+MakeOneOff.swift"; sourceTree = "<group>"; };
 		6BBECD7023ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplifyAWSServiceConfiguration.swift; sourceTree = "<group>"; };
 		6BBECD7323ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplifyAWSServiceConfigurationTests.swift; sourceTree = "<group>"; };
+		6BDD631F256353F0008D70DF /* Evaluable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Evaluable.swift; sourceTree = "<group>"; };
 		6BDF15B52541262000B5BE69 /* ModelWithOwnerAuthAndGroupWithGroupClaim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelWithOwnerAuthAndGroupWithGroupClaim.swift; sourceTree = "<group>"; };
 		6BDF15B725412DE600B5BE69 /* ModelWithOwnerAuthAndMultiGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelWithOwnerAuthAndMultiGroup.swift; sourceTree = "<group>"; };
 		6BEE0816253114FD00133961 /* AWSAuthServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAuthServiceTests.swift; sourceTree = "<group>"; };
@@ -2079,6 +2107,24 @@
 			path = AuthProvider;
 			sourceTree = "<group>";
 		};
+		6B59798B2564DB210038C3E2 /* Query */ = {
+			isa = PBXGroup;
+			children = (
+				6B5087CE25674F99000AB673 /* QueryPredicateEvaluateTests.swift */,
+				6BAF4F37256893B900A811BA /* QueryPredicateEvaluateGenerator.swift */,
+				6B5979CA2565D18B0038C3E2 /* QueryPredicateEvaluateGeneratedBoolTests.swift */,
+				6B5087BC2565E5AD000AB673 /* QueryPredicateEvaluateGeneratedDoubleTests.swift */,
+				6B5087C025662DC3000AB673 /* QueryPredicateEvaluateGeneratedDoubleIntTests.swift */,
+				6B5087C82566F0FF000AB673 /* QueryPredicateEvaluateGeneratedIntDoubleTests.swift */,
+				6B5087C2256630DB000AB673 /* QueryPredicateEvaluateGeneratedIntTests.swift */,
+				6B5087C4256632D3000AB673 /* QueryPredicateEvaluateGeneratedStringTests.swift */,
+				6B5087C6256638EA000AB673 /* QueryPredicateEvaluateGeneratedDateTests.swift */,
+				6B5087CA2566F70F000AB673 /* QueryPredicateEvaluateGeneratedDateTimeTests.swift */,
+				6B5087CC25673AC8000AB673 /* QueryPredicateEvaluateGeneratedTimeTests.swift */,
+			);
+			path = Query;
+			sourceTree = "<group>";
+		};
 		6BBECD6F23ADA7C100C8DFBE /* ServiceConfiguration */ = {
 			isa = PBXGroup;
 			children = (
@@ -2550,6 +2596,8 @@
 				6BEE08232533D30800133961 /* OGCScenarioBMGroupPost+Schema.swift */,
 				6BEE081B2533CCFA00133961 /* OGCScenarioBPost.swift */,
 				6BEE081A2533CCFA00133961 /* OGCScenarioBPost+Schema.swift */,
+				6B597A092565D3E50038C3E2 /* QPredGen.swift */,
+				6B597A082565D3E40038C3E2 /* QPredGen+Schema.swift */,
 				B952182F237E21B900F53237 /* schema.graphql */,
 				6B9F7C542526864800F1F71C /* ScenarioATest6Post.swift */,
 				6B9F7C532526864800F1F71C /* ScenarioATest6Post+Schema.swift */,
@@ -2582,6 +2630,7 @@
 		B98E9D042372236200934B51 /* Query */ = {
 			isa = PBXGroup;
 			children = (
+				6BDD631F256353F0008D70DF /* Evaluable.swift */,
 				B98E9D062372236200934B51 /* ModelKey.swift */,
 				B98E9D0A2372236200934B51 /* QueryField.swift */,
 				B98E9D072372236200934B51 /* QueryOperator.swift */,
@@ -2770,6 +2819,7 @@
 				6BEE0815253114E600133961 /* Auth */,
 				FA131ABB2360FE070008381C /* Info.plist */,
 				2129BE2223948085006363A1 /* Model */,
+				6B59798B2564DB210038C3E2 /* Query */,
 				2129BE4523948975006363A1 /* Sync */,
 				6BBECD7223ADA9B400C8DFBE /* ServiceConfiguration */,
 			);
@@ -4345,6 +4395,8 @@
 				2183A56923EA4A9100232880 /* GraphQLUpdateMutationTests.swift in Sources */,
 				21A3FDB9246494CD00E76120 /* GraphQLRequestAuthRuleTests.swift in Sources */,
 				21A3FDB62464590600E76120 /* ModelMultipleOwnerAuthRuleTests.swift in Sources */,
+				6B5087BD2565E5AD000AB673 /* QueryPredicateEvaluateGeneratedDoubleTests.swift in Sources */,
+				6B5087C5256632D3000AB673 /* QueryPredicateEvaluateGeneratedStringTests.swift in Sources */,
 				2129BE3A2394828B006363A1 /* QueryPredicateGraphQLTests.swift in Sources */,
 				2129BE48239489AC006363A1 /* MutationSyncMetadataTests.swift in Sources */,
 				216E45F1248E971E0035E3CE /* GraphQLRequestEmbeddableTypeTests.swift in Sources */,
@@ -4352,21 +4404,30 @@
 				6BDF15B825412DE600B5BE69 /* ModelWithOwnerAuthAndMultiGroup.swift in Sources */,
 				2183A56823EA4A8E00232880 /* GraphQLDeleteMutationTests.swift in Sources */,
 				21A3FDB42463C49F00E76120 /* ModelReadUpdateAuthRuleTests.swift in Sources */,
+				6B5087CB2566F70F000AB673 /* QueryPredicateEvaluateGeneratedDateTimeTests.swift in Sources */,
 				2183A56323EA4A7800232880 /* GraphQLSubscriptionTests.swift in Sources */,
 				214F497E2486DA5000DA616C /* GraphQLRequestOptionalAssociationTests.swift in Sources */,
+				6B5087C92566F0FF000AB673 /* QueryPredicateEvaluateGeneratedIntDoubleTests.swift in Sources */,
 				2129BE562395CAF9006363A1 /* PaginatedListTests.swift in Sources */,
 				2183A56723EA4A8B00232880 /* GraphQLCreateMutationTests.swift in Sources */,
+				6B5087CF25674F99000AB673 /* QueryPredicateEvaluateTests.swift in Sources */,
+				6B5979CB2565D18B0038C3E2 /* QueryPredicateEvaluateGeneratedBoolTests.swift in Sources */,
 				2183A56623EA4A8700232880 /* GraphQLSyncQueryTests.swift in Sources */,
 				B43D7C392538B532002659DB /* GraphQLRequestEmbeddableTypeJSONTests.swift in Sources */,
+				6B5087C125662DC3000AB673 /* QueryPredicateEvaluateGeneratedDoubleIntTests.swift in Sources */,
 				219A888723EB89C200BBC5F2 /* GraphQLRequestAnyModelWithSyncTests.swift in Sources */,
 				2183A56423EA4A7F00232880 /* GraphQLGetQueryTests.swift in Sources */,
+				6B5087C7256638EA000AB673 /* QueryPredicateEvaluateGeneratedDateTests.swift in Sources */,
 				6BBECD7423ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift in Sources */,
+				6BAF4F38256893B900A811BA /* QueryPredicateEvaluateGenerator.swift in Sources */,
 				6B9F7C5225267E1500F1F71C /* MockAWSAuthUser.swift in Sources */,
+				6B5087CD25673AC8000AB673 /* QueryPredicateEvaluateGeneratedTimeTests.swift in Sources */,
 				21AD425A249C0D910016FE95 /* AnyModelTester.swift in Sources */,
 				6BDF15B62541262000B5BE69 /* ModelWithOwnerAuthAndGroupWithGroupClaim.swift in Sources */,
 				2129BE3C2394828B006363A1 /* GraphQLRequestModelTests.swift in Sources */,
 				2183A56523EA4A8400232880 /* GraphQLListQueryTests.swift in Sources */,
 				6BEE08192533CAA600133961 /* GraphQLRequestOwnerAndGroupTests.swift in Sources */,
+				6B5087C3256630DB000AB673 /* QueryPredicateEvaluateGeneratedIntTests.swift in Sources */,
 				21AD425B249C0DBE0016FE95 /* AnyModelTests.swift in Sources */,
 				D83C5160248964780091548E /* ModelGraphQLTests.swift in Sources */,
 			);
@@ -4715,6 +4776,7 @@
 				FA56F72522B14B6A0039754A /* Resumable.swift in Sources */,
 				B4C498FA2415D24B00067992 /* AuthProvider.swift in Sources */,
 				FAA2E8C023A00C6500E420EA /* AmplifyAPICategory+APICategory.swift in Sources */,
+				6BDD6320256353F0008D70DF /* Evaluable.swift in Sources */,
 				21FFF997230C96CB005878EA /* StorageRemoveOperation.swift in Sources */,
 				FAC2351C227A053D00424678 /* APICategoryPlugin.swift in Sources */,
 				FA176ED52385012000C5C5F9 /* DataStoreCategory+HubPayloadEventName.swift in Sources */,
@@ -4889,7 +4951,9 @@
 				FACA36152327FC39000E74F6 /* MessageReporter.swift in Sources */,
 				FAF512AE23986791001ADF4E /* AmplifyModels.swift in Sources */,
 				B9FAA11C23879B35009414B4 /* Book.swift in Sources */,
+				6B597A0B2565D3E50038C3E2 /* QPredGen.swift in Sources */,
 				975751B424D21DE000FA0A6E /* MockDevMenuContextProvider.swift in Sources */,
+				6B597A0A2565D3E50038C3E2 /* QPredGen+Schema.swift in Sources */,
 				214F49772486D8A200DA616C /* UserFollowers+Schema.swift in Sources */,
 				B9FAA11423878CEA009414B4 /* UserProfile+Schema.swift in Sources */,
 				214F49792486D8A200DA616C /* UserFollowing+Schema.swift in Sources */,

--- a/Amplify/Categories/DataStore/Model/Internal/Persistable.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Persistable.swift
@@ -67,4 +67,176 @@ struct PersistableHelper {
             return false
         }
     }
+
+    public static func isEqual(_ lhs: Persistable?, _ rhs: Any?) -> Bool {
+        if lhs == nil && rhs == nil {
+            return true
+        }
+        switch (lhs, rhs) {
+        case let (lhs, rhs) as (Bool, Bool):
+            return lhs == rhs
+        case let (lhs, rhs) as (Temporal.Date, Temporal.Date):
+            return lhs == rhs
+        case let (lhs, rhs) as (Temporal.DateTime, Temporal.DateTime):
+            return lhs == rhs
+        case let (lhs, rhs) as (Temporal.Time, Temporal.Time):
+            return lhs == rhs
+        case let (lhs, rhs) as (Double, Double):
+            return lhs == rhs
+        case let (lhs, rhs) as (Int, Int):
+            return lhs == rhs
+        case let (lhs, rhs) as (Int, Double):
+            return Double(lhs) == rhs
+        case let (lhs, rhs) as (Double, Int):
+            return lhs == Double(rhs)
+        case let (lhs, rhs) as (String, String):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+
+    public static func isLessOrEqual(_ lhs: Persistable?, _ rhs: Any?) -> Bool {
+        if lhs == nil && rhs == nil {
+            return true
+        }
+        switch (lhs, rhs) {
+        //case Bool Removed
+        case let (lhs, rhs) as (Temporal.Date, Temporal.Date):
+            return rhs <= lhs
+        case let (lhs, rhs) as (Temporal.DateTime, Temporal.DateTime):
+            return rhs <= lhs
+        case let (lhs, rhs) as (Temporal.Time, Temporal.Time):
+            return rhs <= lhs
+        case let (lhs, rhs) as (Double, Double):
+            return rhs <= lhs
+        case let (lhs, rhs) as (Int, Int):
+            return rhs <= lhs
+        case let (lhs, rhs) as (Int, Double):
+            return rhs <= Double(lhs)
+        case let (lhs, rhs) as (Double, Int):
+            return Double(rhs) <= lhs
+        case let (lhs, rhs) as (String, String):
+            return rhs <= lhs
+        default:
+            return false
+        }
+    }
+
+    public static func isLessThan(_ lhs: Persistable?, _ rhs: Any?) -> Bool {
+        if lhs == nil && rhs == nil {
+            return false
+        }
+        switch (lhs, rhs) {
+        //case Bool Removed
+        case let (lhs, rhs) as (Temporal.Date, Temporal.Date):
+            return rhs < lhs
+        case let (lhs, rhs) as (Temporal.DateTime, Temporal.DateTime):
+            return rhs < lhs
+        case let (lhs, rhs) as (Temporal.Time, Temporal.Time):
+            return rhs < lhs
+        case let (lhs, rhs) as (Double, Double):
+            return rhs < lhs
+        case let (lhs, rhs) as (Int, Int):
+            return rhs < lhs
+        case let (lhs, rhs) as (Int, Double):
+            return rhs < Double(lhs)
+        case let (lhs, rhs) as (Double, Int):
+            return Double(rhs) < lhs
+        case let (lhs, rhs) as (String, String):
+            return rhs < lhs
+        default:
+            return false
+        }
+    }
+
+    public static func isGreaterOrEqual(_ lhs: Persistable?, _ rhs: Any?) -> Bool {
+        if lhs == nil && rhs == nil {
+            return true
+        }
+        switch (lhs, rhs) {
+        //case Bool Removed
+        case let (lhs, rhs) as (Temporal.Date, Temporal.Date):
+            return rhs >= lhs
+        case let (lhs, rhs) as (Temporal.DateTime, Temporal.DateTime):
+            return rhs >= lhs
+        case let (lhs, rhs) as (Temporal.Time, Temporal.Time):
+            return rhs >= lhs
+        case let (lhs, rhs) as (Double, Double):
+            return rhs >= lhs
+        case let (lhs, rhs) as (Int, Int):
+            return rhs >= lhs
+        case let (lhs, rhs) as (Int, Double):
+            return rhs >= Double(lhs)
+        case let (lhs, rhs) as (Double, Int):
+            return Double(rhs) >= lhs
+        case let (lhs, rhs) as (String, String):
+            return rhs >= lhs
+        default:
+            return false
+        }
+    }
+
+    public static func isGreaterThan(_ lhs: Persistable?, _ rhs: Any?) -> Bool {
+        if lhs == nil && rhs == nil {
+            return false
+        }
+        switch (lhs, rhs) {
+        //case Bool Removed
+        case let (lhs, rhs) as (Temporal.Date, Temporal.Date):
+            return rhs > lhs
+        case let (lhs, rhs) as (Temporal.DateTime, Temporal.DateTime):
+            return rhs > lhs
+        case let (lhs, rhs) as (Temporal.Time, Temporal.Time):
+            return rhs > lhs
+        case let (lhs, rhs) as (Double, Double):
+            return rhs > lhs
+        case let (lhs, rhs) as (Int, Int):
+            return rhs > lhs
+        case let (lhs, rhs) as (Double, Int):
+            return Double(rhs) > lhs
+        case let (lhs, rhs) as (Int, Double):
+            return rhs > Double(lhs)
+        case let (lhs, rhs) as (String, String):
+            return rhs > lhs
+        default:
+            return false
+        }
+    }
+
+    public static func isBetween(_ start: Persistable, _ end: Persistable, _ rhs: Any?) -> Bool {
+        if rhs == nil {
+            return false
+        }
+        switch (start, end, rhs) {
+        //case Bool Removed
+        case let (start, end, rhs) as (Temporal.Date, Temporal.Date, Temporal.Date):
+            return start < rhs && rhs < end
+        case let (start, end, rhs) as (Temporal.DateTime, Temporal.DateTime, Temporal.DateTime):
+            return start < rhs && rhs < end
+        case let (start, end, rhs) as (Temporal.Time, Temporal.Time, Temporal.Time):
+            return start < rhs && rhs < end
+        case let (start, end, rhs) as (Int, Int, Int):
+            return start < rhs && rhs < end
+        case let (start, end, rhs) as (Int, Int, Double):
+            return Double(start) < Double(rhs) && Double(rhs) < Double(end)
+        case let (start, end, rhs) as (Int, Double, Int):
+            return Double(start) < Double(rhs) && Double(rhs) < Double(end)
+        case let (start, end, rhs) as (Int, Double, Double):
+            return Double(start) < Double(rhs) && Double(rhs) < Double(end)
+        case let (start, end, rhs) as (Double, Int, Int):
+            return Double(start) < Double(rhs) && Double(rhs) < Double(end)
+        case let (start, end, rhs) as (Double, Int, Double):
+            return Double(start) < Double(rhs) && Double(rhs) < Double(end)
+        case let (start, end, rhs) as (Double, Double, Int):
+            return Double(start) < Double(rhs) && Double(rhs) < Double(end)
+        case let (start, end, rhs) as (Double, Double, Double):
+            return Double(start) < Double(rhs) && Double(rhs) < Double(end)
+
+        case let (start, end, rhs) as (String, String, String):
+            return start < rhs && rhs < end
+        default:
+            return false
+        }
+    }
 }

--- a/Amplify/Categories/DataStore/Model/Internal/Persistable.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Persistable.swift
@@ -68,6 +68,7 @@ struct PersistableHelper {
         }
     }
 
+    //We are promoting Int to Double in the case where we are comparing these two types
     public static func isEqual(_ lhs: Any?, _ rhs: Persistable?) -> Bool {
         if lhs == nil && rhs == nil {
             return true
@@ -96,6 +97,7 @@ struct PersistableHelper {
         }
     }
 
+    //We are promoting Int to Double in the case where we are comparing these two types
     public static func isLessOrEqual(_ lhs: Any?, _ rhs: Persistable?) -> Bool {
         if lhs == nil && rhs == nil {
             return true
@@ -123,6 +125,7 @@ struct PersistableHelper {
         }
     }
 
+    //We are promoting Int to Double in the case where we are comparing these two types
     public static func isLessThan(_ lhs: Any?, _ rhs: Persistable?) -> Bool {
         if lhs == nil && rhs == nil {
             return false
@@ -150,6 +153,7 @@ struct PersistableHelper {
         }
     }
 
+    //We are promoting Int to Double in the case where we are comparing these two types
     public static func isGreaterOrEqual(_ lhs: Any?, _ rhs: Persistable?) -> Bool {
         if lhs == nil && rhs == nil {
             return true
@@ -177,6 +181,7 @@ struct PersistableHelper {
         }
     }
 
+    //We are promoting Int to Double in the case where we are comparing these two types
     public static func isGreaterThan(_ lhs: Any?, _ rhs: Persistable?) -> Bool {
         if lhs == nil && rhs == nil {
             return false
@@ -204,38 +209,10 @@ struct PersistableHelper {
         }
     }
 
-    public static func isBetween(_ start: Persistable, _ end: Persistable, _ rhs: Any?) -> Bool {
-        if rhs == nil {
+    public static func isBetween(_ start: Persistable, _ end: Persistable, _ value: Any?) -> Bool {
+        if value == nil {
             return false
         }
-        switch (start, end, rhs) {
-        //case Bool Removed
-        case let (start, end, rhs) as (Temporal.Date, Temporal.Date, Temporal.Date):
-            return start <= rhs && rhs <= end
-        case let (start, end, rhs) as (Temporal.DateTime, Temporal.DateTime, Temporal.DateTime):
-            return start <= rhs && rhs <= end
-        case let (start, end, rhs) as (Temporal.Time, Temporal.Time, Temporal.Time):
-            return start <= rhs && rhs <= end
-        case let (start, end, rhs) as (Int, Int, Int):
-            return start <= rhs && rhs <= end
-        case let (start, end, rhs) as (Int, Int, Double):
-            return Double(start) <= rhs && rhs <= Double(end)
-        case let (start, end, rhs) as (Int, Double, Int):
-            return start <= rhs && Double(rhs) <= end
-        case let (start, end, rhs) as (Int, Double, Double):
-            return Double(start) <= rhs && rhs <= end
-        case let (start, end, rhs) as (Double, Int, Int):
-            return start <= Double(rhs) && rhs <= end
-        case let (start, end, rhs) as (Double, Int, Double):
-            return start <= rhs && rhs <= Double(end)
-        case let (start, end, rhs) as (Double, Double, Int):
-            return start <= Double(rhs) && Double(rhs) <= end
-        case let (start, end, rhs) as (Double, Double, Double):
-            return start <= rhs && rhs <= end
-        case let (start, end, rhs) as (String, String, String):
-            return start <= rhs && rhs <= end
-        default:
-            return false
-        }
+        return isGreaterOrEqual(value, start) && isLessOrEqual(value, end)
     }
 }

--- a/Amplify/Categories/DataStore/Model/Internal/Persistable.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Persistable.swift
@@ -68,7 +68,7 @@ struct PersistableHelper {
         }
     }
 
-    public static func isEqual(_ lhs: Persistable?, _ rhs: Any?) -> Bool {
+    public static func isEqual(_ lhs: Any?, _ rhs: Persistable?) -> Bool {
         if lhs == nil && rhs == nil {
             return true
         }
@@ -96,109 +96,109 @@ struct PersistableHelper {
         }
     }
 
-    public static func isLessOrEqual(_ lhs: Persistable?, _ rhs: Any?) -> Bool {
+    public static func isLessOrEqual(_ lhs: Any?, _ rhs: Persistable?) -> Bool {
         if lhs == nil && rhs == nil {
             return true
         }
         switch (lhs, rhs) {
         //case Bool Removed
         case let (lhs, rhs) as (Temporal.Date, Temporal.Date):
-            return rhs <= lhs
+            return lhs <= rhs
         case let (lhs, rhs) as (Temporal.DateTime, Temporal.DateTime):
-            return rhs <= lhs
+            return lhs <= rhs
         case let (lhs, rhs) as (Temporal.Time, Temporal.Time):
-            return rhs <= lhs
+            return lhs <= rhs
         case let (lhs, rhs) as (Double, Double):
-            return rhs <= lhs
+            return lhs <= rhs
         case let (lhs, rhs) as (Int, Int):
-            return rhs <= lhs
+            return lhs <= rhs
         case let (lhs, rhs) as (Int, Double):
-            return rhs <= Double(lhs)
+            return Double(lhs) <= rhs
         case let (lhs, rhs) as (Double, Int):
-            return Double(rhs) <= lhs
+            return lhs <= Double(rhs)
         case let (lhs, rhs) as (String, String):
-            return rhs <= lhs
+            return lhs <= rhs
         default:
             return false
         }
     }
 
-    public static func isLessThan(_ lhs: Persistable?, _ rhs: Any?) -> Bool {
+    public static func isLessThan(_ lhs: Any?, _ rhs: Persistable?) -> Bool {
         if lhs == nil && rhs == nil {
             return false
         }
         switch (lhs, rhs) {
         //case Bool Removed
         case let (lhs, rhs) as (Temporal.Date, Temporal.Date):
-            return rhs < lhs
+            return lhs < rhs
         case let (lhs, rhs) as (Temporal.DateTime, Temporal.DateTime):
-            return rhs < lhs
+            return lhs < rhs
         case let (lhs, rhs) as (Temporal.Time, Temporal.Time):
-            return rhs < lhs
+            return lhs < rhs
         case let (lhs, rhs) as (Double, Double):
-            return rhs < lhs
+            return lhs < rhs
         case let (lhs, rhs) as (Int, Int):
-            return rhs < lhs
+            return lhs < rhs
         case let (lhs, rhs) as (Int, Double):
-            return rhs < Double(lhs)
+            return Double(lhs) < rhs
         case let (lhs, rhs) as (Double, Int):
-            return Double(rhs) < lhs
+            return lhs < Double(rhs)
         case let (lhs, rhs) as (String, String):
-            return rhs < lhs
+            return lhs < rhs
         default:
             return false
         }
     }
 
-    public static func isGreaterOrEqual(_ lhs: Persistable?, _ rhs: Any?) -> Bool {
+    public static func isGreaterOrEqual(_ lhs: Any?, _ rhs: Persistable?) -> Bool {
         if lhs == nil && rhs == nil {
             return true
         }
         switch (lhs, rhs) {
         //case Bool Removed
         case let (lhs, rhs) as (Temporal.Date, Temporal.Date):
-            return rhs >= lhs
+            return lhs >= rhs
         case let (lhs, rhs) as (Temporal.DateTime, Temporal.DateTime):
-            return rhs >= lhs
+            return lhs >= rhs
         case let (lhs, rhs) as (Temporal.Time, Temporal.Time):
-            return rhs >= lhs
+            return lhs >= rhs
         case let (lhs, rhs) as (Double, Double):
-            return rhs >= lhs
+            return lhs >= rhs
         case let (lhs, rhs) as (Int, Int):
-            return rhs >= lhs
+            return lhs >= rhs
         case let (lhs, rhs) as (Int, Double):
-            return rhs >= Double(lhs)
+            return Double(lhs) >= rhs
         case let (lhs, rhs) as (Double, Int):
-            return Double(rhs) >= lhs
+            return lhs >= Double(rhs)
         case let (lhs, rhs) as (String, String):
-            return rhs >= lhs
+            return lhs >= rhs
         default:
             return false
         }
     }
 
-    public static func isGreaterThan(_ lhs: Persistable?, _ rhs: Any?) -> Bool {
+    public static func isGreaterThan(_ lhs: Any?, _ rhs: Persistable?) -> Bool {
         if lhs == nil && rhs == nil {
             return false
         }
         switch (lhs, rhs) {
         //case Bool Removed
         case let (lhs, rhs) as (Temporal.Date, Temporal.Date):
-            return rhs > lhs
+            return lhs > rhs
         case let (lhs, rhs) as (Temporal.DateTime, Temporal.DateTime):
-            return rhs > lhs
+            return lhs > rhs
         case let (lhs, rhs) as (Temporal.Time, Temporal.Time):
-            return rhs > lhs
+            return lhs > rhs
         case let (lhs, rhs) as (Double, Double):
-            return rhs > lhs
+            return lhs > rhs
         case let (lhs, rhs) as (Int, Int):
-            return rhs > lhs
+            return lhs > rhs
         case let (lhs, rhs) as (Double, Int):
-            return Double(rhs) > lhs
+            return lhs > Double(rhs)
         case let (lhs, rhs) as (Int, Double):
-            return rhs > Double(lhs)
+            return Double(lhs) > rhs
         case let (lhs, rhs) as (String, String):
-            return rhs > lhs
+            return lhs > rhs
         default:
             return false
         }

--- a/Amplify/Categories/DataStore/Model/Internal/Persistable.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Persistable.swift
@@ -211,30 +211,29 @@ struct PersistableHelper {
         switch (start, end, rhs) {
         //case Bool Removed
         case let (start, end, rhs) as (Temporal.Date, Temporal.Date, Temporal.Date):
-            return start < rhs && rhs < end
+            return start <= rhs && rhs <= end
         case let (start, end, rhs) as (Temporal.DateTime, Temporal.DateTime, Temporal.DateTime):
-            return start < rhs && rhs < end
+            return start <= rhs && rhs <= end
         case let (start, end, rhs) as (Temporal.Time, Temporal.Time, Temporal.Time):
-            return start < rhs && rhs < end
+            return start <= rhs && rhs <= end
         case let (start, end, rhs) as (Int, Int, Int):
-            return start < rhs && rhs < end
+            return start <= rhs && rhs <= end
         case let (start, end, rhs) as (Int, Int, Double):
-            return Double(start) < Double(rhs) && Double(rhs) < Double(end)
+            return Double(start) <= rhs && rhs <= Double(end)
         case let (start, end, rhs) as (Int, Double, Int):
-            return Double(start) < Double(rhs) && Double(rhs) < Double(end)
+            return start <= rhs && Double(rhs) <= end
         case let (start, end, rhs) as (Int, Double, Double):
-            return Double(start) < Double(rhs) && Double(rhs) < Double(end)
+            return Double(start) <= rhs && rhs <= end
         case let (start, end, rhs) as (Double, Int, Int):
-            return Double(start) < Double(rhs) && Double(rhs) < Double(end)
+            return start <= Double(rhs) && rhs <= end
         case let (start, end, rhs) as (Double, Int, Double):
-            return Double(start) < Double(rhs) && Double(rhs) < Double(end)
+            return start <= rhs && rhs <= Double(end)
         case let (start, end, rhs) as (Double, Double, Int):
-            return Double(start) < Double(rhs) && Double(rhs) < Double(end)
+            return start <= Double(rhs) && Double(rhs) <= end
         case let (start, end, rhs) as (Double, Double, Double):
-            return Double(start) < Double(rhs) && Double(rhs) < Double(end)
-
+            return start <= rhs && rhs <= end
         case let (start, end, rhs) as (String, String, String):
-            return start < rhs && rhs < end
+            return start <= rhs && rhs <= end
         default:
             return false
         }

--- a/Amplify/Categories/DataStore/Query/Evaluable.swift
+++ b/Amplify/Categories/DataStore/Query/Evaluable.swift
@@ -1,0 +1,12 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public protocol Evaluable {
+    func evaluate(target: Model) -> Bool
+}

--- a/Amplify/Categories/DataStore/Query/QueryOperator.swift
+++ b/Amplify/Categories/DataStore/Query/QueryOperator.swift
@@ -17,4 +17,33 @@ public enum QueryOperator {
     case contains(_ value: String)
     case between(start: Persistable, end: Persistable)
     case beginsWith(_ value: String)
+
+    public func evaluate(target: Any) -> Bool {
+        switch self {
+        case .notEqual(let value):
+            return !PersistableHelper.isEqual(value, target)
+        case .equals(let value):
+            return PersistableHelper.isEqual(value, target)
+        case .lessOrEqual(let value):
+            return PersistableHelper.isLessOrEqual(value, target)
+        case .lessThan(let value):
+            return PersistableHelper.isLessThan(value, target)
+        case .greaterOrEqual(let value):
+            return PersistableHelper.isGreaterOrEqual(value, target)
+        case .greaterThan(let value):
+            return PersistableHelper.isGreaterThan(value, target)
+        case .contains(let value):
+            if let targetString = target as? String {
+                return targetString.contains(value)
+            }
+            return false
+        case .between(let start, let end):
+            return PersistableHelper.isBetween(start, end, target)
+        case .beginsWith(let value):
+            if let targetString = target as? String {
+                return targetString.starts(with: value)
+            }
+        }
+        return false
+    }
 }

--- a/Amplify/Categories/DataStore/Query/QueryOperator.swift
+++ b/Amplify/Categories/DataStore/Query/QueryOperator.swift
@@ -20,28 +20,28 @@ public enum QueryOperator {
 
     public func evaluate(target: Any) -> Bool {
         switch self {
-        case .notEqual(let value):
-            return !PersistableHelper.isEqual(value, target)
-        case .equals(let value):
-            return PersistableHelper.isEqual(value, target)
-        case .lessOrEqual(let value):
-            return PersistableHelper.isLessOrEqual(value, target)
-        case .lessThan(let value):
-            return PersistableHelper.isLessThan(value, target)
-        case .greaterOrEqual(let value):
-            return PersistableHelper.isGreaterOrEqual(value, target)
-        case .greaterThan(let value):
-            return PersistableHelper.isGreaterThan(value, target)
-        case .contains(let value):
+        case .notEqual(let predicateValue):
+            return !PersistableHelper.isEqual(target, predicateValue)
+        case .equals(let predicateValue):
+            return PersistableHelper.isEqual(target, predicateValue)
+        case .lessOrEqual(let predicateValue):
+            return PersistableHelper.isLessOrEqual(target, predicateValue)
+        case .lessThan(let predicateValue):
+            return PersistableHelper.isLessThan(target, predicateValue)
+        case .greaterOrEqual(let predicateValue):
+            return PersistableHelper.isGreaterOrEqual(target, predicateValue)
+        case .greaterThan(let predicateValue):
+            return PersistableHelper.isGreaterThan(target, predicateValue)
+        case .contains(let predicateString):
             if let targetString = target as? String {
-                return targetString.contains(value)
+                return targetString.contains(predicateString)
             }
             return false
         case .between(let start, let end):
             return PersistableHelper.isBetween(start, end, target)
-        case .beginsWith(let value):
+        case .beginsWith(let predicateValue):
             if let targetString = target as? String {
-                return targetString.starts(with: value)
+                return targetString.starts(with: predicateValue)
             }
         }
         return false

--- a/Amplify/Categories/DataStore/Query/QueryPredicate.swift
+++ b/Amplify/Categories/DataStore/Query/QueryPredicate.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Protocol that indicates concrete types conforming to it can be used a predicate member.
-public protocol QueryPredicate {}
+public protocol QueryPredicate: Evaluable {}
 
 public enum QueryPredicateGroupType: String {
     case and
@@ -28,6 +28,9 @@ public func not<Predicate: QueryPredicate>(_ predicate: Predicate) -> QueryPredi
 /// specify an action applies to an entire data set.
 public enum QueryPredicateConstant: QueryPredicate {
     case all
+    public func evaluate(target: Model) -> Bool {
+        return true
+    }
 }
 
 public class QueryPredicateGroup: QueryPredicate {
@@ -67,6 +70,28 @@ public class QueryPredicateGroup: QueryPredicate {
     public static prefix func ! (rhs: QueryPredicateGroup) -> QueryPredicateGroup {
         return not(rhs)
     }
+
+    public func evaluate(target: Model) -> Bool {
+        switch type {
+        case .or:
+            for predicate in predicates {
+                if predicate.evaluate(target: target) {
+                    return true
+                }
+            }
+            return false
+        case .and:
+            for predicate in predicates {
+                if !predicate.evaluate(target: target) {
+                    return false
+                }
+            }
+            return true
+        case .not:
+            let predicate = predicates[0]
+            return !predicate.evaluate(target: target)
+        }
+    }
 }
 
 public class QueryPredicateOperation: QueryPredicate {
@@ -99,5 +124,31 @@ public class QueryPredicateOperation: QueryPredicate {
 
     public static prefix func ! (rhs: QueryPredicateOperation) -> QueryPredicateGroup {
         return not(rhs)
+    }
+
+    public func evaluate(target: Model) -> Bool {
+        guard let fieldValue = target[field] else {
+            return false
+        }
+        guard let value = fieldValue else {
+            return false
+        }
+
+        if let booleanValue = value as? Bool {
+            return self.operator.evaluate(target: booleanValue)
+        }
+
+        if let doubleValue = value as? Double {
+            return self.operator.evaluate(target: doubleValue)
+        }
+
+        if let intValue = value as? Int {
+            return self.operator.evaluate(target: intValue)
+        }
+        if let timeValue = value as? Temporal.Time {
+            return self.operator.evaluate(target: timeValue)
+        }
+
+        return self.operator.evaluate(target: value)
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedBoolTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedBoolTests.swift
@@ -1,0 +1,129 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+class QueryPredicateEvaluateGeneratedBoolTests: XCTestCase {
+    func testBooltruenotEqualBooltrue() throws {
+        let predicate = QPredGen.keys.myBool.ne(true)
+        var instance = QPredGen(name: "test")
+        instance.myBool = true
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testBooltruenotEqualBoolfalse() throws {
+        let predicate = QPredGen.keys.myBool.ne(true)
+        var instance = QPredGen(name: "test")
+        instance.myBool = false
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testBooltruenotEqualBool() throws {
+        let predicate = QPredGen.keys.myBool.ne(true)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testBoolfalsenotEqualBooltrue() throws {
+        let predicate = QPredGen.keys.myBool.ne(false)
+        var instance = QPredGen(name: "test")
+        instance.myBool = true
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testBoolfalsenotEqualBoolfalse() throws {
+        let predicate = QPredGen.keys.myBool.ne(false)
+        var instance = QPredGen(name: "test")
+        instance.myBool = false
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testBoolfalsenotEqualBool() throws {
+        let predicate = QPredGen.keys.myBool.ne(false)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testBooltrueequalsBooltrue() throws {
+        let predicate = QPredGen.keys.myBool.eq(true)
+        var instance = QPredGen(name: "test")
+        instance.myBool = true
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testBooltrueequalsBoolfalse() throws {
+        let predicate = QPredGen.keys.myBool.eq(true)
+        var instance = QPredGen(name: "test")
+        instance.myBool = false
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testBooltrueequalsBool() throws {
+        let predicate = QPredGen.keys.myBool.eq(true)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testBoolfalseequalsBooltrue() throws {
+        let predicate = QPredGen.keys.myBool.eq(false)
+        var instance = QPredGen(name: "test")
+        instance.myBool = true
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testBoolfalseequalsBoolfalse() throws {
+        let predicate = QPredGen.keys.myBool.eq(false)
+        var instance = QPredGen(name: "test")
+        instance.myBool = false
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testBoolfalseequalsBool() throws {
+        let predicate = QPredGen.keys.myBool.eq(false)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTests.swift
@@ -1,0 +1,1252 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+//swiftlint:disable type_body_length
+//swiftlint:disable file_length
+//swiftlint:disable line_length
+class QueryPredicateEvaluateGeneratedDateTests: XCTestCase {
+    func testTemporalDateTemporal_Date_nownotEqualTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nownotEqualTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nownotEqualTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nownotEqualTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nownotEqualTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now())
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daynotEqualTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daynotEqualTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daynotEqualTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daynotEqualTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daynotEqualTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now().add(value: 1, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daynotEqualTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daynotEqualTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daynotEqualTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daynotEqualTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daynotEqualTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now().add(value: 2, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daynotEqualTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daynotEqualTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daynotEqualTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daynotEqualTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daynotEqualTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now().add(value: 3, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowequalsTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowequalsTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowequalsTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowequalsTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowequalsTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now())
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_dayequalsTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_dayequalsTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_dayequalsTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_dayequalsTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_dayequalsTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now().add(value: 1, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_dayequalsTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_dayequalsTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_dayequalsTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_dayequalsTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_dayequalsTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now().add(value: 2, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_dayequalsTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_dayequalsTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_dayequalsTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_dayequalsTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_dayequalsTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.eq(Temporal.Date.now().add(value: 3, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowlessOrEqualTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowlessOrEqualTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowlessOrEqualTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowlessOrEqualTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowlessOrEqualTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now())
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daylessOrEqualTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daylessOrEqualTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daylessOrEqualTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daylessOrEqualTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daylessOrEqualTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now().add(value: 1, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daylessOrEqualTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daylessOrEqualTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daylessOrEqualTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daylessOrEqualTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daylessOrEqualTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now().add(value: 2, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daylessOrEqualTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daylessOrEqualTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daylessOrEqualTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daylessOrEqualTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daylessOrEqualTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.le(Temporal.Date.now().add(value: 3, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowlessThanTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowlessThanTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowlessThanTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowlessThanTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowlessThanTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now())
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daylessThanTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daylessThanTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daylessThanTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daylessThanTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daylessThanTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now().add(value: 1, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daylessThanTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daylessThanTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daylessThanTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daylessThanTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daylessThanTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now().add(value: 2, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daylessThanTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daylessThanTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daylessThanTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daylessThanTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daylessThanTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.lt(Temporal.Date.now().add(value: 3, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowgreaterOrEqualTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowgreaterOrEqualTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowgreaterOrEqualTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowgreaterOrEqualTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowgreaterOrEqualTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now())
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daygreaterOrEqualTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daygreaterOrEqualTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daygreaterOrEqualTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daygreaterOrEqualTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daygreaterOrEqualTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now().add(value: 1, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daygreaterOrEqualTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daygreaterOrEqualTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daygreaterOrEqualTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daygreaterOrEqualTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daygreaterOrEqualTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now().add(value: 2, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daygreaterOrEqualTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daygreaterOrEqualTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daygreaterOrEqualTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daygreaterOrEqualTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daygreaterOrEqualTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.ge(Temporal.Date.now().add(value: 3, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowgreaterThanTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowgreaterThanTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowgreaterThanTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowgreaterThanTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now())
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_nowgreaterThanTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now())
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daygreaterThanTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daygreaterThanTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daygreaterThanTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daygreaterThanTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now().add(value: 1, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue1to_daygreaterThanTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now().add(value: 1, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daygreaterThanTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daygreaterThanTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daygreaterThanTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daygreaterThanTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now().add(value: 2, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue2to_daygreaterThanTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now().add(value: 2, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daygreaterThanTemporalDateTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daygreaterThanTemporalDateTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daygreaterThanTemporalDateTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daygreaterThanTemporalDateTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTemporal_Date_now_addvalue3to_daygreaterThanTemporalDate() throws {
+        let predicate = QPredGen.keys.myDate.gt(Temporal.Date.now().add(value: 3, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenTemporalDateTemporal_Date_now_addvalue1to_daybetweenTemporalDateTemporal_Date_now_addvalue3to_daywithTemporal_Date_now() throws {
+        let predicate = QPredGen.keys.myDate.between(start: Temporal.Date.now().add(value: 1, to: .day), end: Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now()
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenTemporalDateTemporal_Date_now_addvalue1to_daybetweenTemporalDateTemporal_Date_now_addvalue3to_daywithTemporal_Date_now_addvalue1to_day() throws {
+        let predicate = QPredGen.keys.myDate.between(start: Temporal.Date.now().add(value: 1, to: .day), end: Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 1, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenTemporalDateTemporal_Date_now_addvalue1to_daybetweenTemporalDateTemporal_Date_now_addvalue3to_daywithTemporal_Date_now_addvalue2to_day() throws {
+        let predicate = QPredGen.keys.myDate.between(start: Temporal.Date.now().add(value: 1, to: .day), end: Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 2, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenTemporalDateTemporal_Date_now_addvalue1to_daybetweenTemporalDateTemporal_Date_now_addvalue3to_daywithTemporal_Date_now_addvalue3to_day() throws {
+        let predicate = QPredGen.keys.myDate.between(start: Temporal.Date.now().add(value: 1, to: .day), end: Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 3, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenTemporalDateTemporal_Date_now_addvalue1to_daybetweenTemporalDateTemporal_Date_now_addvalue3to_daywithTemporal_Date_now_addvalue4to_day() throws {
+        let predicate = QPredGen.keys.myDate.between(start: Temporal.Date.now().add(value: 1, to: .day), end: Temporal.Date.now().add(value: 3, to: .day))
+        var instance = QPredGen(name: "test")
+        instance.myDate = Temporal.Date.now().add(value: 4, to: .day)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenTemporalDateTemporal_Date_now_addvalue1to_daybetweenTemporalDateTemporal_Date_now_addvalue3to_daywith() throws {
+        let predicate = QPredGen.keys.myDate.between(start: Temporal.Date.now().add(value: 1, to: .day), end: Temporal.Date.now().add(value: 3, to: .day))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+}
+

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTests.swift
@@ -1249,4 +1249,3 @@ class QueryPredicateEvaluateGeneratedDateTests: XCTestCase {
         XCTAssertFalse(evaluation)
     }
 }
-

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTests.swift
@@ -1207,7 +1207,7 @@ class QueryPredicateEvaluateGeneratedDateTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenTemporalDateTemporal_Date_now_addvalue1to_daybetweenTemporalDateTemporal_Date_now_addvalue3to_daywithTemporal_Date_now_addvalue2to_day() throws {
@@ -1227,7 +1227,7 @@ class QueryPredicateEvaluateGeneratedDateTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenTemporalDateTemporal_Date_now_addvalue1to_daybetweenTemporalDateTemporal_Date_now_addvalue3to_daywithTemporal_Date_now_addvalue4to_day() throws {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTimeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTimeTests.swift
@@ -1,0 +1,1380 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+//swiftlint:disable type_body_length
+//swiftlint:disable file_length
+//swiftlint:disable type_name
+//swiftlint:disable line_length
+class QueryPredicateEvaluateGeneratedDateTimeTests: XCTestCase {
+    func testTemporalDateTimeTemporal_DateTime_nownotEqualTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nownotEqualTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nownotEqualTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nownotEqualTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nownotEqualTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hournotEqualTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hournotEqualTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hournotEqualTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hournotEqualTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hournotEqualTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow.add(value: 1, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hournotEqualTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hournotEqualTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hournotEqualTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hournotEqualTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hournotEqualTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow.add(value: 2, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hournotEqualTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hournotEqualTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hournotEqualTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hournotEqualTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hournotEqualTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow.add(value: 3, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowequalsTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowequalsTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowequalsTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowequalsTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowequalsTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourequalsTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourequalsTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourequalsTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourequalsTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourequalsTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow.add(value: 1, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourequalsTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourequalsTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourequalsTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourequalsTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourequalsTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow.add(value: 2, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourequalsTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourequalsTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourequalsTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourequalsTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourequalsTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.eq(dateTimeNow.add(value: 3, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowlessOrEqualTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowlessOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowlessOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowlessOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowlessOrEqualTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourlessOrEqualTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourlessOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourlessOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourlessOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourlessOrEqualTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow.add(value: 1, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourlessOrEqualTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourlessOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourlessOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourlessOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourlessOrEqualTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow.add(value: 2, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourlessOrEqualTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourlessOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourlessOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourlessOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourlessOrEqualTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.le(dateTimeNow.add(value: 3, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowlessThanTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowlessThanTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowlessThanTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowlessThanTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowlessThanTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourlessThanTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourlessThanTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourlessThanTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourlessThanTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourlessThanTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow.add(value: 1, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourlessThanTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourlessThanTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourlessThanTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourlessThanTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourlessThanTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow.add(value: 2, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourlessThanTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourlessThanTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourlessThanTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourlessThanTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourlessThanTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.lt(dateTimeNow.add(value: 3, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowgreaterOrEqualTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowgreaterOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowgreaterOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowgreaterOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowgreaterOrEqualTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourgreaterOrEqualTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourgreaterOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourgreaterOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourgreaterOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourgreaterOrEqualTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow.add(value: 1, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourgreaterOrEqualTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourgreaterOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourgreaterOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourgreaterOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourgreaterOrEqualTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow.add(value: 2, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourgreaterOrEqualTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourgreaterOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourgreaterOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourgreaterOrEqualTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourgreaterOrEqualTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.ge(dateTimeNow.add(value: 3, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowgreaterThanTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowgreaterThanTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowgreaterThanTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowgreaterThanTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow)
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_nowgreaterThanTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourgreaterThanTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourgreaterThanTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourgreaterThanTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourgreaterThanTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourgreaterThanTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow.add(value: 1, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourgreaterThanTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourgreaterThanTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourgreaterThanTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourgreaterThanTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hourgreaterThanTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow.add(value: 2, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourgreaterThanTemporalDateTimeTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourgreaterThanTemporalDateTimeTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourgreaterThanTemporalDateTimeTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourgreaterThanTemporalDateTimeTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourgreaterThanTemporalDateTime() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.gt(dateTimeNow.add(value: 3, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourbetweenTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourwithTemporal_DateTime_now() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.between(start: dateTimeNow.add(value: 1, to: .hour), end: dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourbetweenTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourwithTemporal_DateTime_now_addvalue1to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.between(start: dateTimeNow.add(value: 1, to: .hour), end: dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourbetweenTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourwithTemporal_DateTime_now_addvalue2to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.between(start: dateTimeNow.add(value: 1, to: .hour), end: dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourbetweenTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourwithTemporal_DateTime_now_addvalue3to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.between(start: dateTimeNow.add(value: 1, to: .hour), end: dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourbetweenTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourwithTemporal_DateTime_now_addvalue4to_hour() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.between(start: dateTimeNow.add(value: 1, to: .hour), end: dateTimeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myDateTime = dateTimeNow.add(value: 4, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourbetweenTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourwith() throws {
+        let dateTimeNow = Temporal.DateTime.now()
+        let predicate = QPredGen.keys.myDateTime.between(start: dateTimeNow.add(value: 1, to: .hour), end: dateTimeNow.add(value: 3, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTimeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTimeTests.swift
@@ -1375,6 +1375,4 @@ class QueryPredicateEvaluateGeneratedDateTimeTests: XCTestCase {
 
         XCTAssertFalse(evaluation)
     }
-
-
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTimeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTimeTests.swift
@@ -1330,7 +1330,7 @@ class QueryPredicateEvaluateGeneratedDateTimeTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourbetweenTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourwithTemporal_DateTime_now_addvalue2to_hour() throws {
@@ -1352,7 +1352,7 @@ class QueryPredicateEvaluateGeneratedDateTimeTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenTemporalDateTimeTemporal_DateTime_now_addvalue1to_hourbetweenTemporalDateTimeTemporal_DateTime_now_addvalue3to_hourwithTemporal_DateTime_now_addvalue4to_hour() throws {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleIntTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleIntTests.swift
@@ -1438,6 +1438,16 @@ class QueryPredicateEvaluateGeneratedDoubleIntTests: XCTestCase {
         XCTAssertFalse(evaluation)
     }
 
+    func testbetweenDouble1_1betweenInt3with1() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
     func testbetweenDouble1_1betweenInt3with1_1() throws {
         let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3)
         var instance = QPredGen(name: "test")
@@ -1445,7 +1455,7 @@ class QueryPredicateEvaluateGeneratedDoubleIntTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenDouble1_1betweenInt3with2() throws {
@@ -1475,7 +1485,7 @@ class QueryPredicateEvaluateGeneratedDoubleIntTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenDouble1_1betweenInt3with3_1() throws {
@@ -1537,6 +1547,16 @@ class QueryPredicateEvaluateGeneratedDoubleIntTests: XCTestCase {
         XCTAssertFalse(evaluation)
     }
 
+    func testbetweenDouble1betweenInt3with1() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
     func testbetweenDouble1betweenInt3with1_1() throws {
         let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
         var instance = QPredGen(name: "test")
@@ -1574,7 +1594,7 @@ class QueryPredicateEvaluateGeneratedDoubleIntTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenDouble1betweenInt3with3_1() throws {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleIntTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleIntTests.swift
@@ -1,0 +1,1618 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+//swiftlint:disable type_body_length
+//swiftlint:disable file_length
+//swiftlint:disable type_name
+class QueryPredicateEvaluateGeneratedDoubleIntTests: XCTestCase {
+    func testDouble1_1notEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1notEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1notEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1notEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1notEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1notEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1notEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1notEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1notEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1notEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1notEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1notEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1notEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1notEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1notEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1notEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2notEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2notEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2notEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2notEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3notEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3notEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3notEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3notEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1equalsInt1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1equalsInt2() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1equalsInt3() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1equalsInt() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1equalsInt1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1equalsInt2() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1equalsInt3() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1equalsInt() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1equalsInt1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1equalsInt2() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1equalsInt3() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1equalsInt() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1equalsInt1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1equalsInt2() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1equalsInt3() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1equalsInt() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2equalsInt1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2equalsInt2() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2equalsInt3() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2equalsInt() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3equalsInt1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3equalsInt2() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3equalsInt3() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3equalsInt() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.le(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1lessOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.le(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.le(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessOrEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.le(1.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1lessOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.le(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1lessOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.le(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1lessOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.le(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1lessOrEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.le(2.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1lessOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.le(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.le(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.le(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessOrEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.le(3.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.le(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1lessOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.le(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.le(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessOrEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.le(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2lessOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.le(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2lessOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.le(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2lessOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.le(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2lessOrEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.le(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3lessOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.le(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3lessOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.le(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3lessOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.le(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3lessOrEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.le(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessThanInt1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1lessThanInt2() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessThanInt3() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessThanInt() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1lessThanInt1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1lessThanInt2() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1lessThanInt3() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1lessThanInt() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1lessThanInt1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessThanInt2() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessThanInt3() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessThanInt() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessThanInt1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessThanInt2() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessThanInt3() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessThanInt() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2lessThanInt1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2lessThanInt2() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2lessThanInt3() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2lessThanInt() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3lessThanInt1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3lessThanInt2() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3lessThanInt3() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3lessThanInt() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1greaterOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1greaterOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1greaterOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1greaterOrEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1greaterOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1greaterOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1greaterOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1greaterOrEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterOrEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1greaterOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1greaterOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1greaterOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1greaterOrEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2greaterOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2greaterOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2greaterOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2greaterOrEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3greaterOrEqualInt() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1greaterThanInt1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1greaterThanInt2() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1greaterThanInt3() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1greaterThanInt() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1greaterThanInt1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1greaterThanInt2() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1greaterThanInt3() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1greaterThanInt() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterThanInt1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterThanInt2() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterThanInt3() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterThanInt() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1greaterThanInt1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1greaterThanInt2() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1greaterThanInt3() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1greaterThanInt() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2greaterThanInt1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2greaterThanInt2() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2greaterThanInt3() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2greaterThanInt() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterThanInt1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterThanInt2() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterThanInt3() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterThanInt() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenInt3with0() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 0
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenInt3with0_0() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 0.0
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenInt3with1_1() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenInt3with2() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenInt3with1_2() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenInt3with3() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenInt3with3_1() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenInt3with3_2() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenInt3with4() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 4
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenInt3with() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1betweenInt3with0() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 0
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1betweenInt3with0_0() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 0.0
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1betweenInt3with1_1() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenDouble1betweenInt3with2() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenDouble1betweenInt3with1_2() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenDouble1betweenInt3with3() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1betweenInt3with3_1() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1betweenInt3with3_2() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1betweenInt3with4() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 4
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1betweenInt3with() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleTests.swift
@@ -2518,6 +2518,16 @@ class QueryPredicateEvaluateGeneratedDoubleTests: XCTestCase {
         XCTAssertFalse(evaluation)
     }
 
+    func testbetweenDouble1_1betweenDouble3_1with1() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
     func testbetweenDouble1_1betweenDouble3_1with1_1() throws {
         let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3.1)
         var instance = QPredGen(name: "test")
@@ -2525,7 +2535,7 @@ class QueryPredicateEvaluateGeneratedDoubleTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenDouble1_1betweenDouble3_1with2() throws {
@@ -2565,7 +2575,7 @@ class QueryPredicateEvaluateGeneratedDoubleTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenDouble1_1betweenDouble3_1with3_2() throws {
@@ -2617,6 +2627,16 @@ class QueryPredicateEvaluateGeneratedDoubleTests: XCTestCase {
         XCTAssertFalse(evaluation)
     }
 
+    func testbetweenDouble1betweenDouble3with1() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
     func testbetweenDouble1betweenDouble3with1_1() throws {
         let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
         var instance = QPredGen(name: "test")
@@ -2654,7 +2674,7 @@ class QueryPredicateEvaluateGeneratedDoubleTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenDouble1betweenDouble3with3_1() throws {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleTests.swift
@@ -1,0 +1,2698 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+//swiftlint:disable type_body_length
+//swiftlint:disable file_length
+//swiftlint:disable type_name
+class QueryPredicateEvaluateGeneratedDoubleTests: XCTestCase {
+    func testDouble1_1notEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1notEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1notEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1notEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1notEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1notEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1notEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1notEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1notEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1notEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1notEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1notEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1notEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1notEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1notEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1notEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1notEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1notEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1notEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1notEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1notEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1notEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1notEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1notEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1notEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1notEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1notEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1notEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.ne(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2notEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2notEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2notEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2notEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2notEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2notEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2notEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.ne(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3notEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3notEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3notEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3notEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3notEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3notEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3notEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.ne(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1equalsDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1equalsDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1equalsDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1equalsDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1equalsDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1equalsDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1equalsDouble() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1equalsDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1equalsDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1equalsDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1equalsDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1equalsDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1equalsDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1equalsDouble() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1equalsDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1equalsDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1equalsDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1equalsDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1equalsDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1equalsDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1equalsDouble() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1equalsDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1equalsDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1equalsDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1equalsDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1equalsDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1equalsDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1equalsDouble() throws {
+        let predicate = QPredGen.keys.myDouble.eq(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2equalsDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2equalsDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2equalsDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2equalsDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2equalsDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2equalsDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2equalsDouble() throws {
+        let predicate = QPredGen.keys.myDouble.eq(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3equalsDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3equalsDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3equalsDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3equalsDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3equalsDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3equalsDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3equalsDouble() throws {
+        let predicate = QPredGen.keys.myDouble.eq(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessOrEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1lessOrEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessOrEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessOrEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.le(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1lessOrEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.le(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessOrEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.le(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessOrEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.le(1.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1lessOrEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1lessOrEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1lessOrEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1lessOrEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.le(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1lessOrEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.le(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1lessOrEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.le(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1lessOrEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.le(2.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1lessOrEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessOrEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessOrEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessOrEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.le(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessOrEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.le(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessOrEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.le(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessOrEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.le(3.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessOrEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessOrEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessOrEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessOrEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.le(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1lessOrEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.le(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessOrEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.le(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessOrEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.le(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2lessOrEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2lessOrEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2lessOrEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2lessOrEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.le(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2lessOrEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.le(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2lessOrEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.le(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2lessOrEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.le(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3lessOrEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3lessOrEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3lessOrEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.le(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3lessOrEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.le(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3lessOrEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.le(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3lessOrEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.le(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3lessOrEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.le(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessThanDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessThanDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessThanDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessThanDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1lessThanDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessThanDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1lessThanDouble() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1lessThanDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1lessThanDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1lessThanDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1lessThanDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1lessThanDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1lessThanDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1lessThanDouble() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1lessThanDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessThanDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessThanDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1lessThanDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessThanDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessThanDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1lessThanDouble() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessThanDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessThanDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessThanDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessThanDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessThanDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessThanDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1lessThanDouble() throws {
+        let predicate = QPredGen.keys.myDouble.lt(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2lessThanDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2lessThanDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2lessThanDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2lessThanDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2lessThanDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2lessThanDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2lessThanDouble() throws {
+        let predicate = QPredGen.keys.myDouble.lt(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3lessThanDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3lessThanDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3lessThanDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3lessThanDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3lessThanDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3lessThanDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3lessThanDouble() throws {
+        let predicate = QPredGen.keys.myDouble.lt(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1greaterOrEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1greaterOrEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1greaterOrEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1greaterOrEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1greaterOrEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1greaterOrEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1greaterOrEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1greaterOrEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1greaterOrEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1greaterOrEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1greaterOrEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1greaterOrEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1greaterOrEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1greaterOrEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterOrEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterOrEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterOrEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3_1greaterOrEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterOrEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterOrEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterOrEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1greaterOrEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1greaterOrEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1greaterOrEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1greaterOrEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1greaterOrEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1greaterOrEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1greaterOrEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.ge(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2greaterOrEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2greaterOrEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2greaterOrEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2greaterOrEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2greaterOrEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2greaterOrEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2greaterOrEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.ge(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterOrEqualDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterOrEqualDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterOrEqualDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3greaterOrEqualDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterOrEqualDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterOrEqualDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3greaterOrEqualDouble() throws {
+        let predicate = QPredGen.keys.myDouble.ge(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1greaterThanDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1greaterThanDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1greaterThanDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1greaterThanDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1_1greaterThanDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1greaterThanDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1_1greaterThanDouble() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1greaterThanDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1greaterThanDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1greaterThanDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1greaterThanDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1greaterThanDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2_1greaterThanDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2_1greaterThanDouble() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterThanDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterThanDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterThanDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterThanDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterThanDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterThanDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3_1greaterThanDouble() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1greaterThanDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1greaterThanDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1greaterThanDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1greaterThanDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble1greaterThanDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1greaterThanDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble1greaterThanDouble() throws {
+        let predicate = QPredGen.keys.myDouble.gt(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2greaterThanDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2greaterThanDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2greaterThanDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2greaterThanDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2greaterThanDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble2greaterThanDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble2greaterThanDouble() throws {
+        let predicate = QPredGen.keys.myDouble.gt(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterThanDouble1_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterThanDouble2_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterThanDouble3_1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testDouble3greaterThanDouble1() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterThanDouble2() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterThanDouble3() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testDouble3greaterThanDouble() throws {
+        let predicate = QPredGen.keys.myDouble.gt(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenDouble3_1with0() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 0
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenDouble3_1with0_0() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 0.0
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenDouble3_1with1_1() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenDouble3_1with2() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenDouble3_1with1_2() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenDouble3_1with3() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenDouble3_1with3_1() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenDouble3_1with3_2() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenDouble3_1with4() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3.1)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 4
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1_1betweenDouble3_1with() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1.1, end: 3.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1betweenDouble3with0() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 0
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1betweenDouble3with0_0() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 0.0
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1betweenDouble3with1_1() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenDouble1betweenDouble3with2() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenDouble1betweenDouble3with1_2() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 1.2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenDouble1betweenDouble3with3() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1betweenDouble3with3_1() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1betweenDouble3with3_2() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 3.2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1betweenDouble3with4() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myDouble = 4
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenDouble1betweenDouble3with() throws {
+        let predicate = QPredGen.keys.myDouble.between(start: 1, end: 3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntDoubleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntDoubleTests.swift
@@ -30,7 +30,7 @@ class QueryPredicateEvaluateGeneratedIntDoubleTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenInt1betweenDouble3_1with2() throws {
@@ -89,7 +89,7 @@ class QueryPredicateEvaluateGeneratedIntDoubleTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenInt1betweenDouble3with2() throws {
@@ -109,7 +109,7 @@ class QueryPredicateEvaluateGeneratedIntDoubleTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenInt1betweenDouble3with4() throws {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntDoubleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntDoubleTests.swift
@@ -1,0 +1,134 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+
+//swiftlint:disable type_name
+class QueryPredicateEvaluateGeneratedIntDoubleTests: XCTestCase {
+    func testbetweenInt1betweenDouble3_1with0() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3.1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 0
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenInt1betweenDouble3_1with1() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3.1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenInt1betweenDouble3_1with2() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3.1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenInt1betweenDouble3_1with3() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3.1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenInt1betweenDouble3_1with4() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3.1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 4
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenInt1betweenDouble3_1with() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3.1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenInt1betweenDouble3with0() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 0
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenInt1betweenDouble3with1() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenInt1betweenDouble3with2() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenInt1betweenDouble3with3() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenInt1betweenDouble3with4() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 4
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenInt1betweenDouble3with() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntDoubleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntDoubleTests.swift
@@ -130,5 +130,4 @@ class QueryPredicateEvaluateGeneratedIntDoubleTests: XCTestCase {
 
         XCTAssertFalse(evaluation)
     }
-
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntTests.swift
@@ -733,7 +733,7 @@ class QueryPredicateEvaluateGeneratedIntBetweenTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenInt1betweenInt3with2() throws {
@@ -753,7 +753,7 @@ class QueryPredicateEvaluateGeneratedIntBetweenTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenInt1betweenInt3with4() throws {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntTests.swift
@@ -1,0 +1,777 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+//swiftlint:disable type_body_length
+//swiftlint:disable file_length
+//swiftlint:disable type_name
+class QueryPredicateEvaluateGeneratedIntBetweenTests: XCTestCase {
+    func testInt1notEqualInt1() throws {
+        let predicate = QPredGen.keys.myInt.ne(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt1notEqualInt2() throws {
+        let predicate = QPredGen.keys.myInt.ne(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt1notEqualInt3() throws {
+        let predicate = QPredGen.keys.myInt.ne(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt1notEqualInt() throws {
+        let predicate = QPredGen.keys.myInt.ne(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt2notEqualInt1() throws {
+        let predicate = QPredGen.keys.myInt.ne(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt2notEqualInt2() throws {
+        let predicate = QPredGen.keys.myInt.ne(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt2notEqualInt3() throws {
+        let predicate = QPredGen.keys.myInt.ne(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt2notEqualInt() throws {
+        let predicate = QPredGen.keys.myInt.ne(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt3notEqualInt1() throws {
+        let predicate = QPredGen.keys.myInt.ne(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt3notEqualInt2() throws {
+        let predicate = QPredGen.keys.myInt.ne(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt3notEqualInt3() throws {
+        let predicate = QPredGen.keys.myInt.ne(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt3notEqualInt() throws {
+        let predicate = QPredGen.keys.myInt.ne(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt1equalsInt1() throws {
+        let predicate = QPredGen.keys.myInt.eq(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt1equalsInt2() throws {
+        let predicate = QPredGen.keys.myInt.eq(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt1equalsInt3() throws {
+        let predicate = QPredGen.keys.myInt.eq(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt1equalsInt() throws {
+        let predicate = QPredGen.keys.myInt.eq(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt2equalsInt1() throws {
+        let predicate = QPredGen.keys.myInt.eq(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt2equalsInt2() throws {
+        let predicate = QPredGen.keys.myInt.eq(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt2equalsInt3() throws {
+        let predicate = QPredGen.keys.myInt.eq(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt2equalsInt() throws {
+        let predicate = QPredGen.keys.myInt.eq(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt3equalsInt1() throws {
+        let predicate = QPredGen.keys.myInt.eq(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt3equalsInt2() throws {
+        let predicate = QPredGen.keys.myInt.eq(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt3equalsInt3() throws {
+        let predicate = QPredGen.keys.myInt.eq(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt3equalsInt() throws {
+        let predicate = QPredGen.keys.myInt.eq(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt1lessOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myInt.le(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt1lessOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myInt.le(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt1lessOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myInt.le(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt1lessOrEqualInt() throws {
+        let predicate = QPredGen.keys.myInt.le(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt2lessOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myInt.le(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt2lessOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myInt.le(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt2lessOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myInt.le(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt2lessOrEqualInt() throws {
+        let predicate = QPredGen.keys.myInt.le(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt3lessOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myInt.le(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt3lessOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myInt.le(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt3lessOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myInt.le(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt3lessOrEqualInt() throws {
+        let predicate = QPredGen.keys.myInt.le(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt1lessThanInt1() throws {
+        let predicate = QPredGen.keys.myInt.lt(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt1lessThanInt2() throws {
+        let predicate = QPredGen.keys.myInt.lt(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt1lessThanInt3() throws {
+        let predicate = QPredGen.keys.myInt.lt(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt1lessThanInt() throws {
+        let predicate = QPredGen.keys.myInt.lt(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt2lessThanInt1() throws {
+        let predicate = QPredGen.keys.myInt.lt(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt2lessThanInt2() throws {
+        let predicate = QPredGen.keys.myInt.lt(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt2lessThanInt3() throws {
+        let predicate = QPredGen.keys.myInt.lt(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt2lessThanInt() throws {
+        let predicate = QPredGen.keys.myInt.lt(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt3lessThanInt1() throws {
+        let predicate = QPredGen.keys.myInt.lt(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt3lessThanInt2() throws {
+        let predicate = QPredGen.keys.myInt.lt(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt3lessThanInt3() throws {
+        let predicate = QPredGen.keys.myInt.lt(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt3lessThanInt() throws {
+        let predicate = QPredGen.keys.myInt.lt(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt1greaterOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myInt.ge(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt1greaterOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myInt.ge(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt1greaterOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myInt.ge(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt1greaterOrEqualInt() throws {
+        let predicate = QPredGen.keys.myInt.ge(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt2greaterOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myInt.ge(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt2greaterOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myInt.ge(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt2greaterOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myInt.ge(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt2greaterOrEqualInt() throws {
+        let predicate = QPredGen.keys.myInt.ge(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt3greaterOrEqualInt1() throws {
+        let predicate = QPredGen.keys.myInt.ge(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt3greaterOrEqualInt2() throws {
+        let predicate = QPredGen.keys.myInt.ge(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt3greaterOrEqualInt3() throws {
+        let predicate = QPredGen.keys.myInt.ge(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt3greaterOrEqualInt() throws {
+        let predicate = QPredGen.keys.myInt.ge(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt1greaterThanInt1() throws {
+        let predicate = QPredGen.keys.myInt.gt(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt1greaterThanInt2() throws {
+        let predicate = QPredGen.keys.myInt.gt(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt1greaterThanInt3() throws {
+        let predicate = QPredGen.keys.myInt.gt(1)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt1greaterThanInt() throws {
+        let predicate = QPredGen.keys.myInt.gt(1)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt2greaterThanInt1() throws {
+        let predicate = QPredGen.keys.myInt.gt(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt2greaterThanInt2() throws {
+        let predicate = QPredGen.keys.myInt.gt(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt2greaterThanInt3() throws {
+        let predicate = QPredGen.keys.myInt.gt(2)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testInt2greaterThanInt() throws {
+        let predicate = QPredGen.keys.myInt.gt(2)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt3greaterThanInt1() throws {
+        let predicate = QPredGen.keys.myInt.gt(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt3greaterThanInt2() throws {
+        let predicate = QPredGen.keys.myInt.gt(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt3greaterThanInt3() throws {
+        let predicate = QPredGen.keys.myInt.gt(3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testInt3greaterThanInt() throws {
+        let predicate = QPredGen.keys.myInt.gt(3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenInt1betweenInt3with0() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 0
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenInt1betweenInt3with1() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenInt1betweenInt3with2() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenInt1betweenInt3with3() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 3
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenInt1betweenInt3with4() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 4
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenInt1betweenInt3with() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 3)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedStringTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedStringTests.swift
@@ -1403,7 +1403,7 @@ class QueryPredicateEvaluateGeneratedStringTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenStringbbbetweenStringddwithc() throws {
@@ -1423,7 +1423,7 @@ class QueryPredicateEvaluateGeneratedStringTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenStringbbbetweenStringddwithe() throws {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedStringTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedStringTests.swift
@@ -1,0 +1,1643 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+//swiftlint:disable type_body_length
+//swiftlint:disable file_length
+//swiftlint:disable type_name
+class QueryPredicateEvaluateGeneratedStringTests: XCTestCase {
+    func testStringanotEqualStringa() throws {
+        let predicate = QPredGen.keys.myString.ne("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringanotEqualStringbb() throws {
+        let predicate = QPredGen.keys.myString.ne("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringanotEqualStringaa() throws {
+        let predicate = QPredGen.keys.myString.ne("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringanotEqualStringc() throws {
+        let predicate = QPredGen.keys.myString.ne("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringanotEqualString() throws {
+        let predicate = QPredGen.keys.myString.ne("a")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbnotEqualStringa() throws {
+        let predicate = QPredGen.keys.myString.ne("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringbbnotEqualStringbb() throws {
+        let predicate = QPredGen.keys.myString.ne("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbnotEqualStringaa() throws {
+        let predicate = QPredGen.keys.myString.ne("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringbbnotEqualStringc() throws {
+        let predicate = QPredGen.keys.myString.ne("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringbbnotEqualString() throws {
+        let predicate = QPredGen.keys.myString.ne("bb")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaanotEqualStringa() throws {
+        let predicate = QPredGen.keys.myString.ne("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringaanotEqualStringbb() throws {
+        let predicate = QPredGen.keys.myString.ne("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringaanotEqualStringaa() throws {
+        let predicate = QPredGen.keys.myString.ne("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaanotEqualStringc() throws {
+        let predicate = QPredGen.keys.myString.ne("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringaanotEqualString() throws {
+        let predicate = QPredGen.keys.myString.ne("aa")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcnotEqualStringa() throws {
+        let predicate = QPredGen.keys.myString.ne("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringcnotEqualStringbb() throws {
+        let predicate = QPredGen.keys.myString.ne("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringcnotEqualStringaa() throws {
+        let predicate = QPredGen.keys.myString.ne("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringcnotEqualStringc() throws {
+        let predicate = QPredGen.keys.myString.ne("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcnotEqualString() throws {
+        let predicate = QPredGen.keys.myString.ne("c")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaequalsStringa() throws {
+        let predicate = QPredGen.keys.myString.eq("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringaequalsStringbb() throws {
+        let predicate = QPredGen.keys.myString.eq("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaequalsStringaa() throws {
+        let predicate = QPredGen.keys.myString.eq("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaequalsStringc() throws {
+        let predicate = QPredGen.keys.myString.eq("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaequalsString() throws {
+        let predicate = QPredGen.keys.myString.eq("a")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbequalsStringa() throws {
+        let predicate = QPredGen.keys.myString.eq("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbequalsStringbb() throws {
+        let predicate = QPredGen.keys.myString.eq("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringbbequalsStringaa() throws {
+        let predicate = QPredGen.keys.myString.eq("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbequalsStringc() throws {
+        let predicate = QPredGen.keys.myString.eq("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbequalsString() throws {
+        let predicate = QPredGen.keys.myString.eq("bb")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaaequalsStringa() throws {
+        let predicate = QPredGen.keys.myString.eq("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaaequalsStringbb() throws {
+        let predicate = QPredGen.keys.myString.eq("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaaequalsStringaa() throws {
+        let predicate = QPredGen.keys.myString.eq("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringaaequalsStringc() throws {
+        let predicate = QPredGen.keys.myString.eq("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaaequalsString() throws {
+        let predicate = QPredGen.keys.myString.eq("aa")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcequalsStringa() throws {
+        let predicate = QPredGen.keys.myString.eq("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcequalsStringbb() throws {
+        let predicate = QPredGen.keys.myString.eq("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcequalsStringaa() throws {
+        let predicate = QPredGen.keys.myString.eq("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcequalsStringc() throws {
+        let predicate = QPredGen.keys.myString.eq("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringcequalsString() throws {
+        let predicate = QPredGen.keys.myString.eq("c")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringalessOrEqualStringa() throws {
+        let predicate = QPredGen.keys.myString.le("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringalessOrEqualStringbb() throws {
+        let predicate = QPredGen.keys.myString.le("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringalessOrEqualStringaa() throws {
+        let predicate = QPredGen.keys.myString.le("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringalessOrEqualStringc() throws {
+        let predicate = QPredGen.keys.myString.le("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringalessOrEqualString() throws {
+        let predicate = QPredGen.keys.myString.le("a")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbblessOrEqualStringa() throws {
+        let predicate = QPredGen.keys.myString.le("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringbblessOrEqualStringbb() throws {
+        let predicate = QPredGen.keys.myString.le("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringbblessOrEqualStringaa() throws {
+        let predicate = QPredGen.keys.myString.le("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringbblessOrEqualStringc() throws {
+        let predicate = QPredGen.keys.myString.le("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbblessOrEqualString() throws {
+        let predicate = QPredGen.keys.myString.le("bb")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaalessOrEqualStringa() throws {
+        let predicate = QPredGen.keys.myString.le("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringaalessOrEqualStringbb() throws {
+        let predicate = QPredGen.keys.myString.le("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaalessOrEqualStringaa() throws {
+        let predicate = QPredGen.keys.myString.le("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringaalessOrEqualStringc() throws {
+        let predicate = QPredGen.keys.myString.le("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaalessOrEqualString() throws {
+        let predicate = QPredGen.keys.myString.le("aa")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringclessOrEqualStringa() throws {
+        let predicate = QPredGen.keys.myString.le("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringclessOrEqualStringbb() throws {
+        let predicate = QPredGen.keys.myString.le("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringclessOrEqualStringaa() throws {
+        let predicate = QPredGen.keys.myString.le("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringclessOrEqualStringc() throws {
+        let predicate = QPredGen.keys.myString.le("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringclessOrEqualString() throws {
+        let predicate = QPredGen.keys.myString.le("c")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringalessThanStringa() throws {
+        let predicate = QPredGen.keys.myString.lt("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringalessThanStringbb() throws {
+        let predicate = QPredGen.keys.myString.lt("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringalessThanStringaa() throws {
+        let predicate = QPredGen.keys.myString.lt("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringalessThanStringc() throws {
+        let predicate = QPredGen.keys.myString.lt("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringalessThanString() throws {
+        let predicate = QPredGen.keys.myString.lt("a")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbblessThanStringa() throws {
+        let predicate = QPredGen.keys.myString.lt("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringbblessThanStringbb() throws {
+        let predicate = QPredGen.keys.myString.lt("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbblessThanStringaa() throws {
+        let predicate = QPredGen.keys.myString.lt("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringbblessThanStringc() throws {
+        let predicate = QPredGen.keys.myString.lt("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbblessThanString() throws {
+        let predicate = QPredGen.keys.myString.lt("bb")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaalessThanStringa() throws {
+        let predicate = QPredGen.keys.myString.lt("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringaalessThanStringbb() throws {
+        let predicate = QPredGen.keys.myString.lt("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaalessThanStringaa() throws {
+        let predicate = QPredGen.keys.myString.lt("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaalessThanStringc() throws {
+        let predicate = QPredGen.keys.myString.lt("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaalessThanString() throws {
+        let predicate = QPredGen.keys.myString.lt("aa")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringclessThanStringa() throws {
+        let predicate = QPredGen.keys.myString.lt("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringclessThanStringbb() throws {
+        let predicate = QPredGen.keys.myString.lt("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringclessThanStringaa() throws {
+        let predicate = QPredGen.keys.myString.lt("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringclessThanStringc() throws {
+        let predicate = QPredGen.keys.myString.lt("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringclessThanString() throws {
+        let predicate = QPredGen.keys.myString.lt("c")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringagreaterOrEqualStringa() throws {
+        let predicate = QPredGen.keys.myString.ge("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringagreaterOrEqualStringbb() throws {
+        let predicate = QPredGen.keys.myString.ge("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringagreaterOrEqualStringaa() throws {
+        let predicate = QPredGen.keys.myString.ge("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringagreaterOrEqualStringc() throws {
+        let predicate = QPredGen.keys.myString.ge("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringagreaterOrEqualString() throws {
+        let predicate = QPredGen.keys.myString.ge("a")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbgreaterOrEqualStringa() throws {
+        let predicate = QPredGen.keys.myString.ge("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbgreaterOrEqualStringbb() throws {
+        let predicate = QPredGen.keys.myString.ge("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringbbgreaterOrEqualStringaa() throws {
+        let predicate = QPredGen.keys.myString.ge("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbgreaterOrEqualStringc() throws {
+        let predicate = QPredGen.keys.myString.ge("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringbbgreaterOrEqualString() throws {
+        let predicate = QPredGen.keys.myString.ge("bb")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaagreaterOrEqualStringa() throws {
+        let predicate = QPredGen.keys.myString.ge("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaagreaterOrEqualStringbb() throws {
+        let predicate = QPredGen.keys.myString.ge("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringaagreaterOrEqualStringaa() throws {
+        let predicate = QPredGen.keys.myString.ge("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringaagreaterOrEqualStringc() throws {
+        let predicate = QPredGen.keys.myString.ge("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringaagreaterOrEqualString() throws {
+        let predicate = QPredGen.keys.myString.ge("aa")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcgreaterOrEqualStringa() throws {
+        let predicate = QPredGen.keys.myString.ge("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcgreaterOrEqualStringbb() throws {
+        let predicate = QPredGen.keys.myString.ge("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcgreaterOrEqualStringaa() throws {
+        let predicate = QPredGen.keys.myString.ge("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcgreaterOrEqualStringc() throws {
+        let predicate = QPredGen.keys.myString.ge("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringcgreaterOrEqualString() throws {
+        let predicate = QPredGen.keys.myString.ge("c")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringagreaterThanStringa() throws {
+        let predicate = QPredGen.keys.myString.gt("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringagreaterThanStringbb() throws {
+        let predicate = QPredGen.keys.myString.gt("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringagreaterThanStringaa() throws {
+        let predicate = QPredGen.keys.myString.gt("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringagreaterThanStringc() throws {
+        let predicate = QPredGen.keys.myString.gt("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringagreaterThanString() throws {
+        let predicate = QPredGen.keys.myString.gt("a")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbgreaterThanStringa() throws {
+        let predicate = QPredGen.keys.myString.gt("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbgreaterThanStringbb() throws {
+        let predicate = QPredGen.keys.myString.gt("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbgreaterThanStringaa() throws {
+        let predicate = QPredGen.keys.myString.gt("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbgreaterThanStringc() throws {
+        let predicate = QPredGen.keys.myString.gt("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringbbgreaterThanString() throws {
+        let predicate = QPredGen.keys.myString.gt("bb")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaagreaterThanStringa() throws {
+        let predicate = QPredGen.keys.myString.gt("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaagreaterThanStringbb() throws {
+        let predicate = QPredGen.keys.myString.gt("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringaagreaterThanStringaa() throws {
+        let predicate = QPredGen.keys.myString.gt("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaagreaterThanStringc() throws {
+        let predicate = QPredGen.keys.myString.gt("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringaagreaterThanString() throws {
+        let predicate = QPredGen.keys.myString.gt("aa")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcgreaterThanStringa() throws {
+        let predicate = QPredGen.keys.myString.gt("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcgreaterThanStringbb() throws {
+        let predicate = QPredGen.keys.myString.gt("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcgreaterThanStringaa() throws {
+        let predicate = QPredGen.keys.myString.gt("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcgreaterThanStringc() throws {
+        let predicate = QPredGen.keys.myString.gt("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcgreaterThanString() throws {
+        let predicate = QPredGen.keys.myString.gt("c")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringacontainsStringa() throws {
+        let predicate = QPredGen.keys.myString.contains("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringacontainsStringbb() throws {
+        let predicate = QPredGen.keys.myString.contains("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringacontainsStringaa() throws {
+        let predicate = QPredGen.keys.myString.contains("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringacontainsStringc() throws {
+        let predicate = QPredGen.keys.myString.contains("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringacontainsString() throws {
+        let predicate = QPredGen.keys.myString.contains("a")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbcontainsStringa() throws {
+        let predicate = QPredGen.keys.myString.contains("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbcontainsStringbb() throws {
+        let predicate = QPredGen.keys.myString.contains("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringbbcontainsStringaa() throws {
+        let predicate = QPredGen.keys.myString.contains("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbcontainsStringc() throws {
+        let predicate = QPredGen.keys.myString.contains("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbcontainsString() throws {
+        let predicate = QPredGen.keys.myString.contains("bb")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaacontainsStringa() throws {
+        let predicate = QPredGen.keys.myString.contains("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaacontainsStringbb() throws {
+        let predicate = QPredGen.keys.myString.contains("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaacontainsStringaa() throws {
+        let predicate = QPredGen.keys.myString.contains("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringaacontainsStringc() throws {
+        let predicate = QPredGen.keys.myString.contains("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaacontainsString() throws {
+        let predicate = QPredGen.keys.myString.contains("aa")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringccontainsStringa() throws {
+        let predicate = QPredGen.keys.myString.contains("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringccontainsStringbb() throws {
+        let predicate = QPredGen.keys.myString.contains("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringccontainsStringaa() throws {
+        let predicate = QPredGen.keys.myString.contains("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringccontainsStringc() throws {
+        let predicate = QPredGen.keys.myString.contains("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringccontainsString() throws {
+        let predicate = QPredGen.keys.myString.contains("c")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenStringbbbetweenStringddwitha() throws {
+        let predicate = QPredGen.keys.myString.between(start: "bb", end: "dd")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenStringbbbetweenStringddwithbb() throws {
+        let predicate = QPredGen.keys.myString.between(start: "bb", end: "dd")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenStringbbbetweenStringddwithc() throws {
+        let predicate = QPredGen.keys.myString.between(start: "bb", end: "dd")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenStringbbbetweenStringddwithdd() throws {
+        let predicate = QPredGen.keys.myString.between(start: "bb", end: "dd")
+        var instance = QPredGen(name: "test")
+        instance.myString = "dd"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenStringbbbetweenStringddwithe() throws {
+        let predicate = QPredGen.keys.myString.between(start: "bb", end: "dd")
+        var instance = QPredGen(name: "test")
+        instance.myString = "e"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenStringbbbetweenStringddwith() throws {
+        let predicate = QPredGen.keys.myString.between(start: "bb", end: "dd")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringabeginsWithStringa() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringabeginsWithStringbb() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringabeginsWithStringaa() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringabeginsWithStringc() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("a")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringabeginsWithString() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("a")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbbeginsWithStringa() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbbeginsWithStringbb() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringbbbeginsWithStringaa() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbbeginsWithStringc() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("bb")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringbbbeginsWithString() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("bb")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaabeginsWithStringa() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaabeginsWithStringbb() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaabeginsWithStringaa() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringaabeginsWithStringc() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("aa")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringaabeginsWithString() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("aa")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcbeginsWithStringa() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "a"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcbeginsWithStringbb() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "bb"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcbeginsWithStringaa() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "aa"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testStringcbeginsWithStringc() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("c")
+        var instance = QPredGen(name: "test")
+        instance.myString = "c"
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testStringcbeginsWithString() throws {
+        let predicate = QPredGen.keys.myString.beginsWith("c")
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedTimeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedTimeTests.swift
@@ -1,0 +1,1377 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+//swiftlint:disable type_body_length
+//swiftlint:disable file_length
+//swiftlint:disable line_length
+class QueryPredicateEvaluateGeneratedTimeTests: XCTestCase {
+    func testTemporalTimeTemporal_Time_nownotEqualTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nownotEqualTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nownotEqualTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nownotEqualTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nownotEqualTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hournotEqualTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hournotEqualTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hournotEqualTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hournotEqualTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hournotEqualTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow.add(value: 1, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hournotEqualTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hournotEqualTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hournotEqualTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hournotEqualTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hournotEqualTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow.add(value: 2, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hournotEqualTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hournotEqualTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hournotEqualTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hournotEqualTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hournotEqualTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ne(timeNow.add(value: 3, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowequalsTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowequalsTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowequalsTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowequalsTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowequalsTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourequalsTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourequalsTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourequalsTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourequalsTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourequalsTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow.add(value: 1, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourequalsTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourequalsTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourequalsTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourequalsTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourequalsTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow.add(value: 2, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourequalsTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourequalsTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourequalsTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourequalsTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourequalsTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.eq(timeNow.add(value: 3, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowlessOrEqualTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowlessOrEqualTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowlessOrEqualTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowlessOrEqualTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowlessOrEqualTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourlessOrEqualTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourlessOrEqualTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourlessOrEqualTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourlessOrEqualTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourlessOrEqualTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow.add(value: 1, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourlessOrEqualTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourlessOrEqualTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourlessOrEqualTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourlessOrEqualTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourlessOrEqualTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow.add(value: 2, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourlessOrEqualTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourlessOrEqualTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourlessOrEqualTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourlessOrEqualTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourlessOrEqualTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.le(timeNow.add(value: 3, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowlessThanTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowlessThanTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowlessThanTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowlessThanTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowlessThanTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourlessThanTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourlessThanTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourlessThanTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourlessThanTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourlessThanTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow.add(value: 1, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourlessThanTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourlessThanTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourlessThanTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourlessThanTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourlessThanTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow.add(value: 2, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourlessThanTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourlessThanTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourlessThanTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourlessThanTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourlessThanTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.lt(timeNow.add(value: 3, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowgreaterOrEqualTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowgreaterOrEqualTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowgreaterOrEqualTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowgreaterOrEqualTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowgreaterOrEqualTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourgreaterOrEqualTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourgreaterOrEqualTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourgreaterOrEqualTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourgreaterOrEqualTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourgreaterOrEqualTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow.add(value: 1, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourgreaterOrEqualTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourgreaterOrEqualTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourgreaterOrEqualTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourgreaterOrEqualTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourgreaterOrEqualTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow.add(value: 2, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourgreaterOrEqualTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourgreaterOrEqualTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourgreaterOrEqualTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourgreaterOrEqualTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourgreaterOrEqualTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.ge(timeNow.add(value: 3, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowgreaterThanTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowgreaterThanTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowgreaterThanTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowgreaterThanTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow)
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_nowgreaterThanTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow)
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourgreaterThanTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourgreaterThanTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourgreaterThanTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourgreaterThanTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow.add(value: 1, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue1to_hourgreaterThanTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow.add(value: 1, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourgreaterThanTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourgreaterThanTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourgreaterThanTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourgreaterThanTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow.add(value: 2, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue2to_hourgreaterThanTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow.add(value: 2, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourgreaterThanTemporalTimeTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourgreaterThanTemporalTimeTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourgreaterThanTemporalTimeTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourgreaterThanTemporalTimeTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testTemporalTimeTemporal_Time_now_addvalue3to_hourgreaterThanTemporalTime() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.gt(timeNow.add(value: 3, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenTemporalTimeTemporal_Time_now_addvalue1to_hourbetweenTemporalTimeTemporal_Time_now_addvalue3to_hourwithTemporal_Time_now() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.between(start: timeNow.add(value: 1, to: .hour), end: timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenTemporalTimeTemporal_Time_now_addvalue1to_hourbetweenTemporalTimeTemporal_Time_now_addvalue3to_hourwithTemporal_Time_now_addvalue1to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.between(start: timeNow.add(value: 1, to: .hour), end: timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 1, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenTemporalTimeTemporal_Time_now_addvalue1to_hourbetweenTemporalTimeTemporal_Time_now_addvalue3to_hourwithTemporal_Time_now_addvalue2to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.between(start: timeNow.add(value: 1, to: .hour), end: timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 2, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testbetweenTemporalTimeTemporal_Time_now_addvalue1to_hourbetweenTemporalTimeTemporal_Time_now_addvalue3to_hourwithTemporal_Time_now_addvalue3to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.between(start: timeNow.add(value: 1, to: .hour), end: timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 3, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenTemporalTimeTemporal_Time_now_addvalue1to_hourbetweenTemporalTimeTemporal_Time_now_addvalue3to_hourwithTemporal_Time_now_addvalue4to_hour() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.between(start: timeNow.add(value: 1, to: .hour), end: timeNow.add(value: 3, to: .hour))
+        var instance = QPredGen(name: "test")
+        instance.myTime = timeNow.add(value: 4, to: .hour)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testbetweenTemporalTimeTemporal_Time_now_addvalue1to_hourbetweenTemporalTimeTemporal_Time_now_addvalue3to_hourwith() throws {
+        let timeNow = try Temporal.Time.init(iso8601String: "10:16:44")
+        let predicate = QPredGen.keys.myTime.between(start: timeNow.add(value: 1, to: .hour), end: timeNow.add(value: 3, to: .hour))
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedTimeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedTimeTests.swift
@@ -1329,7 +1329,7 @@ class QueryPredicateEvaluateGeneratedTimeTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenTemporalTimeTemporal_Time_now_addvalue1to_hourbetweenTemporalTimeTemporal_Time_now_addvalue3to_hourwithTemporal_Time_now_addvalue2to_hour() throws {
@@ -1351,7 +1351,7 @@ class QueryPredicateEvaluateGeneratedTimeTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssert(evaluation)
     }
 
     func testbetweenTemporalTimeTemporal_Time_now_addvalue1to_hourbetweenTemporalTimeTemporal_Time_now_addvalue3to_hourwithTemporal_Time_now_addvalue4to_hour() throws {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGenerator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGenerator.swift
@@ -1,0 +1,547 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+
+let dateNow = Date()
+let dateNowPlus1hour = dateNow.addingTimeInterval(60 * 60 * 1)
+let dateNowPlus2hour = dateNow.addingTimeInterval(60 * 60 * 2)
+let dateNowPlus3hour = dateNow.addingTimeInterval(60 * 60 * 3)
+let dateNowPlus4hour = dateNow.addingTimeInterval(60 * 60 * 4)
+
+let dateNowPlus1day = dateNow.addingTimeInterval(60 * 60 * 1 * 24)
+let dateNowPlus2day = dateNow.addingTimeInterval(60 * 60 * 2 * 24)
+let dateNowPlus3day = dateNow.addingTimeInterval(60 * 60 * 3 * 24)
+let dateNowPlus4day = dateNow.addingTimeInterval(60 * 60 * 4 * 24)
+
+// This is a generator that was used to generate the unit tests.
+// This code was originally created as a standalone iphone app, but was moved into
+// this unit test class so that it could be run by other developers
+
+//swiftlint:disable type_body_length
+//swiftlint:disable file_length
+//swiftlint:disable line_length
+//swiftlint:disable identifier_name
+//swiftlint:disable function_parameter_count
+class QueryPredicateGenerator: XCTestCase {
+    func testBoolBool() throws {
+        generate("Bool,Bool")
+    }
+    func testDoubleDouble() {
+        generate("Double,Double")
+    }
+    func testDoubleInt() {
+        generate("Double,Int")
+    }
+    func testIntDouble() {
+        generate("Int,Double")
+    }
+    func testIntInt() {
+        generate("Int,Int")
+    }
+    func testStringString() {
+        generate("String,String")
+    }
+    func testDateDate() {
+        generate("Temporal.Date,Temporal.Date")
+    }
+    func testDateTimeDateTime() {
+        generate("Temporal.DateTime,Temporal.DateTime")
+    }
+    func testTimeTime() {
+        generate("Temporal.Time,Temporal.Time")
+    }
+
+    let types: [String] = ["Bool", "Double", "Int", "String", "Temporal.Date", "Temporal.DateTime", "Temporal.Time"]
+    let operations: [String] = ["notEqual", "equals", "lessOrEqual", "lessThan", "greaterOrEqual", "greaterThan", "contains", "between", "beginsWith"]
+    var requestedList: [String: [String]] = [
+        "Bool,Bool": ["notEqual", "equals"],
+        "Double,Double": ["notEqual", "equals", "less", "greater", "between"],
+        "Double,Int": ["notEqual", "equals", "less", "greater", "between"],
+        "Int,Double": ["notEqual", "equals", "less", "greater", "between"],
+        "Int,Int": ["notEqual", "equals", "less", "greater", "between"],
+        "String,String": ["notEqual", "equals", "less", "greater", "contains", "between", "beginsWith"],
+
+        "Temporal.Date,Temporal.Date": ["notEqual", "equals", "less", "greater", "between"],
+        "Temporal.DateTime,Temporal.DateTime": ["notEqual", "equals", "less", "greater", "between"],
+        "Temporal.Time,Temporal.Time": ["notEqual", "equals", "less", "greater", "between"]
+    ]
+
+    let operationMap: [String: String] = [
+        "equals": "eq",
+        "notEqual": "ne",
+        "lessOrEqual": "le",
+        "lessThan": "lt",
+        "greaterOrEqual": "ge",
+        "greaterThan": "gt",
+        "contains": "contains",
+        "between": "between",
+        "beginsWith": "beginsWith"
+    ]
+
+    let typeToValuesMap: [String: [String]] = [
+        "Bool": ["true", "false", ""],
+        "Double": ["1.1", "2.1", "3.1", "1", "2", "3", ""],
+        "Int": ["1", "2", "3", ""],
+        "String": ["\"a\"", "\"bb\"", "\"aa\"", "\"c\"", ""],
+        "Temporal.Date": ["Temporal.Date.now()",
+                          "Temporal.Date.now().add(value:1, to:.day)",
+                          "Temporal.Date.now().add(value:2, to:.day)",
+                          "Temporal.Date.now().add(value:3, to:.day)",
+                          ""],
+        "Temporal.DateTime": ["Temporal.DateTime.now()",
+                              "Temporal.DateTime.now().add(value:1, to:.hour)",
+                              "Temporal.DateTime.now().add(value:2, to:.hour)",
+                              "Temporal.DateTime.now().add(value:3, to:.hour)",
+                              ""],
+        "Temporal.Time": ["Temporal.Time.now()",
+                          "Temporal.Time.now().add(value:1, to:.hour)",
+                          "Temporal.Time.now().add(value:2, to:.hour)",
+                          "Temporal.Time.now().add(value:3, to:.hour)",
+                          ""]
+    ]
+
+    let temporalToTimeMap: [String: Date] = [
+        "Temporal.Date.now()": dateNow,
+        "Temporal.Date.now().add(value:1, to:.day)": dateNowPlus1day,
+        "Temporal.Date.now().add(value:2, to:.day)": dateNowPlus2day,
+        "Temporal.Date.now().add(value:3, to:.day)": dateNowPlus3day,
+        "Temporal.Date.now().add(value:4, to:.day)": dateNowPlus4day,
+
+        "Temporal.DateTime.now()": dateNow,
+        "Temporal.DateTime.now().add(value:1, to:.hour)": dateNowPlus1hour,
+        "Temporal.DateTime.now().add(value:2, to:.hour)": dateNowPlus2hour,
+        "Temporal.DateTime.now().add(value:3, to:.hour)": dateNowPlus3hour,
+        "Temporal.DateTime.now().add(value:4, to:.hour)": dateNowPlus4hour,
+
+        "Temporal.Time.now()": dateNow,
+        "Temporal.Time.now().add(value:1, to:.hour)": dateNowPlus1hour,
+        "Temporal.Time.now().add(value:2, to:.hour)": dateNowPlus2hour,
+        "Temporal.Time.now().add(value:3, to:.hour)": dateNowPlus3hour,
+        "Temporal.Time.now().add(value:4, to:.hour)": dateNowPlus4hour
+    ]
+
+    let typePairTov1v2BetweenTestsMap = [
+        "Double,Double": [("1.1", "3.1"), ("1", "3")],
+        "Double,Int": [("1.1", "3"), ("1", "3")],
+        "Int,Double": [("1", "3.1"), ("1", "3")],
+        "Int,Int": [("1", "3")],
+        "String,String": [("\"bb\"", "\"dd\"")],
+        "Temporal.Date,Temporal.Date": [("Temporal.Date.now().add(value:1, to:.day)", "Temporal.Date.now().add(value:3, to:.day)")],
+        "Temporal.DateTime,Temporal.DateTime": [("Temporal.DateTime.now().add(value:1, to:.hour)", "Temporal.DateTime.now().add(value:3, to:.hour)")],
+        "Temporal.Time,Temporal.Time": [("Temporal.Time.now().add(value:1, to:.hour)", "Temporal.Time.now().add(value:3, to:.hour)")]
+    ]
+
+    //the type of v3 is the type of v1 (which is the first part of the key)
+    let typePairTov3BetweenTestsMap = [
+        "Double,Double": ["0", "0.0", "1.1", "2", "1.2", "3", "3.1", "3.2", "4", ""],
+        "Double,Int": ["0", "0.0", "1.1", "2", "1.2", "3", "3.1", "3.2", "4", ""],
+        "Int,Double": ["0", "1", "2", "3", "4", ""],
+        "Int,Int": ["0", "1", "2", "3", "4", ""],
+        "String,String": ["\"a\"", "\"bb\"", "\"c\"", "\"dd\"", "\"e\"", ""],
+        "Temporal.Date,Temporal.Date": ["Temporal.Date.now()",
+                                        "Temporal.Date.now().add(value:1, to:.day)",
+                                        "Temporal.Date.now().add(value:2, to:.day)",
+                                        "Temporal.Date.now().add(value:3, to:.day)",
+                                        "Temporal.Date.now().add(value:4, to:.day)",
+                                        ""],
+        "Temporal.DateTime,Temporal.DateTime": ["Temporal.DateTime.now()",
+                                                "Temporal.DateTime.now().add(value:1, to:.hour)",
+                                                "Temporal.DateTime.now().add(value:2, to:.hour)",
+                                                "Temporal.DateTime.now().add(value:3, to:.hour)",
+                                                "Temporal.DateTime.now().add(value:4, to:.hour)",
+                                                ""],
+        "Temporal.Time,Temporal.Time": ["Temporal.Time.now()",
+                                        "Temporal.Time.now().add(value:1, to:.hour)",
+                                        "Temporal.Time.now().add(value:2, to:.hour)",
+                                        "Temporal.Time.now().add(value:3, to:.hour)",
+                                        "Temporal.Time.now().add(value:4, to:.hour)",
+                                        ""]
+    ]
+
+    let fieldForType: [String: String] = [
+        "Bool": "myBool",
+        "Double": "myDouble",
+        "Int": "myInt",
+        "String": "myString",
+        "Temporal.Date": "myDate",
+        "Temporal.DateTime": "myDateTime",
+        "Temporal.Time": "myTime"
+    ]
+
+    func generate(_ filter: String, printCount: Bool = false) {
+        var count = 0
+        for t1 in types {
+            for t2 in types {
+                for operation in operations {
+                    let key = "\(t1),\(t2)"
+                    if key != filter {
+                        continue
+                    }
+                    if let requestedOperations = requestedList[key] {
+                        for requestedOperation in requestedOperations {
+                            if operation.contains(requestedOperation) {
+                                count += performGeneration(t1: t1, t2: t2, operation: operation)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if printCount {
+            print("numberOfFunctions=\(count)")
+        }
+    }
+
+    func performGeneration(t1: String, t2: String, operation: String) -> Int {
+        var count = 0
+        guard let values1 = typeToValuesMap[t1],
+            let values2 = typeToValuesMap[t2] else {
+                print("failed to find values map!")
+                exit(1)
+        }
+        if operation == "between" {
+            let key = "\(t1),\(t2)"
+            let v1v2s = typePairTov1v2BetweenTestsMap[key]!
+            let v3s = typePairTov3BetweenTestsMap[key]!
+            for (v1, v2) in v1v2s {
+                for v3 in v3s {
+                    if handleBetween(t1: t1, v1: v1, t2: t2, v2: v2, v3: v3, operation: operation) {
+                        count += 1
+                    }
+                }
+            }
+        } else {
+            if t1 == "Int" && t2 == "Double" {
+                //Unable to assign a double value to a Int Type, so these tests are invalid
+                return 0
+            }
+            for v1 in values1 {
+                if v1 == "" {
+                    continue
+                }
+                for v2 in values2 {
+                    if handleOtherOperations(t1: t1, v1: v1, t2: t2, v2: v2, operation: operation) {
+                        count += 1
+                    }
+                }
+            }
+
+        }
+        return count
+    }
+
+    // handleBetween generates a test to check if v3 (value3) is between v1 and v2
+    func handleBetween(t1: String, v1: String, t2: String, v2: String, v3: String, operation: String) -> Bool {
+        guard let op = operationMap[operation],
+            let fieldName = fieldForType[t1] else {
+                print("Failed to look up operation")
+                return false
+        }
+
+        let v1FnName = v1.replacingOccurrences(of: ".", with: "_")
+            .replacingOccurrences(of: "\"", with: "")
+            .replacingOccurrences(of: "(", with: "")
+            .replacingOccurrences(of: ")", with: "")
+            .replacingOccurrences(of: ":", with: "")
+            .replacingOccurrences(of: ",", with: "")
+            .replacingOccurrences(of: " ", with: "")
+
+        let v2FnName = v2.replacingOccurrences(of: ".", with: "_")
+            .replacingOccurrences(of: "\"", with: "")
+            .replacingOccurrences(of: "(", with: "")
+            .replacingOccurrences(of: ")", with: "")
+            .replacingOccurrences(of: ":", with: "")
+            .replacingOccurrences(of: ",", with: "")
+            .replacingOccurrences(of: " ", with: "")
+        let type1 = t1.replacingOccurrences(of: ".", with: "")
+        let type2 = t2.replacingOccurrences(of: ".", with: "")
+
+        //In cases of between, we should check we have v1, v2 and v3, E.g.: (v1 < v3 && v3 > v2)
+        if v2 == "" {
+            return false
+        }
+
+        let v3FnName = v3.replacingOccurrences(of: ".", with: "_")
+            .replacingOccurrences(of: "\"", with: "")
+            .replacingOccurrences(of: "(", with: "")
+            .replacingOccurrences(of: ")", with: "")
+            .replacingOccurrences(of: ":", with: "")
+            .replacingOccurrences(of: ",", with: "")
+            .replacingOccurrences(of: " ", with: "")
+
+        print("func test\(operation)\(type1)\(v1FnName)\(operation)\(type2)\(v2FnName)with\(v3FnName)() throws {")
+
+        if t1 == "Temporal.DateTime" {
+            print("   let dateTimeNow = Temporal.DateTime.now()")
+        } else if t1 == "Temporal.Time" {
+            print("   let timeNow = try Temporal.Time.init(iso8601String: \"10:16:44\")")
+        }
+        let v1LocalRef = v1.replacingOccurrences(of: "Temporal.DateTime.now()",
+                                                 with: "dateTimeNow")
+            .replacingOccurrences(of: "Temporal.Time.now()",
+                                  with: "timeNow")
+        let v2LocalRef = v2.replacingOccurrences(of: "Temporal.DateTime.now()",
+                                                 with: "dateTimeNow")
+            .replacingOccurrences(of: "Temporal.Time.now()",
+                                  with: "timeNow")
+        let v3LocalRef = v3.replacingOccurrences(of: "Temporal.DateTime.now()",
+                                                 with: "dateTimeNow")
+            .replacingOccurrences(of: "Temporal.Time.now()",
+                                  with: "timeNow")
+
+        print("   let predicate = QPredGen.keys.\(fieldName).\(op)(start: \(v1LocalRef), end: \(v2LocalRef))")
+        if v3 != "" {
+            print("   var instance = QPredGen(name: \"test\")")
+            print("   instance.\(fieldName) = \(v3LocalRef)")
+        } else {
+            print("   let instance = QPredGen(name: \"test\")")
+        }
+        print("")
+        print("   let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)")
+        print("")
+        if type1 == "String" {
+            if attemptToResolveBetweenString(v1, v2, v3) {
+                print("   XCTAssert(evaluation)")
+            } else {
+                print("   XCTAssertFalse(evaluation)")
+            }
+        } else if type1.contains("Temporal") {
+            if attemptToResolveBetweenTemporal(t1, v1, t2, v2, v3) {
+                print("   XCTAssert(evaluation)")
+            } else {
+                print("   XCTAssertFalse(evaluation)")
+            }
+        } else {
+            if attemptToResolveBetweenDouble(v1, v2, v3) {
+                print("   XCTAssert(evaluation)")
+            } else {
+                print("   XCTAssertFalse(evaluation)")
+            }
+        }
+        print("}")
+        print("")
+        return true
+    }
+
+    func handleOtherOperations(t1: String, v1: String, t2: String, v2: String, operation: String) -> Bool {
+        guard let op = operationMap[operation],
+            let fieldName = fieldForType[t1] else {
+                print("Failed to look up operation")
+                return false
+        }
+
+        let v1FnName = v1.replacingOccurrences(of: ".", with: "_")
+            .replacingOccurrences(of: "\"", with: "")
+            .replacingOccurrences(of: "(", with: "")
+            .replacingOccurrences(of: ")", with: "")
+            .replacingOccurrences(of: ":", with: "")
+            .replacingOccurrences(of: ",", with: "")
+            .replacingOccurrences(of: " ", with: "")
+
+        let v2FnName = v2.replacingOccurrences(of: ".", with: "_")
+            .replacingOccurrences(of: "\"", with: "")
+            .replacingOccurrences(of: "(", with: "")
+            .replacingOccurrences(of: ")", with: "")
+            .replacingOccurrences(of: ":", with: "")
+            .replacingOccurrences(of: ",", with: "")
+            .replacingOccurrences(of: " ", with: "")
+
+        let type1 = t1.replacingOccurrences(of: ".", with: "")
+        let type2 = t2.replacingOccurrences(of: ".", with: "")
+
+        print("func test\(type1)\(v1FnName)\(operation)\(type2)\(v2FnName)() throws {")
+        if t1 == "Temporal.DateTime" {
+            print("   let dateTimeNow = Temporal.DateTime.now()")
+        } else if t1 == "Temporal.Time" {
+            print("   let timeNow = try Temporal.Time.init(iso8601String: \"10:16:44\")")
+        }
+        let v1LocalRef = v1.replacingOccurrences(of: "Temporal.DateTime.now()",
+                                                 with: "dateTimeNow")
+            .replacingOccurrences(of: "Temporal.Time.now()",
+                                  with: "timeNow")
+        let v2LocalRef = v2.replacingOccurrences(of: "Temporal.DateTime.now()",
+                                                 with: "dateTimeNow")
+            .replacingOccurrences(of: "Temporal.Time.now()",
+                                  with: "timeNow")
+
+        print("   let predicate = QPredGen.keys.\(fieldName).\(op)(\(v1LocalRef))")
+
+        if v2LocalRef != "" {
+            print("   var instance = QPredGen(name: \"test\")")
+            print("   instance.\(fieldName) = \(v2LocalRef)")
+        } else {
+            print("   let instance = QPredGen(name: \"test\")")
+        }
+        print("")
+        print("   let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)")
+        print("")
+
+        if attemptToResolve(type1,
+                            v1.replacingOccurrences(of: "\"", with: ""), type2,
+                            v2.replacingOccurrences(of: "\"", with: ""), op) {
+            print("   XCTAssert(evaluation)")
+        } else {
+            print("   XCTAssertFalse(evaluation)")
+        }
+        print("}")
+        print("")
+        return true
+    }
+
+    func attemptToResolve(_ t1: String, _ v1: String,
+                          _ t2: String, _ v2: String,
+                          _ op: String) -> Bool {
+        if t1 == "Double" && t2 == "Int" ||
+            t1 == "Int" && t2 == "Double" ||
+            t1 == "Double" && t2 == "Double" ||
+            t1 == "Int" && t2 == "Int" {
+            return attemptToResolveNumeric(t1, v1, t2, v2, op)
+        }
+        if t1.contains("Temporal") {
+            return attemptToResolveTemporal(t1, v1, t2, v2, op)
+        }
+
+        if v2 == "" {
+            return false
+        }
+        switch op {
+        case "eq":
+            return v2 == v1
+        case "ne":
+            return v2 != v1
+        case "le":
+            return v2 <= v1
+        case "lt":
+            return v2 < v1
+        case "ge":
+            return v2 >= v1
+        case "gt":
+            return v2 > v1
+        case "between":
+            print("FAILED: THIS FUNCTION SHOULD NOT BE CALLED WITH BETWEEN")
+            return false
+        case "beginsWith":
+            return v2.starts(with: v1)
+        case "contains":
+            return v2.contains(v1)
+        default:
+            print("FAILED: THIS FUNCTION SHOULD NOT BE CALLED WITH: \(op)")
+            return false
+        }
+    }
+
+    func attemptToResolveNumeric(_ t1: String, _ sv1: String,
+                                 _ t2: String, _ sv2: String,
+                                 _ op: String) -> Bool {
+        if sv2 == "" {
+            return false
+        }
+
+        guard let v1 = Double(sv1),
+            let v2 = Double(sv2) else {
+                print("FAILED NUMERIC!")
+                return false
+        }
+
+        switch op {
+        case "eq":
+            return v2 == v1
+        case "ne":
+            return v2 != v1
+        case "le":
+            return v2 <= v1
+        case "lt":
+            return v2 < v1
+        case "ge":
+            return v2 >= v1
+        case "gt":
+            return v2 > v1
+        case "between":
+            print("FATAL ERROR DO NOT ENTER!")
+        case "beginsWith":
+            return false
+        default:
+            return false
+        }
+        return false
+    }
+
+    func attemptToResolveTemporal(_ t1: String, _ sv1: String,
+                                  _ t2: String, _ sv2: String,
+                                  _ op: String) -> Bool {
+        if sv2 == "" {
+            return false
+        }
+
+        //Use built-in Date to determine the assert logic
+        let v1 = temporalToTimeMap[sv1]!
+        let v2 = temporalToTimeMap[sv2]!
+
+        switch op {
+        case "eq":
+            return v2 == v1
+        case "ne":
+            return v2 != v1
+        case "le":
+            return v2 <= v1
+        case "lt":
+            return v2 < v1
+        case "ge":
+            return v2 >= v1
+        case "gt":
+            return v2 > v1
+        case "between":
+            print("FATAL: between Temporal")
+        case "beginsWith":
+            print("FATAL: beginsWith Temporal")
+            return false
+        default:
+            return false
+        }
+        return false
+    }
+
+    func attemptToResolveBetweenTemporal(_ st1: String, _ sv1: String,
+                                         _ st2: String, _ sv2: String,
+                                         _ sv3: String) -> Bool {
+        if sv3 == "" {
+            return false
+        }
+        //Use built-in Date to determine the assert logic
+        let v1 = temporalToTimeMap[sv1]!
+        let v2 = temporalToTimeMap[sv2]!
+        let v3 = temporalToTimeMap[sv3]!
+        return v1 < v3 && v2 > v3
+    }
+
+    func attemptToResolveBetweenDouble(_ sv1: String,
+                                       _ sv2: String,
+                                       _ sv3: String) -> Bool {
+        if sv3 == "" {
+            return false
+        }
+
+        guard let v1 = Double(sv1),
+            let v2 = Double(sv2),
+            let v3 = Double(sv3) else {
+                print("FAILED DOUBLE!")
+                return false
+        }
+        return v1 < v3 && v2 > v3
+
+    }
+    func attemptToResolveBetweenString(_ sv1: String,
+                                       _ sv2: String,
+                                       _ sv3: String) -> Bool {
+        return sv1 < sv3 && sv2 > sv3
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGenerator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGenerator.swift
@@ -141,8 +141,8 @@ class QueryPredicateGenerator: XCTestCase {
 
     //the type of v3 is the type of v1 (which is the first part of the key)
     let typePairTov3BetweenTestsMap = [
-        "Double,Double": ["0", "0.0", "1.1", "2", "1.2", "3", "3.1", "3.2", "4", ""],
-        "Double,Int": ["0", "0.0", "1.1", "2", "1.2", "3", "3.1", "3.2", "4", ""],
+        "Double,Double": ["0", "0.0", "1", "1.1", "2", "1.2", "3", "3.1", "3.2", "4", ""],
+        "Double,Int": ["0", "0.0", "1", "1.1", "2", "1.2", "3", "3.1", "3.2", "4", ""],
         "Int,Double": ["0", "1", "2", "3", "4", ""],
         "Int,Int": ["0", "1", "2", "3", "4", ""],
         "String,String": ["\"a\"", "\"bb\"", "\"c\"", "\"dd\"", "\"e\"", ""],
@@ -525,7 +525,7 @@ class QueryPredicateGenerator: XCTestCase {
         let val1 = temporalToTimeMap[sv1]!
         let val2 = temporalToTimeMap[sv2]!
         let val3 = temporalToTimeMap[sv3]!
-        return val1 < val3 && val2 > val3
+        return val1 <= val3 && val2 >= val3
     }
 
     func attemptToResolveBetweenDouble(_ sv1: String,
@@ -541,13 +541,13 @@ class QueryPredicateGenerator: XCTestCase {
                 print("FAILED DOUBLE!")
                 return false
         }
-        return val1 < val3 && val2 > val3
+        return val1 <= val3 && val2 >= val3
 
     }
 
     func attemptToResolveBetweenString(_ sv1: String,
                                        _ sv2: String,
                                        _ sv3: String) -> Bool {
-        return sv1 < sv3 && sv2 > sv3
+        return sv1 <= sv3 && sv2 >= sv3
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateTests.swift
@@ -1,0 +1,128 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+class QueryPredicateEvaluateTests: XCTestCase {
+    func testMultiGroupAndPlusOr() throws {
+        let predicate = (QPredGen.keys.myBool.eq(true) && QPredGen.keys.name.eq("NotMatch")
+                                                       && QPredGen.keys.myString.eq("NotMatch"))
+                        || (QPredGen.keys.myInt.gt(1) && QPredGen.keys.myInt.le(10))
+                        || (QPredGen.keys.myDouble.gt(1) && QPredGen.keys.myDouble.le(10))
+        var instance = QPredGen(name: "test")
+        instance.myBool = true
+        instance.myInt = 2
+        instance.myDouble = 5
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testMultiAndPlusOr() throws {
+        let predicate = (QPredGen.keys.name.eq("test") && QPredGen.keys.myString.eq("NotMatch"))
+             || QPredGen.keys.myInt.eq(2)
+        var instance = QPredGen(name: "test")
+        instance.myString = "doe"
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testOrPlusMultiAnd() throws {
+        let predicate = QPredGen.keys.myInt.eq(2) ||
+            (QPredGen.keys.myBool.eq(true) && QPredGen.keys.name.eq("NotMatch")
+                                           || QPredGen.keys.myString.eq("NotMatch"))
+
+        var instance = QPredGen(name: "test")
+        instance.myBool = true
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testMultiOrPlusAnd() throws {
+        let predicate = (QPredGen.keys.myBool.eq(true) || QPredGen.keys.myString.eq("NotMatch"))
+        && QPredGen.keys.myInt.eq(3)
+
+        var instance = QPredGen(name: "test")
+        instance.myBool = true
+        instance.myString = "test"
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testBoolorStringWithAllAnd_false() throws {
+        let predicate = (QPredGen.keys.myBool.eq(true) && QPredGen.keys.name.eq("test"))
+        && QPredGen.keys.myInt.eq(3)
+
+        var instance = QPredGen(name: "test")
+        instance.myBool = true
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+    func testBoolorStringWithAllAnd_true() throws {
+        let predicate = (QPredGen.keys.myBool.eq(true) && QPredGen.keys.name.eq("test"))
+        && QPredGen.keys.myInt.eq(2)
+
+        var instance = QPredGen(name: "test")
+        instance.myBool = true
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+    func testBoolorStringWithAllOr_true() throws {
+        let predicate = (QPredGen.keys.myBool.eq(false) || QPredGen.keys.myString.eq("NotMatch"))
+        || QPredGen.keys.myInt.eq(2)
+
+        var instance = QPredGen(name: "test")
+        instance.myBool = true
+        instance.myString = "test"
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+    func testBoolorStringWithAllOr_false() throws {
+        let predicate = (QPredGen.keys.myBool.eq(false) || QPredGen.keys.myString.eq("NotMatch"))
+        || QPredGen.keys.myInt.eq(3)
+
+        var instance = QPredGen(name: "test")
+        instance.myBool = true
+        instance.myString = "test"
+        instance.myInt = 2
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testConstantall() throws {
+        let predicate = QueryPredicateConstant.all
+        let instance = QPredGen(name: "test")
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateTests.swift
@@ -116,7 +116,33 @@ class QueryPredicateEvaluateTests: XCTestCase {
 
         XCTAssertFalse(evaluation)
     }
+    func testBetweenIntStart() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 10)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 1
 
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+    func testBetweenIntBeyondEnd() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 10)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 11
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+    func testBetweenIntEnd() throws {
+        let predicate = QPredGen.keys.myInt.between(start: 1, end: 10)
+        var instance = QPredGen(name: "test")
+        instance.myInt = 10
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
     func testConstantall() throws {
         let predicate = QueryPredicateConstant.all
         let instance = QPredGen(name: "test")

--- a/AmplifyTestCommon/Models/QPredGen+Schema.swift
+++ b/AmplifyTestCommon/Models/QPredGen+Schema.swift
@@ -1,0 +1,46 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension QPredGen {
+  // MARK: - CodingKeys
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case name
+    case myBool
+    case myDouble
+    case myInt
+    case myString
+    case myDate
+    case myDateTime
+    case myTime
+  }
+
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema
+
+  public static let schema = defineSchema { model in
+    let qPredGen = QPredGen.keys
+
+    model.pluralName = "QPredGens"
+
+    model.fields(
+      .id(),
+      .field(qPredGen.name, is: .required, ofType: .string),
+      .field(qPredGen.myBool, is: .optional, ofType: .bool),
+      .field(qPredGen.myDouble, is: .optional, ofType: .double),
+      .field(qPredGen.myInt, is: .optional, ofType: .int),
+      .field(qPredGen.myString, is: .optional, ofType: .string),
+      .field(qPredGen.myDate, is: .optional, ofType: .date),
+      .field(qPredGen.myDateTime, is: .optional, ofType: .dateTime),
+      .field(qPredGen.myTime, is: .optional, ofType: .time)
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/QPredGen.swift
+++ b/AmplifyTestCommon/Models/QPredGen.swift
@@ -1,0 +1,56 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+/*
+ Generated from:
+
+ type QPredGen @model {
+   id: ID!
+   name: String!
+   myBool: Boolean
+   myDouble: Float
+   myInt: Int
+   myString: String
+   myDate: AWSDate
+   myDateTime: AWSDateTime
+   myTime: AWSTime
+ }
+ */
+public struct QPredGen: Model {
+  public let id: String
+  public var name: String
+  public var myBool: Bool?
+  public var myDouble: Double?
+  public var myInt: Int?
+  public var myString: String?
+  public var myDate: Temporal.Date?
+  public var myDateTime: Temporal.DateTime?
+  public var myTime: Temporal.Time?
+
+  public init(id: String = UUID().uuidString,
+      name: String,
+      myBool: Bool? = nil,
+      myDouble: Double? = nil,
+      myInt: Int? = nil,
+      myString: String? = nil,
+      myDate: Temporal.Date? = nil,
+      myDateTime: Temporal.DateTime? = nil,
+      myTime: Temporal.Time? = nil) {
+      self.id = id
+      self.name = name
+      self.myBool = myBool
+      self.myDouble = myDouble
+      self.myInt = myInt
+      self.myString = myString
+      self.myDate = myDate
+      self.myDateTime = myDateTime
+      self.myTime = myTime
+  }
+}


### PR DESCRIPTION
What to review in this PR:
```
Evaluable.swift
project.pbxproj
Persistable.swift
QueryOperator.swift
QueryPredicate.swift
QueryPredicateEvaluateTests.swift
QPredGen+Schema.swift
QPredGen.swift
```

What you might want to review, but..... eh, might not want to review is:
```
QueryPredicateEvaluateGenerator
```

You might want to spot check:
```
any generated tests
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
