### PR TITLE
fix(DataStore): SyncMutationToCloudOperationTests thread sanitizer bug

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
@@ -51,8 +51,8 @@ class SyncMutationToCloudOperationTests: XCTestCase {
                 listenerFromFirstRequestOptional = eventListener
                 expectFirstCallToAPIMutate.fulfill()
             } else if numberOfTimesEntered == 1 {
-                expectSecondCallToAPIMutate.fulfill()
                 listenerFromSecondRequestOptional = eventListener
+                expectSecondCallToAPIMutate.fulfill()
             } else {
                 XCTFail("This should not be called more than once")
             }


### PR DESCRIPTION
Addresses bug filed here:
https://github.com/aws-amplify/amplify-ios/issues/914


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
