### PR TITLE
fix(Auth): Dismiss empty UIViewController

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -225,7 +225,6 @@ extension AuthenticationProviderAdapter {
 class PresentingNavigationController: UINavigationController {
 
     override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
-        print("present is being called")
         if #available(iOS 13, *) {
             viewControllerToPresent.isModalInPresentation = true
         }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -146,8 +146,6 @@ extension AuthenticationProviderAdapter {
 
         parentViewController?.present(navController, animated: false, completion: {
 
-            navController.dismiss(animated: false, completion: {})
-
             self.awsMobileClient.showSignIn(navigationController: navController,
                                             signInUIOptions: SignInUIOptions(),
                                             hostedUIOptions: hostedUIOptions) { [weak self] state, error in

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -133,8 +133,7 @@ extension AuthenticationProviderAdapter {
                                               tokenURIQueryParameters: request.options.tokenQueryParameters,
                                               signOutURIQueryParameters: request.options.signOutQueryParameters)
 
-        // Create a navigation controller with an empty UIViewController.
-        let navController = PresentingNavigationController(rootViewController: UIViewController())
+        let navController = ModalPresentingNavigationController(rootViewController: UIViewController())
         navController.isNavigationBarHidden = true
         navController.modalPresentationStyle = .overCurrentContext
 
@@ -219,15 +218,15 @@ extension AuthenticationProviderAdapter {
         let authError = AuthErrorHelper.toAuthError(error)
         return authError
     }
+    
+    private class ModalPresentingNavigationController: UINavigationController {
 
-}
-
-class PresentingNavigationController: UINavigationController {
-
-    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
-        if #available(iOS 13, *) {
-            viewControllerToPresent.isModalInPresentation = true
+        override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+            if #available(iOS 13, *) {
+                viewControllerToPresent.isModalInPresentation = true
+            }
+            super.present(viewControllerToPresent, animated: flag, completion: completion)
         }
-        super.present(viewControllerToPresent, animated: flag, completion: completion)
     }
+
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -134,8 +134,7 @@ extension AuthenticationProviderAdapter {
                                               signOutURIQueryParameters: request.options.signOutQueryParameters)
 
         // Create a navigation controller with an empty UIViewController.
-        let uiViewController = UIViewController()
-        let navController = UINavigationController(rootViewController: uiViewController)
+        let navController = PresentingNavigationController(rootViewController: UIViewController())
         navController.isNavigationBarHidden = true
         navController.modalPresentationStyle = .overCurrentContext
 
@@ -146,9 +145,9 @@ extension AuthenticationProviderAdapter {
         }
 
         parentViewController?.present(navController, animated: false, completion: {
-            
-            uiViewController.dismiss(animated: false, completion: {})
-            
+
+            navController.dismiss(animated: false, completion: {})
+
             self.awsMobileClient.showSignIn(navigationController: navController,
                                             signInUIOptions: SignInUIOptions(),
                                             hostedUIOptions: hostedUIOptions) { [weak self] state, error in
@@ -223,4 +222,15 @@ extension AuthenticationProviderAdapter {
         return authError
     }
 
+}
+
+class PresentingNavigationController: UINavigationController {
+
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        print("present is being called")
+        if #available(iOS 13, *) {
+            viewControllerToPresent.isModalInPresentation = true
+        }
+        super.present(viewControllerToPresent, animated: flag, completion: completion)
+    }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -134,7 +134,8 @@ extension AuthenticationProviderAdapter {
                                               signOutURIQueryParameters: request.options.signOutQueryParameters)
 
         // Create a navigation controller with an empty UIViewController.
-        let navController = UINavigationController(rootViewController: UIViewController())
+        let uiViewController = UIViewController()
+        let navController = UINavigationController(rootViewController: uiViewController)
         navController.isNavigationBarHidden = true
         navController.modalPresentationStyle = .overCurrentContext
 
@@ -145,7 +146,9 @@ extension AuthenticationProviderAdapter {
         }
 
         parentViewController?.present(navController, animated: false, completion: {
-
+            
+            uiViewController.dismiss(animated: false, completion: {})
+            
             self.awsMobileClient.showSignIn(navigationController: navController,
                                             signInUIOptions: SignInUIOptions(),
                                             hostedUIOptions: hostedUIOptions) { [weak self] state, error in


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/936

*Description of changes:*

The buggy behavior is:
If user taps on `Cancel` button, the WebView is going to disappear without affecting other ui components, because it is cancelling both ViewControllers. But when user taps outside of the WebView, then other UI components will be blocked by the empty transparent `UIViewController`.

As we investigated, we believe it is a regression from Apple, it only happens on iPad running on iOS 14+.

Thanks for Wooj2's solution: disable view from disappearing if users tap outside.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
