### PR TITLE
fix: add blog post comment schema and tests

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -148,6 +148,12 @@
 		21F40A3C23A2952C0074678E /* AuthHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F40A3B23A2952C0074678E /* AuthHelper.swift */; };
 		21F40A3E23A295390074678E /* AWSMobileClient+Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F40A3D23A295390074678E /* AWSMobileClient+Message.swift */; };
 		21F40A4023A295470074678E /* TestCommonConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F40A3F23A295470074678E /* TestCommonConstants.swift */; };
+		21FDBB612587D7A30086FCDC /* Blog6.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FDBB5B2587D7A30086FCDC /* Blog6.swift */; };
+		21FDBB622587D7A30086FCDC /* Post6.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FDBB5C2587D7A30086FCDC /* Post6.swift */; };
+		21FDBB632587D7A30086FCDC /* Comment6.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FDBB5D2587D7A30086FCDC /* Comment6.swift */; };
+		21FDBB642587D7A30086FCDC /* Post6+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FDBB5E2587D7A30086FCDC /* Post6+Schema.swift */; };
+		21FDBB652587D7A30086FCDC /* Comment6+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FDBB5F2587D7A30086FCDC /* Comment6+Schema.swift */; };
+		21FDBB662587D7A30086FCDC /* Blog6+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FDBB602587D7A30086FCDC /* Blog6+Schema.swift */; };
 		21FFF988230B7B2C005878EA /* AsychronousOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFF986230B7A5D005878EA /* AsychronousOperation.swift */; };
 		21FFF98E230C81E6005878EA /* StorageAccessLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFF98D230C81E6005878EA /* StorageAccessLevel.swift */; };
 		21FFF994230C96CB005878EA /* StorageUploadDataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFF98F230C96CA005878EA /* StorageUploadDataOperation.swift */; };
@@ -912,6 +918,12 @@
 		21F40A3B23A2952C0074678E /* AuthHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthHelper.swift; sourceTree = "<group>"; };
 		21F40A3D23A295390074678E /* AWSMobileClient+Message.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSMobileClient+Message.swift"; sourceTree = "<group>"; };
 		21F40A3F23A295470074678E /* TestCommonConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCommonConstants.swift; sourceTree = "<group>"; };
+		21FDBB5B2587D7A30086FCDC /* Blog6.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Blog6.swift; sourceTree = "<group>"; };
+		21FDBB5C2587D7A30086FCDC /* Post6.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post6.swift; sourceTree = "<group>"; };
+		21FDBB5D2587D7A30086FCDC /* Comment6.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment6.swift; sourceTree = "<group>"; };
+		21FDBB5E2587D7A30086FCDC /* Post6+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post6+Schema.swift"; sourceTree = "<group>"; };
+		21FDBB5F2587D7A30086FCDC /* Comment6+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Comment6+Schema.swift"; sourceTree = "<group>"; };
+		21FDBB602587D7A30086FCDC /* Blog6+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Blog6+Schema.swift"; sourceTree = "<group>"; };
 		21FFF986230B7A5D005878EA /* AsychronousOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsychronousOperation.swift; sourceTree = "<group>"; };
 		21FFF98D230C81E6005878EA /* StorageAccessLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAccessLevel.swift; sourceTree = "<group>"; };
 		21FFF98F230C96CA005878EA /* StorageUploadDataOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageUploadDataOperation.swift; sourceTree = "<group>"; };
@@ -1908,6 +1920,7 @@
 				217D5F0525780564009F0639 /* 3 */,
 				217D5F0D2578057A009F0639 /* 4 */,
 				217D5F152578058A009F0639 /* 5 */,
+				21FDBB5A2587D7A30086FCDC /* 6 */,
 				217D5ECD2577FA1B009F0639 /* connection-schema.graphql */,
 			);
 			path = Collection;
@@ -2023,6 +2036,20 @@
 			);
 			path = API;
 			sourceTree = "<group>";
+		};
+		21FDBB5A2587D7A30086FCDC /* 6 */ = {
+			isa = PBXGroup;
+			children = (
+				21FDBB5B2587D7A30086FCDC /* Blog6.swift */,
+				21FDBB5C2587D7A30086FCDC /* Post6.swift */,
+				21FDBB5D2587D7A30086FCDC /* Comment6.swift */,
+				21FDBB5E2587D7A30086FCDC /* Post6+Schema.swift */,
+				21FDBB5F2587D7A30086FCDC /* Comment6+Schema.swift */,
+				21FDBB602587D7A30086FCDC /* Blog6+Schema.swift */,
+			);
+			name = 6;
+			path = AmplifyTestCommon/Models/Collection/6;
+			sourceTree = SOURCE_ROOT;
 		};
 		21FFF999230C96E0005878EA /* Operation */ = {
 			isa = PBXGroup;
@@ -5056,6 +5083,7 @@
 				FA176ED7238503C200C5C5F9 /* HubListenerTestUtilities.swift in Sources */,
 				216E45EE248E914F0035E3CE /* Todo.swift in Sources */,
 				6BEE081D2533CCFA00133961 /* OGCScenarioBPost.swift in Sources */,
+				21FDBB632587D7A30086FCDC /* Comment6.swift in Sources */,
 				217D5EC52577F9DF009F0639 /* Project2.swift in Sources */,
 				B4F3543525361E0E0050FEE0 /* DynamicModel.swift in Sources */,
 				217D5EC02577F9DF009F0639 /* Post3.swift in Sources */,
@@ -5068,6 +5096,8 @@
 				FAD3937F23820DAE00463F5E /* MockDataStoreCategoryPlugin.swift in Sources */,
 				217D5EBB2577F9DF009F0639 /* Team1.swift in Sources */,
 				6BEE08252533D30800133961 /* OGCScenarioBMGroupPost+Schema.swift in Sources */,
+				21FDBB662587D7A30086FCDC /* Blog6+Schema.swift in Sources */,
+				21FDBB612587D7A30086FCDC /* Blog6.swift in Sources */,
 				FACA361A2327FC69000E74F6 /* MockStorageCategoryPlugin.swift in Sources */,
 				217D5EB92577F9DF009F0639 /* Post3+Schema.swift in Sources */,
 				B9521837237E21BA00F53237 /* Post.swift in Sources */,
@@ -5123,10 +5153,13 @@
 				21F40A3C23A2952C0074678E /* AuthHelper.swift in Sources */,
 				6BEE08242533D30800133961 /* OGCScenarioBMGroupPost.swift in Sources */,
 				217D5EC22577F9DF009F0639 /* User5+Schema.swift in Sources */,
+				21FDBB642587D7A30086FCDC /* Post6+Schema.swift in Sources */,
 				217D5EB12577F9DF009F0639 /* Team2+Schema.swift in Sources */,
 				B4F3E9FA24314ECC00F23296 /* MockAuthCategoryPlugin.swift in Sources */,
+				21FDBB652587D7A30086FCDC /* Comment6+Schema.swift in Sources */,
 				214F49CE24898E8500DA616C /* Article+Schema.swift in Sources */,
 				216E460A249183230035E3CE /* Section.swift in Sources */,
+				21FDBB622587D7A30086FCDC /* Post6.swift in Sources */,
 				217D5EBA2577F9DF009F0639 /* Post4+Schema.swift in Sources */,
 				217D5EBD2577F9DF009F0639 /* Post5.swift in Sources */,
 				FA1846EE23998E44009B9D01 /* MockAPIResponders.swift in Sources */,

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		21E2E22A2451E6B5007D7767 /* GraphQLResponseDecoderDecodeErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E2E2292451E6B5007D7767 /* GraphQLResponseDecoderDecodeErrorTests.swift */; };
 		21F40A2B23A0423C0074678E /* GraphQLSyncBasedTests-amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21F40A2923A0423C0074678E /* GraphQLSyncBasedTests-amplifyconfiguration.json */; };
 		21F40A2E23A0707E0074678E /* GraphQLModelBasedTests-amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21F40A2D23A0707E0074678E /* GraphQLModelBasedTests-amplifyconfiguration.json */; };
+		21FDBB762587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FDBB752587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift */; };
 		241355B5778C3B2C3826CE96 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithIAMIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D57635393A9898E665C00A1 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithIAMIntegrationTests.framework */; };
 		2CEBACDFF438BD3D3C28A92E /* Pods_HostApp_AWSAPICategoryPluginTestCommon_GraphQLWithIAMIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5B78DFE063D156DDD5BC634 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_GraphQLWithIAMIntegrationTests.framework */; };
 		34AC2D987AA9068173601F3A /* Pods_HostApp_AWSAPICategoryPluginTestCommon_AWSAPICategoryPluginFunctionalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CAC5A88BE3D8AAD8B926A28 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_AWSAPICategoryPluginFunctionalTests.framework */; };
@@ -373,6 +374,7 @@
 		21E2E2292451E6B5007D7767 /* GraphQLResponseDecoderDecodeErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLResponseDecoderDecodeErrorTests.swift; sourceTree = "<group>"; };
 		21F40A2923A0423C0074678E /* GraphQLSyncBasedTests-amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GraphQLSyncBasedTests-amplifyconfiguration.json"; sourceTree = "<group>"; };
 		21F40A2D23A0707E0074678E /* GraphQLModelBasedTests-amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GraphQLModelBasedTests-amplifyconfiguration.json"; sourceTree = "<group>"; };
+		21FDBB752587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQLConnectionScenario6Tests.swift; sourceTree = "<group>"; };
 		226F79D02FF47C0A8AE75467 /* Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests/Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		2A9C1061115A6639265D6C9C /* Pods-GraphQLWithIAMIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GraphQLWithIAMIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-GraphQLWithIAMIntegrationTests/Pods-GraphQLWithIAMIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		2D57635393A9898E665C00A1 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithIAMIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithIAMIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -651,6 +653,7 @@
 				217D5FFF2578369F009F0639 /* GraphQLConnectionScenario3Tests.swift */,
 				217D5FFC2578369E009F0639 /* GraphQLConnectionScenario4Tests.swift */,
 				217D5FFD2578369E009F0639 /* GraphQLConnectionScenario5Tests.swift */,
