### PR TITLE
chore(API): Optimistically remove comment in code

### DIFF
--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+InterceptorBehaviorTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+InterceptorBehaviorTests.swift
@@ -12,7 +12,6 @@ import AWSPluginsCore
 // swiftlint:disable:next type_name
 class AWSAPICategoryPluginInterceptorBehaviorTests: AWSAPICategoryPluginTestBase {
 
-    // TODO: Fix test failure
     func testAddInterceptor() throws {
         XCTAssertNotNil(apiPlugin.pluginConfig.endpoints[apiName])
         XCTAssertEqual(apiPlugin.pluginConfig.endpoints[apiName]?.interceptors.count, 0)


### PR DESCRIPTION
See below for the way the test was failing.  This should get fixed by this PR:
https://github.com/aws-amplify/amplify-ios/pull/937

```
Test Case '-[AWSAPICategoryPluginTests.AWSAPICategoryPluginGraphQLBehaviorTests testMutate]' started.
Test Case '-[AWSAPICategoryPluginTests.AWSAPICategoryPluginGraphQLBehaviorTests testMutate]' passed (0.007 seconds).
Test Case '-[AWSAPICategoryPluginTests.AWSAPICategoryPluginGraphQLBehaviorTests testQuery]' started.
Test Case '-[AWSAPICategoryPluginTests.AWSAPICategoryPluginGraphQLBehaviorTests testQuery]' passed (0.003 seconds).
Test Case '-[AWSAPICategoryPluginTests.AWSAPICategoryPluginGraphQLBehaviorTests testSubscribe]' started.
Test Case '-[AWSAPICategoryPluginTests.AWSAPICategoryPluginGraphQLBehaviorTests testSubscribe]' passed (0.005 seconds).
Test Suite 'AWSAPICategoryPluginGraphQLBehaviorTests' passed at 2020-12-03 22:26:16.702.
	 Executed 3 tests, with 0 failures (0 unexpected) in 0.015 (0.019) seconds
Test Suite 'AWSAPICategoryPluginInterceptorBehaviorTests' started at 2020-12-03 22:26:16.703
Test Case '-[AWSAPICategoryPluginTests.AWSAPICategoryPluginInterceptorBehaviorTests testAddInterceptor]' started.
2020-12-03 22:26:16.703935+0000 xctest[2147:68454] Task <26C9D69F-31D8-411A-A7A5-A7ABC6DE6507>.<1> finished with error [-1100] Error Domain=NSURLErrorDomain Code=-1100 "The requested URL was not found on this server." UserInfo={NSLocalizedDescription=The requested URL was not found on this server., NSErrorFailingURLStringKey=file:///Users/distiller/Library/Developer/CoreSimulator/Devices/9D54507D-3B55-400A-A4C7-1743AAF38A79/data/path, NSErrorFailingURLKey=file:///Users/distiller/Library/Developer/CoreSimulator/Devices/9D54507D-3B55-400A-A4C7-1743AAF38A79/data/path, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalDataTask <26C9D69F-31D8-411A-A7A5-A7ABC6DE6507>.<1>"
), _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <26C9D69F-31D8-411A-A7A5-A7ABC6DE6507>.<1>, NSUnderlyingError=0x7b0c000cfe10 {Error Domain=kCFErrorDomainCFNetwork Code=-1100 "(null)"}}
2020-12-03 22:26:16.706297+0000 xctest[2147:68455] Task <4EF88365-7CAA-4D04-9EF4-B4AB63CFE483>.<1> finished with error [-1100] Error Domain=NSURLErrorDomain Code=-1100 "The requested URL was not found on this server." UserInfo={NSLocalizedDescription=The requested URL was not found on this server., NSErrorFailingURLStringKey=file:///Users/distiller/Library/Developer/CoreSimulator/Devices/9D54507D-3B55-400A-A4C7-1743AAF38A79/data/path, NSErrorFailingURLKey=file:///Users/distiller/Library/Developer/CoreSimulator/Devices/9D54507D-3B55-400A-A4C7-1743AAF38A79/data/path, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalDataTask <4EF88365-7CAA-4D04-9EF4-B4AB63CFE483>.<1>"
), _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <4EF88365-7CAA-4D04-9EF4-B4AB63CFE483>.<1>, NSUnderlyingError=0x7b0c000ec5b0 {Error Domain=kCFErrorDomainCFNetwork Code=-1100 "(null)"}}
==================
WARNING: ThreadSanitizer: data race (pid=2147)
  Write of size 8 at 0x000131ac97c8 by main thread:
    #0 static Amplify.reset() Amplify+Reset.swift:67 (Amplify:x86_64+0x9c99)
    #1 AWSAPICategoryPluginTestBase.setUp() AWSAPICategoryPluginTestBase.swift:60 (AWSAPICategoryPluginTests:x86_64+0x3079a)
    #2 @objc AWSAPICategoryPluginTestBase.setUp() <compiler-generated> (AWSAPICategoryPluginTests:x86_64+0x314d4)
    #3 __70-[XCTestCase _shouldContinueAfterPerformingSetUpSequenceWithSelector:]_block_invoke_2 <null>:2 (XCTest:x86_64+0x2ac3f)
  Previous read of size 8 at 0x000131ac97c8 by thread T6:
    #0 AmplifyOperation.dispatch(result:) AmplifyOperation.swift:175 (Amplify:x86_64+0x3cdd1)
    #1 AWSGraphQLOperation.complete(with:response:) AWSGraphQLOperation+APIOperation.swift:52 (AWSAPICategoryPlugin:x86_64+0x380cf)
    #2 protocol witness for APIOperation.complete(with:response:) in conformance AWSGraphQLOperation<A> <compiler-generated> (AWSAPICategoryPlugin:x86_64+0x398ce)
    #3 AWSAPIPlugin.urlSessionBehavior(_:dataTaskBehavior:didCompleteWithError:) AWSAPIPlugin+URLSessionBehaviorDelegate.swift:14 (AWSAPICategoryPlugin:x86_64+0x4db43)
    #4 AWSAPIPlugin.urlSession(_:task:didCompleteWithError:) AWSAPIPlugin+URLSessionDelegate.swift:32 (AWSAPICategoryPlugin:x86_64+0x5be5c)
    #5 @objc AWSAPIPlugin.urlSession(_:task:didCompleteWithError:) <compiler-generated> (AWSAPICategoryPlugin:x86_64+0x5c020)
    #6 <null> <null>:2 (CFNetwork:x86_64+0x1bba93)
    #7 _dispatch_client_callout <null>:2 (libdispatch.dylib:x86_64+0x3533)
  Location is global 'static Amplify.Hub' at 0x000131ac97c8 (Amplify+0x0000002c67c8)
  Thread T6 (tid=68454, running) is a GCD worker thread
SUMMARY: ThreadSanitizer: data race Amplify+Reset.swift:67 in static Amplify.reset()
==================
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
