### PR TITLE
fix(API): subscription cancel unit test failing intermittently

### DIFF
--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
@@ -6,12 +6,12 @@
 //
 
 import XCTest
-import Foundation
+
 @testable import Amplify
 @testable import AWSAPICategoryPlugin
 @testable import AmplifyTestCommon
 @testable import AppSyncRealTimeClient
-import AWSPluginsCore
+@testable import AWSPluginsCore
 
 // swiftlint:disable:next type_name
 class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
@@ -6,15 +6,79 @@
 //
 
 import XCTest
-
+import Foundation
 @testable import Amplify
 @testable import AWSAPICategoryPlugin
 @testable import AmplifyTestCommon
+@testable import AppSyncRealTimeClient
+import AWSPluginsCore
 
 // swiftlint:disable:next type_name
-class AWSGraphQLSubscriptionOperationCancelTests: AWSAPICategoryPluginTestBase {
+class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
+    var apiPlugin: AWSAPIPlugin!
+    var authService: MockAWSAuthService!
+    var pluginConfig: AWSAPICategoryPluginConfiguration!
+
+    let apiName = "apiName"
+    let baseURL = URL(fileURLWithPath: "path")
+    let region = "us-east-1".aws_regionTypeValue()
+
+    let testDocument = "query { getTodo { id name description }}"
+    let testVariables = ["id": 123]
+
+    let testBody = Data()
+    let testPath = "testPath"
+
+    func setUp(subscriptionConnectionFactory: SubscriptionConnectionFactory) {
+        apiPlugin = AWSAPIPlugin()
+
+        let authService = MockAWSAuthService()
+        self.authService = authService
+
+        do {
+            let endpointConfig = [apiName: try AWSAPICategoryPluginConfiguration.EndpointConfig(
+                name: apiName,
+                baseURL: baseURL,
+                region: region,
+                authorizationType: AWSAuthorizationType.none,
+                authorizationConfiguration: AWSAuthorizationConfiguration.none,
+                endpointType: .graphQL,
+                apiAuthProviderFactory: APIAuthProviderFactory())]
+            let pluginConfig = AWSAPICategoryPluginConfiguration(endpoints: endpointConfig)
+            self.pluginConfig = pluginConfig
+
+            let dependencies = AWSAPIPlugin.ConfigurationDependencies(
+                pluginConfig: pluginConfig,
+                authService: authService,
+                subscriptionConnectionFactory: subscriptionConnectionFactory
+            )
+            apiPlugin.configure(using: dependencies)
+        } catch {
+            XCTFail("Failed to create endpoint config")
+        }
+
+        Amplify.reset()
+        let config = AmplifyConfiguration()
+        do {
+            try Amplify.configure(config)
+        } catch {
+            XCTFail("Error setting up Amplify: \(error)")
+        }
+    }
 
     func testCancelSendsCompletion() {
+        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _ in
+            return MockSubscriptionConnection(onSubscribe: { (_, _, eventHandler) -> SubscriptionItem in
+                let item = SubscriptionItem(requestString: "", variables: nil, eventHandler: { _, _ in
+                })
+                eventHandler(.connection(.connecting), item)
+                return item
+            }, onUnsubscribe: {_ in
+            })
+        })
+        setUp(subscriptionConnectionFactory: mockSubscriptionConnectionFactory)
+
+        let connectingSemaphore = DispatchSemaphore(value: 0)
         let request = GraphQLRequest(apiName: apiName,
                                      document: testDocument,
                                      variables: nil,
@@ -23,7 +87,111 @@ class AWSGraphQLSubscriptionOperationCancelTests: AWSAPICategoryPluginTestBase {
         let receivedCompletion = expectation(description: "Received completion")
         let receivedFailure = expectation(description: "Received failure")
         receivedFailure.isInverted = true
-        let receivedValue = expectation(description: "Received value")
+        let receivedValueConnecting = expectation(description: "Received value for connecting")
+        let receivedValueDisconnected = expectation(description: "Received value for disconnected")
+
+        let valueListener: GraphQLSubscriptionOperation<JSONValue>.InProcessListener = { value in
+            switch value {
+            case .connection(let state):
+                switch state {
+                case .connecting:
+                    receivedValueConnecting.fulfill()
+                    connectingSemaphore.signal()
+                case .disconnected:
+                    receivedValueDisconnected.fulfill()
+                default:
+                    XCTFail("Unexpected value on value listener: \(state)")
+                }
+            default:
+                XCTFail("Unexpected value on on value listener: \(value)")
+            }
+        }
+
+        let completionListener: GraphQLSubscriptionOperation<JSONValue>.ResultListener = { result in
+            switch result {
+            case .failure:
+                receivedFailure.fulfill()
+            case .success:
+                receivedCompletion.fulfill()
+            }
+        }
+
+        let operation = apiPlugin.subscribe(
+            request: request,
+            valueListener: valueListener,
+            completionListener: completionListener
+        )
+        connectingSemaphore.wait()
+
+        operation.cancel()
+
+        XCTAssert(operation.isCancelled)
+        waitForExpectations(timeout: 0.3)
+    }
+
+    func testFailureOnConnection() {
+        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _ in
+            throw APIError.invalidConfiguration("something went wrong", "", nil)
+        })
+
+        setUp(subscriptionConnectionFactory: mockSubscriptionConnectionFactory)
+
+        let failureSemaphore = DispatchSemaphore(value: 0)
+        let request = GraphQLRequest(apiName: apiName,
+                                     document: testDocument,
+                                     variables: nil,
+                                     responseType: JSONValue.self)
+
+        let receivedCompletion = expectation(description: "Received completion")
+        receivedCompletion.isInverted = true
+        let receivedFailure = expectation(description: "Received failure")
+        let receivedValue = expectation(description: "Received value for connecting")
+        receivedValue.isInverted = true
+
+        let valueListener: GraphQLSubscriptionOperation<JSONValue>.InProcessListener = { _ in
+            receivedValue.fulfill()
+        }
+
+        let completionListener: GraphQLSubscriptionOperation<JSONValue>.ResultListener = { result in
+            switch result {
+            case .failure:
+                receivedFailure.fulfill()
+                failureSemaphore.signal()
+            case .success:
+                receivedCompletion.fulfill()
+            }
+        }
+
+        let operation = apiPlugin.subscribe(
+            request: request,
+            valueListener: valueListener,
+            completionListener: completionListener
+        )
+        failureSemaphore.wait()
+
+        XCTAssert(operation.isFinished)
+        waitForExpectations(timeout: 0.3)
+    }
+
+    func testCallingCancelWhileCreatingConnectionShouldCallCompletionListener() {
+        let creatingConnectionSemaphore = DispatchSemaphore(value: 0)
+        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _ in
+            creatingConnectionSemaphore.signal()
+            sleep(5)
+            throw APIError.invalidConfiguration("something went wrong", "", nil)
+        })
+
+        setUp(subscriptionConnectionFactory: mockSubscriptionConnectionFactory)
+
+        let request = GraphQLRequest(apiName: apiName,
+                                     document: testDocument,
+                                     variables: nil,
+                                     responseType: JSONValue.self)
+
+        let receivedCompletion = expectation(description: "Received completion")
+        let receivedFailure = expectation(description: "Received failure")
+        receivedFailure.isInverted = true
+        let receivedValue = expectation(description: "Received value for connecting")
         receivedValue.isInverted = true
 
         let valueListener: GraphQLSubscriptionOperation<JSONValue>.InProcessListener = { _ in
@@ -44,12 +212,10 @@ class AWSGraphQLSubscriptionOperationCancelTests: AWSAPICategoryPluginTestBase {
             valueListener: valueListener,
             completionListener: completionListener
         )
+        creatingConnectionSemaphore.wait()
 
         operation.cancel()
-
         XCTAssert(operation.isCancelled)
-
-        waitForExpectations(timeout: 0.05)
+        waitForExpectations(timeout: 0.3)
     }
-
 }


### PR DESCRIPTION
While implementing start/stop for datastore, I noticed these tests were failing because the `SubscriptionConnectionFactory` was able to throw an exception and fail, prior to `cancel()` execution happening.  When this happens, the `operation` ends up in a `finished` state rather than the expected `canceled` state.

So.. to remedy this, I re-worked these tests by using the existing `MockSubscriptionConnectionFactory` to test various cases.

To reproduce the unexpected behavior, revert these changes, and add a `sleep(2)` right before the call to `operation.cancel()`, then run the test.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