+				21FDBB752587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift */,
 				21F40A2D23A0707E0074678E /* GraphQLModelBasedTests-amplifyconfiguration.json */,
 				217856C12383339D00A30D19 /* GraphQLModelBasedTests.swift */,
 				21598CEF23A00F8400529F29 /* README.md */,
@@ -2133,6 +2136,7 @@
 				217D60032578369F009F0639 /* GraphQLConnectionScenario3Tests.swift in Sources */,
 				FAC5F9B1238B70EE00F70F02 /* APICategoryPluginConcurrencyTests.swift in Sources */,
 				216201E323920A6200AB2E10 /* GraphQLSyncBasedTests.swift in Sources */,
+				21FDBB762587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift in Sources */,
 				FA97F5532386CCF500EE9EFE /* AnyModelIntegrationTests.swift in Sources */,
 				217D60012578369F009F0639 /* GraphQLConnectionScenario5Tests.swift in Sources */,
 				217D5FE925783559009F0639 /* GraphQLConnectionScenario2Tests.swift in Sources */,

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
@@ -90,6 +90,8 @@
 		21F40A2B23A0423C0074678E /* GraphQLSyncBasedTests-amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21F40A2923A0423C0074678E /* GraphQLSyncBasedTests-amplifyconfiguration.json */; };
 		21F40A2E23A0707E0074678E /* GraphQLModelBasedTests-amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21F40A2D23A0707E0074678E /* GraphQLModelBasedTests-amplifyconfiguration.json */; };
 		21FDBB762587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FDBB752587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift */; };
+		21FE04BB25894F8800B81D72 /* GraphQLConnectionScenario3Tests+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FE04B825894F8800B81D72 /* GraphQLConnectionScenario3Tests+Helpers.swift */; };
+		21FE04BD25894F8800B81D72 /* GraphQLConnectionScenario3Tests+Subscribe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FE04BA25894F8800B81D72 /* GraphQLConnectionScenario3Tests+Subscribe.swift */; };
 		241355B5778C3B2C3826CE96 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithIAMIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D57635393A9898E665C00A1 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithIAMIntegrationTests.framework */; };
 		2CEBACDFF438BD3D3C28A92E /* Pods_HostApp_AWSAPICategoryPluginTestCommon_GraphQLWithIAMIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5B78DFE063D156DDD5BC634 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_GraphQLWithIAMIntegrationTests.framework */; };
 		34AC2D987AA9068173601F3A /* Pods_HostApp_AWSAPICategoryPluginTestCommon_AWSAPICategoryPluginFunctionalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CAC5A88BE3D8AAD8B926A28 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_AWSAPICategoryPluginFunctionalTests.framework */; };
@@ -375,6 +377,8 @@
 		21F40A2923A0423C0074678E /* GraphQLSyncBasedTests-amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GraphQLSyncBasedTests-amplifyconfiguration.json"; sourceTree = "<group>"; };
 		21F40A2D23A0707E0074678E /* GraphQLModelBasedTests-amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GraphQLModelBasedTests-amplifyconfiguration.json"; sourceTree = "<group>"; };
 		21FDBB752587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQLConnectionScenario6Tests.swift; sourceTree = "<group>"; };
+		21FE04B825894F8800B81D72 /* GraphQLConnectionScenario3Tests+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQLConnectionScenario3Tests+Helpers.swift"; sourceTree = "<group>"; };
+		21FE04BA25894F8800B81D72 /* GraphQLConnectionScenario3Tests+Subscribe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQLConnectionScenario3Tests+Subscribe.swift"; sourceTree = "<group>"; };
 		226F79D02FF47C0A8AE75467 /* Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests/Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		2A9C1061115A6639265D6C9C /* Pods-GraphQLWithIAMIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GraphQLWithIAMIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-GraphQLWithIAMIntegrationTests/Pods-GraphQLWithIAMIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		2D57635393A9898E665C00A1 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithIAMIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithIAMIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -651,6 +655,8 @@
 				217D5FFE2578369E009F0639 /* GraphQLConnectionScenario1Tests.swift */,
 				217D5FE825783559009F0639 /* GraphQLConnectionScenario2Tests.swift */,
 				217D5FFF2578369F009F0639 /* GraphQLConnectionScenario3Tests.swift */,
+				21FE04B825894F8800B81D72 /* GraphQLConnectionScenario3Tests+Helpers.swift */,
+				21FE04BA25894F8800B81D72 /* GraphQLConnectionScenario3Tests+Subscribe.swift */,
 				217D5FFC2578369E009F0639 /* GraphQLConnectionScenario4Tests.swift */,
 				217D5FFD2578369E009F0639 /* GraphQLConnectionScenario5Tests.swift */,
 				21FDBB752587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift */,
@@ -2135,7 +2141,9 @@
 				217D60002578369F009F0639 /* GraphQLConnectionScenario4Tests.swift in Sources */,
 				217D60032578369F009F0639 /* GraphQLConnectionScenario3Tests.swift in Sources */,
 				FAC5F9B1238B70EE00F70F02 /* APICategoryPluginConcurrencyTests.swift in Sources */,
+				21FE04BD25894F8800B81D72 /* GraphQLConnectionScenario3Tests+Subscribe.swift in Sources */,
 				216201E323920A6200AB2E10 /* GraphQLSyncBasedTests.swift in Sources */,
+				21FE04BB25894F8800B81D72 /* GraphQLConnectionScenario3Tests+Helpers.swift in Sources */,
 				21FDBB762587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift in Sources */,
 				FA97F5532386CCF500EE9EFE /* AnyModelIntegrationTests.swift in Sources */,
 				217D60012578369F009F0639 /* GraphQLConnectionScenario5Tests.swift in Sources */,

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSAPICategoryPluginFunctionalTests.xcscheme
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSAPICategoryPluginFunctionalTests.xcscheme
@@ -46,6 +46,9 @@
                <Test
                   Identifier = "GraphQLConnectionScenario5Tests/testListPostEditorByUser()">
                </Test>
+               <Test
+                  Identifier = "GraphQLSyncBasedTests">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario1Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario1Tests.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-import AWSMobileClient
 @testable import AWSAPICategoryPlugin
 @testable import Amplify
 @testable import AmplifyTestCommon
