### PR TITLE
fix(API): Fix unstable AWSAPICategoryPluginResetTests.testReset()

### DIFF
--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ResetTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ResetTests.swift
@@ -23,6 +23,7 @@ class AWSAPICategoryPluginResetTests: AWSAPICategoryPluginTestBase {
         XCTAssertNil(apiPlugin.session)
         XCTAssertNil(apiPlugin.pluginConfig)
         XCTAssertNil(apiPlugin.authService)
+        apiPlugin = nil
     }
 
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPluginTestBase.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPluginTestBase.swift
@@ -65,4 +65,11 @@ class AWSAPICategoryPluginTestBase: XCTestCase {
             XCTFail("Error setting up Amplify: \(error)")
         }
     }
+
+    override func tearDown() {
+        if let api = apiPlugin {
+            api.reset {
+            }
+        }
+    }
 }


### PR DESCRIPTION
My best analysis as to what is happening is the following:

Test case Post:
https://github.com/aws-amplify/amplify-ios/blob/main/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+RESTClientBehaviorTests.swift

Test case reset:
https://github.com/aws-amplify/amplify-ios/blob/main/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ResetTests.swift

Base class
https://github.com/aws-amplify/amplify-ios/blob/main/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPluginTestBase.swift

Imagine that test case “post” is running.  The Post test first kicks off an operation.  The operation continues to execute even after the actual test case finishes.  The problem is that we haven’t killed the operation associated with the Post unit test, and this operation executes while the next test (Reset test) has modified the state of the system, which causes a data race.

Since we are immediately assigning apiPlugin in the base class's setup() function, I am proposing to call reset after each of the unit tests.  The only time we do not want `reset` to be called is if we already called `reset`.  If we call reset twice, we will hit an implicitly unwrapped optional which will cause a segfault.  To prevent this from happening we set it to `nil` so that the tearDown() code is rendered inactive.

The following is the data race output by Xcode.  Notice that one of the threads is an AWSAPIPlugin thread, which is completely out of the scope of `testReset()` :)
```
Test Case '-[AWSAPICategoryPluginTests.AWSAPICategoryPluginResetTests testReset]' started.
==================
WARNING: ThreadSanitizer: data race (pid=2145)
  Read of size 1 at 0x7b0c000f2060 by thread T7:
    #0 HubCategory.plugin.getter HubCategory.swift:43 (Amplify:x86_64+0xffe7f)
    #1 HubCategory.dispatch(to:payload:) HubCategory+ClientBehavior.swift:15 (Amplify:x86_64+0xfe1f9)
    #2 AmplifyOperation.dispatch(result:) AmplifyOperation.swift:175 (Amplify:x86_64+0x3ce1e)
    #3 AWSGraphQLOperation.complete(with:response:) AWSGraphQLOperation+APIOperation.swift:52 (AWSAPICategoryPlugin:x86_64+0x380cf)
    #4 protocol witness for APIOperation.complete(with:response:) in conformance AWSGraphQLOperation<A> <compiler-generated> (AWSAPICategoryPlugin:x86_64+0x398ce)
    #5 AWSAPIPlugin.urlSessionBehavior(_:dataTaskBehavior:didCompleteWithError:) AWSAPIPlugin+URLSessionBehaviorDelegate.swift:14 (AWSAPICategoryPlugin:x86_64+0x4db43)
    #6 AWSAPIPlugin.urlSession(_:task:didCompleteWithError:) AWSAPIPlugin+URLSessionDelegate.swift:32 (AWSAPICategoryPlugin:x86_64+0x5be5c)
    #7 @objc AWSAPIPlugin.urlSession(_:task:didCompleteWithError:) <compiler-generated> (AWSAPICategoryPlugin:x86_64+0x5c020)
    #8 <null> <null>:2 (CFNetwork:x86_64+0x1bba93)
    #9 _dispatch_client_callout <null>:2 (libdispatch.dylib:x86_64+0x3533)

  Previous write of size 1 at 0x7b0c000f2060 by main thread:
    #0 HubCategory.configure(using:) HubCategory+CategoryConfigurable.swift:23 (Amplify:x86_64+0xfd58f)
    #1 HubCategory.configure(using:) HubCategory+CategoryConfigurable.swift:27 (Amplify:x86_64+0xfdcb5)
    #2 protocol witness for CategoryConfigurable.configure(using:) in conformance HubCategory <compiler-generated> (Amplify:x86_64+0xfdec2)
    #3 static Amplify.configure(_:using:) AmplifyConfiguration.swift:152 (Amplify:x86_64+0x1d87e)
    #4 static Amplify.configure(_:) AmplifyConfiguration.swift:110 (Amplify:x86_64+0x1be5c)
    #5 AWSAPICategoryPluginTestBase.setUp() AWSAPICategoryPluginTestBase.swift:63 (AWSAPICategoryPluginTests:x86_64+0x30a14)
    #6 @objc AWSAPICategoryPluginTestBase.setUp() <compiler-generated> (AWSAPICategoryPluginTests:x86_64+0x314d4)
    #7 __70-[XCTestCase _shouldContinueAfterPerformingSetUpSequenceWithSelector:]_block_invoke_2 <null>:2 (XCTest:x86_64+0x2ac3f)

  Location is heap block of size 33 at 0x7b0c000f2040 allocated by main thread:
    #0 __sanitizer_mz_malloc <null>:2 (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x4f2fa)
    #1 _malloc_zone_malloc <null>:2 (libsystem_malloc.dylib:x86_64+0x12a0f)
    #2 static Amplify.reset() Amplify+Reset.swift:67 (Amplify:x86_64+0x9c34)
    #3 AWSAPICategoryPluginTestBase.setUp() AWSAPICategoryPluginTestBase.swift:60 (AWSAPICategoryPluginTests:x86_64+0x3079a)
    #4 @objc AWSAPICategoryPluginTestBase.setUp() <compiler-generated> (AWSAPICategoryPluginTests:x86_64+0x314d4)
    #5 __70-[XCTestCase _shouldContinueAfterPerformingSetUpSequenceWithSelector:]_block_invoke_2 <null>:2 (XCTest:x86_64+0x2ac3f)

  Thread T7 (tid=66130, running) is a GCD worker thread

SUMMARY: ThreadSanitizer: data race HubCategory.swift:43 in HubCategory.plugin.getter
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
