### PR TITLE
bug(core): Pass the right amplify version in user agent

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration+Platform.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration+Platform.swift
@@ -21,7 +21,7 @@ extension AmplifyAWSServiceConfiguration {
 
     static func platformInformation() -> String {
         var platformTokens = platformMapping.map { "\($0.rawValue)/\($1)" }
-        platformTokens.append("amplify-iOS/\(version)")
+        platformTokens.append("amplify-iOS/\(AmplifyAWSServiceConfiguration.version)")
         return platformTokens.joined(separator: " ")
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -9,7 +9,7 @@ import Foundation
 import AWSCore
 
 public class AmplifyAWSServiceConfiguration: AWSServiceConfiguration {
-    private static let version = "1.5.0"
+    static let version = "1.5.0"
 
     override public class func baseUserAgent() -> String! {
         //TODO: Retrieve this version from a centralized location:

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
@@ -34,7 +34,7 @@ class AmplifyAWSServiceConfigurationTests: XCTestCase {
         XCTAssertNotNil(configuration.userAgent)
         let userAgentParts = configuration.userAgent.components(separatedBy: " ")
         XCTAssertEqual(3, userAgentParts.count)
-        XCTAssert(userAgentParts[0].starts(with: "amplify-iOS/"))
+        XCTAssertEqual("amplify-iOS/\(AmplifyAWSServiceConfiguration.version)", userAgentParts[0])
         XCTAssertEqual(expectedSystem, userAgentParts[1])
         XCTAssertEqual(expectedLocale, userAgentParts[2])
     }

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -62,7 +62,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
     func start(completion: @escaping DataStoreCallback<Void>) {
         notify("start")
     }
-    
+
     func stop(completion: @escaping DataStoreCallback<Void>) {
         notify("stop")
     }


### PR DESCRIPTION
User agent string was malformed. Before this PR the user agent string was this:
```
amplify-iOS/(Function) iOS/14.0 en_US
```

After this PR

```
amplify-iOS/1.5.0 iOS/14.0 en_US
```

- Added unit test to check the version value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