@@ -206,7 +205,7 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
     func createTeam(id: String = UUID().uuidString, name: String) -> Team1? {
         let team = Team1(id: id, name: name)
         var result: Team1?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         Amplify.API.mutate(request: .create(team)) { event in
             switch event {
             case .success(let data):
@@ -216,12 +215,12 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
@@ -230,7 +229,7 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
                        team: Team1? = nil) -> Project1? {
         let project = Project1(id: id, name: name, team: team)
         var result: Project1?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         Amplify.API.mutate(request: .create(project)) { event in
             switch event {
             case .success(let data):
@@ -240,12 +239,12 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario2Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario2Tests.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-import AWSMobileClient
 @testable import AWSAPICategoryPlugin
 @testable import Amplify
 @testable import AmplifyTestCommon
@@ -220,7 +219,7 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
     func createTeam2(id: String = UUID().uuidString, name: String) -> Team2? {
         let team = Team2(id: id, name: name)
         var result: Team2?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         Amplify.API.mutate(request: .create(team)) { event in
             switch event {
             case .success(let data):
@@ -230,12 +229,12 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
@@ -245,7 +244,7 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
                         team: Team2? = nil) -> Project2? {
         let project = Project2(id: id, name: name, teamID: teamID, team: team)
         var result: Project2?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         Amplify.API.mutate(request: .create(project)) { event in
             switch event {
             case .success(let data):
@@ -255,12 +254,12 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests+Helpers.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests+Helpers.swift
@@ -1,0 +1,104 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AWSMobileClient
+@testable import AWSAPICategoryPlugin
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSAPICategoryPluginTestCommon
+
+extension GraphQLConnectionScenario3Tests {
+
+    func createPost(id: String = UUID().uuidString, title: String) -> Post3? {
+        let post = Post3(id: id, title: title)
+        var result: Post3?
+        let completeInvoked = expectation(description: "request completed")
+        Amplify.API.mutate(request: .create(post)) { event in
+            switch event {
+            case .success(let data):
+                switch data {
+                case .success(let post):
+                    result = post
+                default:
+                    XCTFail("Could not get data back")
+                }
+                completeInvoked.fulfill()
+            case .failure(let error):
+                XCTFail("Failed \(error)")
+            }
+        }
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        return result
+    }
+
+    func createComment(id: String = UUID().uuidString, postID: String, content: String) -> Comment3? {
+        let comment = Comment3(id: id, postID: postID, content: content)
+        var result: Comment3?
+        let completeInvoked = expectation(description: "request completed")
+        Amplify.API.mutate(request: .create(comment)) { event in
+            switch event {
+            case .success(let data):
+                switch data {
+                case .success(let comment):
+                    result = comment
+                default:
+                    XCTFail("Could not get data back")
+                }
+                completeInvoked.fulfill()
+            case .failure(let error):
+                XCTFail("Failed \(error)")
+            }
+        }
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        return result
+    }
+
+    func updatePost(id: String, title: String) -> Post3? {
+        var result: Post3?
+        let completeInvoked = expectation(description: "request completed")
+
+        let post = Post3(id: id, title: title)
+        _ = Amplify.API.mutate(request: .update(post)) { event in
+            switch event {
+            case .success(let data):
+                switch data {
+                case .success(let post):
+                    result = post
+                default:
+                    XCTFail("Could not get data back")
+                }
+                completeInvoked.fulfill()
+            case .failure(let error):
+                print(error)
+            }
+        }
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        return result
+    }
+
+    func deletePost(post: Post3) -> Post3? {
+        var result: Post3?
+        let completeInvoked = expectation(description: "request completed")
+        _ = Amplify.API.mutate(request: .delete(post)) { event in
+            switch event {
+            case .success(let data):
+                switch data {
+                case .success(let post):
+                    result = post
+                default:
+                    XCTFail("Could not get data back")
+                }
+                completeInvoked.fulfill()
+            case .failure(let error):
+                print(error)
+            }
+        }
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        return result
+    }
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests+Helpers.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests+Helpers.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-import AWSMobileClient
 @testable import AWSAPICategoryPlugin
 @testable import Amplify
 @testable import AmplifyTestCommon
@@ -17,7 +16,7 @@ extension GraphQLConnectionScenario3Tests {
     func createPost(id: String = UUID().uuidString, title: String) -> Post3? {
         let post = Post3(id: id, title: title)
         var result: Post3?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         Amplify.API.mutate(request: .create(post)) { event in
             switch event {
             case .success(let data):
@@ -27,19 +26,19 @@ extension GraphQLConnectionScenario3Tests {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
     func createComment(id: String = UUID().uuidString, postID: String, content: String) -> Comment3? {
         let comment = Comment3(id: id, postID: postID, content: content)
         var result: Comment3?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         Amplify.API.mutate(request: .create(comment)) { event in
             switch event {
             case .success(let data):
@@ -49,20 +48,18 @@ extension GraphQLConnectionScenario3Tests {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
-    func updatePost(id: String, title: String) -> Post3? {
+    func mutatePost(post: Post3) -> Post3? {
         var result: Post3?
-        let completeInvoked = expectation(description: "request completed")
-
-        let post = Post3(id: id, title: title)
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         _ = Amplify.API.mutate(request: .update(post)) { event in
             switch event {
             case .success(let data):
@@ -72,18 +69,18 @@ extension GraphQLConnectionScenario3Tests {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
-                print(error)
+                XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
     func deletePost(post: Post3) -> Post3? {
         var result: Post3?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         _ = Amplify.API.mutate(request: .delete(post)) { event in
             switch event {
             case .success(let data):
@@ -93,12 +90,12 @@ extension GraphQLConnectionScenario3Tests {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
-                print(error)
+                XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests+Subscribe.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests+Subscribe.swift
@@ -1,0 +1,232 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AWSMobileClient
+@testable import AWSAPICategoryPlugin
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSAPICategoryPluginTestCommon
+
+extension GraphQLConnectionScenario3Tests {
+
+    func testOnCreatePostSubscriptionWithModel() {
+        let connectedInvoked = expectation(description: "Connection established")
+        let disconnectedInvoked = expectation(description: "Connection disconnected")
+        let completedInvoked = expectation(description: "Completed invoked")
+        let progressInvoked = expectation(description: "progress invoked")
+        progressInvoked.expectedFulfillmentCount = 2
+
+        let operation = Amplify.API.subscribe(
+            request: .subscription(of: Post3.self, type: .onCreate),
+            valueListener: { event in
+                switch event {
+                case .connection(let state):
+                    switch state {
+                    case .connecting:
+                        break
+                    case .connected:
+                        connectedInvoked.fulfill()
+                    case .disconnected:
+                        disconnectedInvoked.fulfill()
+                    }
+                case .data:
+                    progressInvoked.fulfill()
+                }
+
+        },
+            completionListener: { event in
+                switch event {
+                case .failure(let error):
+                    print("Unexpected .failed event: \(error)")
+                case .success:
+                    completedInvoked.fulfill()
+                }
+        })
+
+        XCTAssertNotNil(operation)
+        wait(for: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        let uuid = UUID().uuidString
+        let testMethodName = String("\(#function)".dropLast(2))
+        let title = testMethodName + "Title"
+
+        guard createPost(id: uuid, title: title) != nil else {
+            XCTFail("Failed to create post")
+            return
+        }
+
+        let uuid2 = UUID().uuidString
+        guard createPost(id: uuid2, title: title) != nil else {
+            XCTFail("Failed to create post")
+            return
+        }
+
+        wait(for: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        operation.cancel()
+        wait(for: [disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
+        XCTAssertTrue(operation.isFinished)
+    }
+
+    func testOnUpdatePostSubscriptionWithModel() {
+        let connectedInvoked = expectation(description: "Connection established")
+        let disconnectedInvoked = expectation(description: "Connection disconnected")
+        let completedInvoked = expectation(description: "Completed invoked")
+        let progressInvoked = expectation(description: "progress invoked")
+
+        let operation = Amplify.API.subscribe(
+            request: .subscription(of: Post3.self, type: .onUpdate),
+            valueListener: { event in
+                switch event {
+                case .connection(let state):
+                    switch state {
+                    case .connecting:
+                        break
+                    case .connected:
+                        connectedInvoked.fulfill()
+                    case .disconnected:
+                        disconnectedInvoked.fulfill()
+                    }
+                case .data:
+                    progressInvoked.fulfill()
+                }
+        },
+            completionListener: { event in
+                switch event {
+                case .failure(let error):
+                    print("Unexpected .failed event: \(error)")
+                case .success:
+                    completedInvoked.fulfill()
+                }
+        })
+        XCTAssertNotNil(operation)
+        wait(for: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        let uuid = UUID().uuidString
+        let testMethodName = String("\(#function)".dropLast(2))
+        let title = testMethodName + "Title"
+
+        guard createPost(id: uuid, title: title) != nil else {
+            XCTFail("Failed to create post")
+            return
+        }
+
+        guard updatePost(id: uuid, title: title) != nil else {
+            XCTFail("Failed to update post")
+            return
+        }
+
+        wait(for: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        operation.cancel()
+        wait(for: [disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
+        XCTAssertTrue(operation.isFinished)
+    }
+
+    func testOnDeletePostSubscriptionWithModel() {
+        let connectedInvoked = expectation(description: "Connection established")
+        let disconnectedInvoked = expectation(description: "Connection disconnected")
+        let completedInvoked = expectation(description: "Completed invoked")
+        let progressInvoked = expectation(description: "progress invoked")
+
+        let operation = Amplify.API.subscribe(
+            request: .subscription(of: Post3.self, type: .onDelete),
+            valueListener: { event in
+                switch event {
+                case .connection(let state):
+                    switch state {
+                    case .connecting:
+                        break
+                    case .connected:
+                        connectedInvoked.fulfill()
+                    case .disconnected:
+                        disconnectedInvoked.fulfill()
+                    }
+                case .data:
+                    progressInvoked.fulfill()
+                }
+        },
+            completionListener: { event in
+                switch event {
+                case .failure(let error):
+                    print("Unexpected .failed event: \(error)")
+                case .success:
+                    completedInvoked.fulfill()
+                }
+        })
+        XCTAssertNotNil(operation)
+        wait(for: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        let uuid = UUID().uuidString
+        let testMethodName = String("\(#function)".dropLast(2))
+        let title = testMethodName + "Title"
+
+        guard let post = createPost(id: uuid, title: title) else {
+            XCTFail("Failed to create post")
+            return
+        }
+
+        guard deletePost(post: post) != nil else {
+            XCTFail("Failed to update post")
+            return
+        }
+
+        wait(for: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        operation.cancel()
+        wait(for: [disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
+        XCTAssertTrue(operation.isFinished)
+    }
+
+    func testOnCreateCommentSubscriptionWithModel() {
+        let connectedInvoked = expectation(description: "Connection established")
+        let disconnectedInvoked = expectation(description: "Connection disconnected")
+        let completedInvoked = expectation(description: "Completed invoked")
+        let progressInvoked = expectation(description: "progress invoked")
+
+        let operation = Amplify.API.subscribe(
+            request: .subscription(of: Comment3.self, type: .onCreate),
+            valueListener: { event in
+                switch event {
+                case .connection(let state):
+                    switch state {
+                    case .connecting:
+                        break
+                    case .connected:
+                        connectedInvoked.fulfill()
+                    case .disconnected:
+                        disconnectedInvoked.fulfill()
+                    }
+                case .data:
+                    progressInvoked.fulfill()
+                }
+        },
+            completionListener: { event in
+                switch event {
+                case .failure(let error):
+                    print("Unexpected .failed event: \(error)")
+                case .success:
+                    completedInvoked.fulfill()
+                }
+        })
+        XCTAssertNotNil(operation)
+        wait(for: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        let uuid = UUID().uuidString
+        let testMethodName = String("\(#function)".dropLast(2))
+        let title = testMethodName + "Title"
+
+        guard let createdPost = createPost(id: uuid, title: title) else {
+            XCTFail("Failed to create post")
+            return
+        }
+
+        guard createComment(postID: createdPost.id, content: "content") != nil else {
+            XCTFail("Failed to create comment with post")
+            return
+        }
+
+        wait(for: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        operation.cancel()
+        wait(for: [disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
+        XCTAssertTrue(operation.isFinished)
+    }
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests.swift
@@ -53,6 +53,37 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
         Amplify.reset()
     }
 
+    func testQuerySinglePost() {
+        guard let post = createPost(title: "title") else {
+            XCTFail("Failed to set up test")
+            return
+        }
+
+        let completeInvoked = expectation(description: "request completed")
+        _ = Amplify.API.query(request: .get(Post3.self, byId: post.id)) { event in
+            switch event {
+            case .success(let graphQLResponse):
+                guard case let .success(data) = graphQLResponse else {
+                    XCTFail("Missing successful response")
+                    return
+                }
+                guard let resultPost = data else {
+                    XCTFail("Missing post from querySingle")
+                    return
+                }
+
+                XCTAssertEqual(resultPost.id, post.id)
+                completeInvoked.fulfill()
+            case .failure(let error):
+                XCTFail("Unexpected .failed event: \(error)")
+            }
+        }
+
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+    }
+
+    // Create a post and a comment for the post
+    // Retrieve the comment and ensure that the comment is associated with the correct post
     func testCreatAndGetComment() {
         guard let post = createPost(title: "title") else {
             XCTFail("Could not create post")
@@ -86,40 +117,10 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
         wait(for: [getCommentCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    // TODO: complete this test with lazy loading of API (https://github.com/aws-amplify/amplify-ios/pull/845)
-    func testCreateCommentAndGetPostWithComments() {
-        guard let post = createPost(title: "title") else {
-            XCTFail("Could not create post")
-            return
-        }
-        guard createComment(postID: post.id, content: "content") != nil else {
-            XCTFail("Could not create comment")
-            return
-        }
-
-        let getPostCompleted = expectation(description: "get post complete")
-        Amplify.API.query(request: .get(Post3.self, byId: post.id)) { result in
-            switch result {
-            case .success(let result):
-                switch result {
-                case .success(let queriedPostOptional):
-                    guard let queriedPost = queriedPostOptional else {
-                        XCTFail("Could not get post")
-                        return
-                    }
-                    XCTAssertEqual(queriedPost.id, post.id)
-                    getPostCompleted.fulfill()
-                // TODO: Load comments
-                case .failure(let response):
-                    XCTFail("Failed with: \(response)")
-                }
-            case .failure(let error):
-                XCTFail("\(error)")
-            }
-        }
-        wait(for: [getPostCompleted], timeout: TestCommonConstants.networkTimeout)
-    }
-
+    // Create a post and a comment associated with that post.
+    // Create another post that will be used to update the existing comment
+    // Update the existing comment to point to the other post
+    // Expect that the queried comment is associated with the other post
     func testUpdateComment() {
         guard let post = createPost(title: "title") else {
             XCTFail("Could not create post")
@@ -152,6 +153,83 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
         wait(for: [updateCommentSuccessful], timeout: TestCommonConstants.networkTimeout)
     }
 
+    func testUpdateExistingPost() {
+        let uuid = UUID().uuidString
+        let testMethodName = String("\(#function)".dropLast(2))
+        let title = testMethodName + "Title"
+        guard var post = createPost(id: uuid, title: title) else {
+            XCTFail("Failed to ensure at least one Post to be retrieved on the listQuery")
+            return
+        }
+        let updatedTitle = title + "Updated"
+        post.title = updatedTitle
+        let completeInvoked = expectation(description: "request completed")
+        _ = Amplify.API.mutate(request: .update(post)) { event in
+            switch event {
+            case .success(let data):
+                switch data {
+                case .success(let post):
+                    XCTAssertEqual(post.title, updatedTitle)
+                case .failure(let error):
+                    print(error)
+                }
+                completeInvoked.fulfill()
+            case .failure(let error):
+                print(error)
+            }
+        }
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+    }
+
+    func testDeleteExistingPost() {
+        let uuid = UUID().uuidString
+        let testMethodName = String("\(#function)".dropLast(2))
+        let title = testMethodName + "Title"
+        guard let post = createPost(id: uuid, title: title) else {
+            XCTFail("Failed to ensure at least one Post to be retrieved on the listQuery")
+            return
+        }
+
+        let completeInvoked = expectation(description: "request completed")
+
+        _ = Amplify.API.mutate(request: .delete(post)) { event in
+            switch event {
+            case .success(let data):
+                switch data {
+                case .success(let post):
+                    XCTAssertEqual(post.title, title)
+                case .failure(let error):
+                    print(error)
+                }
+                completeInvoked.fulfill()
+            case .failure(let error):
+                print(error)
+            }
+        }
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+
+        let queryComplete = expectation(description: "query complete")
+
+        _ = Amplify.API.query(request: .get(Post3.self, byId: uuid)) { event in
+            switch event {
+            case .success(let graphQLResponse):
+                guard case let .success(post) = graphQLResponse else {
+                    XCTFail("Missing successful response")
+                    return
+                }
+                XCTAssertNil(post)
+                queryComplete.fulfill()
+            case .failure(let error):
+                XCTFail("Unexpected .failed event: \(error)")
+            }
+        }
+
+        wait(for: [queryComplete], timeout: TestCommonConstants.networkTimeout)
+    }
+
+    // Create a post and then create a comment associated with the post
+    // Delete the comment and then query for the comment
+    // Expected query should return `nil` comment
     func testDeleteAndGetComment() {
         guard let post = createPost(title: "title") else {
             XCTFail("Could not create post")
@@ -198,77 +276,5 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
             }
         }
         wait(for: [getCommentAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
-    }
-
-    func testListCommentsByPostID() {
-        guard let post = createPost(title: "title") else {
-            XCTFail("Could not create post")
-            return
-        }
-        guard createComment(postID: post.id, content: "content") != nil else {
-            XCTFail("Could not create comment")
-            return
-        }
-        let listCommentByPostIDCompleted = expectation(description: "list projects completed")
-        let predicate = Comment3.keys.postID.eq(post.id)
-        Amplify.API.query(request: .list(Comment3.self, where: predicate)) { result in
-            switch result {
-            case .success(let result):
-                switch result {
-                case .success(let projects):
-                    print(projects)
-                    listCommentByPostIDCompleted.fulfill()
-                case .failure(let response):
-                    XCTFail("Failed with: \(response)")
-                }
-            case .failure(let error):
-                XCTFail("\(error)")
-            }
-        }
-        wait(for: [listCommentByPostIDCompleted], timeout: TestCommonConstants.networkTimeout)
-    }
-
-    func createPost(id: String = UUID().uuidString, title: String) -> Post3? {
-        let post = Post3(id: id, title: title)
-        var result: Post3?
-        let completeInvoked = expectation(description: "request completed")
-        Amplify.API.mutate(request: .create(post)) { event in
-            switch event {
-            case .success(let data):
-                switch data {
-                case .success(let post):
-                    result = post
-                default:
-                    XCTFail("Could not get data back")
-                }
-                completeInvoked.fulfill()
-            case .failure(let error):
-                XCTFail("Failed \(error)")
-            }
-        }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
-        return result
-    }
-
-    func createComment(id: String = UUID().uuidString, postID: String, content: String) -> Comment3? {
-        let comment = Comment3(id: id, postID: postID, content: content)
-        var result: Comment3?
-        let completeInvoked = expectation(description: "request completed")
-        Amplify.API.mutate(request: .create(comment)) { event in
-            switch event {
-            case .success(let data):
-                switch data {
-                case .success(let comment):
-                    result = comment
-                default:
-                    XCTFail("Could not get data back")
-                }
-                completeInvoked.fulfill()
-            case .failure(let error):
-                XCTFail("Failed \(error)")
-            }
-        }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
-        return result
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-import AWSMobileClient
 @testable import AWSAPICategoryPlugin
 @testable import Amplify
 @testable import AmplifyTestCommon
@@ -59,7 +58,7 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
             return
         }
 
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         _ = Amplify.API.query(request: .get(Post3.self, byId: post.id)) { event in
             switch event {
             case .success(let graphQLResponse):
@@ -68,18 +67,18 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
                     return
                 }
                 guard let resultPost = data else {
-                    XCTFail("Missing post from querySingle")
+                    XCTFail("Missing post from query")
                     return
                 }
 
                 XCTAssertEqual(resultPost.id, post.id)
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Unexpected .failed event: \(error)")
             }
         }
 
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
     }
 
     // Create a post and a comment for the post
@@ -163,7 +162,7 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
         }
         let updatedTitle = title + "Updated"
         post.title = updatedTitle
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         _ = Amplify.API.mutate(request: .update(post)) { event in
             switch event {
             case .success(let data):
@@ -171,14 +170,14 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
                 case .success(let post):
                     XCTAssertEqual(post.title, updatedTitle)
                 case .failure(let error):
-                    print(error)
+                    XCTFail("\(error)")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
-                print(error)
+                XCTFail("\(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeleteExistingPost() {
@@ -186,11 +185,11 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
         guard let post = createPost(id: uuid, title: title) else {
-            XCTFail("Failed to ensure at least one Post to be retrieved on the listQuery")
+            XCTFail("Could not create post")
             return
         }
 
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
 
         _ = Amplify.API.mutate(request: .delete(post)) { event in
             switch event {
@@ -199,14 +198,14 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
                 case .success(let post):
                     XCTAssertEqual(post.title, title)
                 case .failure(let error):
-                    print(error)
+                    XCTFail("\(error)")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
-                print(error)
+                XCTFail("\(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
 
         let queryComplete = expectation(description: "query complete")
 

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario4Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario4Tests.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-import AWSMobileClient
 @testable import AWSAPICategoryPlugin
 @testable import Amplify
 @testable import AmplifyTestCommon
@@ -236,7 +235,7 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
     func createPost(id: String = UUID().uuidString, title: String) -> Post4? {
         let post = Post4(id: id, title: title)
         var result: Post4?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         Amplify.API.mutate(request: .create(post)) { event in
             switch event {
             case .success(let data):
@@ -246,19 +245,19 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
     func createComment(id: String = UUID().uuidString, content: String, post: Post4) -> Comment4? {
         let comment = Comment4(id: id, content: content, post: post)
         var result: Comment4?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         Amplify.API.mutate(request: .create(comment)) { event in
             switch event {
             case .success(let data):
@@ -268,12 +267,12 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario5Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario5Tests.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-import AWSMobileClient
 @testable import AWSAPICategoryPlugin
 @testable import Amplify
 @testable import AmplifyTestCommon
@@ -207,7 +206,7 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
     func createPost(id: String = UUID().uuidString, title: String) -> Post5? {
         let post = Post5(id: id, title: title)
         var result: Post5?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         Amplify.API.mutate(request: .create(post)) { event in
             switch event {
             case .success(let data):
@@ -217,19 +216,19 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
     func createUser(id: String = UUID().uuidString, username: String) -> User5? {
         let user = User5(id: id, username: username)
         var result: User5?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         Amplify.API.mutate(request: .create(user)) { event in
             switch event {
             case .success(let data):
@@ -239,19 +238,19 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
     func createPostEditor(id: String = UUID().uuidString, post: Post5, editor: User5) -> PostEditor5? {
         let postEditor = PostEditor5(id: id, post: post, editor: editor)
         var result: PostEditor5?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         Amplify.API.mutate(request: .create(postEditor)) { event in
             switch event {
             case .success(let data):
@@ -261,12 +260,12 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario6Tests.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-import AWSMobileClient
 @testable import AWSAPICategoryPlugin
 @testable import Amplify
 @testable import AmplifyTestCommon
@@ -64,7 +63,7 @@ class GraphQLConnectionScenario6Tests: XCTestCase {
     func createBlog(id: String = UUID().uuidString, name: String) -> Blog6? {
         let blog = Blog6(id: id, name: name)
         var result: Blog6?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         Amplify.API.mutate(request: .create(blog)) { event in
             switch event {
             case .success(let data):
@@ -74,19 +73,19 @@ class GraphQLConnectionScenario6Tests: XCTestCase {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
     func createPost(id: String = UUID().uuidString, title: String, blog: Blog6) -> Post6? {
         let post = Post6(id: id, title: title, blog: blog)
         var result: Post6?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         Amplify.API.mutate(request: .create(post)) { event in
             switch event {
             case .success(let data):
@@ -96,19 +95,19 @@ class GraphQLConnectionScenario6Tests: XCTestCase {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
     func createComment(id: String = UUID().uuidString, post: Post6, content: String) -> Comment6? {
         let comment = Comment6(id: id, post: post, content: content)
         var result: Comment6?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         Amplify.API.mutate(request: .create(comment)) { event in
             switch event {
             case .success(let data):
@@ -118,12 +117,12 @@ class GraphQLConnectionScenario6Tests: XCTestCase {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario6Tests.swift
@@ -126,31 +126,4 @@ class GraphQLConnectionScenario6Tests: XCTestCase {
         wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
-
-    func getAll<M>(list: List<M>?) -> [M] {
-        guard var subsequentResults = list else {
-            XCTFail("Could not get first results")
-            return []
-        }
-        var resultsArray: [M] = []
-        resultsArray.append(contentsOf: subsequentResults)
-        while subsequentResults.hasNextPage() {
-            let semaphore = DispatchSemaphore(value: 0)
-            subsequentResults.getNextPage { result in
-                defer {
-                    semaphore.signal()
-                }
-                switch result {
-                case .success(let listResult):
-                    subsequentResults = listResult
-                    resultsArray.append(contentsOf: subsequentResults)
-                case .failure(let coreError):
-                    XCTFail("Unexpected error: \(coreError)")
-                }
-
-            }
-            semaphore.wait()
-        }
-        return resultsArray
-    }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario6Tests.swift
@@ -1,0 +1,156 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AWSMobileClient
+@testable import AWSAPICategoryPlugin
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSAPICategoryPluginTestCommon
+
+/*
+ ```
+ # 6 - Blog Post Comment
+ type Blog6 @model {
+   id: ID!
+   name: String!
+   posts: [Post6] @connection(keyName: "byBlog", fields: ["id"])
+ }
+
+ type Post6 @model @key(name: "byBlog", fields: ["blogID"]) {
+   id: ID!
+   title: String!
+   blogID: ID!
+   blog: Blog6 @connection(fields: ["blogID"])
+   comments: [Comment6] @connection(keyName: "byPost", fields: ["id"])
+ }
+
+ type Comment6 @model @key(name: "byPost", fields: ["postID", "content"]) {
+   id: ID!
+   postID: ID!
+   post: Post6 @connection(fields: ["postID"])
+   content: String!
+ }
+ ```
+ */
+class GraphQLConnectionScenario6Tests: XCTestCase {
+
+    override func setUp() {
+        do {
+            Amplify.Logging.logLevel = .verbose
+            try Amplify.add(plugin: AWSAPIPlugin())
+
+            let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(
+                forResource: GraphQLModelBasedTests.amplifyConfiguration)
+            try Amplify.configure(amplifyConfig)
+
+            ModelRegistry.register(modelType: Blog6.self)
+            ModelRegistry.register(modelType: Post6.self)
+            ModelRegistry.register(modelType: Comment6.self)
+
+        } catch {
+            XCTFail("Error during setup: \(error)")
+        }
+    }
+
+    override func tearDown() {
+        Amplify.reset()
+    }
+
+    func createBlog(id: String = UUID().uuidString, name: String) -> Blog6? {
+        let blog = Blog6(id: id, name: name)
+        var result: Blog6?
+        let completeInvoked = expectation(description: "request completed")
+        Amplify.API.mutate(request: .create(blog)) { event in
+            switch event {
+            case .success(let data):
+                switch data {
+                case .success(let post):
+                    result = post
+                default:
+                    XCTFail("Could not get data back")
+                }
+                completeInvoked.fulfill()
+            case .failure(let error):
+                XCTFail("Failed \(error)")
+            }
+        }
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        return result
+    }
+
+    func createPost(id: String = UUID().uuidString, title: String, blog: Blog6) -> Post6? {
+        let post = Post6(id: id, title: title, blog: blog)
+        var result: Post6?
+        let completeInvoked = expectation(description: "request completed")
+        Amplify.API.mutate(request: .create(post)) { event in
+            switch event {
+            case .success(let data):
+                switch data {
+                case .success(let post):
+                    result = post
+                default:
+                    XCTFail("Could not get data back")
+                }
+                completeInvoked.fulfill()
+            case .failure(let error):
+                XCTFail("Failed \(error)")
+            }
+        }
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        return result
+    }
+
+    func createComment(id: String = UUID().uuidString, post: Post6, content: String) -> Comment6? {
+        let comment = Comment6(id: id, post: post, content: content)
+        var result: Comment6?
+        let completeInvoked = expectation(description: "request completed")
+        Amplify.API.mutate(request: .create(comment)) { event in
+            switch event {
+            case .success(let data):
+                switch data {
+                case .success(let comment):
+                    result = comment
+                default:
+                    XCTFail("Could not get data back")
+                }
+                completeInvoked.fulfill()
+            case .failure(let error):
+                XCTFail("Failed \(error)")
+            }
+        }
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        return result
+    }
+
+    func getAll<M>(list: List<M>?) -> [M] {
+        guard var subsequentResults = list else {
+            XCTFail("Could not get first results")
+            return []
+        }
+        var resultsArray: [M] = []
+        resultsArray.append(contentsOf: subsequentResults)
+        while subsequentResults.hasNextPage() {
+            let semaphore = DispatchSemaphore(value: 0)
+            subsequentResults.getNextPage { result in
+                defer {
+                    semaphore.signal()
+                }
+                switch result {
+                case .success(let listResult):
+                    subsequentResults = listResult
+                    resultsArray.append(contentsOf: subsequentResults)
+                case .failure(let coreError):
+                    XCTFail("Unexpected error: \(coreError)")
+                }
+
+            }
+            semaphore.wait()
+        }
+        return resultsArray
+    }
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLModelBasedTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLModelBasedTests.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-import AWSMobileClient
 @testable import AWSAPICategoryPlugin
 @testable import Amplify
 @testable import AmplifyTestCommon
@@ -49,7 +48,7 @@ class GraphQLModelBasedTests: XCTestCase {
             return
         }
 
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         _ = Amplify.API.query(request: .get(Post.self, byId: uuid)) { event in
             switch event {
             case .success(let graphQLResponse):
@@ -58,19 +57,19 @@ class GraphQLModelBasedTests: XCTestCase {
                     return
                 }
                 guard let resultPost = data else {
-                    XCTFail("Missing post from querySingle")
+                    XCTFail("Missing post from query")
                     return
                 }
 
                 XCTAssertEqual(resultPost.id, post.id)
                 XCTAssertEqual(resultPost.title, title)
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Unexpected .failed event: \(error)")
             }
         }
 
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
     }
 
     /// Test custom GraphQLRequest with nested list deserializes to generated Post Model
@@ -94,7 +93,7 @@ class GraphQLModelBasedTests: XCTestCase {
             return
         }
 
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         let document = """
         query getPost($id: ID!) {
           getPost(id: $id){
@@ -140,7 +139,7 @@ class GraphQLModelBasedTests: XCTestCase {
                     return
                 }
                 guard let resultPost = data else {
-                    XCTFail("Missing post from querySingle")
+                    XCTFail("Missing post from query")
                     return
                 }
 
@@ -151,13 +150,13 @@ class GraphQLModelBasedTests: XCTestCase {
                     return
                 }
                 XCTAssertEqual(comments.count, 1)
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Unexpected .failed event: \(error)")
             }
         }
 
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testListQueryWithModel() {
@@ -169,7 +168,7 @@ class GraphQLModelBasedTests: XCTestCase {
             return
         }
 
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
 
         _ = Amplify.API.query(request: .list(Post.self)) { event in
             switch event {
@@ -179,14 +178,13 @@ class GraphQLModelBasedTests: XCTestCase {
                     return
                 }
                 XCTAssertTrue(!posts.isEmpty)
-                print(posts)
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Unexpected .failed event: \(error)")
             }
         }
 
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testListQueryWithPredicate() {
@@ -204,7 +202,7 @@ class GraphQLModelBasedTests: XCTestCase {
             return
         }
 
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         let post = Post.keys
         let predicate = post.id == uuid &&
             post.title == uniqueTitle &&
@@ -231,17 +229,17 @@ class GraphQLModelBasedTests: XCTestCase {
                 XCTAssertEqual(singlePost.createdAt.iso8601String, createdPost.createdAt.iso8601String)
                 XCTAssertEqual(singlePost.rating, 12.3)
                 XCTAssertEqual(singlePost.draft, true)
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
                 XCTFail("Unexpected .failed event: \(error)")
             }
         }
 
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testCreatPostWithModel() {
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
 
         let post = Post(title: "title", content: "content", createdAt: .now())
         _ = Amplify.API.mutate(request: .create(post)) { event in
@@ -250,15 +248,15 @@ class GraphQLModelBasedTests: XCTestCase {
                 switch data {
                 case .success(let post):
                     XCTAssertEqual(post.title, "title")
-                    completeInvoked.fulfill()
+                    requestInvokedSuccessfully.fulfill()
                 case .failure(let error):
                     XCTFail("Unexpected response with error \(error)")
                 }
             case .failure(let error):
-                print(error)
+                XCTFail("\(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testCreateCommentWithModel() {
@@ -270,7 +268,7 @@ class GraphQLModelBasedTests: XCTestCase {
             return
         }
 
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         let comment = Comment(content: "commentContent",
                               createdAt: .now(),
                               post: createdPost)
@@ -282,15 +280,15 @@ class GraphQLModelBasedTests: XCTestCase {
                     XCTAssertEqual(comment.content, "commentContent")
                     XCTAssertNotNil(comment.post)
                     XCTAssertEqual(comment.post.id, uuid)
-                    completeInvoked.fulfill()
+                    requestInvokedSuccessfully.fulfill()
                 case .failure(let error):
                     XCTFail("Unexpected response with error \(error)")
                 }
             case .failure(let error):
-                print(error)
+                XCTFail("\(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeletePostWithModel() {
@@ -302,7 +300,7 @@ class GraphQLModelBasedTests: XCTestCase {
             return
         }
 
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
 
         _ = Amplify.API.mutate(request: .delete(post)) { event in
             switch event {
@@ -311,14 +309,14 @@ class GraphQLModelBasedTests: XCTestCase {
                 case .success(let post):
                     XCTAssertEqual(post.title, title)
                 case .failure(let error):
-                    print(error)
+                    XCTFail("\(error)")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
-                print(error)
+                XCTFail("\(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
 
         let queryComplete = expectation(description: "query complete")
 
@@ -349,7 +347,7 @@ class GraphQLModelBasedTests: XCTestCase {
         }
         let updatedTitle = title + "Updated"
         let updatedPost = Post(id: uuid, title: updatedTitle, content: post.content, createdAt: post.createdAt)
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         _ = Amplify.API.mutate(request: .update(updatedPost)) { event in
             switch event {
             case .success(let data):
@@ -357,14 +355,14 @@ class GraphQLModelBasedTests: XCTestCase {
                 case .success(let post):
                     XCTAssertEqual(post.title, updatedTitle)
                 case .failure(let error):
-                    print(error)
+                    XCTFail("\(error)")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
-                print(error)
+                XCTFail("\(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testOnCreatePostSubscriptionWithModel() {
@@ -373,6 +371,10 @@ class GraphQLModelBasedTests: XCTestCase {
         let completedInvoked = expectation(description: "Completed invoked")
         let progressInvoked = expectation(description: "progress invoked")
         progressInvoked.expectedFulfillmentCount = 2
+        let uuid = UUID().uuidString
+        let uuid2 = UUID().uuidString
+        let testMethodName = String("\(#function)".dropLast(2))
+        let title = testMethodName + "Title"
 
         let operation = Amplify.API.subscribe(
             request: .subscription(of: Post.self, type: .onCreate),
@@ -387,15 +389,22 @@ class GraphQLModelBasedTests: XCTestCase {
                     case .disconnected:
                         disconnectedInvoked.fulfill()
                     }
-                case .data:
-                    progressInvoked.fulfill()
+                case .data(let result):
+                    switch result {
+                    case .success(let post):
+                        if post.id == uuid || post.id == uuid2 {
+                            progressInvoked.fulfill()
+                        }
+                    case .failure(let error):
+                        XCTFail("\(error)")
+                    }
                 }
 
         },
             completionListener: { event in
                 switch event {
                 case .failure(let error):
-                    print("Unexpected .failed event: \(error)")
+                    XCTFail("Unexpected .failed event: \(error)")
                 case .success:
                     completedInvoked.fulfill()
                 }
@@ -403,16 +412,12 @@ class GraphQLModelBasedTests: XCTestCase {
 
         XCTAssertNotNil(operation)
         wait(for: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
-        let uuid = UUID().uuidString
-        let testMethodName = String("\(#function)".dropLast(2))
-        let title = testMethodName + "Title"
 
         guard createPost(id: uuid, title: title) != nil else {
             XCTFail("Failed to create post")
             return
         }
 
-        let uuid2 = UUID().uuidString
         guard createPost(id: uuid2, title: title) != nil else {
             XCTFail("Failed to create post")
             return
@@ -450,7 +455,7 @@ class GraphQLModelBasedTests: XCTestCase {
             completionListener: { event in
                 switch event {
                 case .failure(let error):
-                    print("Unexpected .failed event: \(error)")
+                    XCTFail("Unexpected .failed event: \(error)")
                 case .success:
                     completedInvoked.fulfill()
                 }
@@ -461,12 +466,12 @@ class GraphQLModelBasedTests: XCTestCase {
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
 
-        guard createPost(id: uuid, title: title) != nil else {
+        guard let createdPost = createPost(id: uuid, title: title) else {
             XCTFail("Failed to create post")
             return
         }
 
-        guard updatePost(id: uuid, title: title) != nil else {
+        guard mutatePost(createdPost) != nil else {
             XCTFail("Failed to update post")
             return
         }
@@ -503,7 +508,7 @@ class GraphQLModelBasedTests: XCTestCase {
             completionListener: { event in
                 switch event {
                 case .failure(let error):
-                    print("Unexpected .failed event: \(error)")
+                    XCTFail("Unexpected .failed event: \(error)")
                 case .success:
                     completedInvoked.fulfill()
                 }
@@ -556,7 +561,7 @@ class GraphQLModelBasedTests: XCTestCase {
             completionListener: { event in
                 switch event {
                 case .failure(let error):
-                    print("Unexpected .failed event: \(error)")
+                    XCTFail("Unexpected .failed event: \(error)")
                 case .success:
                     completedInvoked.fulfill()
                 }
@@ -597,7 +602,7 @@ class GraphQLModelBasedTests: XCTestCase {
 
     func createPost(post: Post) -> Post? {
         var result: Post?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
 
         _ = Amplify.API.mutate(request: .create(post)) { event in
             switch event {
@@ -608,18 +613,18 @@ class GraphQLModelBasedTests: XCTestCase {
                 default:
                     XCTFail("Create Post was not successful: \(data)")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
-                print(error)
+                XCTFail("\(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
     func createComment(comment: Comment) -> Comment? {
         var result: Comment?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
 
         _ = Amplify.API.mutate(request: .create(comment)) { event in
             switch event {
@@ -630,20 +635,18 @@ class GraphQLModelBasedTests: XCTestCase {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
-                print(error)
+                XCTFail("\(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
-    func updatePost(id: String, title: String) -> Post? {
+    func mutatePost(_ post: Post) -> Post? {
         var result: Post?
-        let completeInvoked = expectation(description: "request completed")
-
-        let post = Post(id: id, title: title, content: "content", createdAt: .now())
+        let requestInvokedSuccessfully = expectation(description: "request completed")
         _ = Amplify.API.mutate(request: .update(post)) { event in
             switch event {
             case .success(let data):
@@ -653,18 +656,18 @@ class GraphQLModelBasedTests: XCTestCase {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
-                print(error)
+                XCTFail("\(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
     func deletePost(post: Post) -> Post? {
         var result: Post?
-        let completeInvoked = expectation(description: "request completed")
+        let requestInvokedSuccessfully = expectation(description: "request completed")
 
         _ = Amplify.API.mutate(request: .delete(post)) { event in
             switch event {
@@ -675,12 +678,12 @@ class GraphQLModelBasedTests: XCTestCase {
                 default:
                     XCTFail("Could not get data back")
                 }
-                completeInvoked.fulfill()
+                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
-                print(error)
+                XCTFail("\(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/README.md
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/README.md
@@ -131,6 +131,32 @@ type User5 @model {
   posts: [PostEditor5] @connection(keyName: "byEditor5", fields: ["id"])
 }
 
+# This is one of the default schemas provided when you run `amplify add api`
+# > Do you have an annotated GraphQL schema? `No`
+# > Choose a schema template: `One-to-many relationship (e.g., “Blogs” with “Posts” and “Comments”)`
+
+# 6 - Blog Post Comment
+type Blog6 @model {
+  id: ID!
+  name: String!
+  posts: [Post6] @connection(keyName: "byBlog", fields: ["id"])
+}
+
+type Post6 @model @key(name: "byBlog", fields: ["blogID"]) {
+  id: ID!
+  title: String!
+  blogID: ID!
+  blog: Blog6 @connection(fields: ["blogID"])
+  comments: [Comment6] @connection(keyName: "byPost", fields: ["id"])
+}
+
+type Comment6 @model @key(name: "byPost", fields: ["postID", "content"]) {
+  id: ID!
+  postID: ID!
+  post: Post6 @connection(fields: ["postID"])
+  content: String!
+}
+
 ```
 
 3.  `amplify push`

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario6Tests.swift
@@ -1,0 +1,143 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AmplifyPlugins
+import AWSMobileClient
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+/*
+ ```
+ # 6 - Blog Post Comment
+ type Blog6 @model {
+   id: ID!
+   name: String!
+   posts: [Post6] @connection(keyName: "byBlog", fields: ["id"])
+ }
+
+ type Post6 @model @key(name: "byBlog", fields: ["blogID"]) {
+   id: ID!
+   title: String!
+   blogID: ID!
+   blog: Blog6 @connection(fields: ["blogID"])
+   comments: [Comment6] @connection(keyName: "byPost", fields: ["id"])
+ }
+
+ type Comment6 @model @key(name: "byPost", fields: ["postID", "content"]) {
+   id: ID!
+   postID: ID!
+   post: Post6 @connection(fields: ["postID"])
+   content: String!
+ }
+ ```
+ */
+
+class DataStoreConnectionScenario6Tests: SyncEngineIntegrationTestBase {
+
+    func testGetBlogThenFetchPostsThenFetchComments() throws {
+        try startAmplifyAndWaitForSync()
+        guard let blog = saveBlog(name: "name"),
+              let post1 = savePost(title: "title", blog: blog),
+              let post2 = savePost(title: "title", blog: blog),
+              let comment1post1 = saveComment(post: post1, content: "content"),
+              let comment2post1 = saveComment(post: post1, content: "content") else {
+            XCTFail("Could not create blog, posts, and comments")
+            return
+        }
+        let getBlogCompleted = expectation(description: "get blog complete")
+        var resultPosts: List<Post6>?
+        Amplify.DataStore.query(Blog6.self, byId: blog.id) { result in
+            switch result {
+            case .success(let queriedBlogOptional):
+                guard let queriedBlog = queriedBlogOptional else {
+                    XCTFail("Could not get blog")
+                    return
+                }
+                XCTAssertEqual(queriedBlog.id, blog.id)
+                resultPosts = queriedBlog.posts
+                getBlogCompleted.fulfill()
+            case .failure(let response): XCTFail("Failed with: \(response)")
+            }
+        }
+        wait(for: [getBlogCompleted], timeout: TestCommonConstants.networkTimeout)
+        guard let posts = resultPosts else {
+            XCTFail("Could not get posts")
+            return
+        }
+        XCTAssertEqual(posts.count, 2)
+        guard let fetchedPost = posts.first(where: { (post) -> Bool in
+            post.id == post1.id
+        }), let comments = fetchedPost.comments else {
+            XCTFail("Could not set up - failed to get a post and its comments")
+            return
+        }
+        XCTAssertEqual(comments.count, 2)
+        XCTAssertTrue(comments.contains(where: { (comment) -> Bool in
+            comment.id == comment1post1.id
+        }))
+        XCTAssertTrue(comments.contains(where: { (comment) -> Bool in
+            comment.id == comment2post1.id
+        }))
+        if let post = comments[0].post {
+            XCTAssertEqual(post.comments?.count, 2)
+        }
+    }
+
+    func saveBlog(id: String = UUID().uuidString, name: String) -> Blog6? {
+        let blog = Blog6(id: id, name: name)
+        var result: Blog6?
+        let completeInvoked = expectation(description: "request completed")
+        Amplify.DataStore.save(blog) { event in
+            switch event {
+            case .success(let data):
+                result = data
+                completeInvoked.fulfill()
+            case .failure(let error):
+                XCTFail("Failed \(error)")
+            }
+        }
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        return result
+    }
+
+    func savePost(id: String = UUID().uuidString, title: String, blog: Blog6) -> Post6? {
+        let post = Post6(id: id, title: title, blog: blog)
+        var result: Post6?
+        let completeInvoked = expectation(description: "request completed")
+        Amplify.DataStore.save(post) { event in
+            switch event {
+            case .success(let data):
+                result = data
+                completeInvoked.fulfill()
+            case .failure(let error):
+                XCTFail("Failed \(error)")
+            }
+        }
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        return result
+    }
+
+    func saveComment(id: String = UUID().uuidString, post: Post6, content: String) -> Comment6? {
+        let comment = Comment6(id: id, post: post, content: content)
+        var result: Comment6?
+        let completeInvoked = expectation(description: "request completed")
+        Amplify.DataStore.save(comment) { event in
+            switch event {
+            case .success(let data):
+                result = data
+                completeInvoked.fulfill()
+            case .failure(let error):
+                XCTFail("Failed \(error)")
+            }
+        }
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        return result
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/README.md
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/README.md
@@ -7,9 +7,7 @@ The following steps demonstrate how to set up DataStore with a conflict resoluti
 
 1. `amplify init` and choose `iOS` for type of app you are building
 
-2. Create the `schema.graphql` file in the same directory and use the schema from [AmplifyTestCommon](https://github.com/aws-amplify/amplify-ios/blob/main/AmplifyTestCommon/Models/schema.graphql)
-
-3. `amplify add api`
+2. `amplify add api`
 
 ```perl
 ? Please select from one of the below mentioned services: `GraphQL`
@@ -24,9 +22,146 @@ The following steps demonstrate how to set up DataStore with a conflict resoluti
 ? Do you have an annotated GraphQL schema? `Yes`
 ? Provide your schema file path: `schema.graphql`
 ```
+When asked to provide the schema, create the `schema.graphql` file
+```
+enum PostStatus {
+    PRIVATE
+    DRAFT
+    PUBLISHED
+}
 
-4. `amplify push`
+type Post @model {
+    id: ID!
+    title: String!
+    content: String!
+    createdAt: AWSDateTime!
+    updatedAt: AWSDateTime
+    draft: Boolean
+    rating: Float
+    status: PostStatus
+    comments: [Comment] @connection(name: "PostComment")
+}
 
-5. Copy `amplifyconfiguration.json` over to the Config folder
+type Comment @model {
+    id: ID!
+    content: String!
+    createdAt: AWSDateTime!
+    post: Post @connection(name: "PostComment")
+}
+
+## These are examples from https://docs.amplify.aws/cli/graphql-transformer/connection
+
+# 1 - Project has a single optional Team
+type Project1 @model {
+  id: ID!
+  name: String
+  team: Team1 @connection
+}
+
+type Team1 @model {
+  id: ID!
+  name: String!
+}
+
+# 2 - Project with explicit field for team’s id
+type Project2 @model {
+  id: ID!
+  name: String
+  teamID: ID!
+  team: Team2 @connection(fields: ["teamID"])
+}
+
+type Team2 @model {
+  id: ID!
+  name: String!
+}
+
+# 3 - Post Comment - keyName reference key directive
+
+type Post3 @model {
+  id: ID!
+  title: String!
+  comments: [Comment3] @connection(keyName: "byPost3", fields: ["id"])
+}
+
+type Comment3 @model
+  @key(name: "byPost3", fields: ["postID", "content"]) {
+  id: ID!
+  postID: ID!
+  content: String!
+}
+
+# 4 - Post Comment bi-directional belongs to
+
+type Post4 @model {
+  id: ID!
+  title: String!
+  comments: [Comment4] @connection(keyName: "byPost4", fields: ["id"])
+}
+
+type Comment4 @model
+  @key(name: "byPost4", fields: ["postID", "content"]) {
+  id: ID!
+  postID: ID!
+  content: String!
+  post: Post4 @connection(fields: ["postID"])
+}
+
+# 5 Many to Many
+
+type Post5 @model {
+  id: ID!
+  title: String!
+  editors: [PostEditor5] @connection(keyName: "byPost5", fields: ["id"])
+}
+
+# Create a join model
+type PostEditor5
+  @model
+  @key(name: "byPost5", fields: ["postID", "editorID"])
+  @key(name: "byEditor5", fields: ["editorID", "postID"]) {
+  id: ID!
+  postID: ID!
+  editorID: ID!
+  post: Post5! @connection(fields: ["postID"])
+  editor: User5! @connection(fields: ["editorID"])
+}
+
+type User5 @model {
+  id: ID!
+  username: String!
+  posts: [PostEditor5] @connection(keyName: "byEditor5", fields: ["id"])
+}
+
+# This is one of the default schemas provided when you run `amplify add api`
+# > Do you have an annotated GraphQL schema? `No`
+# > Choose a schema template: `One-to-many relationship (e.g., “Blogs” with “Posts” and “Comments”)`
+
+# 6 - Blog Post Comment
+type Blog6 @model {
+  id: ID!
+  name: String!
+  posts: [Post6] @connection(keyName: "byBlog", fields: ["id"])
+}
+
+type Post6 @model @key(name: "byBlog", fields: ["blogID"]) {
+  id: ID!
+  title: String!
+  blogID: ID!
+  blog: Blog6 @connection(fields: ["blogID"])
+  comments: [Comment6] @connection(keyName: "byPost", fields: ["id"])
+}
+
+type Comment6 @model @key(name: "byPost", fields: ["postID", "content"]) {
+  id: ID!
+  postID: ID!
+  post: Post6 @connection(fields: ["postID"])
+  content: String!
+}
+
+```
+3. `amplify push`
+
+4. Copy `amplifyconfiguration.json` over to the Config folder
 
 You should now be able to run all of the tests 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
@@ -52,10 +52,7 @@ class HubEventsIntegrationTestBase: XCTestCase {
             try Amplify.add(plugin: AWSAPIPlugin(modelRegistration: TestModelRegistration()))
             try Amplify.configure(amplifyConfig)
             Amplify.DataStore.start { result in
-                switch result {
-                case .success:
-                    break
-                case .failure(let error):
+                if case .failure(let error) = result {
                     XCTFail("\(error)")
                 }
             }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
@@ -51,6 +51,14 @@ class HubEventsIntegrationTestBase: XCTestCase {
             try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: TestModelRegistration()))
             try Amplify.add(plugin: AWSAPIPlugin(modelRegistration: TestModelRegistration()))
             try Amplify.configure(amplifyConfig)
+            Amplify.DataStore.start { result in
+                switch result {
+                case .success:
+                    break
+                case .failure(let error):
+                    XCTFail("\(error)")
+                }
+            }
         } catch {
             XCTFail(String(describing: error))
             return

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
@@ -78,6 +78,14 @@ class SyncEngineIntegrationTestBase: XCTestCase {
         DispatchQueue.global().async {
             do {
                 try Amplify.configure(amplifyConfig)
+                Amplify.DataStore.start { result in
+                    switch result {
+                    case .success:
+                        break
+                    case .failure(let error):
+                        XCTFail("\(error)")
+                    }
+                }
             } catch {
                 XCTFail(String(describing: error))
             }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
@@ -79,10 +79,7 @@ class SyncEngineIntegrationTestBase: XCTestCase {
             do {
                 try Amplify.configure(amplifyConfig)
                 Amplify.DataStore.start { result in
-                    switch result {
-                    case .success:
-                        break
-                    case .failure(let error):
+                    if case .failure(let error) = result {
                         XCTFail("\(error)")
                     }
                 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/TestModelRegistration.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/TestModelRegistration.swift
@@ -24,6 +24,9 @@ struct TestModelRegistration: AmplifyModelRegistration {
         registry.register(modelType: Post5.self)
         registry.register(modelType: PostEditor5.self)
         registry.register(modelType: User5.self)
+        registry.register(modelType: Blog6.self)
+        registry.register(modelType: Post6.self)
+        registry.register(modelType: Comment6.self)
     }
 
     let version: String = "1"

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		217D622C2579E15F009F0639 /* DataStoreConnectionScenario4Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217D62292579E15F009F0639 /* DataStoreConnectionScenario4Tests.swift */; };
 		217D622D2579E15F009F0639 /* DataStoreConnectionScenario3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217D622A2579E15F009F0639 /* DataStoreConnectionScenario3Tests.swift */; };
 		21B3AD27242BB58000C7E1DA /* ProcessMutationErrorFromCloudOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B3AD26242BB58000C7E1DA /* ProcessMutationErrorFromCloudOperationTests.swift */; };
+		21FDBBDB2587DB7A0086FCDC /* DataStoreConnectionScenario6Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FDBBDA2587DB7A0086FCDC /* DataStoreConnectionScenario6Tests.swift */; };
 		6B01B71D23A4615900AD0E97 /* SyncMutationToCloudOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B01B71C23A4615900AD0E97 /* SyncMutationToCloudOperationTests.swift */; };
 		6B01B72023A4672500AD0E97 /* RequestRetryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B01B71E23A4672500AD0E97 /* RequestRetryable.swift */; };
 		6B01B72223A4672500AD0E97 /* RequestRetryablePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B01B71F23A4672500AD0E97 /* RequestRetryablePolicy.swift */; };
@@ -298,6 +299,7 @@
 		217D62292579E15F009F0639 /* DataStoreConnectionScenario4Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataStoreConnectionScenario4Tests.swift; sourceTree = "<group>"; };
 		217D622A2579E15F009F0639 /* DataStoreConnectionScenario3Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataStoreConnectionScenario3Tests.swift; sourceTree = "<group>"; };
 		21B3AD26242BB58000C7E1DA /* ProcessMutationErrorFromCloudOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMutationErrorFromCloudOperationTests.swift; sourceTree = "<group>"; };
+		21FDBBDA2587DB7A0086FCDC /* DataStoreConnectionScenario6Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataStoreConnectionScenario6Tests.swift; sourceTree = "<group>"; };
 		280D7C45F839531215A44B34 /* Pods-HostApp-AWSDataStoreCategoryPluginAuthIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSDataStoreCategoryPluginAuthIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSDataStoreCategoryPluginAuthIntegrationTests/Pods-HostApp-AWSDataStoreCategoryPluginAuthIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		32AD9436C9FB473423CA9786 /* Pods-AWSDataStoreCategoryPlugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSDataStoreCategoryPlugin.release.xcconfig"; path = "Target Support Files/Pods-AWSDataStoreCategoryPlugin/Pods-AWSDataStoreCategoryPlugin.release.xcconfig"; sourceTree = "<group>"; };
 		6A1D332BE6CF885805360B3D /* Pods_AWSDataStoreCategoryPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSDataStoreCategoryPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -676,6 +678,7 @@
 				217D622A2579E15F009F0639 /* DataStoreConnectionScenario3Tests.swift */,
 				217D62292579E15F009F0639 /* DataStoreConnectionScenario4Tests.swift */,
 				217D62282579E15F009F0639 /* DataStoreConnectionScenario5Tests.swift */,
+				21FDBBDA2587DB7A0086FCDC /* DataStoreConnectionScenario6Tests.swift */,
 			);
 			path = Connection;
 			sourceTree = "<group>";
@@ -1708,6 +1711,7 @@
 				D888E80C24A65DC200F4CE3E /* LocalStoreIntegrationTestBase.swift in Sources */,
 				FA3841EB23889D6C0070AD5B /* SubscriptionEndToEndTests.swift in Sources */,
 				217D622B2579E15F009F0639 /* DataStoreConnectionScenario5Tests.swift in Sources */,
+				21FDBBDB2587DB7A0086FCDC /* DataStoreConnectionScenario6Tests.swift in Sources */,
 				FAB571422395A3E80006A5F8 /* DataStoreEndToEndTests.swift in Sources */,
 				217D622C2579E15F009F0639 /* DataStoreConnectionScenario4Tests.swift in Sources */,
 				D8E99926250142790006170A /* HubEventsIntegrationTestBase.swift in Sources */,

--- a/AmplifyTestCommon/Models/Collection/6/Blog6+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/6/Blog6+Schema.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Blog6 {
+  // MARK: - CodingKeys
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case name
+    case posts
+  }
+
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema
+
+  public static let schema = defineSchema { model in
+    let blog6 = Blog6.keys
+
+    model.pluralName = "Blog6s"
+
+    model.fields(
+      .id(),
+      .field(blog6.name, is: .required, ofType: .string),
+      .hasMany(blog6.posts, is: .optional, ofType: Post6.self, associatedWith: Post6.keys.blog)
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/Collection/6/Blog6.swift
+++ b/AmplifyTestCommon/Models/Collection/6/Blog6.swift
@@ -1,0 +1,24 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Blog6: Model {
+  public let id: String
+  public var name: String
+  public var posts: List<Post6>?
+
+  public init(id: String = UUID().uuidString,
+      name: String,
+      posts: List<Post6>? = []) {
+      self.id = id
+      self.name = name
+      self.posts = posts
+  }
+}

--- a/AmplifyTestCommon/Models/Collection/6/Comment6+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/6/Comment6+Schema.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Comment6 {
+  // MARK: - CodingKeys
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case post
+    case content
+  }
+
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema
+
+  public static let schema = defineSchema { model in
+    let comment6 = Comment6.keys
+
+    model.pluralName = "Comment6s"
+
+    model.fields(
+      .id(),
+      .belongsTo(comment6.post, is: .optional, ofType: Post6.self, targetName: "postID"),
+      .field(comment6.content, is: .required, ofType: .string)
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/Collection/6/Comment6.swift
+++ b/AmplifyTestCommon/Models/Collection/6/Comment6.swift
@@ -1,0 +1,24 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Comment6: Model {
+  public let id: String
+  public var post: Post6?
+  public var content: String
+
+  public init(id: String = UUID().uuidString,
+      post: Post6? = nil,
+      content: String) {
+      self.id = id
+      self.post = post
+      self.content = content
+  }
+}

--- a/AmplifyTestCommon/Models/Collection/6/Post6+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/6/Post6+Schema.swift
@@ -1,0 +1,36 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post6 {
+  // MARK: - CodingKeys
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case title
+    case blog
+    case comments
+  }
+
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema
+
+  public static let schema = defineSchema { model in
+    let post6 = Post6.keys
+
+    model.pluralName = "Post6s"
+
+    model.fields(
+      .id(),
+      .field(post6.title, is: .required, ofType: .string),
+      .belongsTo(post6.blog, is: .optional, ofType: Blog6.self, targetName: "blogID"),
+      .hasMany(post6.comments, is: .optional, ofType: Comment6.self, associatedWith: Comment6.keys.post)
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/Collection/6/Post6.swift
+++ b/AmplifyTestCommon/Models/Collection/6/Post6.swift
@@ -1,0 +1,27 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post6: Model {
+  public let id: String
+  public var title: String
+  public var blog: Blog6?
+  public var comments: List<Comment6>?
+
+  public init(id: String = UUID().uuidString,
+      title: String,
+      blog: Blog6? = nil,
+      comments: List<Comment6>? = []) {
+      self.id = id
+      self.title = title
+      self.blog = blog
+      self.comments = comments
+  }
+}

--- a/AmplifyTestCommon/Models/Collection/connection-schema.graphql
+++ b/AmplifyTestCommon/Models/Collection/connection-schema.graphql
@@ -81,3 +81,27 @@ type User5 @model {
   username: String!
   posts: [PostEditor5] @connection(keyName: "byEditor5", fields: ["id"])
 }
+
+# This is one of the default schemas provided when you run `amplify add api`
+
+# 6 - Blog Post Comment
+type Blog6 @model {
+  id: ID!
+  name: String!
+  posts: [Post6] @connection(keyName: "byBlog", fields: ["id"])
+}
+
+type Post6 @model @key(name: "byBlog", fields: ["blogID"]) {
+  id: ID!
+  title: String!
+  blogID: ID!
+  blog: Blog6 @connection(fields: ["blogID"])
+  comments: [Comment6] @connection(keyName: "byPost", fields: ["id"])
+}
+
+type Comment6 @model @key(name: "byPost", fields: ["postID", "content"]) {
+  id: ID!
+  postID: ID!
+  post: Post6 @connection(fields: ["postID"])
+  content: String!
+}

--- a/AmplifyTestCommon/Models/Collection/connection-schema.graphql
+++ b/AmplifyTestCommon/Models/Collection/connection-schema.graphql
@@ -83,6 +83,8 @@ type User5 @model {
 }
 
 # This is one of the default schemas provided when you run `amplify add api`
+# > Do you have an annotated GraphQL schema? `No`
+# > Choose a schema template: `One-to-many relationship (e.g., “Blogs” with “Posts” and “Comments”)`
 
 # 6 - Blog Post Comment
 type Blog6 @model {

--- a/AmplifyTestCommon/Models/schema.graphql
+++ b/AmplifyTestCommon/Models/schema.graphql
@@ -142,3 +142,27 @@ type User5 @model {
   username: String!
   posts: [PostEditor5] @connection(keyName: "byEditor5", fields: ["id"])
 }
+
+# This is one of the default schemas provided when you run `amplify add api`
+
+# 6 - Blog Post Comment
+type Blog6 @model {
+  id: ID!
+  name: String!
+  posts: [Post6] @connection(keyName: "byBlog", fields: ["id"])
+}
+
+type Post6 @model @key(name: "byBlog", fields: ["blogID"]) {
+  id: ID!
+  title: String!
+  blogID: ID!
+  blog: Blog6 @connection(fields: ["blogID"])
+  comments: [Comment6] @connection(keyName: "byPost", fields: ["id"])
+}
+
+type Comment6 @model @key(name: "byPost", fields: ["postID", "content"]) {
+  id: ID!
+  postID: ID!
+  post: Post6 @connection(fields: ["postID"])
+  content: String!
+}

--- a/AmplifyTestCommon/Models/schema.graphql
+++ b/AmplifyTestCommon/Models/schema.graphql
@@ -144,6 +144,8 @@ type User5 @model {
 }
 
 # This is one of the default schemas provided when you run `amplify add api`
+# > Do you have an annotated GraphQL schema? `No`
+# > Choose a schema template: `One-to-many relationship (e.g., “Blogs” with “Posts” and “Comments”)`
 
 # 6 - Blog Post Comment
 type Blog6 @model {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add the blog, post, comment schema that developers can get when they run `amplify add api`
- Add placeholder for API integration tests (this is in anticipation of lazy loading test for infinitely traversable data)
- Add datastore integration test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
