### PR TITLE
feat(DataStore): Start/Stop implementation, 2nd approach

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
@@ -38,6 +38,14 @@ extension DataStoreCategory: DataStoreBaseBehavior {
         plugin.delete(modelType, withId: id, completion: completion)
     }
 
+    public func start(completion: @escaping DataStoreCallback<Void>) {
+        plugin.start(completion: completion)
+    }
+
+    public func stop(completion: @escaping DataStoreCallback<Void>) {
+        plugin.stop(completion: completion)
+    }
+
     public func clear(completion: @escaping DataStoreCallback<Void>) {
         plugin.clear(completion: completion)
     }

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -47,7 +47,7 @@ public protocol DataStoreBaseBehavior {
      This can also be used to modify DataStore sync expressions at runtime by calling stop(), then start()
      to force your sync expressions to be re-evaluated.
 
-     - parameter completion: callback is executed on completion or failure
+     - parameter completion: callback to be invoked on success or failure
      */
     func stop(completion: @escaping DataStoreCallback<Void>)
 

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -34,6 +34,10 @@ public protocol DataStoreBaseBehavior {
                           withId id: String,
                           completion: @escaping DataStoreCallback<Void>)
 
+    func start(completion: @escaping DataStoreCallback<Void>)
+
+    func stop(completion: @escaping DataStoreCallback<Void>)
+
     func clear(completion: @escaping DataStoreCallback<Void>)
 }
 

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -54,7 +54,7 @@ public protocol DataStoreBaseBehavior {
     /**
      To clear local data from DataStore, use the clear method.
 
-     - parameter completion: callback is executed on completion or failure
+     - parameter completion: callback to be invoked on success or failure
      */
     func clear(completion: @escaping DataStoreCallback<Void>)
 }

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -33,11 +33,29 @@ public protocol DataStoreBaseBehavior {
     func delete<M: Model>(_ modelType: M.Type,
                           withId id: String,
                           completion: @escaping DataStoreCallback<Void>)
+    /**
+     Synchronization starts automatically whenever you run any DataStore operation (query(), save(), delete())
+     however, you can explicitly begin the process with DatasStore.start()
 
+     - parameter completion: callback is executed on completion or failure
+     */
     func start(completion: @escaping DataStoreCallback<Void>)
 
+    /**
+     To stop the DataStore sync process, you can use DataStore.stop(). This ensures the real time subscription
+     connection is closed when your app is no longer interested in updates, such as when you application is closed.
+     This can also be used to modify DataStore sync expressions at runtime by calling stop(), then start()
+     to force your sync expressions to be re-evaluated.
+
+     - parameter completion: callback is executed on completion or failure
+     */
     func stop(completion: @escaping DataStoreCallback<Void>)
 
+    /**
+     To clear local data from DataStore, use the clear method.
+
+     - parameter completion: callback is executed on completion or failure
+     */
     func clear(completion: @escaping DataStoreCallback<Void>)
 }
 

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -37,7 +37,7 @@ public protocol DataStoreBaseBehavior {
      Synchronization starts automatically whenever you run any DataStore operation (query(), save(), delete())
      however, you can explicitly begin the process with DatasStore.start()
 
-     - parameter completion: callback is executed on completion or failure
+     - parameter completion: callback to be invoked on success or failure
      */
     func start(completion: @escaping DataStoreCallback<Void>)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -174,13 +174,12 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
 
     public func stop(completion: @escaping DataStoreCallback<Void>) {
         storageEngineInitSemaphore.wait()
-        defer {
-            storageEngineInitSemaphore.signal()
-        }
         if storageEngine == nil {
+            storageEngineInitSemaphore.signal()
             completion(.successfulVoid)
             return
         }
+        storageEngineInitSemaphore.signal()
         storageEngine.stopSync { result in
             self.storageEngine = nil
             if #available(iOS 13.0, *) {
@@ -193,13 +192,12 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
 
     public func clear(completion: @escaping DataStoreCallback<Void>) {
         storageEngineInitSemaphore.wait()
-        defer {
-            storageEngineInitSemaphore.signal()
-        }
         if storageEngine == nil {
+            storageEngineInitSemaphore.signal()
             completion(.successfulVoid)
             return
         }
+        storageEngineInitSemaphore.signal()
         storageEngine.clear { result in
             self.storageEngine = nil
             if #available(iOS 13.0, *) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -168,6 +168,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                              predicate: predicate,
                              completion: onCompletion)
     }
+
     public func start(completion: @escaping DataStoreCallback<Void>) {
         reinitStorageEngineIfNeeded(completion: completion)
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -168,6 +168,24 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                              predicate: predicate,
                              completion: onCompletion)
     }
+    public func start(completion: @escaping DataStoreCallback<Void>) {
+        reinitStorageEngineIfNeeded(completion: completion)
+    }
+
+    public func stop(completion: @escaping DataStoreCallback<Void>) {
+        if storageEngine == nil {
+            completion(.successfulVoid)
+            return
+        }
+        storageEngine.stopSync { result in
+            self.storageEngine = nil
+            if #available(iOS 13.0, *) {
+                self.dataStorePublisher?.sendFinished()
+            }
+            self.dataStorePublisher = nil
+            completion(result)
+        }
+    }
 
     public func clear(completion: @escaping DataStoreCallback<Void>) {
         if storageEngine == nil {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -173,6 +173,10 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
 
     public func stop(completion: @escaping DataStoreCallback<Void>) {
+        storageEngineInitSemaphore.wait()
+        defer {
+            storageEngineInitSemaphore.signal()
+        }
         if storageEngine == nil {
             completion(.successfulVoid)
             return
@@ -188,6 +192,10 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
 
     public func clear(completion: @escaping DataStoreCallback<Void>) {
+        storageEngineInitSemaphore.wait()
+        defer {
+            storageEngineInitSemaphore.signal()
+        }
         if storageEngine == nil {
             completion(.successfulVoid)
             return

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -93,7 +93,9 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
         }
         do {
             if #available(iOS 13.0, *) {
-                self.dataStorePublisher = DataStorePublisher()
+                if self.dataStorePublisher == nil {
+                    self.dataStorePublisher = DataStorePublisher()
+                }
             }
             try resolveStorageEngine(dataStoreConfiguration: dataStoreConfiguration)
             try storageEngine.setUp(modelSchemas: ModelRegistry.modelSchemas)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+SyncRequirement.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+SyncRequirement.swift
@@ -12,9 +12,11 @@ import AWSPluginsCore
 
 extension StorageEngine {
 
-    func startSync() {
+    func startSync(completion: @escaping DataStoreCallback<Void>) {
         guard let api = tryGetAPIPlugin() else {
             log.info("Unable to find suitable API plugin for syncEngine. syncEngine will not be started")
+            completion(.failure(.configuration("Unable to find suitable API plugin for syncEngine. syncEngine will not be started",
+                                               "Ensure the API category has been setup and configured for your project", nil)))
             return
         }
 
@@ -22,15 +24,18 @@ extension StorageEngine {
 
         guard authPluginRequired else {
             syncEngine?.start(api: api, auth: nil)
+            completion(.successfulVoid)
             return
         }
 
         guard let auth = tryGetAuthPlugin() else {
             log.warn("Unable to find suitable Auth plugin for syncEngine. Models require auth")
+            completion(.failure(.configuration("Unable to find suitable Auth plugin for syncEngine. Models require auth",
+                                               "Ensure the Auth category has been setup and configured for your project", nil)))
             return
         }
-
         syncEngine?.start(api: api, auth: auth)
+        completion(.successfulVoid)
     }
 
     private func tryGetAPIPlugin() -> APICategoryGraphQLBehavior? {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -10,6 +10,14 @@ import Combine
 import Foundation
 import AWSPluginsCore
 
+typealias StorageEngineBehaviorFactory =
+    (Bool,
+    DataStoreConfiguration,
+    String,
+    String,
+    String,
+    UserDefaults) throws -> StorageEngineBehavior
+
 // swiftlint:disable type_body_length
 final class StorageEngine: StorageEngineBehavior {
 
@@ -383,6 +391,16 @@ final class StorageEngine: StorageEngineBehavior {
             })
         } else {
             storageAdapter.clear(completion: completion)
+        }
+    }
+
+    func stopSync(completion: @escaping DataStoreCallback<Void>) {
+        if let syncEngine = syncEngine {
+            syncEngine.stop { _ in
+                completion(.successfulVoid)
+            }
+        } else {
+            completion(.successfulVoid)
         }
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineBehavior.swift
@@ -20,7 +20,7 @@ protocol StorageEngineBehavior: class, ModelStorageBehavior {
     var publisher: AnyPublisher<StorageEngineEvent, DataStoreError> { get }
 
     /// start remote sync, based on if sync is enabled and/or authentication is required
-    func startSync()
-
+    func startSync(completion: @escaping DataStoreCallback<Void>)
+    func stopSync(completion: @escaping DataStoreCallback<Void>)
     func clear(completion: @escaping DataStoreCallback<Void>)
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSAPICategoryPluginTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSAPICategoryPluginTests.swift
@@ -1,0 +1,259 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@testable import Amplify
+@testable import AWSDataStoreCategoryPlugin
+
+class AWSAPICategoryPluginTests: XCTestCase {
+    func testStorageEngineDoesNotStartsOnConfigure() throws {
+        let startExpectation = expectation(description: "Start Sync should not be called")
+        startExpectation.isInverted = true
+        let storageEngine = MockStorageEngineBehavior()
+        storageEngine.responders[.startSync] = StartSyncResponder { _ in
+            startExpectation.fulfill()
+        }
+        let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+            return storageEngine
+        }
+        let dataStorePublisher = DataStorePublisher()
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        storageEngineBehaviorFactory: storageEngineBehaviorFactory,
+                                        dataStorePublisher: dataStorePublisher,
+                                        validAPIPluginKey: "MockAPICategoryPlugin",
+                                        validAuthPluginKey: "MockAuthCategoryPlugin")
+        do {
+            try plugin.configure(using: nil)
+        } catch {
+            XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testStorageEngineStartsOnPluginStart() throws {
+        let startExpectation = expectation(description: "Start Sync should be called")
+        let storageEngine = MockStorageEngineBehavior()
+        storageEngine.responders[.startSync] = StartSyncResponder { _ in
+            startExpectation.fulfill()
+        }
+        let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+            return storageEngine
+        }
+        let dataStorePublisher = DataStorePublisher()
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        storageEngineBehaviorFactory: storageEngineBehaviorFactory,
+                                        dataStorePublisher: dataStorePublisher,
+                                        validAPIPluginKey: "MockAPICategoryPlugin",
+                                        validAuthPluginKey: "MockAuthCategoryPlugin")
+        do {
+            try plugin.configure(using: nil)
+            plugin.start(completion: {_ in})
+        } catch {
+            XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testStorageEngineStartsOnQuery() throws {
+        let startExpectation = expectation(description: "Start Sync should be called with Query")
+        let storageEngine = MockStorageEngineBehavior()
+        storageEngine.responders[.startSync] = StartSyncResponder { _ in
+            startExpectation.fulfill()
+        }
+        let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+            return storageEngine
+        }
+        let dataStorePublisher = DataStorePublisher()
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        storageEngineBehaviorFactory: storageEngineBehaviorFactory,
+                                        dataStorePublisher: dataStorePublisher,
+                                        validAPIPluginKey: "MockAPICategoryPlugin",
+                                        validAuthPluginKey: "MockAuthCategoryPlugin")
+        do {
+            try plugin.configure(using: nil)
+            plugin.query(ExampleWithEveryType.self)
+        } catch {
+            XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testStorageEngineStartStopStart() throws {
+        let startExpectation = expectation(description: "Start Sync should be called with start")
+        let stopExpectation = expectation(description: "stop should be called")
+        let startExpectationOnSecondStart = expectation(description: "Start Sync should be called again")
+        var count = 0
+
+        let storageEngine = MockStorageEngineBehavior()
+        storageEngine.responders[.startSync] = StartSyncResponder { _ in
+            count = self.expect(startExpectation, count, 1)
+        }
+        storageEngine.responders[.stopSync] = StopSyncResponder { _ in
+            count = self.expect(stopExpectation, count, 2)
+        }
+
+        let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+            return storageEngine
+        }
+        let dataStorePublisher = DataStorePublisher()
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        storageEngineBehaviorFactory: storageEngineBehaviorFactory,
+                                        dataStorePublisher: dataStorePublisher,
+                                        validAPIPluginKey: "MockAPICategoryPlugin",
+                                        validAuthPluginKey: "MockAuthCategoryPlugin")
+        do {
+            try plugin.configure(using: nil)
+            XCTAssert(plugin.storageEngine == nil)
+
+            let semaphore = DispatchSemaphore(value: 0)
+            plugin.start(completion: {_ in
+                XCTAssert(plugin.storageEngine != nil)
+                XCTAssert(plugin.dataStorePublisher != nil)
+                semaphore.signal()
+            })
+            semaphore.wait()
+
+            plugin.stop(completion: { _ in
+                XCTAssert(plugin.storageEngine == nil)
+                XCTAssert(plugin.dataStorePublisher == nil)
+                semaphore.signal()
+            })
+            semaphore.wait()
+
+            storageEngine.responders[.startSync] = StartSyncResponder { _ in
+                count = self.expect(startExpectationOnSecondStart, count, 3)
+            }
+
+            plugin.start(completion: { _ in
+                XCTAssert(plugin.storageEngine != nil)
+                XCTAssert(plugin.dataStorePublisher != nil)
+            })
+
+        } catch {
+            XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testStorageEngineStartClearStart() throws {
+        let startExpectation = expectation(description: "Start Sync should be called with start")
+        let clearExpectation = expectation(description: "Clear should be called")
+        let startExpectationOnSecondStart = expectation(description: "Start Sync should be called again")
+        var count = 0
+        let storageEngine = MockStorageEngineBehavior()
+        storageEngine.responders[.startSync] = StartSyncResponder { _ in
+            count = self.expect(startExpectation, count, 1)
+        }
+        storageEngine.responders[.clear] = ClearResponder { _ in
+            count = self.expect(clearExpectation, count, 2)
+        }
+        let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+            return storageEngine
+        }
+        let dataStorePublisher = DataStorePublisher()
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        storageEngineBehaviorFactory: storageEngineBehaviorFactory,
+                                        dataStorePublisher: dataStorePublisher,
+                                        validAPIPluginKey: "MockAPICategoryPlugin",
+                                        validAuthPluginKey: "MockAuthCategoryPlugin")
+        do {
+            try plugin.configure(using: nil)
+            XCTAssert(plugin.storageEngine == nil)
+
+            let semaphore = DispatchSemaphore(value: 0)
+            plugin.start(completion: {_ in
+                XCTAssert(plugin.storageEngine != nil)
+                XCTAssert(plugin.dataStorePublisher != nil)
+                semaphore.signal()
+            })
+            semaphore.wait()
+
+            plugin.clear(completion: { _ in
+                XCTAssert(plugin.storageEngine == nil)
+                XCTAssert(plugin.dataStorePublisher == nil)
+                semaphore.signal()
+            })
+            semaphore.wait()
+            storageEngine.responders[.startSync] = StartSyncResponder {_ in
+                count = self.expect(startExpectationOnSecondStart, count, 3)
+            }
+
+            plugin.start(completion: { _ in
+                XCTAssert(plugin.storageEngine != nil)
+                XCTAssert(plugin.dataStorePublisher != nil)
+            })
+
+        } catch {
+            XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testStorageEngineQueryClearQuery() throws {
+        let startExpectation = expectation(description: "Start Sync should be called with Query")
+        let clearExpectation = expectation(description: "Clear should be called")
+        let startExpectationOnQuery = expectation(description: "Start Sync should be called again with Query")
+        var count = 0
+        let storageEngine = MockStorageEngineBehavior()
+        storageEngine.responders[.query] = QueryResponder { _ in
+            count = self.expect(startExpectation, count, 1)
+        }
+        storageEngine.responders[.clear] = ClearResponder { _ in
+            count = self.expect(clearExpectation, count, 2)
+        }
+
+        let dataStorePublisher = DataStorePublisher()
+        let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+            return storageEngine
+        }
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        storageEngineBehaviorFactory: storageEngineBehaviorFactory,
+                                        dataStorePublisher: dataStorePublisher,
+                                        validAPIPluginKey: "MockAPICategoryPlugin",
+                                        validAuthPluginKey: "MockAuthCategoryPlugin")
+        do {
+            try plugin.configure(using: nil)
+            XCTAssert(plugin.storageEngine == nil)
+
+            let semaphore = DispatchSemaphore(value: 0)
+            plugin.query(ExampleWithEveryType.self, completion: {_ in
+                XCTAssert(plugin.storageEngine != nil)
+                XCTAssert(plugin.dataStorePublisher != nil)
+                semaphore.signal()
+            })
+            semaphore.wait()
+
+            plugin.clear(completion: { _ in
+                XCTAssert(plugin.storageEngine == nil)
+                XCTAssert(plugin.dataStorePublisher == nil)
+                semaphore.signal()
+            })
+            semaphore.wait()
+            storageEngine.responders[.query] = QueryResponder {_ in
+                count = self.expect(startExpectationOnQuery, count, 3)
+            }
+
+            plugin.query(ExampleWithEveryType.self, completion: { _ in
+                XCTAssert(plugin.storageEngine != nil)
+                XCTAssert(plugin.dataStorePublisher != nil)
+            })
+
+        } catch {
+            XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
+        }
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func expect(_ expectation: XCTestExpectation, _ currCount: Int, _ expectedCount: Int) -> Int {
+        let count = currCount + 1
+        if count == expectedCount {
+            expectation.fulfill()
+        }
+        return count
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/ConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/ConfigurationTests.swift
@@ -13,10 +13,9 @@ import XCTest
 class AWSAPICategoryPluginConfigureTests: XCTestCase {
 
     func testConfigureSuccessForNilConfiguration() throws {
-        let storageEngine = MockStorageEngineBehavior()
         let dataStorePublisher = DataStorePublisher()
         let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
-                                        storageEngine: storageEngine,
+                                        storageEngineBehaviorFactory: MockStorageEngineBehavior.mockStorageEngineBehaviorFactory,
                                         dataStorePublisher: dataStorePublisher,
                                         validAPIPluginKey: "MockAPICategoryPlugin",
                                         validAuthPluginKey: "MockAuthCategoryPlugin")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
@@ -47,10 +47,12 @@ class SQLiteStorageEngineAdapterJsonTests: XCTestCase {
             XCTFail(String(describing: error))
             return
         }
-
+        let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+            return self.storageEngine
+        }
         let dataStorePublisher = DataStorePublisher()
         let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestJsonModelRegistration(),
-                                                 storageEngine: storageEngine,
+                                                 storageEngineBehaviorFactory: storageEngineBehaviorFactory,
                                                  dataStorePublisher: dataStorePublisher,
                                                  validAPIPluginKey: validAPIPluginKey,
                                                  validAuthPluginKey: validAuthPluginKey)
@@ -64,6 +66,7 @@ class SQLiteStorageEngineAdapterJsonTests: XCTestCase {
 
             try Amplify.add(plugin: dataStorePlugin)
             try Amplify.configure(amplifyConfig)
+            Amplify.DataStore.start(completion: {_ in})
         } catch {
             XCTFail(String(describing: error))
             return

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
@@ -76,10 +76,13 @@ extension APICategoryDependencyTests {
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)
+        let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+            return storageEngine
+        }
 
         let dataStorePublisher = DataStorePublisher()
         let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
-                                                 storageEngine: storageEngine,
+                                                 storageEngineBehaviorFactory: storageEngineBehaviorFactory,
                                                  dataStorePublisher: dataStorePublisher,
                                                  validAPIPluginKey: validAPIPluginKey,
                                                  validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
@@ -61,9 +61,12 @@ class LocalSubscriptionTests: XCTestCase {
             return
         }
 
+        let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+            return storageEngine
+        }
         let dataStorePublisher = DataStorePublisher()
         let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
-                                                 storageEngine: storageEngine,
+                                                 storageEngineBehaviorFactory: storageEngineBehaviorFactory,
                                                  dataStorePublisher: dataStorePublisher,
                                                  validAPIPluginKey: validAPIPluginKey,
                                                  validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionWithJSONModelTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionWithJSONModelTests.swift
@@ -16,7 +16,6 @@ import Combine
 /// Tests behavior of local DataStore subscriptions (as opposed to remote API subscription behaviors)
 /// using serialized JSON models
 class LocalSubscriptionWithJSONModelTests: XCTestCase {
-
     var dataStorePlugin: AWSDataStorePlugin!
 
     override func setUp() {
@@ -64,9 +63,12 @@ class LocalSubscriptionWithJSONModelTests: XCTestCase {
             return
         }
 
+        let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+            return storageEngine
+        }
         let dataStorePublisher = DataStorePublisher()
         dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestJsonModelRegistration(),
-                                             storageEngine: storageEngine,
+                                             storageEngineBehaviorFactory: storageEngineBehaviorFactory,
                                              dataStorePublisher: dataStorePublisher,
                                              validAPIPluginKey: validAPIPluginKey,
                                              validAuthPluginKey: validAuthPluginKey)
@@ -313,5 +315,4 @@ class LocalSubscriptionWithJSONModelTests: XCTestCase {
 
         subscription.cancel()
     }
-
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
@@ -13,7 +13,6 @@ import SQLite
 @testable import AWSDataStoreCategoryPlugin
 
 class AWSMutationEventIngesterTests: XCTestCase {
-
     // Used by tests to assert that the MutationEvent table is being updated
     var storageAdapter: SQLiteStorageEngineAdapter!
 
@@ -48,9 +47,12 @@ class AWSMutationEventIngesterTests: XCTestCase {
                                               validAPIPluginKey: validAPIPluginKey,
                                               validAuthPluginKey: validAuthPluginKey)
 
+            let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+                return storageEngine
+            }
             let publisher = DataStorePublisher()
             let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
-                                                     storageEngine: storageEngine,
+                                                     storageEngineBehaviorFactory: storageEngineBehaviorFactory,
                                                      dataStorePublisher: publisher,
                                                      validAPIPluginKey: validAPIPluginKey,
                                                      validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
@@ -282,10 +282,9 @@ extension OutgoingMutationQueueMockStateTest {
     private func setUpCore() throws -> AmplifyConfiguration {
         Amplify.reset()
 
-        let storageEngine = MockStorageEngineBehavior()
         let dataStorePublisher = DataStorePublisher()
         let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
-                                                 storageEngine: storageEngine,
+                                                 storageEngineBehaviorFactory: MockStorageEngineBehavior.mockStorageEngineBehaviorFactory,
                                                  dataStorePublisher: dataStorePublisher,
                                                  validAPIPluginKey: "MockAPICategoryPlugin",
                                                  validAuthPluginKey: "MockAuthCategoryPlugin")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -901,10 +901,9 @@ extension ProcessMutationErrorFromCloudOperationTests {
     private func setUpCore() throws -> AmplifyConfiguration {
         Amplify.reset()
 
-        let storageEngine = MockStorageEngineBehavior()
         let dataStorePublisher = DataStorePublisher()
         let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
-                                                 storageEngine: storageEngine,
+                                                 storageEngineBehaviorFactory: MockStorageEngineBehavior.mockStorageEngineBehaviorFactory,
                                                  dataStorePublisher: dataStorePublisher,
                                                  validAPIPluginKey: "MockAPICategoryPlugin",
                                                  validAuthPluginKey: "MockAuthCategoryPlugin")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
@@ -236,10 +236,9 @@ extension SyncMutationToCloudOperationTests {
     private func setUpCore() throws -> AmplifyConfiguration {
         Amplify.reset()
 
-        let storageEngine = MockStorageEngineBehavior()
         let dataStorePublisher = DataStorePublisher()
         let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
-                                                 storageEngine: storageEngine,
+                                                 storageEngineBehaviorFactory: MockStorageEngineBehavior.mockStorageEngineBehaviorFactory,
                                                  dataStorePublisher: dataStorePublisher,
                                                  validAPIPluginKey: "MockAPICategoryPlugin",
                                                  validAuthPluginKey: "MockAuthCategoryPlugin")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
@@ -53,10 +53,12 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
             XCTFail(String(describing: error))
             return
         }
-
+        let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+            return storageEngine
+        }
         let dataStorePublisher = DataStorePublisher()
         let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
-                                                 storageEngine: storageEngine,
+                                                 storageEngineBehaviorFactory: storageEngineBehaviorFactory,
                                                  dataStorePublisher: dataStorePublisher,
                                                  validAPIPluginKey: validAPIPluginKey,
                                                  validAuthPluginKey: validAuthPluginKey)
@@ -104,7 +106,7 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
         }
 
         try Amplify.configure(amplifyConfig)
-
+        Amplify.DataStore.start(completion: {_ in})
         waitForExpectations(timeout: 1.0)
     }
     // TODO: Implement the test below

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -297,10 +297,9 @@ extension ReconcileAndLocalSaveOperationTests {
     private func setUpCore() throws -> AmplifyConfiguration {
         Amplify.reset()
 
-        let storageEngine = MockStorageEngineBehavior()
         let dataStorePublisher = DataStorePublisher()
         let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
-                                                 storageEngine: storageEngine,
+                                                 storageEngineBehaviorFactory: MockStorageEngineBehavior.mockStorageEngineBehaviorFactory,
                                                  dataStorePublisher: dataStorePublisher,
                                                  validAPIPluginKey: "MockAPICategoryPlugin",
                                                  validAuthPluginKey: "MockAuthCategoryPlugin")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -206,6 +206,20 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
 }
 
 class MockStorageEngineBehavior: StorageEngineBehavior {
+    static let mockStorageEngineBehaviorFactory =
+        MockStorageEngineBehavior.init(isSyncEnabled:dataStoreConfiguration:validAPIPluginKey:validAuthPluginKey:modelRegistryVersion:userDefault:)
+    var responders = [ResponderKeys: Any]()
+
+    init() {
+    }
+
+    init(isSyncEnabled: Bool,
+         dataStoreConfiguration: DataStoreConfiguration,
+         validAPIPluginKey: String = "awsAPIPlugin",
+         validAuthPluginKey: String = "awsCognitoAuthPlugin",
+         modelRegistryVersion: String,
+         userDefault: UserDefaults = UserDefaults.standard) throws {
+    }
 
     func setupPublisher() {
 
@@ -215,7 +229,18 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
         return PassthroughSubject<StorageEngineEvent, DataStoreError>().eraseToAnyPublisher()
     }
 
-    func startSync() {
+    func startSync(completion: @escaping DataStoreCallback<Void>) {
+        completion(.successfulVoid)
+        if let responder = responders[.startSync] as? StartSyncResponder {
+            return responder.callback("")
+        }
+    }
+
+    func stopSync(completion: @escaping DataStoreCallback<Void>) {
+        completion(.successfulVoid)
+        if let responder = responders[.stopSync] as? StopSyncResponder {
+            return responder.callback("")
+        }
     }
 
     func setUp(modelSchemas: [ModelSchema]) throws {
@@ -251,7 +276,10 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
                          sort: [QuerySortDescriptor]?,
                          paginationInput: QueryPaginationInput?,
                          completion: DataStoreCallback<[M]>) {
-        //TODO: Find way to mock this
+        completion(.success([]))
+        if let responder = responders[.query] as? QueryResponder {
+            return responder.callback("")
+        }
     }
 
     func query<M: Model>(_ modelType: M.Type,
@@ -260,10 +288,16 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
                          sort: [QuerySortDescriptor]?,
                          paginationInput: QueryPaginationInput?,
                          completion: (DataStoreResult<[M]>) -> Void) {
-        //TODO: Find way to mock this
+        completion(.success([]))
+        if let responder = responders[.query] as? QueryResponder {
+            return responder.callback("")
+        }
     }
 
     func clear(completion: @escaping DataStoreCallback<Void>) {
-        //TODO: Find way to mock this
+        completion(.successfulVoid)
+        if let responder = responders[.clear] as? ClearResponder {
+            return responder.callback("")
+        }
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapterResponders.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapterResponders.swift
@@ -35,3 +35,19 @@ typealias SaveModelCompletionResponder<M: Model> = MockResponder<(M, DataStoreCa
 typealias SaveUntypedModelResponder = MockResponder<(Model, DataStoreCallback<Model>), Void>
 
 typealias DeleteUntypedModelCompletionResponder = MockResponder<(Model.Type, String), Void>
+
+extension MockStorageEngineBehavior {
+    enum ResponderKeys {
+        case initConstructor
+        case startSync
+        case stopSync
+        case clear
+        case query
+    }
+}
+
+typealias InitResponder = MockResponder<MockStorageEngineBehavior, Void>
+typealias StartSyncResponder = MockResponder<String, Void>
+typealias StopSyncResponder = MockResponder<String, Void>
+typealias ClearResponder = MockResponder<String, Void>
+typealias QueryResponder = MockResponder<String, Void>

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapterResponders.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapterResponders.swift
@@ -38,7 +38,6 @@ typealias DeleteUntypedModelCompletionResponder = MockResponder<(Model.Type, Str
 
 extension MockStorageEngineBehavior {
     enum ResponderKeys {
-        case initConstructor
         case startSync
         case stopSync
         case clear
@@ -46,7 +45,6 @@ extension MockStorageEngineBehavior {
     }
 }
 
-typealias InitResponder = MockResponder<MockStorageEngineBehavior, Void>
 typealias StartSyncResponder = MockResponder<String, Void>
 typealias StopSyncResponder = MockResponder<String, Void>
 typealias ClearResponder = MockResponder<String, Void>

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
@@ -46,10 +46,12 @@ class BaseDataStoreTests: XCTestCase {
             XCTFail(String(describing: error))
             return
         }
-
+        let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+            return self.storageEngine
+        }
         let dataStorePublisher = DataStorePublisher()
         let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
-                                                 storageEngine: storageEngine,
+                                                 storageEngineBehaviorFactory: storageEngineBehaviorFactory,
                                                  dataStorePublisher: dataStorePublisher,
                                                  validAPIPluginKey: validAPIPluginKey,
                                                  validAuthPluginKey: validAuthPluginKey)
@@ -68,6 +70,7 @@ class BaseDataStoreTests: XCTestCase {
             try Amplify.add(plugin: apiPlugin)
             try Amplify.add(plugin: dataStorePlugin)
             try Amplify.configure(amplifyConfig)
+            Amplify.DataStore.start(completion: {_ in})
         } catch {
             XCTFail(String(describing: error))
             return

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -111,7 +111,7 @@ class SyncEngineTestBase: XCTestCase {
                     default:
                         break
                     }
-        })
+            })
 
         let validAPIPluginKey = "MockAPICategoryPlugin"
         let validAuthPluginKey = "MockAuthCategoryPlugin"
@@ -121,10 +121,12 @@ class SyncEngineTestBase: XCTestCase {
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)
-
+        let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+            return storageEngine
+        }
         let publisher = DataStorePublisher()
         let dataStorePlugin = AWSDataStorePlugin(modelRegistration: modelRegistration,
-                                                 storageEngine: storageEngine,
+                                                 storageEngineBehaviorFactory: storageEngineBehaviorFactory,
                                                  dataStorePublisher: publisher,
                                                  validAPIPluginKey: validAPIPluginKey,
                                                  validAuthPluginKey: validAuthPluginKey)
@@ -135,6 +137,7 @@ class SyncEngineTestBase: XCTestCase {
     /// Starts amplify by invoking `Amplify.configure(amplifyConfig)`
     func startAmplify() throws {
         try Amplify.configure(amplifyConfig)
+        Amplify.DataStore.start(completion: {_ in})
     }
 
     /// Starts amplify by invoking `Amplify.configure(amplifyConfig)`, and waits to receive a `syncStarted` Hub message

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		6BC4FDAA23A899680027D20C /* MockRequestRetryablePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */; };
 		6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */; };
 		6BDC224223E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */; };
+		6BE7431C2575B8B000009FCB /* AWSAPICategoryPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE7431B2575B8B000009FCB /* AWSAPICategoryPluginTests.swift */; };
 		8141657E756CC7B2EE1CE851 /* Pods_HostApp_AWSDataStoreCategoryPluginAuthIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA320D973669D3843FDF755E /* Pods_HostApp_AWSDataStoreCategoryPluginAuthIntegrationTests.framework */; };
 		A209418EED69D7B1BB8A55C2 /* Pods_AWSDataStoreCategoryPlugin_AWSDataStoreCategoryPluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C63AE18F2569D004E94BD550 /* Pods_AWSDataStoreCategoryPlugin_AWSDataStoreCategoryPluginTests.framework */; };
 		A569484A6FBAE7EC7ADF3FD4 /* Pods_AWSDataStoreCategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A1D332BE6CF885805360B3D /* Pods_AWSDataStoreCategoryPlugin.framework */; };
@@ -312,6 +313,7 @@
 		6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRequestRetryablePolicy.swift; sourceTree = "<group>"; };
 		6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSyncEngineTests.swift; sourceTree = "<group>"; };
 		6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSInitialSyncOrchestrator.swift; sourceTree = "<group>"; };
