### PR TITLE
test(auth): Added test for authorizationProvider

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		B43DC74F2410572400D40275 /* AWSCognitoAuthPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B43DC7452410572400D40275 /* AWSCognitoAuthPlugin.framework */; };
 		B44373A1247C869100DEF43C /* AuthSessionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44373A0247C869100DEF43C /* AuthSessionHelper.swift */; };
 		B44373A4247C8CCE00DEF43C /* AuthSignOutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44373A3247C8CCE00DEF43C /* AuthSignOutTests.swift */; };
+		B4D5411B256F2C8A00436E5C /* BaseAuthorizationProviderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D5411A256F2C8A00436E5C /* BaseAuthorizationProviderTest.swift */; };
 		B4F3EA47243A776800F23296 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B4F3EA41243A776800F23296 /* Assets.xcassets */; };
 		B4F3EA48243A776800F23296 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B4F3EA42243A776800F23296 /* LaunchScreen.storyboard */; };
 		B4F3EA49243A776800F23296 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B4F3EA44243A776800F23296 /* Main.storyboard */; };
@@ -334,6 +335,7 @@
 		B4672B5A24777C7500C83E96 /* AWSCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AWSCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4672B5B24777C7500C83E96 /* AWSMobileClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AWSMobileClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4672B5C24777C7500C83E96 /* AWSPluginsCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AWSPluginsCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B4D5411A256F2C8A00436E5C /* BaseAuthorizationProviderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAuthorizationProviderTest.swift; sourceTree = "<group>"; };
 		B4F3EA20243A65BD00F23296 /* HostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4F3EA41243A776800F23296 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B4F3EA43243A776800F23296 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -503,6 +505,7 @@
 			children = (
 				B4136E5D256D7A690011210B /* AuthorizationProviderSessionSignInTests.swift */,
 				B4136E63256D7A740011210B /* AuthorizationProviderSessionSignoutTests.swift */,
+				B4D5411A256F2C8A00436E5C /* BaseAuthorizationProviderTest.swift */,
 			);
 			path = AuthorizationProviderTests;
 			sourceTree = "<group>";
@@ -1495,6 +1498,7 @@
 				B43B4E1A2565FBFE008F345D /* AWSCognitoAuthDeviceBehaviorTests.swift in Sources */,
 				B43B4E032565E95E008F345D /* MockAuthDeviceServiceBehavior.swift in Sources */,
 				B4136E6C256D7AF30011210B /* UserBehaviorFetchAttributeTests.swift in Sources */,
