### PR TITLE
fix(DataStore): QueryPredicate translation

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
@@ -64,7 +64,10 @@ private func translateQueryPredicate(from modelSchema: ModelSchema,
             }
         }
     }
-    translate(predicate, predicateIndex: -1, groupType: .and) //
+
+    // the very first `and` is always prepended, using -1 for if statement checking
+    // the very first `and` is to connect `where` clause with translated QueryPredicate
+    translate(predicate, predicateIndex: -1, groupType: .and)
     return (sql.joined(separator: "\n"), bindings)
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
@@ -26,7 +26,7 @@ private func translateQueryPredicate(from modelSchema: ModelSchema,
     let indentPrefix = "  "
     var indentSize = 1
 
-    func translate(_ pred: QueryPredicate, predicateIndex: Int, groupType: QueryPredicateGroupType) {
+    func translate(_ pred: QueryPredicate, predicateIndex: Int? = nil, groupType: QueryPredicateGroupType) {
         let indent = String(repeating: indentPrefix, count: indentSize)
         if let operation = pred as? QueryPredicateOperation {
             let column = operation.operator.columnFor(field: operation.field,
@@ -64,7 +64,7 @@ private func translateQueryPredicate(from modelSchema: ModelSchema,
             }
         }
     }
-    translate(predicate, predicateIndex: 1, groupType: .and) //
+    translate(predicate, predicateIndex: -1, groupType: .and) //
     return (sql.joined(separator: "\n"), bindings)
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
@@ -26,7 +26,7 @@ private func translateQueryPredicate(from modelSchema: ModelSchema,
     let indentPrefix = "  "
     var indentSize = 1
 
-    func translate(_ pred: QueryPredicate, predicateIndex: Int? = nil, groupType: QueryPredicateGroupType) {
+    func translate(_ pred: QueryPredicate, predicateIndex: Int, groupType: QueryPredicateGroupType) {
         let indent = String(repeating: indentPrefix, count: indentSize)
         if let operation = pred as? QueryPredicateOperation {
             let column = operation.operator.columnFor(field: operation.field,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
@@ -52,6 +52,7 @@ private func translateQueryPredicate(from modelSchema: ModelSchema,
 
             indentSize += 1
             shouldClose = true
+
             var predicateIndex = 0
             group.predicates.forEach {
                 translate($0, opAhead: predicateIndex != 0, groupType: group.type)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
@@ -13,6 +13,7 @@ import XCTest
 @testable import AWSDataStoreCategoryPlugin
 
 // swiftlint:disable type_body_length
+// swiftlint:disable file_length
 // TODO: Refactor this into separate test suites
 class SQLStatementTests: XCTestCase {
 
@@ -299,8 +300,10 @@ class SQLStatementTests: XCTestCase {
           "root"."title" as "title", "root"."updatedAt" as "updatedAt"
         from Post as "root"
         where 1 = 1
-          and "root"."draft" = ?
-          and "root"."rating" > ?
+          and (
+            "root"."draft" = ?
+            and "root"."rating" > ?
+          )
         """
         XCTAssertEqual(statement.stringValue, expectedStatement)
 
@@ -588,7 +591,7 @@ class SQLStatementTests: XCTestCase {
     ///   - the predicate contains a set of different operations
     /// - Then:
     ///   - it generates a valid series of SQL conditions
-    func testTranslateComplexGroupedQueryPredicate() {
+    func testTranslateComplexGroupedQueryPredicateScenario1() {
         let post = Post.keys
 
         let predicate = post.id != nil
@@ -602,15 +605,17 @@ class SQLStatementTests: XCTestCase {
         let statement = ConditionStatement(modelSchema: Post.schema, predicate: predicate)
 
         XCTAssertEqual("""
-          and "id" is not null
-          and "draft" = ?
-          and "rating" > ?
-          and "rating" between ? and ?
-          and "status" <> ?
-          and "updatedAt" is null
           and (
-            "content" like ?
-            or "title" like ?
+            "id" is not null
+            and "draft" = ?
+            and "rating" > ?
+            and "rating" between ? and ?
+            and "status" <> ?
+            and "updatedAt" is null
+            and (
+              "content" like ?
+              or "title" like ?
+            )
           )
         """, statement.stringValue)
 
@@ -622,6 +627,112 @@ class SQLStatementTests: XCTestCase {
         XCTAssertEqual(variables[4] as? String, PostStatus.draft.rawValue)
         XCTAssertEqual(variables[5] as? String, "%gelato%")
         XCTAssertEqual(variables[6] as? String, "ice cream%")
+    }
+
+    /// - Given: a `Model` type
+    /// - When:
+    ///   - the model is of type `Post`
+    ///   - a predicate with a few conditions
+    /// - Then:
+    ///   - check if the generated SQL statement is valid
+    ///   - `where` clause is added to the select query
+    func testTranslateComplexGroupedQueryPredicateScenario2() {
+        let post = Post.keys
+        let predicate = (post.id == "postID" && post.draft == false) || post.rating > 3
+        let statement = SelectStatement(from: Post.schema, predicate: predicate)
+        let expectedStatement = """
+        select
+          "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
+          "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
+          "root"."title" as "title", "root"."updatedAt" as "updatedAt"
+        from Post as "root"
+        where 1 = 1
+          and (
+            (
+              "root"."id" = ?
+              and "root"."draft" = ?
+            )
+            or "root"."rating" > ?
+          )
+        """
+        XCTAssertEqual(statement.stringValue, expectedStatement)
+
+        let variables = statement.variables
+        XCTAssertEqual(variables[0] as? String, "postID")
+        XCTAssertEqual(variables[1] as? Int, 0)
+        XCTAssertEqual(variables[2] as? Int, 3)
+    }
+
+    /// - Given: a `Model` type
+    /// - When:
+    ///   - the model is of type `Post`
+    ///   - a predicate with a few conditions
+    /// - Then:
+    ///   - check if the generated SQL statement is valid
+    ///   - `where` clause is added to the select query
+    func testTranslateComplexGroupedQueryPredicateScenario3() {
+        let post = Post.keys
+        let predicate = (post.id == "postID" || post.draft == false) && post.rating > 3
+        let statement = SelectStatement(from: Post.schema, predicate: predicate)
+        let expectedStatement = """
+        select
+          "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
+          "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
+          "root"."title" as "title", "root"."updatedAt" as "updatedAt"
+        from Post as "root"
+        where 1 = 1
+          and (
+            (
+              "root"."id" = ?
+              or "root"."draft" = ?
+            )
+            and "root"."rating" > ?
+          )
+        """
+        XCTAssertEqual(statement.stringValue, expectedStatement)
+
+        let variables = statement.variables
+        XCTAssertEqual(variables[0] as? String, "postID")
+        XCTAssertEqual(variables[1] as? Int, 0)
+        XCTAssertEqual(variables[2] as? Int, 3)
+    }
+
+    /// - Given: a `Model` type
+    /// - When:
+    ///   - the model is of type `Post`
+    ///   - a predicate with a few conditions
+    /// - Then:
+    ///   - check if the generated SQL statement is valid
+    ///   - `where` clause is added to the select query
+    func testTranslateComplexGroupedQueryPredicateScenario4() {
+        let post = Post.keys
+        let predicate = (post.id == "postID" || post.draft == false) && (post.rating > 3 || post.createdAt == "time")
+        let statement = SelectStatement(from: Post.schema, predicate: predicate)
+        let expectedStatement = """
+        select
+          "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
+          "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
+          "root"."title" as "title", "root"."updatedAt" as "updatedAt"
+        from Post as "root"
+        where 1 = 1
+          and (
+            (
+              "root"."id" = ?
+              or "root"."draft" = ?
+            )
+            and (
+              "root"."rating" > ?
+              or "root"."createdAt" = ?
+            )
+          )
+        """
+        XCTAssertEqual(statement.stringValue, expectedStatement)
+
+        let variables = statement.variables
+        XCTAssertEqual(variables[0] as? String, "postID")
+        XCTAssertEqual(variables[1] as? Int, 0)
+        XCTAssertEqual(variables[2] as? Int, 3)
+        XCTAssertEqual(variables[3] as? String, "time")
     }
 
     /// - Given: a grouped predicate and namespace
@@ -640,18 +751,21 @@ class SQLStatementTests: XCTestCase {
             && (post.content ~= "gelato" || post.title.beginsWith("ice cream"))
 
         let statement = ConditionStatement(modelSchema: Post.schema, predicate: predicate, namespace: "root")
-
-        XCTAssertEqual("""
-          and "root"."id" is not null
-          and "root"."draft" = ?
-          and "root"."rating" > ?
-          and "root"."rating" between ? and ?
-          and "root"."updatedAt" is null
-          and (
-            "root"."content" like ?
-            or "root"."title" like ?
-          )
-        """, statement.stringValue)
+        let expectedStatement =
+            """
+              and (
+                "root"."id" is not null
+                and "root"."draft" = ?
+                and "root"."rating" > ?
+                and "root"."rating" between ? and ?
+                and "root"."updatedAt" is null
+                and (
+                  "root"."content" like ?
+                  or "root"."title" like ?
+                )
+              )
+            """
+        XCTAssertEqual(statement.stringValue, expectedStatement)
 
         let variables = statement.variables
         XCTAssertEqual(variables[0] as? Int, 1)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
@@ -777,6 +777,50 @@ class SQLStatementTests: XCTestCase {
         XCTAssertEqual(variables[3] as? String, "time")
     }
 
+    /// - Given: a `Model` type
+    /// - When:
+    ///   - the model is of type `Post`
+    ///   - a predicate with a few grouped conditions
+    /// - Then:
+    ///   - check if the generated SQL statement is valid
+    ///   - `where` clause is added to the select query
+    ///   - `where` clause is correctly generated
+    func testTranslateComplexGroupedQueryPredicateScenario6() {
+        let post = Post.keys
+        let predicate = (post.id == "postID" || post.draft == false && post.content == "content")
+            && (post.rating > 3 && post.createdAt == "time")
+        let statement = SelectStatement(from: Post.schema, predicate: predicate)
+        let expectedStatement = """
+        select
+          "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
+          "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
+          "root"."title" as "title", "root"."updatedAt" as "updatedAt"
+        from Post as "root"
+        where 1 = 1
+          and (
+            (
+              "root"."id" = ?
+              or (
+                "root"."draft" = ?
+                and "root"."content" = ?
+              )
+            )
+            and (
+              "root"."rating" > ?
+              and "root"."createdAt" = ?
+            )
+          )
+        """
+        XCTAssertEqual(statement.stringValue, expectedStatement)
+
+        let variables = statement.variables
+        XCTAssertEqual(variables[0] as? String, "postID")
+        XCTAssertEqual(variables[1] as? Int, 0)
+        XCTAssertEqual(variables[2] as? String, "content")
+        XCTAssertEqual(variables[3] as? Int, 3)
+        XCTAssertEqual(variables[4] as? String, "time")
+    }
+
     /// - Given: a grouped predicate and namespace
     /// - When:
     ///   - the predicate contains a set of different operations

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
@@ -632,10 +632,11 @@ class SQLStatementTests: XCTestCase {
     /// - Given: a `Model` type
     /// - When:
     ///   - the model is of type `Post`
-    ///   - a predicate with a few conditions
+    ///   - a predicate with a few grouped conditions
     /// - Then:
     ///   - check if the generated SQL statement is valid
     ///   - `where` clause is added to the select query
+    ///   - `where` clause is correctly generated
     func testTranslateComplexGroupedQueryPredicateScenario2() {
         let post = Post.keys
         let predicate = (post.id == "postID" && post.draft == false) || post.rating > 3
@@ -666,10 +667,11 @@ class SQLStatementTests: XCTestCase {
     /// - Given: a `Model` type
     /// - When:
     ///   - the model is of type `Post`
-    ///   - a predicate with a few conditions
+    ///   - a predicate with a few grouped conditions
     /// - Then:
     ///   - check if the generated SQL statement is valid
     ///   - `where` clause is added to the select query
+    ///   - `where` clause is correctly generated
     func testTranslateComplexGroupedQueryPredicateScenario3() {
         let post = Post.keys
         let predicate = (post.id == "postID" || post.draft == false) && post.rating > 3
@@ -700,10 +702,11 @@ class SQLStatementTests: XCTestCase {
     /// - Given: a `Model` type
     /// - When:
     ///   - the model is of type `Post`
-    ///   - a predicate with a few conditions
+    ///   - a predicate with a few grouped conditions
     /// - Then:
     ///   - check if the generated SQL statement is valid
     ///   - `where` clause is added to the select query
+    ///   - `where` clause is correctly generated
     func testTranslateComplexGroupedQueryPredicateScenario4() {
         let post = Post.keys
         let predicate = (post.id == "postID" || post.draft == false) && (post.rating > 3 || post.createdAt == "time")
@@ -723,6 +726,45 @@ class SQLStatementTests: XCTestCase {
             and (
               "root"."rating" > ?
               or "root"."createdAt" = ?
+            )
+          )
+        """
+        XCTAssertEqual(statement.stringValue, expectedStatement)
+
+        let variables = statement.variables
+        XCTAssertEqual(variables[0] as? String, "postID")
+        XCTAssertEqual(variables[1] as? Int, 0)
+        XCTAssertEqual(variables[2] as? Int, 3)
+        XCTAssertEqual(variables[3] as? String, "time")
+    }
+
+    /// - Given: a `Model` type
+    /// - When:
+    ///   - the model is of type `Post`
+    ///   - a predicate with a few grouped conditions
+    /// - Then:
+    ///   - check if the generated SQL statement is valid
+    ///   - `where` clause is added to the select query
+    ///   - `where` clause is correctly generated
+    func testTranslateComplexGroupedQueryPredicateScenario5() {
+        let post = Post.keys
+        let predicate = (post.id == "postID" && post.draft == false) || (post.rating > 3 && post.createdAt == "time")
+        let statement = SelectStatement(from: Post.schema, predicate: predicate)
+        let expectedStatement = """
+        select
+          "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
+          "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
+          "root"."title" as "title", "root"."updatedAt" as "updatedAt"
+        from Post as "root"
+        where 1 = 1
+          and (
+            (
+              "root"."id" = ?
+              and "root"."draft" = ?
+            )
+            or (
+              "root"."rating" > ?
+              and "root"."createdAt" = ?
             )
           )
         """


### PR DESCRIPTION
*Issue #, if available:*
A fix for issue: https://github.com/aws-amplify/amplify-ios/issues/907

*Description of changes:*
The previous translation from `QueryPredicate` to sql statement is incorrect

For example:
If I have a predicate like 
```swift
let predicate = (todo.name == "name2" && todo.tag == "optional") || todo.description == "wake up"
```
SQL statement generated by the incorrect code is:
```
select
  "root"."id" as "id", "root"."description" as "description", "root"."name" as "name",
  "root"."tag" as "tag"
from Todo as "root"
where 1 = 1
  and (
    or (
      "root"."name" = ?
      and "root"."tag" = ?
    )
    and "root"."description" = ?
  )
```
which fails `DataStore.query()`

The correct one should be:
```
select
  "root"."id" as "id", "root"."description" as "description", "root"."name" as "name",
  "root"."tag" as "tag"
from Todo as "root"
where 1 = 1
  and (
    (
      "root"."name" = ?
      and "root"."tag" = ?
    )
    or "root"."description" = ?
  )
```
My PR update the implementation of ConditionStatement generation
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
