### PR TITLE
chore: Improve codecov reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,9 @@ jobs:
       - run:
           name: Test AWS plugins core
           command: xcodebuild test -workspace Amplify.xcworkspace -scheme AWSPluginsCore -sdk iphonesimulator -destination "${destination}" | tee "artifacts/test-AWSPluginsCore.log" | xcpretty --simple --color --report junit
+      - run:
+          name: Upload coverage report to Codecov
+          command: bash ~/amplify-ios/build-support/codecov.sh -F 'AWSPluginsCore' -J '^AWSPluginsCore$'
       - store_test_results:
           path: build/reports
       - upload_artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
           command: xcodebuild test -workspace Amplify.xcworkspace -scheme Amplify -sdk iphonesimulator -destination "${destination}" | tee "artifacts/test-Amplify.log" | xcpretty --simple --color --report junit
       - run:
           name: Upload coverage report to Codecov
-          command: bash ~/amplify-ios/build-support/codecov.sh -F $CIRCLE_JOB -J 'Amplify'
+          command: bash ~/amplify-ios/build-support/codecov.sh -F 'Amplify' -J '^Amplify$'
       - store_test_results:
           path: build/reports
       - upload_artifacts
@@ -182,7 +182,7 @@ jobs:
           command: xcodebuild test -workspace << parameters.workspace >>.xcworkspace -scheme << parameters.scheme >> -sdk iphonesimulator -destination "${destination}" | tee "artifacts/test-<< parameters.scheme >>.log" | xcpretty --simple --color --report junit
       - run:
           name: Upload << parameters.path >> coverage report to Codecov
-          command: bash ~/amplify-ios/build-support/codecov.sh -F << parameters.path >>_plugin_unit_test -J '<< parameters.scheme >>'
+          command: bash ~/amplify-ios/build-support/codecov.sh -F << parameters.path >>_plugin_unit_test -J '^<< parameters.scheme >>$'
       - store_test_results:
           path: build/reports
       - upload_artifacts

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  branch: main
+  status:
+    project:
+      default:
+        threshold: 1%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,5 @@
 coverage:
+  branch: main
   status:
     project:
       default:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,7 @@
 coverage:
-  branch: main
   status:
     project:
       default:
         threshold: 1%
+        branches:
+        - main

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,5 +3,3 @@ coverage:
     project:
       default:
         threshold: 1%
-        branches:
-        - main


### PR DESCRIPTION
*Description of changes:*

- Improve codecov labels; limit packages to be reported
- Add codecov reporting for AWSPluginsCore
- Added a config file to set the failure threshold

This is an attempt to reduce spurious code coverage failures and alarming reports of low coverage for things like test targets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