+				B4D5411B256F2C8A00436E5C /* BaseAuthorizationProviderTest.swift in Sources */,
 				B43B4E102565EA64008F345D /* AWSCognitoAuthClientBehaviorTests.swift in Sources */,
 				B4136E2C256D764B0011210B /* AuthenticationProviderResendSignupCodeTests.swift in Sources */,
 				B41D0FE32475A3A10049D08D /* AuthHubEventHandlerTests.swift in Sources */,

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedInSession.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedInSession.swift
@@ -155,12 +155,10 @@ extension AuthorizationProviderAdapter {
             guard task.error == nil else {
                 if let urlError = task.error as NSError?, urlError.domain == NSURLErrorDomain {
                     self.fetchSignedInSessionWithOfflineError(completionHandler)
-                    return nil
 
                 } else if let awsMobileClientError = task.error as? AWSMobileClientError {
                     if case .unableToSignIn = awsMobileClientError {
                         self.fetchSignedInSessionWithSessionExpiredError(completionHandler)
-                        return nil
                     }
                 }
                 let authError = AuthErrorHelper.toAuthError(task.error!)

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedInSession.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedInSession.swift
@@ -155,10 +155,12 @@ extension AuthorizationProviderAdapter {
             guard task.error == nil else {
                 if let urlError = task.error as NSError?, urlError.domain == NSURLErrorDomain {
                     self.fetchSignedInSessionWithOfflineError(completionHandler)
+                    return nil
 
                 } else if let awsMobileClientError = task.error as? AWSMobileClientError {
                     if case .unableToSignIn = awsMobileClientError {
                         self.fetchSignedInSessionWithSessionExpiredError(completionHandler)
+                        return nil
                     }
                 }
                 let authError = AuthErrorHelper.toAuthError(task.error!)

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthorizationProviderTests/AuthorizationProviderSessionSignInTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthorizationProviderTests/AuthorizationProviderSessionSignInTests.swift
@@ -11,21 +11,706 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 @testable import AWSMobileClient
+import AWSCore
+import AWSPluginsCore
 
-class AuthorizationProviderSessionSignInTests: XCTestCase {
-
-    var authenticationProvider: AuthenticationProviderAdapter!
-    var mockAWSMobileClient: MockAWSMobileClient!
-    var plugin: AWSCognitoAuthPlugin!
+// swiftlint:disable file_length
+// swiftlint:disable type_body_length
+class AuthorizationProviderSessionSignInTests: BaseAuthorizationProviderTest {
 
     override func setUp() {
-        mockAWSMobileClient = MockAWSMobileClient()
-        authenticationProvider = AuthenticationProviderAdapter(awsMobileClient: mockAWSMobileClient!)
-        plugin = AWSCognitoAuthPlugin()
-        plugin?.configure(authenticationProvider: authenticationProvider,
-                         authorizationProvider: MockAuthorizationProviderBehavior(),
-                         userService: MockAuthUserServiceBehavior(),
-                         deviceService: MockAuthDeviceServiceBehavior(),
-                         hubEventHandler: MockAuthHubEventBehavior())
+        super.setUp()
+        mockAWSMobileClient.mockCurrentUserState = .signedIn
+    }
+
+    /// Test signedIn session with a user signed In to userPool and identityPool enabled
+    ///
+    /// - Given: Given an auth plugin with signedIn state and identityPool enabled
+    /// - When:
+    ///    - I invoke fetchAuthSession
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = true
+    ///         - aws credentails = valid values
+    ///         - identity id = valid values
+    ///         - cognito tokens = valid values
+    ///
+    func testSignInSessionWithIdentityPoolEnabled() {
+        mockAWSCredentials()
+        mockCognitoTokens()
+        mockIdentityId()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+
+                XCTAssertTrue(session.isSignedIn)
+
+                let creds = try? (session as? AuthAWSCredentialsProvider)?.getAWSCredentials().get()
+                XCTAssertNotNil(creds?.accessKey)
+                XCTAssertNotNil(creds?.secretKey)
+
+                let identityId = try? (session as? AuthCognitoIdentityProvider)?.getIdentityId().get()
+                XCTAssertNotNil(identityId)
+
+                let tokens = try? (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
+                XCTAssertNotNil(tokens?.accessToken)
+                XCTAssertNotNil(tokens?.idToken)
+                XCTAssertNotNil(tokens?.refreshToken)
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedIn session with a user signed In to  identityPool
+    ///
+    /// - Given: Given an auth plugin with signedIn state
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock notSignedIn for getTokens
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = true
+    ///         - aws credentails = valid values
+    ///         - identity id = valid values
+    ///         - cognito tokens = service error with invalidAccountTypeException error
+    ///
+    func testSignInToIdentityPoolSession() {
+        mockAWSCredentials()
+        mockIdentityId()
+        mockAWSMobileClient.tokensMockResult = .failure(AWSMobileClientError.notSignedIn(message: "Error"))
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+
+                XCTAssertTrue(session.isSignedIn)
+
+                let creds = try? (session as? AuthAWSCredentialsProvider)?.getAWSCredentials().get()
+                XCTAssertNotNil(creds?.accessKey)
+                XCTAssertNotNil(creds?.secretKey)
+
+                let identityId = try? (session as? AuthCognitoIdentityProvider)?.getIdentityId().get()
+                XCTAssertNotNil(identityId)
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .service(_, _, let underlyingError) = error,
+                      case .invalidAccountTypeException = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return invalidAccountTypeException error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedIn session with session expired
+    ///
+    /// - Given: Given an auth plugin with signedIn state
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock notSignedIn for getTokens
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = true
+    ///         - aws credentails = sessionExpired error
+    ///         - identity id = sessionExpired error
+    ///         - cognito tokens = sessionExpired error
+    ///
+    func testSignInSessionWithExpiredToken() {
+        mockAWSCredentials()
+        mockIdentityId()
+        mockAWSMobileClient.tokensMockResult = .failure(AWSMobileClientError.unableToSignIn(message: "Error"))
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+
+                XCTAssertTrue(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let error) = credentialsResult, case .sessionExpired = error else {
+                    XCTFail("Should return sessionExpired error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .sessionExpired = identityIdError else {
+                    XCTFail("Should return sessionExpired error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let tokenError) = tokensResult,
+                      case .sessionExpired = tokenError else {
+                    XCTFail("Should return sessionExpired error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedIn session with session expired while fetching aws credentials
+    ///
+    /// - Given: Given an auth plugin with signedIn state
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock notSignedIn for getAWSCredentials
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = true
+    ///         - aws credentails = sessionExpired error
+    ///         - identity id = sessionExpired error
+    ///         - cognito tokens = sessionExpired error
+    ///
+    func testSignInSessionWithExpiredTokenInAWSCredentials() {
+        mockCognitoTokens()
+        mockIdentityId()
+        mockAWSMobileClient.awsCredentialsMockResult = .failure(AWSMobileClientError.unableToSignIn(message: "Error"))
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+
+                XCTAssertTrue(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let error) = credentialsResult, case .sessionExpired = error else {
+                    XCTFail("Should return sessionExpired error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .sessionExpired = identityIdError else {
+                    XCTFail("Should return sessionExpired error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let tokenError) = tokensResult,
+                      case .sessionExpired = tokenError else {
+                    XCTFail("Should return sessionExpired error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedIn session with session expired while fetching identity id
+    ///
+    /// - Given: Given an auth plugin with signedIn state
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock notSignedIn for getIdentityId
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = true
+    ///         - aws credentails = sessionExpired error
+    ///         - identity id = sessionExpired error
+    ///         - cognito tokens = sessionExpired error
+    ///
+    func testSignInSessionWithExpiredTokenInIdentityId() {
+        mockAWSCredentials()
+        mockCognitoTokens()
+        mockIdentityId()
+        let error = AWSMobileClientError.unableToSignIn(message: "Error")
+        mockAWSMobileClient.getIdentityIdMockResult = AWSTask(error: error)
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+
+                XCTAssertTrue(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let error) = credentialsResult, case .sessionExpired = error else {
+                    XCTFail("Should return sessionExpired error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .sessionExpired = identityIdError else {
+                    XCTFail("Should return sessionExpired error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let tokenError) = tokensResult,
+                      case .sessionExpired = tokenError else {
+                    XCTFail("Should return sessionExpired error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedIn session with network error for token
+    ///
+    /// - Given: Given an auth plugin with signedIn state
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock netowrk error for getTokens
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = true
+    ///         - aws credentails = service error with network
+    ///         - identity id = service error with network
+    ///         - cognito tokens = service error with network
+    ///
+    func testSignInSessionWithNetworkErrorForToken() {
+        mockAWSCredentials()
+        mockIdentityId()
+        let error = NSError(domain: NSURLErrorDomain, code: 1, userInfo: nil)
+        mockAWSMobileClient.tokensMockResult = .failure(error)
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+
+                XCTAssertTrue(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let error) = credentialsResult,
+                      case .service(_, _, let underlyingError) = error,
+                      case .network = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .service(_, _, let underlyingIdentityIdError) = identityIdError,
+                      case .network = (underlyingIdentityIdError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let tokenError) = tokensResult,
+                      case .service(_, _, let underlyingTokenError) = tokenError,
+                      case .network = (underlyingTokenError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedIn session with network error for identityId
+    ///
+    /// - Given: Given an auth plugin with signedIn state
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock netowrk error for getIdentityId
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = true
+    ///         - aws credentails = service error with network
+    ///         - identity id = service error with network
+    ///         - cognito tokens = service error with network
+    ///
+    func testSignInSessionWithNetworkErrorForIdentityId() {
+        mockAWSCredentials()
+        mockCognitoTokens()
+        mockIdentityId()
+        let error = NSError(domain: NSURLErrorDomain, code: 1, userInfo: nil)
+        mockAWSMobileClient.getIdentityIdMockResult = AWSTask(error: error)
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+
+                XCTAssertTrue(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let error) = credentialsResult,
+                      case .service(_, _, let underlyingError) = error,
+                      case .network = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .service(_, _, let underlyingIdentityIdError) = identityIdError,
+                      case .network = (underlyingIdentityIdError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let tokenError) = tokensResult,
+                      case .service(_, _, let underlyingTokenError) = tokenError,
+                      case .network = (underlyingTokenError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedIn session with network error for aws credentials
+    ///
+    /// - Given: Given an auth plugin with signedIn state
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock netowrk error for getAWSCredentials
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = true
+    ///         - aws credentails = service error with network
+    ///         - identity id = service error with network
+    ///         - cognito tokens = service error with network
+    ///
+    func testSignInSessionWithNetworkErrorForAWSCredentials() {
+        mockAWSCredentials()
+        mockCognitoTokens()
+        mockIdentityId()
+        let error = NSError(domain: NSURLErrorDomain, code: 1, userInfo: nil)
+        mockAWSMobileClient.awsCredentialsMockResult = .failure(error)
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+
+                XCTAssertTrue(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let error) = credentialsResult,
+                      case .service(_, _, let underlyingError) = error,
+                      case .network = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .service(_, _, let underlyingIdentityIdError) = identityIdError,
+                      case .network = (underlyingIdentityIdError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let tokenError) = tokensResult,
+                      case .service(_, _, let underlyingTokenError) = tokenError,
+                      case .network = (underlyingTokenError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedIn session with invalid response for tokens
+    ///
+    /// - Given: Given an auth plugin with signedIn state
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock nil response for tokens
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = true
+    ///         - aws credentails = unknown error
+    ///         - identity id = unknown error
+    ///         - cognito tokens = unknown error
+    ///
+    func testSignInSessionWithInvalidToken() {
+        mockAWSCredentials()
+        mockIdentityId()
+        mockAWSMobileClient.tokensMockResult = nil
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+
+                XCTAssertTrue(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let error) = credentialsResult, case .unknown = error else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .unknown = identityIdError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let tokenError) = tokensResult,
+                      case .unknown = tokenError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedIn session with invalid response for aws credentials
+    ///
+    /// - Given: Given an auth plugin with signedIn state
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock nil response for aws credentials
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = true
+    ///         - aws credentails = unknown error
+    ///         - identity id = unknown error
+    ///         - cognito tokens = unknown error
+    ///
+    func testSignInSessionWithInvalidAWSCredentials() {
+        mockCognitoTokens()
+        mockIdentityId()
+        mockAWSMobileClient.awsCredentialsMockResult = nil
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+
+                XCTAssertTrue(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let error) = credentialsResult, case .unknown = error else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .unknown = identityIdError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let tokenError) = tokensResult,
+                      case .unknown = tokenError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedIn session with invalid response for identity id
+    ///
+    /// - Given: Given an auth plugin with signedIn state
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock nil response for identity id
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = true
+    ///         - aws credentails = unknown error
+    ///         - identity id = unknown error
+    ///         - cognito tokens = unknown error
+    ///
+    func testSignInSessionWithInvalidIdentityId() {
+        mockAWSCredentials()
+        mockCognitoTokens()
+        mockIdentityId()
+        mockAWSMobileClient.getIdentityIdMockResult = AWSTask(result: nil)
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+
+                XCTAssertTrue(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let error) = credentialsResult, case .unknown = error else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .unknown = identityIdError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let tokenError) = tokensResult,
+                      case .unknown = tokenError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedIn session with miss configuration for aws credentials
+    ///
+    /// - Given: Given an auth plugin with signedIn state
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock misconfiguration for aws credentials
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = true
+    ///         - aws credentails = service error with invalidAccountTypeException
+    ///         - identity id = service error with invalidAccountTypeException
+    ///         - cognito tokens = valid values
+    ///
+    func testSignInSessionWithMisConfigurationForAWSCredentials() {
+        mockAWSCredentials()
+        mockCognitoTokens()
+        let error = AWSMobileClientError.cognitoIdentityPoolNotConfigured(message: "Error")
+        mockAWSMobileClient.awsCredentialsMockResult = .failure(error)
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+
+                XCTAssertTrue(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let error) = credentialsResult,
+                      case .service(_, _, let underlyingError) = error,
+                      case .invalidAccountTypeException = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .service(_, _, let underlyingIdentityIdError) = identityIdError,
+                      case .invalidAccountTypeException = (underlyingIdentityIdError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+
+                let tokens = try? (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
+                XCTAssertNotNil(tokens?.accessToken)
+                XCTAssertNotNil(tokens?.idToken)
+                XCTAssertNotNil(tokens?.refreshToken)
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedIn session with notAuthorized for aws credentials
+    ///
+    /// - Given: Given an auth plugin with signedIn state
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock misconfiguration for aws credentials
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = true
+    ///         - aws credentails = service error with invalidAccountTypeException
+    ///         - identity id = service error with invalidAccountTypeException
+    ///         - cognito tokens = valid values
+    ///
+    func testSignInSessionWithNotAuthorizedForAWSCredentials() {
+        mockAWSCredentials()
+        mockCognitoTokens()
+        mockIdentityId()
+        let error = NSError(domain: AWSCognitoIdentityErrorDomain,
+                            code: AWSCognitoIdentityErrorType.notAuthorized.rawValue,
+                            userInfo: nil)
+        mockAWSMobileClient.awsCredentialsMockResult = .failure(error)
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+
+                XCTAssertTrue(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let error) = credentialsResult,
+                      case .service(_, _, let underlyingError) = error,
+                      case .invalidAccountTypeException = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .service(_, _, let underlyingIdentityIdError) = identityIdError,
+                      case .invalidAccountTypeException = (underlyingIdentityIdError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+
+                let tokens = try? (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
+                XCTAssertNotNil(tokens?.accessToken)
+                XCTAssertNotNil(tokens?.idToken)
+                XCTAssertNotNil(tokens?.refreshToken)
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthorizationProviderTests/AuthorizationProviderSessionSignoutTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthorizationProviderTests/AuthorizationProviderSessionSignoutTests.swift
@@ -11,21 +11,873 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 @testable import AWSMobileClient
+import AWSCore
+import AWSPluginsCore
 
-class AuthorizationProviderSessionSignoutTests: XCTestCase {
-
-    var authenticationProvider: AuthenticationProviderAdapter!
-    var mockAWSMobileClient: MockAWSMobileClient!
-    var plugin: AWSCognitoAuthPlugin!
+// swiftlint:disable file_length
+// swiftlint:disable type_body_length
+class AuthorizationProviderSessionSignoutTests: BaseAuthorizationProviderTest {
 
     override func setUp() {
-        mockAWSMobileClient = MockAWSMobileClient()
-        authenticationProvider = AuthenticationProviderAdapter(awsMobileClient: mockAWSMobileClient!)
-        plugin = AWSCognitoAuthPlugin()
-        plugin?.configure(authenticationProvider: authenticationProvider,
-                         authorizationProvider: MockAuthorizationProviderBehavior(),
-                         userService: MockAuthUserServiceBehavior(),
-                         deviceService: MockAuthDeviceServiceBehavior(),
-                         hubEventHandler: MockAuthHubEventBehavior())
+        super.setUp()
+        mockAWSMobileClient.mockCurrentUserState = .guest
+    }
+
+    /// Test signedOut session with unAuthenticated access enabled.
+    ///
+    /// - Given: Given an auth plugin with signedOut state and unauthenticated access enabled in backend
+    /// - When:
+    ///    - I invoke fetchAuthSession
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = false
+    ///         - aws credentails = valid values
+    ///         - identity id = valid values
+    ///         - cognito tokens = .signedOut error
+    ///
+    func testSignoutSessionWithUnAuthAccess() {
+        mockAWSCredentials()
+        mockIdentityId()
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+
+                XCTAssertFalse(session.isSignedIn)
+
+                let creds = try? (session as? AuthAWSCredentialsProvider)?.getAWSCredentials().get()
+                XCTAssertNotNil(creds?.accessKey)
+                XCTAssertNotNil(creds?.secretKey)
+
+                let identityId = try? (session as? AuthCognitoIdentityProvider)?.getIdentityId().get()
+                XCTAssertNotNil(identityId)
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .signedOut = error else {
+                    XCTFail("Should return signedOut error")
+                    return
+                }
+
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedOut session with unAuthenticated access disabled.
+    ///
+    /// - Given: Given an auth plugin with signedOut state and unauthenticated access disabled in backend
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock disabled guest in service
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = false
+    ///         - aws credentails = .service error with .invalidAccountTypeException as underlying error
+    ///         - identity id = .service error with .invalidAccountTypeException as underlying error
+    ///         - cognito tokens = .signedOut error
+    func testSignoutSessionWithUnAuthAccessDisabled() {
+        mockIdentityId()
+        let mockNoGuestError = AWSMobileClientError.guestAccessNotAllowed(message: "Error")
+        mockAWSMobileClient.awsCredentialsMockResult = .failure(mockNoGuestError)
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+                XCTAssertFalse(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let credentialsError) = credentialsResult,
+                      case .service(_, _, let underlyingError) = credentialsError,
+                      case .invalidAccountTypeException = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return service error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .service(_, _, let identityIdUnderlyingError) = identityIdError,
+                      case .invalidAccountTypeException = (identityIdUnderlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return service error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .signedOut = error else {
+                    XCTFail("Should return signedOut error")
+                    return
+                }
+
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedOut session with identity id not available
+    ///
+    /// - Given: Given an auth plugin with signedOut state
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock identity id unavailable error
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = false
+    ///         - aws credentails = .service error
+    ///         - identity id = .service error
+    ///         - cognito tokens = .signedOut error
+    func testSignoutSessionWithIdentityIdUnAvailable() {
+
+        let mockIdentityIdUnAvailError = AWSMobileClientError.identityIdUnavailable(message: "Error")
+        mockAWSMobileClient.awsCredentialsMockResult = .failure(mockIdentityIdUnAvailError)
+        mockAWSMobileClient.getIdentityIdMockResult = AWSTask(error: mockIdentityIdUnAvailError)
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+                XCTAssertFalse(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let credentialsError) = credentialsResult,
+                      case .service(_, _, let underlyingError) = credentialsError else {
+                    XCTFail("Should return service error")
+                    return
+                }
+                XCTAssertNil(underlyingError, "No underlying error is returned")
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .service(_, _, let identityIdUnderlyingError) = identityIdError else {
+                    XCTFail("Should return service error")
+                    return
+                }
+
+                XCTAssertNil(identityIdUnderlyingError, "No underlying error is returned")
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .signedOut = error else {
+                    XCTFail("Should return signedOut error")
+                    return
+                }
+
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedOut session with a invalid response for AWS Credentials
+    ///
+    /// - Given: Given an auth plugin with signedOut state and unauthenticated access enabled in backend
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock invalid response for aws credentials
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = false
+    ///         - aws credentails = .unknown error
+    ///         - identity id = .unknown error
+    ///         - cognito tokens = .signedOut error
+    func testInvalidCredentialsResponseInSignedOut() {
+        mockIdentityId()
+        mockAWSMobileClient.awsCredentialsMockResult = nil
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+                XCTAssertFalse(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let credentialsError) = credentialsResult,
+                      case .unknown = credentialsError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .unknown = identityIdError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .signedOut = error else {
+                    XCTFail("Should return signedOut error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedOut session with a invalid response for AWS Credentials
+    ///
+    /// - Given: Given an auth plugin with signedOut state and unauthenticated access enabled in backend
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock invalid response for identity id
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = false
+    ///         - aws credentails = .unknown error
+    ///         - identity id = .unknown error
+    ///         - cognito tokens = .signedOut error
+    func testInvalidIdentityIdResponseInSignedOut() {
+        mockAWSCredentials()
+        mockAWSMobileClient.getIdentityIdMockResult = AWSTask(result: nil)
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+                XCTAssertFalse(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let credentialsError) = credentialsResult,
+                      case .unknown = credentialsError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .unknown = identityIdError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .signedOut = error else {
+                    XCTFail("Should return signedOut error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedOut session with a network error
+    ///
+    /// - Given: Given an auth plugin with signedOut state and unauthenticated access enabled in backend
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock URL domain error for get aws credentials
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = false
+    ///         - aws credentails = .service error with .network as underlying error
+    ///         - identity id = .service error with .network as underlying error
+    ///         - cognito tokens = .signedOut error
+    func testNetworkErrorForIdentityIdInSignedOut() {
+        mockAWSCredentials()
+        let error = NSError(domain: NSURLErrorDomain, code: 1, userInfo: nil)
+        mockAWSMobileClient.getIdentityIdMockResult = AWSTask(error: error)
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+                XCTAssertFalse(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let credentialsError) = credentialsResult,
+                      case .service(_, _, let underlyingError) = credentialsError,
+                      case .network = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .service(_, _, let identityIdUnderlyingError) = identityIdError,
+                      case .network = (identityIdUnderlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .signedOut = error else {
+                    XCTFail("Should return signedOut error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedOut session with a network error
+    ///
+    /// - Given: Given an auth plugin with signedOut state and unauthenticated access enabled in backend
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock URL domain error for getIdentityId
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = false
+    ///         - aws credentails = .service error with .network as underlying error
+    ///         - identity id = .service error with .network as underlying error
+    ///         - cognito tokens = .signedOut error
+    func testNetworkErrorForAWSCredentialsInSignedOut() {
+        mockIdentityId()
+        let error = NSError(domain: NSURLErrorDomain, code: 1, userInfo: nil)
+        mockAWSMobileClient.awsCredentialsMockResult = .failure(error)
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+                XCTAssertFalse(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let credentialsError) = credentialsResult,
+                      case .service(_, _, let underlyingError) = credentialsError,
+                      case .network = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .service(_, _, let identityIdUnderlyingError) = identityIdError,
+                      case .network = (identityIdUnderlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should return network error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .signedOut = error else {
+                    XCTFail("Should return signedOut error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    // MARK: - Service Error for GetId
+
+    /// Test signedOut session with a service error in identity id. Currently AWSMobileClient converts all
+    /// service error in getID api to `AWSCognitoCredentialsProviderHelperErrorTypeIdentityIsNil` of domain
+    /// `AWSCognitoCredentialsProviderHelperErrorDomain`
+    ///
+    /// - Given: Given an auth plugin with signedOut state and unauthenticated access enabled in backend
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock any service error for  getId
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = false
+    ///         - aws credentails = .unknown error
+    ///         - identity id = .unknown error
+    ///         - cognito tokens = .signedOut error
+    func testNilIdentityIdErrorInSignedOut() {
+        mockAWSCredentials()
+        let error = NSError(domain: AWSCognitoCredentialsProviderHelperErrorDomain,
+                            code: AWSCognitoCredentialsProviderHelperErrorType.identityIsNil.rawValue,
+                            userInfo: nil)
+        mockAWSMobileClient.getIdentityIdMockResult = AWSTask(error: error)
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+                XCTAssertFalse(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let credentialsError) = credentialsResult,
+                      case .unknown = credentialsError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .unknown = identityIdError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .signedOut = error else {
+                    XCTFail("Should return signedOut error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    // MARK: - Service Error for GetCredentialsForIdentity
+
+    /// Test signedOut session with a `ExternalServiceException` service error in aws credential call
+    ///
+    /// - Given: Given an auth plugin with signedOut state and unauthenticated access enabled in backend
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock ExternalServiceException error for get aws credentials
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = false
+    ///         - aws credentails = .unknown error
+    ///         - identity id = .unknown error
+    ///         - cognito tokens = .signedOut error
+    func testSignedOutSessionWithAWSCredentialsExternalServiceException() {
+        mockIdentityId()
+        let error = NSError(domain: AWSCognitoIdentityErrorDomain,
+                            code: AWSCognitoIdentityErrorType.externalService.rawValue,
+                            userInfo: nil)
+        mockAWSMobileClient.awsCredentialsMockResult = .failure(error)
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+                XCTAssertFalse(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let credentialsError) = credentialsResult,
+                      case .unknown = credentialsError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .unknown = identityIdError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .signedOut = error else {
+                    XCTFail("Should return signedOut error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedOut session with a `InternalErrorException` service error in aws credential call
+    ///
+    /// - Given: Given an auth plugin with signedOut state and unauthenticated access enabled in backend
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock InternalErrorException error for get aws credentials
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = false
+    ///         - aws credentails = .unknown error
+    ///         - identity id = .unknown error
+    ///         - cognito tokens = .signedOut error
+    func testSignedOutSessionWithAWSCredentialsInternalErrorException() {
+        mockIdentityId()
+        let error = NSError(domain: AWSCognitoIdentityErrorDomain,
+                            code: AWSCognitoIdentityErrorType.internalError.rawValue,
+                            userInfo: nil)
+        mockAWSMobileClient.awsCredentialsMockResult = .failure(error)
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+                XCTAssertFalse(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let credentialsError) = credentialsResult,
+                      case .unknown = credentialsError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .unknown = identityIdError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .signedOut = error else {
+                    XCTFail("Should return signedOut error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedOut session with a `InvalidIdentityPoolConfigurationException` service error in aws credential call
+    ///
+    /// - Given: Given an auth plugin with signedOut state and unauthenticated access enabled in backend
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock InvalidIdentityPoolConfigurationException error for get aws credentials
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = false
+    ///         - aws credentails = .unknown error
+    ///         - identity id = .unknown error
+    ///         - cognito tokens = .signedOut error
+    func testSignedOutSessionWithAWSCredentialsInvalidIdentityPoolConfigurationException() {
+        mockAWSCredentials()
+        let error = NSError(domain: AWSCognitoIdentityErrorDomain,
+                            code: AWSCognitoIdentityErrorType.invalidIdentityPoolConfiguration.rawValue,
+                            userInfo: nil)
+        mockAWSMobileClient.awsCredentialsMockResult = .failure(error)
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+                XCTAssertFalse(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let credentialsError) = credentialsResult,
+                      case .unknown = credentialsError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .unknown = identityIdError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .signedOut = error else {
+                    XCTFail("Should return signedOut error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedOut session with a `InvalidParameterException` service error in aws credential call
+    ///
+    /// - Given: Given an auth plugin with signedOut state and unauthenticated access enabled in backend
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock InvalidParameterException error for get aws credentials
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = false
+    ///         - aws credentails = .unknown error
+    ///         - identity id = .unknown error
+    ///         - cognito tokens = .signedOut error
+    func testSignedOutSessionWithAWSCredentialsInvalidParameterException() {
+        mockIdentityId()
+        let error = NSError(domain: AWSCognitoIdentityErrorDomain,
+                            code: AWSCognitoIdentityErrorType.invalidParameter.rawValue,
+                            userInfo: nil)
+        mockAWSMobileClient.awsCredentialsMockResult = .failure(error)
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+                XCTAssertFalse(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let credentialsError) = credentialsResult,
+                      case .unknown = credentialsError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .unknown = identityIdError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .signedOut = error else {
+                    XCTFail("Should return signedOut error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedOut session with a `NotAuthorizedException` service error in aws credential call
+    ///
+    /// - Given: Given an auth plugin with signedOut state and unauthenticated access enabled in backend
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock NotAuthorizedException error for get aws credentials
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = false
+    ///         - aws credentails = .unknown error
+    ///         - identity id = .unknown error
+    ///         - cognito tokens = .signedOut error
+    func testSignedOutSessionWithAWSCredentialsNotAuthorizedException() {
+        mockIdentityId()
+        let error = NSError(domain: AWSCognitoIdentityErrorDomain,
+                            code: AWSCognitoIdentityErrorType.notAuthorized.rawValue,
+                            userInfo: nil)
+        mockAWSMobileClient.awsCredentialsMockResult = .failure(error)
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+                XCTAssertFalse(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let credentialsError) = credentialsResult,
+                      case .unknown = credentialsError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .unknown = identityIdError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .signedOut = error else {
+                    XCTFail("Should return signedOut error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedOut session with a `ResourceConflictException` service error in aws credential call
+    ///
+    /// - Given: Given an auth plugin with signedOut state and unauthenticated access enabled in backend
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock ResourceConflictException error for get aws credentials
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = false
+    ///         - aws credentails = .unknown error
+    ///         - identity id = .unknown error
+    ///         - cognito tokens = .signedOut error
+    func testSignedOutSessionWithAWSCredentialsResourceConflictException() {
+        mockIdentityId()
+        let error = NSError(domain: AWSCognitoIdentityErrorDomain,
+                            code: AWSCognitoIdentityErrorType.resourceConflict.rawValue,
+                            userInfo: nil)
+        mockAWSMobileClient.awsCredentialsMockResult = .failure(error)
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+                XCTAssertFalse(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let credentialsError) = credentialsResult,
+                      case .unknown = credentialsError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .unknown = identityIdError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .signedOut = error else {
+                    XCTFail("Should return signedOut error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedOut session with a `ResourceNotFoundException` service error in aws credential call
+    ///
+    /// - Given: Given an auth plugin with signedOut state and unauthenticated access enabled in backend
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock ResourceNotFoundException error for get aws credentials
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = false
+    ///         - aws credentails = .unknown error
+    ///         - identity id = .unknown error
+    ///         - cognito tokens = .signedOut error
+    func testSignedOutSessionWithAWSCredentialsResourceNotFoundException() {
+        mockIdentityId()
+        let error = NSError(domain: AWSCognitoIdentityErrorDomain,
+                            code: AWSCognitoIdentityErrorType.resourceNotFound.rawValue,
+                            userInfo: nil)
+        mockAWSMobileClient.awsCredentialsMockResult = .failure(error)
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+                XCTAssertFalse(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let credentialsError) = credentialsResult,
+                      case .unknown = credentialsError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .unknown = identityIdError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .signedOut = error else {
+                    XCTFail("Should return signedOut error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test signedOut session with a `TooManyRequestsException` service error in aws credential call
+    ///
+    /// - Given: Given an auth plugin with signedOut state and unauthenticated access enabled in backend
+    /// - When:
+    ///    - I invoke fetchAuthSession and mock TooManyRequestsException error for get aws credentials
+    /// - Then:
+    ///    - I should get an a valid session with the following details:
+    ///         - isSignedIn = false
+    ///         - aws credentails = .unknown error
+    ///         - identity id = .unknown error
+    ///         - cognito tokens = .signedOut error
+    func testSignedOutSessionWithAWSCredentialsTooManyRequestsException() {
+        mockIdentityId()
+        let error = NSError(domain: AWSCognitoIdentityErrorDomain,
+                            code: AWSCognitoIdentityErrorType.tooManyRequests.rawValue,
+                            userInfo: nil)
+        mockAWSMobileClient.awsCredentialsMockResult = .failure(error)
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let session):
+                XCTAssertFalse(session.isSignedIn)
+
+                let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+                guard case .failure(let credentialsError) = credentialsResult,
+                      case .unknown = credentialsError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
+                guard case .failure(let identityIdError) = identityIdResult,
+                      case .unknown = identityIdError else {
+                    XCTFail("Should return unknown error")
+                    return
+                }
+
+                let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+                guard case .failure(let error) = tokensResult,
+                      case .signedOut = error else {
+                    XCTFail("Should return signedOut error")
+                    return
+                }
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthorizationProviderTests/BaseAuthorizationProviderTest.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthorizationProviderTests/BaseAuthorizationProviderTest.swift
@@ -1,0 +1,53 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+import XCTest
+@testable import Amplify
+@testable import AWSCognitoAuthPlugin
+@testable import AWSMobileClient
+
+class BaseAuthorizationProviderTest: XCTestCase {
+
+    let apiTimeout = 2.0
+    var authorizationProvider: AuthorizationProviderAdapter!
+    var mockAWSMobileClient: MockAWSMobileClient!
+    var plugin: AWSCognitoAuthPlugin!
+
+    override func setUp() {
+        mockAWSMobileClient = MockAWSMobileClient()
+        authorizationProvider = AuthorizationProviderAdapter(awsMobileClient: mockAWSMobileClient!)
+        plugin = AWSCognitoAuthPlugin()
+        plugin?.configure(authenticationProvider: MockAuthenticationProviderBehavior(),
+                         authorizationProvider: authorizationProvider,
+                         userService: MockAuthUserServiceBehavior(),
+                         deviceService: MockAuthDeviceServiceBehavior(),
+                         hubEventHandler: MockAuthHubEventBehavior())
+    }
+
+    func mockAWSCredentials() {
+        let mockAWSCredentials = AWSCredentials(accessKey: "mockAccess",
+                                                secretKey: "mockSecret",
+                                                sessionKey: "mockSession",
+                                                expiration: Date())
+        mockAWSMobileClient.awsCredentialsMockResult = .success(mockAWSCredentials)
+    }
+
+    func mockCognitoTokens() {
+        let mockSessionToken = SessionToken(tokenString: "mockToken")
+        let tokens = Tokens(idToken: mockSessionToken,
+                            accessToken: mockSessionToken,
+                            refreshToken: mockSessionToken,
+                            expiration: Date())
+        mockAWSMobileClient.tokensMockResult = .success(tokens)
+    }
+
+    func mockIdentityId() {
+        mockAWSMobileClient.getIdentityIdMockResult = AWSTask(result: "identityId")
+    }
+}

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAWSMobileClient.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAWSMobileClient.swift
@@ -31,8 +31,10 @@ class MockAWSMobileClient: AWSMobileClientBehavior {
 
     var getIdentityIdMockResult: AWSTask<NSString>?
     var tokensMockResult: Result<Tokens, Error>?
-    var awsCredentialsMockResult: Result<Tokens, Error>?
+    var awsCredentialsMockResult: Result<AWSCredentials, Error>?
     var getCurrentUserStateMockResult: UserState?
+
+    var mockCurrentUserState: UserState = .unknown
 
     func initialize() throws {
         fatalError()
@@ -151,19 +153,19 @@ class MockAWSMobileClient: AWSMobileClientBehavior {
     }
 
     func getIdentityId() -> AWSTask<NSString> {
-        fatalError()
+        return getIdentityIdMockResult!
     }
 
     func getTokens(_ completionHandler: @escaping (Tokens?, Error?) -> Void) {
-        fatalError()
+        prepareResult(mockResult: tokensMockResult, completionHandler: completionHandler)
     }
 
     func getAWSCredentials(_ completionHandler: @escaping (AWSCredentials?, Error?) -> Void) {
-        fatalError()
+        prepareResult(mockResult: awsCredentialsMockResult, completionHandler: completionHandler)
     }
 
     func getCurrentUserState() -> UserState {
-        fatalError()
+        return mockCurrentUserState
     }
 
     func listDevices(completionHandler: @escaping ((ListDevicesResult?, Error?) -> Void)) {
@@ -192,7 +194,7 @@ class MockAWSMobileClient: AWSMobileClientBehavior {
     }
 
     func addUserStateListener(_ object: AnyObject, _ callback: @escaping UserStateChangeCallback) {
-        fatalError()
+
     }
 
     func removeUserStateListener(_ object: AnyObject) {


### PR DESCRIPTION
*Description of changes:*

1. Added all tests for `fetchAuthSession` in signedOut
2. Added few tests for `fetchAuthSession` in signedIn
Tests will fail until #922 is merged in.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
