### PR TITLE
fix(Amplify): remove a warn level log from CodingKey

### DIFF
--- a/Amplify/Categories/DataStore/Query/ModelKey.swift
+++ b/Amplify/Categories/DataStore/Query/ModelKey.swift
@@ -44,7 +44,6 @@ extension CodingKey where Self: ModelKey {
 
     var columnName: String {
         guard let modelSchema: ModelSchema = ModelRegistry.modelSchema(from: modelName) else {
-            log.warn("Please upgrade to the latest version of Amplify CLI and rerun `amplify codegen models`")
             return stringValue
         }
         switch modelSchema.field(withName: stringValue)?.association {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
the log is printed out too often even `query` is not called

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