+		6BE7431B2575B8B000009FCB /* AWSAPICategoryPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAPICategoryPluginTests.swift; sourceTree = "<group>"; };
 		9D42A96449A4B73735566C07 /* Pods-AWSDataStoreCategoryPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSDataStoreCategoryPlugin/Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; sourceTree = "<group>"; };
 		9F987EC33AAD7C0904A598CA /* Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B40EF02724BF68C900F2264C /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
@@ -806,6 +808,7 @@
 		FAD2BDF423957F35006EB065 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				6BE7431B2575B8B000009FCB /* AWSAPICategoryPluginTests.swift */,
 				B40EF02724BF68C900F2264C /* ConfigurationTests.swift */,
 				B9FAA13F238C600A009414B4 /* ListTests.swift */,
 				B912D1B9242984D10028F05C /* QueryPaginationInputTests.swift */,
@@ -1629,6 +1632,7 @@
 				2149E5FA238869CF00873955 /* APICategoryDependencyTests.swift in Sources */,
 				FA4B8E942391C2CD009FC10F /* MutationIngesterConflictResolutionTests.swift in Sources */,
 				FA4A9557239ACAD7008E876E /* ModelReconciliationQueueBehaviorTests.swift in Sources */,
+				6BE7431C2575B8B000009FCB /* AWSAPICategoryPluginTests.swift in Sources */,
 				FA4A955D239AD810008E876E /* MockSQLiteStorageEngineAdapterResponders.swift in Sources */,
 				D80064F62499297800935DA3 /* MockFileManager.swift in Sources */,
 				6B4E3DF42397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift in Sources */,

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -59,6 +59,14 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         notify("clear")
     }
 
+    func start(completion: @escaping DataStoreCallback<Void>) {
+        notify("start")
+    }
+    
+    func stop(completion: @escaping DataStoreCallback<Void>) {
+        notify("stop")
+    }
+
     @available(iOS 13.0, *)
     func publisher<M: Model>(for modelType: M.Type)
         -> AnyPublisher<MutationEvent, DataStoreError> {


### PR DESCRIPTION
First approach was here:
https://github.com/aws-amplify/amplify-ios/pull/917

I realized late that we have effectively coupled the instantiation of the storageEngine with starting the syncEngine.  The approach in this PR maintains this behavior in order to skirt around having to save state of whether or not the sync engine has been started in conjunction with the storage engine being instantiated.  I believe that by preserving this coupling, makes for a significantly more elegant approach than the design/implementation in PR 917.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
