### PR TITLE
feat(DataStore): Start/Stop implementation

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
@@ -38,6 +38,14 @@ extension DataStoreCategory: DataStoreBaseBehavior {
         plugin.delete(modelType, withId: id, completion: completion)
     }
 
+    public func start(completion: @escaping DataStoreCallback<Void>) {
+        plugin.start(completion: completion)
+    }
+
+    public func stop(completion: @escaping DataStoreCallback<Void>) {
+        plugin.stop(completion: completion)
+    }
+
     public func clear(completion: @escaping DataStoreCallback<Void>) {
         plugin.clear(completion: completion)
     }

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -34,6 +34,10 @@ public protocol DataStoreBaseBehavior {
                           withId id: String,
                           completion: @escaping DataStoreCallback<Void>)
 
+    func start(completion: @escaping DataStoreCallback<Void>)
+
+    func stop(completion: @escaping DataStoreCallback<Void>)
+
     func clear(completion: @escaping DataStoreCallback<Void>)
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -169,23 +169,10 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                              completion: onCompletion)
     }
     public func start(completion: @escaping DataStoreCallback<Void>) {
-        configurationSemaphore.wait()
-        defer {
-            configurationSemaphore.signal()
-        }
-        if storageEngine == nil {
-            reinitStorageEngine(completion: completion)
-        } else {
-            startSyncEngine(completion: completion)
-        }
+        reinitStorageEngineIfNeeded(completion: completion)
     }
 
     public func stop(completion: @escaping DataStoreCallback<Void>) {
-        configurationSemaphore.wait()
-        defer {
-            configurationSemaphore.signal()
-        }
-
         if storageEngine == nil {
             completion(.successfulVoid)
             return
@@ -201,11 +188,6 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
 
     public func clear(completion: @escaping DataStoreCallback<Void>) {
-        configurationSemaphore.wait()
-        defer {
-            configurationSemaphore.signal()
-        }
-
         if storageEngine == nil {
             completion(.successfulVoid)
             return

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -173,20 +173,10 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
         defer {
             configurationSemaphore.signal()
         }
-        let lastActionWasStopOrClear = storageEngine == nil
-        let lastActionWasConfigure = storageEngine != nil && shouldOnlyStartSyncEngineAndInitDataStorePublisher
-        if lastActionWasStopOrClear {
+        if storageEngine == nil {
             reinitStorageEngine(completion: completion)
-        } else if lastActionWasConfigure {
-            startSyncEngineAndInitDataStorePublisher(completion: { result in
-                if case .success = result {
-                    self.shouldOnlyStartSyncEngineAndInitDataStorePublisher = false
-                }
-                completion(result)
-            })
         } else {
-            // start() was called when sync engine is already started
-            completion(.successfulVoid)
+            startSyncEngine(completion: completion)
         }
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+SyncRequirement.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+SyncRequirement.swift
@@ -12,9 +12,11 @@ import AWSPluginsCore
 
 extension StorageEngine {
 
-    func startSync() {
+    func startSync(completion: @escaping DataStoreCallback<Void>) {
         guard let api = tryGetAPIPlugin() else {
             log.info("Unable to find suitable API plugin for syncEngine. syncEngine will not be started")
+            completion(.failure(.configuration("Unable to find suitable API plugin for syncEngine. syncEngine will not be started",
+                                               "Ensure the API category has been setup and configured for your project", nil)))
             return
         }
 
@@ -22,15 +24,19 @@ extension StorageEngine {
 
         guard authPluginRequired else {
             syncEngine?.start(api: api, auth: nil)
+            completion(.successfulVoid)
             return
         }
 
         guard let auth = tryGetAuthPlugin() else {
             log.warn("Unable to find suitable Auth plugin for syncEngine. Models require auth")
+            completion(.failure(.configuration("Unable to find suitable Auth plugin for syncEngine. Models require auth",
+                                               "Ensure the Auth category has been setup and configured for your project", nil)))
             return
         }
 
         syncEngine?.start(api: api, auth: auth)
+        completion(.successfulVoid)
     }
 
     private func tryGetAPIPlugin() -> APICategoryGraphQLBehavior? {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -10,6 +10,14 @@ import Combine
 import Foundation
 import AWSPluginsCore
 
+typealias StorageEngineBehaviorFactory =
+    (Bool,
+    DataStoreConfiguration,
+    String,
+    String,
+    String,
+    UserDefaults) throws -> StorageEngineBehavior
+
 // swiftlint:disable type_body_length
 final class StorageEngine: StorageEngineBehavior {
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -17,6 +17,8 @@ final class StorageEngine: StorageEngineBehavior {
     let storageAdapter: StorageEngineAdapter
     private let dataStoreConfiguration: DataStoreConfiguration
     var syncEngine: RemoteSyncEngineBehavior?
+    var syncEngineCalledStart: Bool
+    let syncEngineStartSerialQueue: DispatchQueue
     let validAPIPluginKey: String
     let validAuthPluginKey: String
     var signInListener: UnsubscribeToken?
@@ -75,6 +77,8 @@ final class StorageEngine: StorageEngineBehavior {
         self.syncEngine = syncEngine
         self.validAPIPluginKey = validAPIPluginKey
         self.validAuthPluginKey = validAuthPluginKey
+        self.syncEngineCalledStart = false
+        self.syncEngineStartSerialQueue = DispatchQueue(label: "com.amazonaws.DataStore.StorageEngineStartSerialQueue")
     }
 
     convenience init(isSyncEnabled: Bool,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -386,6 +386,16 @@ final class StorageEngine: StorageEngineBehavior {
         }
     }
 
+    func stopSync(completion: @escaping DataStoreCallback<Void>) {
+        if let syncEngine = syncEngine {
+            syncEngine.stop { _ in
+                completion(.successfulVoid)
+            }
+        } else {
+            completion(.successfulVoid)
+        }
+    }
+
     func reset(onComplete: () -> Void) {
         // TOOD: Perform cleanup on StorageAdapter, including releasing its `Connection` if needed
         let group = DispatchGroup()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineBehavior.swift
@@ -20,7 +20,7 @@ protocol StorageEngineBehavior: class, ModelStorageBehavior {
     var publisher: AnyPublisher<StorageEngineEvent, DataStoreError> { get }
 
     /// start remote sync, based on if sync is enabled and/or authentication is required
-    func startSync()
-
+    func startSync(completion: @escaping DataStoreCallback<Void>)
+    func stopSync(completion: @escaping DataStoreCallback<Void>)
     func clear(completion: @escaping DataStoreCallback<Void>)
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSAPICategoryPluginTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSAPICategoryPluginTests.swift
@@ -1,0 +1,264 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@testable import Amplify
+@testable import AWSDataStoreCategoryPlugin
+
+class AWSAPICategoryPluginTests: XCTestCase {
+    func testStorageEngineDoesNotStartsOnConfigure() throws {
+        let startExpectation = expectation(description: "Start Sync should not be called")
+        startExpectation.isInverted = true
+        let storageEngine = MockStorageEngineBehavior()
+        storageEngine.responders[.startSync] = StartSyncResponder { _ in
+            startExpectation.fulfill()
+        }
+        let dataStorePublisher = DataStorePublisher()
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        storageEngine: storageEngine,
+                                        dataStorePublisher: dataStorePublisher,
+                                        validAPIPluginKey: "MockAPICategoryPlugin",
+                                        validAuthPluginKey: "MockAuthCategoryPlugin")
+        do {
+            try plugin.configure(using: nil)
+        } catch {
+            XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testStorageEngineStartsOnPluginStart() throws {
+        let startExpectation = expectation(description: "Start Sync should be called")
+        let storageEngine = MockStorageEngineBehavior()
+        storageEngine.responders[.startSync] = StartSyncResponder { _ in
+            startExpectation.fulfill()
+        }
+        let dataStorePublisher = DataStorePublisher()
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        storageEngine: storageEngine,
+                                        dataStorePublisher: dataStorePublisher,
+                                        validAPIPluginKey: "MockAPICategoryPlugin",
+                                        validAuthPluginKey: "MockAuthCategoryPlugin")
+        do {
+            try plugin.configure(using: nil)
+            plugin.start(completion: {_ in})
+        } catch {
+            XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testStorageEngineStartsOnQuery() throws {
+        let startExpectation = expectation(description: "Start Sync should be called with Query")
+        let storageEngine = MockStorageEngineBehavior()
+        storageEngine.responders[.startSync] = StartSyncResponder { _ in
+            startExpectation.fulfill()
+        }
+        let dataStorePublisher = DataStorePublisher()
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        storageEngine: storageEngine,
+                                        dataStorePublisher: dataStorePublisher,
+                                        validAPIPluginKey: "MockAPICategoryPlugin",
+                                        validAuthPluginKey: "MockAuthCategoryPlugin")
+        do {
+            try plugin.configure(using: nil)
+            plugin.query(ExampleWithEveryType.self)
+        } catch {
+            XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testStorageEngineStartStopStart() throws {
+        let startExpectation = expectation(description: "Start Sync should be called with start")
+        let stopExpectation = expectation(description: "stop should be called")
+        let initExpectation = expectation(description: "init should be called")
+        let startExpectationOnSecondStart = expectation(description: "Start Sync should be called again")
+        let storageEngine = MockStorageEngineBehavior()
+        var count = 0
+        storageEngine.responders[.startSync] = StartSyncResponder { _ in
+            count = self.expect(startExpectation, count, 1)
+        }
+        storageEngine.responders[.stopSync] = StopSyncResponder { _ in
+            count = self.expect(stopExpectation, count, 2)
+        }
+        MockStorageEngineBehavior.staticResponders[.initConstructor] = InitResponder { newlyConstructedStorageEngine in
+            count = self.expect(initExpectation, count, 3)
+            newlyConstructedStorageEngine.responders[.startSync] = StartSyncResponder {_ in
+                count = self.expect(startExpectationOnSecondStart, count, 4)
+            }
+        }
+
+        let dataStorePublisher = DataStorePublisher()
+        let storageEngineBehaviorFactory =
+            MockStorageEngineBehavior.init(isSyncEnabled:dataStoreConfiguration:validAPIPluginKey:validAuthPluginKey:modelRegistryVersion:userDefault:)
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        storageEngine: storageEngine,
+                                        storageEngineBehaviorFactory: storageEngineBehaviorFactory,
+                                        dataStorePublisher: dataStorePublisher,
+                                        validAPIPluginKey: "MockAPICategoryPlugin",
+                                        validAuthPluginKey: "MockAuthCategoryPlugin")
+        do {
+            try plugin.configure(using: nil)
+            XCTAssert(plugin.storageEngine != nil)
+            XCTAssert(plugin.dataStorePublisher != nil)
+
+            let semaphore = DispatchSemaphore(value: 0)
+            plugin.start(completion: {_ in
+                XCTAssert(plugin.storageEngine != nil)
+                XCTAssert(plugin.dataStorePublisher != nil)
+                semaphore.signal()
+            })
+            semaphore.wait()
+
+            plugin.stop(completion: { _ in
+                XCTAssert(plugin.storageEngine == nil)
+                XCTAssert(plugin.dataStorePublisher == nil)
+                semaphore.signal()
+            })
+            semaphore.wait()
+
+            plugin.start(completion: { _ in
+                XCTAssert(plugin.storageEngine != nil)
+                XCTAssert(plugin.dataStorePublisher != nil)
+            })
+
+        } catch {
+            XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testStorageEngineStartClearStart() throws {
+        let startExpectation = expectation(description: "Start Sync should be called with start")
+        let clearExpectation = expectation(description: "Clear should be called")
+        let initExpectation = expectation(description: "init should be called")
+        let startExpectationOnSecondStart = expectation(description: "Start Sync should be called again")
+        let storageEngine = MockStorageEngineBehavior()
+        var count = 0
+        storageEngine.responders[.startSync] = StartSyncResponder { _ in
+            count = self.expect(startExpectation, count, 1)
+        }
+        storageEngine.responders[.clear] = ClearResponder { _ in
+            count = self.expect(clearExpectation, count, 2)
+        }
+        MockStorageEngineBehavior.staticResponders[.initConstructor] = InitResponder { newlyConstructedStorageEngine in
+            count = self.expect(initExpectation, count, 3)
+            newlyConstructedStorageEngine.responders[.startSync] = StartSyncResponder {_ in
+                count = self.expect(startExpectationOnSecondStart, count, 4)
+            }
+        }
+
+        let dataStorePublisher = DataStorePublisher()
+        let storageEngineBehaviorFactory =
+            MockStorageEngineBehavior.init(isSyncEnabled:dataStoreConfiguration:validAPIPluginKey:validAuthPluginKey:modelRegistryVersion:userDefault:)
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        storageEngine: storageEngine,
+                                        storageEngineBehaviorFactory: storageEngineBehaviorFactory,
+                                        dataStorePublisher: dataStorePublisher,
+                                        validAPIPluginKey: "MockAPICategoryPlugin",
+                                        validAuthPluginKey: "MockAuthCategoryPlugin")
+        do {
+            try plugin.configure(using: nil)
+            XCTAssert(plugin.storageEngine != nil)
+            XCTAssert(plugin.dataStorePublisher != nil)
+
+            let semaphore = DispatchSemaphore(value: 0)
+            plugin.start(completion: {_ in
+                XCTAssert(plugin.storageEngine != nil)
+                XCTAssert(plugin.dataStorePublisher != nil)
+                semaphore.signal()
+            })
+            semaphore.wait()
+
+            plugin.clear(completion: { _ in
+                XCTAssert(plugin.storageEngine == nil)
+                XCTAssert(plugin.dataStorePublisher == nil)
+                semaphore.signal()
+            })
+            semaphore.wait()
+
+            plugin.start(completion: { _ in
+                XCTAssert(plugin.storageEngine != nil)
+                XCTAssert(plugin.dataStorePublisher != nil)
+            })
+
+        } catch {
+            XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testStorageEngineQueryClearQuery() throws {
+        let startExpectation = expectation(description: "Start Sync should be called with Query")
+        let clearExpectation = expectation(description: "Clear should be called")
+        let initExpectation = expectation(description: "init should be called")
+        let startExpectationOnQuery = expectation(description: "Start Sync should be called again with Query")
+        let storageEngine = MockStorageEngineBehavior()
+        var count = 0
+        storageEngine.responders[.query] = QueryResponder { _ in
+            count = self.expect(startExpectation, count, 1)
+        }
+        storageEngine.responders[.clear] = ClearResponder { _ in
+            count = self.expect(clearExpectation, count, 2)
+        }
+        MockStorageEngineBehavior.staticResponders[.initConstructor] = InitResponder { newlyConstructedStorageEngine in
+            count = self.expect(initExpectation, count, 3)
+            newlyConstructedStorageEngine.responders[.query] = QueryResponder {_ in
+                count = self.expect(startExpectationOnQuery, count, 4)
+            }
+        }
+
+        let dataStorePublisher = DataStorePublisher()
+        let storageEngineBehaviorFactory =
+            MockStorageEngineBehavior.init(isSyncEnabled:dataStoreConfiguration:validAPIPluginKey:validAuthPluginKey:modelRegistryVersion:userDefault:)
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        storageEngine: storageEngine,
+                                        storageEngineBehaviorFactory: storageEngineBehaviorFactory,
+                                        dataStorePublisher: dataStorePublisher,
+                                        validAPIPluginKey: "MockAPICategoryPlugin",
+                                        validAuthPluginKey: "MockAuthCategoryPlugin")
+        do {
+            try plugin.configure(using: nil)
+            XCTAssert(plugin.storageEngine != nil)
+            XCTAssert(plugin.dataStorePublisher != nil)
+
+            let semaphore = DispatchSemaphore(value: 0)
+            plugin.query(ExampleWithEveryType.self, completion: {_ in
+                XCTAssert(plugin.storageEngine != nil)
+                XCTAssert(plugin.dataStorePublisher != nil)
+                semaphore.signal()
+            })
+            semaphore.wait()
+
+            plugin.clear(completion: { _ in
+                XCTAssert(plugin.storageEngine == nil)
+                XCTAssert(plugin.dataStorePublisher == nil)
+                semaphore.signal()
+            })
+            semaphore.wait()
+
+            plugin.query(ExampleWithEveryType.self, completion: { _ in
+                XCTAssert(plugin.storageEngine != nil)
+                XCTAssert(plugin.dataStorePublisher != nil)
+            })
+
+        } catch {
+            XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func expect(_ expectation: XCTestExpectation, _ currCount: Int, _ expectedCount: Int) -> Int {
+        let count = currCount + 1
+        if count == expectedCount {
+            expectation.fulfill()
+        }
+        return count
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
@@ -104,7 +104,7 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
         }
 
         try Amplify.configure(amplifyConfig)
-
+        Amplify.DataStore.start(completion: {_ in})
         waitForExpectations(timeout: 1.0)
     }
     // TODO: Implement the test below

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -215,7 +215,12 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
         return PassthroughSubject<StorageEngineEvent, DataStoreError>().eraseToAnyPublisher()
     }
 
-    func startSync() {
+    func startSync(completion: @escaping DataStoreCallback<Void>) {
+        XCTFail("Not expected to execute")
+    }
+
+    func stopSync(completion: @escaping DataStoreCallback<Void>) {
+        XCTFail("Not expected to execute")
     }
 
     func setUp(modelSchemas: [ModelSchema]) throws {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -206,6 +206,25 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
 }
 
 class MockStorageEngineBehavior: StorageEngineBehavior {
+    var responders = [ResponderKeys: Any]()
+    static var staticResponders = [ResponderKeys: Any]()
+
+    init() {
+        if let responder = MockStorageEngineBehavior.staticResponders[.initConstructor] as? InitResponder {
+            responder.callback(self)
+        }
+    }
+
+    init(isSyncEnabled: Bool,
+         dataStoreConfiguration: DataStoreConfiguration,
+         validAPIPluginKey: String = "awsAPIPlugin",
+         validAuthPluginKey: String = "awsCognitoAuthPlugin",
+         modelRegistryVersion: String,
+         userDefault: UserDefaults = UserDefaults.standard) throws {
+        if let responder = MockStorageEngineBehavior.staticResponders[.initConstructor] as? InitResponder {
+            responder.callback(self)
+        }
+    }
 
     func setupPublisher() {
 
@@ -216,11 +235,17 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
     }
 
     func startSync(completion: @escaping DataStoreCallback<Void>) {
-        XCTFail("Not expected to execute")
+        completion(.successfulVoid)
+        if let responder = responders[.startSync] as? StartSyncResponder {
+            return responder.callback("")
+        }
     }
 
     func stopSync(completion: @escaping DataStoreCallback<Void>) {
-        XCTFail("Not expected to execute")
+        completion(.successfulVoid)
+        if let responder = responders[.stopSync] as? StopSyncResponder {
+            return responder.callback("")
+        }
     }
 
     func setUp(modelSchemas: [ModelSchema]) throws {
@@ -256,7 +281,10 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
                          sort: [QuerySortDescriptor]?,
                          paginationInput: QueryPaginationInput?,
                          completion: DataStoreCallback<[M]>) {
-        //TODO: Find way to mock this
+        completion(.success([]))
+        if let responder = responders[.query] as? QueryResponder {
+            return responder.callback("")
+        }
     }
 
     func query<M: Model>(_ modelType: M.Type,
@@ -265,10 +293,16 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
                          sort: [QuerySortDescriptor]?,
                          paginationInput: QueryPaginationInput?,
                          completion: (DataStoreResult<[M]>) -> Void) {
-        //TODO: Find way to mock this
+        completion(.success([]))
+        if let responder = responders[.query] as? QueryResponder {
+            return responder.callback("")
+        }
     }
 
     func clear(completion: @escaping DataStoreCallback<Void>) {
-        //TODO: Find way to mock this
+        completion(.successfulVoid)
+        if let responder = responders[.clear] as? ClearResponder {
+            return responder.callback("")
+        }
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapterResponders.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapterResponders.swift
@@ -35,3 +35,19 @@ typealias SaveModelCompletionResponder<M: Model> = MockResponder<(M, DataStoreCa
 typealias SaveUntypedModelResponder = MockResponder<(Model, DataStoreCallback<Model>), Void>
 
 typealias DeleteUntypedModelCompletionResponder = MockResponder<(Model.Type, String), Void>
+
+extension MockStorageEngineBehavior {
+    enum ResponderKeys {
+        case initConstructor
+        case startSync
+        case stopSync
+        case clear
+        case query
+    }
+}
+
+typealias InitResponder = MockResponder<MockStorageEngineBehavior, Void>
+typealias StartSyncResponder = MockResponder<String, Void>
+typealias StopSyncResponder = MockResponder<String, Void>
+typealias ClearResponder = MockResponder<String, Void>
+typealias QueryResponder = MockResponder<String, Void>

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -135,6 +135,7 @@ class SyncEngineTestBase: XCTestCase {
     /// Starts amplify by invoking `Amplify.configure(amplifyConfig)`
     func startAmplify() throws {
         try Amplify.configure(amplifyConfig)
+        Amplify.DataStore.start(completion: {_ in})
     }
 
     /// Starts amplify by invoking `Amplify.configure(amplifyConfig)`, and waits to receive a `syncStarted` Hub message

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		6BC4FDAA23A899680027D20C /* MockRequestRetryablePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */; };
 		6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */; };
 		6BDC224223E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */; };
+		6BE7431C2575B8B000009FCB /* AWSAPICategoryPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE7431B2575B8B000009FCB /* AWSAPICategoryPluginTests.swift */; };
 		8141657E756CC7B2EE1CE851 /* Pods_HostApp_AWSDataStoreCategoryPluginAuthIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA320D973669D3843FDF755E /* Pods_HostApp_AWSDataStoreCategoryPluginAuthIntegrationTests.framework */; };
 		A209418EED69D7B1BB8A55C2 /* Pods_AWSDataStoreCategoryPlugin_AWSDataStoreCategoryPluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C63AE18F2569D004E94BD550 /* Pods_AWSDataStoreCategoryPlugin_AWSDataStoreCategoryPluginTests.framework */; };
 		A569484A6FBAE7EC7ADF3FD4 /* Pods_AWSDataStoreCategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A1D332BE6CF885805360B3D /* Pods_AWSDataStoreCategoryPlugin.framework */; };
@@ -312,6 +313,7 @@
 		6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRequestRetryablePolicy.swift; sourceTree = "<group>"; };
 		6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSyncEngineTests.swift; sourceTree = "<group>"; };
 		6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSInitialSyncOrchestrator.swift; sourceTree = "<group>"; };
+		6BE7431B2575B8B000009FCB /* AWSAPICategoryPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAPICategoryPluginTests.swift; sourceTree = "<group>"; };
 		9D42A96449A4B73735566C07 /* Pods-AWSDataStoreCategoryPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSDataStoreCategoryPlugin/Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; sourceTree = "<group>"; };
 		9F987EC33AAD7C0904A598CA /* Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B40EF02724BF68C900F2264C /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
@@ -806,6 +808,7 @@
 		FAD2BDF423957F35006EB065 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				6BE7431B2575B8B000009FCB /* AWSAPICategoryPluginTests.swift */,
 				B40EF02724BF68C900F2264C /* ConfigurationTests.swift */,
 				B9FAA13F238C600A009414B4 /* ListTests.swift */,
 				B912D1B9242984D10028F05C /* QueryPaginationInputTests.swift */,
@@ -1629,6 +1632,7 @@
 				2149E5FA238869CF00873955 /* APICategoryDependencyTests.swift in Sources */,
 				FA4B8E942391C2CD009FC10F /* MutationIngesterConflictResolutionTests.swift in Sources */,
 				FA4A9557239ACAD7008E876E /* ModelReconciliationQueueBehaviorTests.swift in Sources */,
+				6BE7431C2575B8B000009FCB /* AWSAPICategoryPluginTests.swift in Sources */,
 				FA4A955D239AD810008E876E /* MockSQLiteStorageEngineAdapterResponders.swift in Sources */,
 				D80064F62499297800935DA3 /* MockFileManager.swift in Sources */,
 				6B4E3DF42397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift in Sources */,

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -59,6 +59,14 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         notify("clear")
     }
 
+    func start(completion: @escaping DataStoreCallback<Void>) {
+        notify("start")
+    }
+    
+    func stop(completion: @escaping DataStoreCallback<Void>) {
+        notify("stop")
+    }
+
     @available(iOS 13.0, *)
     func publisher<M: Model>(for modelType: M.Type)
         -> AnyPublisher<MutationEvent, DataStoreError> {


### PR DESCRIPTION
* Implementing start/stop was more difficult than expected due to supporting an offline use case.
I am leaving the PR in draft for historical purposes.  This approach attempts to introduce a state into the AWSDataStorePlugin to keep track of whether or not we've issued a start() to the sync engine.  Doing so, in my opinion, overcomplicates the design. 
 In addition, it increases overhead by starting a mostly no-op thread for each data store operation.

A couple of test cases to consider:
1.  No API Configured, customer does not call start(), but publisher needs to be setup
2. API is configured, start(), query(), stop(), start() -- explicit case
3. API is configured, start(), query(), clear(), start() -- explicit case
4. API is configured, query(), query(), stop(), query() -- implicit case, where the first query() will start the sync engine

Known issues:
There is a known issue with this implementation.  If customers attempt to call `stop`, and then immediately call `clear()`, the local database will not be cleared because the instance to the storage engine is set to `nil`.  I don't think this is a use case we really have to worry about, so I am holding off on implementing this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
