### PR TITLE
test(auth): Added authenticationprovider tests for signin, signinout

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
@@ -12,8 +12,19 @@ import XCTest
 @testable import AWSCognitoAuthPlugin
 @testable import AWSMobileClient
 
+// swiftlint:disable file_length
+// swiftlint:disable type_body_length
 class AuthenticationProviderSigninTests: BaseAuthenticationProviderTest {
 
+    /// Test a signIn with valid inputs
+    ///
+    /// - Given: Given an auth plugin with mocked service.
+    ///
+    /// - When:
+    ///    - I invoke signIn with valid values
+    /// - Then:
+    ///    - I should get a .valid response
+    ///
     func testSuccessfulSignIn() {
 
         let mockSigninResult = SignInResult(signInState: .signedIn)
@@ -39,7 +50,784 @@ class AuthenticationProviderSigninTests: BaseAuthenticationProviderTest {
                 XCTFail("Received failure with error \(error)")
             }
         }
-        wait(for: [resultExpectation], timeout: 2)
+        wait(for: [resultExpectation], timeout: apiTimeout)
     }
 
+    /// Test a signIn with empty username
+    ///
+    /// - Given: Given an auth plugin with mocked service.
+    ///
+    /// - When:
+    ///    - I invoke signIn with empty username
+    /// - Then:
+    ///    - I should get a .validation error
+    ///
+    func testSignInWithEmptyUsername() {
+
+        let mockSigninResult = SignInResult(signInState: .signedIn)
+        mockAWSMobileClient?.signInMockResult = .success(mockSigninResult)
+        let options = AuthSignInRequest.Options()
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should not receive a success response \(signinResult)")
+            case .failure(let error):
+                guard case .validation = error else {
+                    XCTFail("Should receive validation error instead got \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with empty password
+    ///
+    /// - Given: Given an auth plugin with mocked service.
+    ///
+    /// - When:
+    ///    - I invoke signIn with no password
+    /// - Then:
+    ///    - I should get a valid response
+    ///
+    func testSignInWithEmptyPassword() {
+
+        let mockSigninResult = SignInResult(signInState: .signedIn)
+        mockAWSMobileClient?.signInMockResult = .success(mockSigninResult)
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                guard case .done = signinResult.nextStep else {
+                    XCTFail("Result should be .done for next step")
+                    return
+                }
+                XCTAssertTrue(signinResult.isSignedIn, "Signin result should be complete")
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with nil as reponse from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mock nil response from service
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .unknown
+    ///
+    func testSignInWithInvalidResult() {
+
+        mockAWSMobileClient?.signInMockResult = nil
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should not receive a success response \(signinResult)")
+            case .failure(let error):
+                guard case .unknown = error else {
+                    XCTFail("Should receive unknown error instead got \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with smsMFA as signIn result response
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mock smsMFA response for signIn result
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .confirmSignInWithSMSMFACode
+    ///
+    func testSignInWithNextStepSMS() {
+
+        let mockSigninResult = SignInResult(signInState: .smsMFA)
+        mockAWSMobileClient?.signInMockResult = .success(mockSigninResult)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                guard case .confirmSignInWithSMSMFACode = signinResult.nextStep else {
+                    XCTFail("Result should be .confirmSignInWithSMSMFACode for next step")
+                    return
+                }
+                XCTAssertFalse(signinResult.isSignedIn, "Signin result should not be complete")
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with customChallenge as signIn result response
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mock customChallenge response for signIn result
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .confirmSignInWithCustomChallenge
+    ///
+    func testSignInWithNextStepCustomChallenge() {
+
+        let mockSigninResult = SignInResult(signInState: .customChallenge)
+        mockAWSMobileClient?.signInMockResult = .success(mockSigninResult)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                guard case .confirmSignInWithCustomChallenge = signinResult.nextStep else {
+                    XCTFail("Result should be .confirmSignInWithCustomChallenge for next step")
+                    return
+                }
+                XCTAssertFalse(signinResult.isSignedIn, "Signin result should not be complete")
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with newPassword as signIn result response
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mock newPassword response for signIn result
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .confirmSignInWithNewPassword
+    ///
+    func testSignInWithNextStepNewPassword() {
+
+        let mockSigninResult = SignInResult(signInState: .newPasswordRequired)
+        mockAWSMobileClient?.signInMockResult = .success(mockSigninResult)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                guard case .confirmSignInWithNewPassword = signinResult.nextStep else {
+                    XCTFail("Result should be .confirmSignInWithNewPassword for next step")
+                    return
+                }
+                XCTAssertFalse(signinResult.isSignedIn, "Signin result should not be complete")
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with invalid response
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mock unknown response for signIn result
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .unknown
+    ///
+    func testSignInWithNextStepUnknown() {
+
+        let mockSigninResult = SignInResult(signInState: .unknown)
+        mockAWSMobileClient?.signInMockResult = .success(mockSigninResult)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+
+                XCTFail("Should not produce result - \(signinResult)")
+            case .failure(let error):
+                guard case .unknown = error else {
+                    XCTFail("Should produce unknown error")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    // MARK: - Service error for initiateAuth
+
+    /// Test a signIn with `InternalErrorException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InternalErrorException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .unknown
+    ///
+    func testSignInWithInternalErrorException() {
+        let error = AWSMobileClientError.internalError(message: "Error")
+        mockAWSMobileClient.signInMockResult = .failure(error)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should not produce result - \(signinResult)")
+            case .failure(let error):
+                guard case .unknown = error else {
+                    XCTFail("Should produce unknown error")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with `InvalidLambdaResponseException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidLambdaResponseException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .lambda error
+    ///
+    func testSignInWithInvalidLambdaResponseException() {
+        let error = AWSMobileClientError.invalidLambdaResponse(message: "Error")
+        mockAWSMobileClient.signInMockResult = .failure(error)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should not produce result - \(signinResult)")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce lambda error but instead produced \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with `InvalidParameterException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidParameterException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .invalidParameter error
+    ///
+    func testSignInWithInvalidParameterException() {
+        let error = AWSMobileClientError.invalidParameter(message: "Error")
+        mockAWSMobileClient.signInMockResult = .failure(error)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should not produce result - \(signinResult)")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce invalidParameter error but instead produced \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with `InvalidUserPoolConfigurationException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidUserPoolConfigurationException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .configuration
+    ///
+    func testSignInWithInvalidUserPoolConfigurationException() {
+        let error = AWSMobileClientError.invalidUserPoolConfiguration(message: "Error")
+        mockAWSMobileClient.signInMockResult = .failure(error)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should not produce result - \(signinResult)")
+            case .failure(let error):
+                guard case .configuration = error else {
+                    XCTFail("Should produce configuration intead produced \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with `NotAuthorizedException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   NotAuthorizedException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .notAuthorized error
+    ///
+    func testSignInWithNotAuthorizedException() {
+        let error = AWSMobileClientError.notAuthorized(message: "Error")
+        mockAWSMobileClient.signInMockResult = .failure(error)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should not produce result - \(signinResult)")
+            case .failure(let error):
+                guard case .notAuthorized = error else {
+                    XCTFail("Should produce notAuthorized error but instead produced \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with `PasswordResetRequiredException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   PasswordResetRequiredException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .resetPassword as next step
+    ///
+    func testSignInWithPasswordResetRequiredException() {
+        let error = AWSMobileClientError.passwordResetRequired(message: "Error")
+        mockAWSMobileClient.signInMockResult = .failure(error)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                guard case .resetPassword = signinResult.nextStep else {
+                    XCTFail("Result should be .resetPassword for next step")
+                    return
+                }
+                XCTAssertFalse(signinResult.isSignedIn, "Signin result should not be complete")
+            case .failure(let error):
+                XCTFail("Should not produce error - \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with `ResourceNotFoundException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   ResourceNotFoundException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .resourceNotFound error
+    ///
+    func testSignInWithResourceNotFoundException() {
+        let error = AWSMobileClientError.resourceNotFound(message: "Error")
+        mockAWSMobileClient.signInMockResult = .failure(error)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should not produce result - \(signinResult)")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce resourceNotFound error but instead produced \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with `TooManyRequestsException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   TooManyRequestsException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .requestLimitExceeded error
+    ///
+    func testSignInWithTooManyRequestsException() {
+        let error = AWSMobileClientError.tooManyRequests(message: "Error")
+        mockAWSMobileClient.signInMockResult = .failure(error)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should not produce result - \(signinResult)")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce requestLimitExceeded error but instead produced \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with `UnexpectedLambdaException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   UnexpectedLambdaException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .lambda error
+    ///
+    func testSignInWithUnexpectedLambdaException() {
+        let error = AWSMobileClientError.unexpectedLambda(message: "Error")
+        mockAWSMobileClient.signInMockResult = .failure(error)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should not produce result - \(signinResult)")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce lambda error but instead produced \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with `UserLambdaValidationException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   UserLambdaValidationException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .lambda error
+    ///
+    func testSignInWithUserLambdaValidationException() {
+        let error = AWSMobileClientError.userLambdaValidation(message: "Error")
+        mockAWSMobileClient.signInMockResult = .failure(error)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should not produce result - \(signinResult)")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce lambda error but instead produced \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with `UserNotConfirmedException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   UserNotConfirmedException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .confirmSignUp as next step
+    ///
+    func testSignInWithUserNotConfirmedException() {
+        let error = AWSMobileClientError.userNotConfirmed(message: "Error")
+        mockAWSMobileClient.signInMockResult = .failure(error)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                guard case .confirmSignUp = signinResult.nextStep else {
+                    XCTFail("Result should be .confirmSignUp for next step")
+                    return
+                }
+                XCTAssertFalse(signinResult.isSignedIn, "Signin result should not be complete")
+            case .failure(let error):
+                XCTFail("Should not produce error - \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with `UserNotFoundException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   UserNotFoundException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .userNotFound error
+    ///
+    func testSignInWithUserNotFoundException() {
+        let error = AWSMobileClientError.userNotFound(message: "Error")
+        mockAWSMobileClient.signInMockResult = .failure(error)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should not produce result - \(signinResult)")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce userNotFound error but instead produced \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    // MARK: - Service error for RespondToAuthChallenge
+
+    /// Test a signIn with `AliasExistsException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   AliasExistsException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .aliasExists error
+    ///
+    func testSignInWithAliasExistsException() {
+        let error = AWSMobileClientError.aliasExists(message: "Error")
+        mockAWSMobileClient.signInMockResult = .failure(error)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should not produce result - \(signinResult)")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .aliasExists = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce aliasExists error but instead produced \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with `CodeMismatchException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   CodeMismatchException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .codeMismatch error
+    ///
+    func testSignInWithCodeMismatchException() {
+        let error = AWSMobileClientError.codeMismatch(message: "Error")
+        mockAWSMobileClient.signInMockResult = .failure(error)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should not produce result - \(signinResult)")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .codeMismatch = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce codeMismatch error but instead produced \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with `ExpiredCodeException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   ExpiredCodeException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .codeMismatch error
+    ///
+    func testSignInWithExpiredCodeException() {
+        let error = AWSMobileClientError.expiredCode(message: "Error")
+        mockAWSMobileClient.signInMockResult = .failure(error)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should not produce result - \(signinResult)")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .codeExpired = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce codeExpired error but instead produced \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with `InvalidPasswordException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidPasswordException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .invalidPassword error
+    ///
+    func testSignInWithInvalidPasswordException() {
+        let error = AWSMobileClientError.invalidPassword(message: "Error")
+        mockAWSMobileClient.signInMockResult = .failure(error)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should not produce result - \(signinResult)")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .invalidPassword = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce invalidPassword error but instead produced \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
@@ -126,7 +126,7 @@ class AuthenticationProviderSigninTests: BaseAuthenticationProviderTest {
     /// - When:
     ///    - I invoke signIn
     /// - Then:
-    ///    - I should get a .unknown
+    ///    - I should get a .unknown error
     ///
     func testSignInWithInvalidResult() {
 
@@ -225,7 +225,7 @@ class AuthenticationProviderSigninTests: BaseAuthenticationProviderTest {
     /// - When:
     ///    - I invoke signIn
     /// - Then:
-    ///    - I should get a .confirmSignInWithNewPassword
+    ///    - I should get a .confirmSignInWithNewPassword error
     ///
     func testSignInWithNextStepNewPassword() {
 
@@ -259,7 +259,7 @@ class AuthenticationProviderSigninTests: BaseAuthenticationProviderTest {
     /// - When:
     ///    - I invoke signIn
     /// - Then:
-    ///    - I should get a .unknown
+    ///    - I should get a .unknown error
     ///
     func testSignInWithNextStepUnknown() {
 
@@ -296,7 +296,7 @@ class AuthenticationProviderSigninTests: BaseAuthenticationProviderTest {
     /// - When:
     ///    - I invoke signIn
     /// - Then:
-    ///    - I should get a .unknown
+    ///    - I should get a .unknown error
     ///
     func testSignInWithInternalErrorException() {
         let error = AWSMobileClientError.internalError(message: "Error")
@@ -397,7 +397,7 @@ class AuthenticationProviderSigninTests: BaseAuthenticationProviderTest {
     /// - When:
     ///    - I invoke signIn
     /// - Then:
-    ///    - I should get a .configuration
+    ///    - I should get a .configuration error
     ///
     func testSignInWithInvalidUserPoolConfigurationException() {
         let error = AWSMobileClientError.invalidUserPoolConfiguration(message: "Error")

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
@@ -23,7 +23,7 @@ class AuthenticationProviderSigninTests: BaseAuthenticationProviderTest {
     /// - When:
     ///    - I invoke signIn with valid values
     /// - Then:
-    ///    - I should get a .valid response
+    ///    - I should get a .done response
     ///
     func testSuccessfulSignIn() {
 
@@ -722,74 +722,6 @@ class AuthenticationProviderSigninTests: BaseAuthenticationProviderTest {
                 guard case .service(_, _, let underlyingError) = error,
                       case .aliasExists = (underlyingError as? AWSCognitoAuthError) else {
                     XCTFail("Should produce aliasExists error but instead produced \(error)")
-                    return
-                }
-            }
-        }
-        wait(for: [resultExpectation], timeout: apiTimeout)
-    }
-
-    /// Test a signIn with `CodeMismatchException` from service
-    ///
-    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
-    ///   CodeMismatchException response for signIn
-    ///
-    /// - When:
-    ///    - I invoke signIn
-    /// - Then:
-    ///    - I should get a .service error with .codeMismatch error
-    ///
-    func testSignInWithCodeMismatchException() {
-        let error = AWSMobileClientError.codeMismatch(message: "Error")
-        mockAWSMobileClient.signInMockResult = .failure(error)
-
-        let options = AuthSignInRequest.Options()
-        let resultExpectation = expectation(description: "Should receive a result")
-        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
-            defer {
-                resultExpectation.fulfill()
-            }
-            switch result {
-            case .success(let signinResult):
-                XCTFail("Should not produce result - \(signinResult)")
-            case .failure(let error):
-                guard case .service(_, _, let underlyingError) = error,
-                      case .codeMismatch = (underlyingError as? AWSCognitoAuthError) else {
-                    XCTFail("Should produce codeMismatch error but instead produced \(error)")
-                    return
-                }
-            }
-        }
-        wait(for: [resultExpectation], timeout: apiTimeout)
-    }
-
-    /// Test a signIn with `ExpiredCodeException` from service
-    ///
-    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
-    ///   ExpiredCodeException response for signIn
-    ///
-    /// - When:
-    ///    - I invoke signIn
-    /// - Then:
-    ///    - I should get a .service error with .codeMismatch error
-    ///
-    func testSignInWithExpiredCodeException() {
-        let error = AWSMobileClientError.expiredCode(message: "Error")
-        mockAWSMobileClient.signInMockResult = .failure(error)
-
-        let options = AuthSignInRequest.Options()
-        let resultExpectation = expectation(description: "Should receive a result")
-        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
-            defer {
-                resultExpectation.fulfill()
-            }
-            switch result {
-            case .success(let signinResult):
-                XCTFail("Should not produce result - \(signinResult)")
-            case .failure(let error):
-                guard case .service(_, _, let underlyingError) = error,
-                      case .codeExpired = (underlyingError as? AWSCognitoAuthError) else {
-                    XCTFail("Should produce codeExpired error but instead produced \(error)")
                     return
                 }
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignoutTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignoutTests.swift
@@ -14,4 +14,256 @@ import XCTest
 
 class AuthenticationProviderSignoutTests: BaseAuthenticationProviderTest {
 
+    func testSignOutSuccess() {
+        let options = AuthSignOutRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signOut(options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+
+            switch result {
+            case .success:
+                print("Signout success, with void result")
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    // MARK: - Service error
+
+    /// Test a signOut with `InternalErrorException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InternalErrorException response
+    ///
+    /// - When:
+    ///    - I invoke signOut
+    /// - Then:
+    ///    - I should get a .unknown error
+    ///
+    func testSignOutWithInternalErrorException() {
+
+        let options = AuthSignOutRequest.Options()
+        mockAWSMobileClient.signOutMockError = AWSMobileClientError.internalError(message: "Error")
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signOut(options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+
+            switch result {
+            case .success:
+                XCTFail("Should not get success")
+            case .failure(let error):
+                guard case .unknown = error else {
+                    XCTFail("Should produce unknown error instead of \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signOut with `InvalidParameterException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidParameterException response
+    ///
+    /// - When:
+    ///    - I invoke signOut
+    /// - Then:
+    ///    - I should get a .service error with .invalidParameter error
+    ///
+    func testSignOutWithInvalidParameterException() {
+
+        let options = AuthSignOutRequest.Options()
+        mockAWSMobileClient.signOutMockError = AWSMobileClientError.invalidParameter(message: "Error")
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signOut(options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+
+            switch result {
+            case .success:
+                XCTFail("Should not get success")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce invalidParameter error instead of \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signOut with `NotAuthorizedException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   NotAuthorizedException response
+    ///
+    /// - When:
+    ///    - I invoke signOut
+    /// - Then:
+    ///    - I should get a success result
+    ///
+    func testSignOutWithNotAuthorizedError() {
+        let options = AuthSignOutRequest.Options()
+        mockAWSMobileClient.signOutMockError = AWSMobileClientError.notAuthorized(message: "Error")
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signOut(options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+
+            switch result {
+            case .success:
+                print("Signout success, with void result")
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signOut with `PasswordResetRequiredException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidParameterException response
+    ///
+    /// - When:
+    ///    - I invoke signOut
+    /// - Then:
+    ///    - I should get a .service error with .invalidParameter error
+    ///
+    func testSignOutWithPasswordResetRequiredException() {
+
+        let options = AuthSignOutRequest.Options()
+        mockAWSMobileClient.signOutMockError = AWSMobileClientError.passwordResetRequired(message: "Error")
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signOut(options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+
+            switch result {
+            case .success:
+                XCTFail("Should not get success")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .passwordResetRequired = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce unknown error instead of \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signOut with `ResourceNotFoundException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   ResourceNotFoundException response
+    ///
+    /// - When:
+    ///    - I invoke signOut
+    /// - Then:
+    ///    - I should get a .service error with .resourceNotFound error
+    ///
+    func testSignOutWithResourceNotFoundException() {
+
+        let options = AuthSignOutRequest.Options()
+        mockAWSMobileClient.signOutMockError = AWSMobileClientError.resourceNotFound(message: "Error")
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signOut(options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+
+            switch result {
+            case .success:
+                XCTFail("Should not get success")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce unknown error instead of \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signOut with `TooManyRequestsException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   TooManyRequestsException response
+    ///
+    /// - When:
+    ///    - I invoke signOut
+    /// - Then:
+    ///    - I should get a .service error with .requestLimitExceeded error
+    ///
+    func testSignOutWithTooManyRequestsException() {
+
+        let options = AuthSignOutRequest.Options()
+        mockAWSMobileClient.signOutMockError = AWSMobileClientError.tooManyRequests(message: "Error")
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signOut(options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+
+            switch result {
+            case .success:
+                XCTFail("Should not get success")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce unknown error instead of \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signOut with `UserNotConfirmedException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   UserNotConfirmedException response
+    ///
+    /// - When:
+    ///    - I invoke signOut
+    /// - Then:
+    ///    - I should get a .service error with .userNotConfirmed error
+    ///
+    func testSignOutWithUserNotConfirmedException() {
+
+        let options = AuthSignOutRequest.Options()
+        mockAWSMobileClient.signOutMockError = AWSMobileClientError.userNotConfirmed(message: "Error")
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signOut(options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+
+            switch result {
+            case .success:
+                XCTFail("Should not get success")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .userNotConfirmed = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce unknown error instead of \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignoutTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignoutTests.swift
@@ -138,7 +138,7 @@ class AuthenticationProviderSignoutTests: BaseAuthenticationProviderTest {
     /// - When:
     ///    - I invoke signOut
     /// - Then:
-    ///    - I should get a .service error with .invalidParameter error
+    ///    - I should get a .service error with .passwordResetRequired error
     ///
     func testSignOutWithPasswordResetRequiredException() {
 

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAWSMobileClient.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAWSMobileClient.swift
@@ -17,7 +17,7 @@ class MockAWSMobileClient: AWSMobileClientBehavior {
     var federatedSignInMockResult: Result<UserState, Error>?
     var showSignInMockResult: Result<UserState, Error>?
     var confirmSignInMockResult: Result<SignInResult, Error>?
-    var signOutMockResult: Result<Void, Error>?
+    var signOutMockError: Error?
     var usernameMockResult: String?
     var usersubMockResult: String?
 
@@ -77,8 +77,6 @@ class MockAWSMobileClient: AWSMobileClientBehavior {
         prepareResult(mockResult: federatedSignInMockResult, completionHandler: completionHandler)
     }
 
-
-
     func showSignIn(navigationController: UINavigationController,
                     signInUIOptions: SignInUIOptions,
                     hostedUIOptions: HostedUIOptions?,
@@ -95,11 +93,11 @@ class MockAWSMobileClient: AWSMobileClientBehavior {
 
     func signOut(options: SignOutOptions,
                  completionHandler: @escaping ((Error?) -> Void)) {
-       // prepareResult(mockResult: signOutMockResult, completionHandler: completionHandler)
+       completionHandler(signOutMockError)
     }
 
     func signOutLocally() {
-        fatalError()
+        //Do nothing
     }
 
     func getUsername() -> String? {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
