### PR TITLE
fix(DataStore): [DRAFT] cascade delete parent/child

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -173,6 +173,13 @@
 		6B5979CB2565D18B0038C3E2 /* QueryPredicateEvaluateGeneratedBoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5979CA2565D18B0038C3E2 /* QueryPredicateEvaluateGeneratedBoolTests.swift */; };
 		6B597A0A2565D3E50038C3E2 /* QPredGen+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B597A082565D3E40038C3E2 /* QPredGen+Schema.swift */; };
 		6B597A0B2565D3E50038C3E2 /* QPredGen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B597A092565D3E50038C3E2 /* QPredGen.swift */; };
+		6B60B1B4258EDC2F0050853D /* Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B60B1AD258EDC2E0050853D /* Menu.swift */; };
+		6B60B1B5258EDC2F0050853D /* Dish+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B60B1AE258EDC2E0050853D /* Dish+Schema.swift */; };
+		6B60B1B6258EDC2F0050853D /* Menu+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B60B1AF258EDC2E0050853D /* Menu+Schema.swift */; };
+		6B60B1B7258EDC2F0050853D /* MenuType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B60B1B0258EDC2F0050853D /* MenuType.swift */; };
+		6B60B1B8258EDC2F0050853D /* Restaurant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B60B1B1258EDC2F0050853D /* Restaurant.swift */; };
+		6B60B1B9258EDC2F0050853D /* Restaurant+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B60B1B2258EDC2F0050853D /* Restaurant+Schema.swift */; };
+		6B60B1BA258EDC2F0050853D /* Dish.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B60B1B3258EDC2F0050853D /* Dish.swift */; };
 		6B767FB723AC092800C683ED /* AmplifyAPICategory+ReachabilityBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B767FB623AC092800C683ED /* AmplifyAPICategory+ReachabilityBehavior.swift */; };
 		6B767FB923AC0A0D00C683ED /* APICategoryReachabilityBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B767FB823AC0A0D00C683ED /* APICategoryReachabilityBehavior.swift */; };
 		6B9F7C5225267E1500F1F71C /* MockAWSAuthUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9F7C5125267E1500F1F71C /* MockAWSAuthUser.swift */; };
@@ -985,6 +992,13 @@
 		6B5979CA2565D18B0038C3E2 /* QueryPredicateEvaluateGeneratedBoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPredicateEvaluateGeneratedBoolTests.swift; sourceTree = "<group>"; };
 		6B597A082565D3E40038C3E2 /* QPredGen+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "QPredGen+Schema.swift"; sourceTree = "<group>"; };
 		6B597A092565D3E50038C3E2 /* QPredGen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QPredGen.swift; sourceTree = "<group>"; };
+		6B60B1AD258EDC2E0050853D /* Menu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Menu.swift; sourceTree = "<group>"; };
+		6B60B1AE258EDC2E0050853D /* Dish+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dish+Schema.swift"; sourceTree = "<group>"; };
+		6B60B1AF258EDC2E0050853D /* Menu+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Menu+Schema.swift"; sourceTree = "<group>"; };
+		6B60B1B0258EDC2F0050853D /* MenuType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuType.swift; sourceTree = "<group>"; };
+		6B60B1B1258EDC2F0050853D /* Restaurant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Restaurant.swift; sourceTree = "<group>"; };
+		6B60B1B2258EDC2F0050853D /* Restaurant+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Restaurant+Schema.swift"; sourceTree = "<group>"; };
+		6B60B1B3258EDC2F0050853D /* Dish.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dish.swift; sourceTree = "<group>"; };
 		6B767FB623AC092800C683ED /* AmplifyAPICategory+ReachabilityBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AmplifyAPICategory+ReachabilityBehavior.swift"; sourceTree = "<group>"; };
 		6B767FB823AC0A0D00C683ED /* APICategoryReachabilityBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICategoryReachabilityBehavior.swift; sourceTree = "<group>"; };
 		6B9F7C5125267E1500F1F71C /* MockAWSAuthUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSAuthUser.swift; sourceTree = "<group>"; };
@@ -2247,6 +2261,20 @@
 			path = Query;
 			sourceTree = "<group>";
 		};
+		6B60B190258EBFE10050853D /* Restaurant */ = {
+			isa = PBXGroup;
+			children = (
+				6B60B1B3258EDC2F0050853D /* Dish.swift */,
+				6B60B1AE258EDC2E0050853D /* Dish+Schema.swift */,
+				6B60B1AD258EDC2E0050853D /* Menu.swift */,
+				6B60B1AF258EDC2E0050853D /* Menu+Schema.swift */,
+				6B60B1B0258EDC2F0050853D /* MenuType.swift */,
+				6B60B1B1258EDC2F0050853D /* Restaurant.swift */,
+				6B60B1B2258EDC2F0050853D /* Restaurant+Schema.swift */,
+			);
+			path = Restaurant;
+			sourceTree = "<group>";
+		};
 		6BBECD6F23ADA7C100C8DFBE /* ServiceConfiguration */ = {
 			isa = PBXGroup;
 			children = (
@@ -2712,6 +2740,7 @@
 				21AD4255249BFFDF0016FE95 /* DeprecatedTodo.swift */,
 				FAA2E8BB239FFC7700E420EA /* MockModels.swift */,
 				216E45E9248E91420035E3CE /* NonModel */,
+				6B60B190258EBFE10050853D /* Restaurant */,
 				6BEE08222533D30800133961 /* OGCScenarioBMGroupPost.swift */,
 				6BEE08232533D30800133961 /* OGCScenarioBMGroupPost+Schema.swift */,
 				6BEE081B2533CCFA00133961 /* OGCScenarioBPost.swift */,
@@ -5050,6 +5079,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6B60B1B5258EDC2F0050853D /* Dish+Schema.swift in Sources */,
 				214F49CD24898E8500DA616C /* Article.swift in Sources */,
 				B9FAA116238799D3009414B4 /* Author.swift in Sources */,
 				B9521833237E21BA00F53237 /* Comment+Schema.swift in Sources */,
@@ -5064,9 +5094,11 @@
 				21F40A3A23A294770074678E /* TestConfigHelper.swift in Sources */,
 				B4BD6B3723708C6700A1F0A7 /* MockPredictionsCategoryPlugin.swift in Sources */,
 				B4F3542C25361BC80050FEE0 /* DynamicEmbedded.swift in Sources */,
+				6B60B1B9258EDC2F0050853D /* Restaurant+Schema.swift in Sources */,
 				FACA361C2327FC7D000E74F6 /* MockHubCategoryPlugin.swift in Sources */,
 				FAD3937F23820DAE00463F5E /* MockDataStoreCategoryPlugin.swift in Sources */,
 				217D5EBB2577F9DF009F0639 /* Team1.swift in Sources */,
+				6B60B1B7258EDC2F0050853D /* MenuType.swift in Sources */,
 				6BEE08252533D30800133961 /* OGCScenarioBMGroupPost+Schema.swift in Sources */,
 				FACA361A2327FC69000E74F6 /* MockStorageCategoryPlugin.swift in Sources */,
 				217D5EB92577F9DF009F0639 /* Post3+Schema.swift in Sources */,
@@ -5077,6 +5109,7 @@
 				FAA2E8BC239FFC7700E420EA /* MockModels.swift in Sources */,
 				B9FAA11E23879B9F009414B4 /* Book+Schema.swift in Sources */,
 				217D5EB52577F9DF009F0639 /* Project1.swift in Sources */,
+				6B60B1B8258EDC2F0050853D /* Restaurant.swift in Sources */,
 				6B9F7C552526864800F1F71C /* ScenarioATest6Post+Schema.swift in Sources */,
 				FACA361B2327FC74000E74F6 /* MockLoggingCategoryPlugin.swift in Sources */,
 				FACF52042329633500646E10 /* TestExtensions.swift in Sources */,
@@ -5086,6 +5119,9 @@
 				217D5EB72577F9DF009F0639 /* Project1+Schema.swift in Sources */,
 				FA4A955F239ADEBD008E876E /* MockResponder.swift in Sources */,
 				214F497A2486D8A200DA616C /* User.swift in Sources */,
+				6B60B1BA258EDC2F0050853D /* Dish.swift in Sources */,
+				6B60B1B4258EDC2F0050853D /* Menu.swift in Sources */,
+				6B60B1B6258EDC2F0050853D /* Menu+Schema.swift in Sources */,
 				B9FAA11223878C96009414B4 /* UserAccount+Schema.swift in Sources */,
 				FACA36152327FC39000E74F6 /* MessageReporter.swift in Sources */,
 				FAF512AE23986791001ADF4E /* AmplifyModels.swift in Sources */,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+DeleteTransaction.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+DeleteTransaction.swift
@@ -1,0 +1,155 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Combine
+import Foundation
+import AWSPluginsCore
+
+extension StorageEngine {
+    func queryAndDeleteTransaction<M: Model>(_ modelType: M.Type,
+                                             modelSchema: ModelSchema,
+                                             predicate: QueryPredicate) -> DataStoreResult<([M], [Model])> {
+        var queriedResult: DataStoreResult<[M]>?
+        var deletedResult: DataStoreResult<[M]>?
+        var associatedModels: [Model] = []
+
+        let queryCompletionBlock: DataStoreCallback<[M]> = { queryResult in
+            queriedResult = queryResult
+            if case .success(let queriedModels) = queryResult {
+                let modelIds = queriedModels.map {$0.id}
+                associatedModels = self.recurseQueryAssociatedModels(modelSchema: modelSchema, ids: modelIds)
+
+                let deleteCompletionWrapper: DataStoreCallback<[M]> = { deleteResult in
+                    deletedResult = deleteResult
+                }
+                self.storageAdapter.delete(modelType,
+                                           modelSchema: modelSchema,
+                                           predicate: predicate,
+                                           completion: deleteCompletionWrapper)
+            }
+        }
+
+        do {
+            try storageAdapter.transaction {
+                storageAdapter.query(modelType,
+                                     modelSchema: modelSchema,
+                                     predicate: predicate,
+                                     sort: nil,
+                                     paginationInput: nil,
+                                     completion: queryCompletionBlock)
+            }
+        } catch {
+            return .failure(causedBy: error)
+        }
+
+        return collapseResults(queryResult: queriedResult, deleteResult: deletedResult, associatedModels: associatedModels)
+    }
+
+    func recurseQueryAssociatedModels(modelSchema: ModelSchema, ids: [Model.Identifier]) -> [Model] {
+        var associatedModels: [Model] = []
+        for (_, modelField) in modelSchema.fields {
+            guard modelField.hasAssociation,
+                modelField.isOneToOne || modelField.isOneToMany,
+                let associatedModelName = modelField.associatedModelName,
+                let associatedField = modelField.associatedField,
+                let associatedModelSchema = ModelRegistry.modelSchema(from: associatedModelName) else {
+                    continue
+            }
+            let queriedModels = queryAssociatedModels(modelName: associatedModelName, associatedField: associatedField, ids: ids)
+            let associatedModelIds = queriedModels.map {$0.id}
+            associatedModels.append(contentsOf: queriedModels)
+            associatedModels.append(contentsOf: recurseQueryAssociatedModels(modelSchema: associatedModelSchema, ids: associatedModelIds))
+        }
+        return associatedModels
+    }
+
+    func queryAssociatedModels(modelName: ModelName, associatedField: ModelField, ids: [Model.Identifier]) -> [Model] {
+        guard let modelType = ModelRegistry.modelType(from: modelName) else {
+            log.error("Failed to lookup \(modelName)")
+            return []
+        }
+
+        //TODO: Add conveinence to queryPredicate where we have a list of items, to be all or'ed
+        var queryPredicates: [QueryPredicateOperation] = []
+        for id in ids {
+            queryPredicates.append(QueryPredicateOperation(field: associatedField.name, operator: .equals(id)))
+        }
+        let groupedQueryPredicates =  QueryPredicateGroup(type: .or, predicates: queryPredicates)
+
+        var queriedModels: [Model] = []
+        let sempahore = DispatchSemaphore(value: 0)
+        storageAdapter.query(untypedModel: modelType, predicate: groupedQueryPredicates) { result in
+            switch result {
+            case .success(let models):
+                queriedModels.append(contentsOf: models)
+
+            case .failure(let error):
+                log.error("Failed to query \(modelType) on mutation event generation: \(error)")
+            }
+            sempahore.signal()
+        }
+        sempahore.wait()
+        return queriedModels
+    }
+
+    private func collapseResults<M: Model>(queryResult: DataStoreResult<[M]>?,
+                                           deleteResult: DataStoreResult<[M]>?,
+                                           associatedModels: [Model]) -> DataStoreResult<([M], [Model])> {
+        if let queryResult = queryResult {
+            switch queryResult {
+            case .success(let models):
+                if let deleteResult = deleteResult {
+                    switch deleteResult {
+                    case .success:
+                        return .success((models, associatedModels))
+                    case .failure(let error):
+                        return .failure(error)
+                    }
+                } else {
+                    return .failure(.unknown("deleteResult not set during transaction", "coding error", nil))
+                }
+            case .failure(let error):
+                return .failure(error)
+            }
+        } else {
+            return .failure(.unknown("queryResult not set during transaction", "coding error", nil))
+        }
+    }
+
+    func collapseMResult<M: Model>(_ result: DataStoreResult<([M], [Model])>) -> DataStoreResult<[M]> {
+        switch result {
+        case .success(let results):
+            return .success(results.0)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    func resolveAssociatedModels<M: Model>(_ result: DataStoreResult<([M], [Model])>) -> [Model] {
+        switch result {
+        case .success(let results):
+            return results.1
+        case .failure:
+            return []
+        }
+    }
+
+    func generateMutationsFromModels(models: [Model]) -> [MutationEvent] {
+        var mutationEvents: [MutationEvent] = []
+        for model in models {
+            do {
+                let mutationEvent = try MutationEvent(untypedModel: model, mutationType: .delete)
+                mutationEvents.append(mutationEvent)
+            } catch {
+                log.error("Failed to generate mutation event. \(model.modelName), \(model.id)")
+            }
+        }
+        return mutationEvents
+    }
+
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -462,6 +462,10 @@ final class StorageEngine: StorageEngineBehavior {
     private func syncDeletions(of associatedModels: [Model],
                                syncEngine: RemoteSyncEngineBehavior,
                                completion: @escaping DataStoreCallback<Void>) {
+        guard !associatedModels.isEmpty else {
+            completion(.successfulVoid)
+            return
+        }
         var mutationEvents: Set<Model.Identifier> = []
         for associatedModel in associatedModels {
             let mutationEvent: MutationEvent

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/StorageEngineTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/StorageEngineTests.swift
@@ -1,0 +1,156 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import SQLite
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+class StorageEngineTests: XCTestCase {
+
+    var connection: Connection!
+    var storageEngine: StorageEngine!
+    var storageAdapter: SQLiteStorageEngineAdapter!
+
+    override func setUp() {
+        super.setUp()
+        Amplify.Logging.logLevel = .warn
+
+        let validAPIPluginKey = "MockAPICategoryPlugin"
+        let validAuthPluginKey = "MockAuthCategoryPlugin"
+        do {
+            connection = try Connection(.inMemory)
+            storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
+            try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
+
+            let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
+                                                  dataStoreConfiguration: .default)
+            storageEngine = StorageEngine(storageAdapter: storageAdapter,
+                                          dataStoreConfiguration: .default,
+                                          syncEngine: syncEngine,
+                                          validAPIPluginKey: validAPIPluginKey,
+                                          validAuthPluginKey: validAuthPluginKey)
+            ModelRegistry.register(modelType: Post.self)
+            ModelRegistry.register(modelType: Comment.self)
+//            guard let postModelSchema = ModelRegistry.modelSchema(from: Post.) else {
+//                XCTFail("Failed to generate model schema")
+//                return
+//            }
+            do {
+            try storageEngine.setUp(modelSchemas: [Post.schema])
+            try storageEngine.setUp(modelSchemas: [Comment.schema])
+
+            } catch {
+                XCTFail("Failed to setup storage engine")
+            }
+        } catch {
+            XCTFail(String(describing: error))
+            return
+        }
+    }
+
+    func testCreationQueryDelete_NAME_TBD() {
+        let post = Post(title: "post1", content: "content1", createdAt: .now())
+        guard case .success(let savedPost1) = saveModelSynchronous(model: post) else {
+                XCTFail("Failed to save")
+                return
+        }
+
+        let comment1 = Comment(content: "comment1ForPost1", createdAt: .now() + .weeks(1), post: savedPost1)
+        let comment2 = Comment(content: "comment2ForPost1", createdAt: .now() + .days(1), post: savedPost1)
+        guard case .success(let savedComment1) = saveModelSynchronous(model: comment1),
+            case .success(let savedComment2) = saveModelSynchronous(model: comment2) else {
+            XCTFail("Failed to save either comment")
+            return
+        }
+
+        guard case .success(let queriedPost) =
+            querySingleModelSynchronous(modelType: Post.self, predicate: Post.keys.id == savedPost1.id) else {
+            XCTFail("Failed to query for single post")
+            return
+        }
+
+        guard case .success(let comments) =
+            queryModelSynchronous(modelType: Comment.self, predicate: Comment.keys.post == savedPost1.id) else {
+            XCTFail("Failed to query comment")
+            return
+        }
+        XCTAssertEqual(comments.count, 2)
+    }
+
+    /**
+     * Below are synchronous conveinence methods.  Please do not add any calls to XCTFail()
+     * in these conveinence methods.  Failures should be handled in the body of the unit test.
+     */
+    func saveModelSynchronous<M: Model>(model: M) -> DataStoreResult<M> {
+        let saveFinished = expectation(description: "Save finished")
+        var result: DataStoreResult<M>?
+
+        storageEngine.save(model) { sResult in
+            result = sResult
+            saveFinished.fulfill()
+        }
+
+        wait(for: [saveFinished], timeout: 1)
+        guard let saveResult = result else {
+            return .failure(causedBy: "Save operation timed out")
+        }
+
+        switch saveResult {
+        case .success(let successPost):
+            return .success(successPost)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    func querySingleModelSynchronous<M: Model>(modelType: M.Type, predicate: QueryPredicate) -> DataStoreResult<M> {
+        let result = queryModelSynchronous(modelType: modelType, predicate: predicate)
+
+        switch result {
+        case .success(let models):
+            if models.isEmpty {
+                return .failure(causedBy: "Found no models, of type \(modelType.modelName)")
+            } else if models.count > 1 {
+                return .failure(causedBy: "Found more than one model of type \(modelType.modelName)")
+            } else {
+                return .success(models.first!)
+            }
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    func queryModelSynchronous<M: Model>(modelType: M.Type, predicate: QueryPredicate) -> DataStoreResult<[M]> {
+        let queryFinished = expectation(description: "Query Finished")
+        var result: DataStoreResult<[M]>?
+
+        storageEngine.query(modelType, predicate: predicate) { qResult in
+            result = qResult
+            queryFinished.fulfill()
+        }
+        wait(for: [queryFinished], timeout: 1)
+
+        guard let queryResult = result else {
+            return .failure(causedBy: "Query operation timed out")
+        }
+
+        switch queryResult {
+        case .success(let successPost):
+            return .success(successPost)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+//    func deleteModelSynchronous<M: Model>() -> DataStoreResult<> {
+//
+//    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockRemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockRemoteSyncEngine.swift
@@ -1,0 +1,49 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import AWSPluginsCore
+import Combine
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+typealias OnSubmitCallBack = (MutationEvent) -> Void
+class MockRemoteSyncEngine: RemoteSyncEngineBehavior {
+
+    let remoteSyncTopicPublisher: PassthroughSubject<RemoteSyncEngineEvent, DataStoreError>
+    var callbackOnSubmit: OnSubmitCallBack?
+    var publisher: AnyPublisher<RemoteSyncEngineEvent, DataStoreError> {
+        return remoteSyncTopicPublisher.eraseToAnyPublisher()
+    }
+
+    init() {
+        self.remoteSyncTopicPublisher = PassthroughSubject<RemoteSyncEngineEvent, DataStoreError>()
+    }
+    func start(api: APICategoryGraphQLBehavior, auth: AuthCategoryBehavior?) {
+
+    }
+
+    func stop(completion: @escaping DataStoreCallback<Void>) {
+
+    }
+
+    @available(iOS 13.0, *)
+    func submit(_ mutationEvent: MutationEvent) -> Future<MutationEvent, DataStoreError> {
+        if let callback = callbackOnSubmit {
+            callback(mutationEvent)
+        }
+        return Future<MutationEvent, DataStoreError> { promise in
+            promise(.success(mutationEvent))
+        }
+    }
+
+    func setCallbackOnSubmit(callback: @escaping OnSubmitCallBack) {
+        callbackOnSubmit = callback
+    }
+}

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		6B52DC9624478E75007F5AD3 /* MockModelReconciliationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B52DC9524478E75007F5AD3 /* MockModelReconciliationQueue.swift */; };
 		6B64027923E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B64027823E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift */; };
 		6B64027B23E38B9900001FD7 /* MockOutgoingMutationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */; };
+		6B6B30B22590347400BACB70 /* StorageEngine+DeleteTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6B30B12590347400BACB70 /* StorageEngine+DeleteTransaction.swift */; };
 		6B91DEBF238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */; };
 		6B92A876258D7DEC0023B9C6 /* MockRemoteSyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B92A875258D7DEC0023B9C6 /* MockRemoteSyncEngine.swift */; };
 		6BB01630255B1B4D00190897 /* DataStoreSyncExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB0162F255B1B4D00190897 /* DataStoreSyncExpression.swift */; };
@@ -320,6 +321,7 @@
 		6B52DC9524478E75007F5AD3 /* MockModelReconciliationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockModelReconciliationQueue.swift; sourceTree = "<group>"; };
 		6B64027823E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSIncomingEventReconciliationQueue.swift; sourceTree = "<group>"; };
 		6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOutgoingMutationQueue.swift; sourceTree = "<group>"; };
+		6B6B30B12590347400BACB70 /* StorageEngine+DeleteTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StorageEngine+DeleteTransaction.swift"; sourceTree = "<group>"; };
 		6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcileAndLocalSaveOperationTests.swift; sourceTree = "<group>"; };
 		6B92A875258D7DEC0023B9C6 /* MockRemoteSyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteSyncEngine.swift; sourceTree = "<group>"; };
 		6BB0162F255B1B4D00190897 /* DataStoreSyncExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreSyncExpression.swift; sourceTree = "<group>"; };
@@ -553,6 +555,7 @@
 			children = (
 				FAED5741238B52CE008EBED8 /* ModelStorageBehavior.swift */,
 				2149E5AA2388684F00873955 /* StorageEngine.swift */,
+				6B6B30B12590347400BACB70 /* StorageEngine+DeleteTransaction.swift */,
 				21233E1224763D0700039337 /* StorageEngine+SyncRequirement.swift */,
 				2149E5A92388684F00873955 /* StorageEngineAdapter.swift */,
 				2149E5A82388684F00873955 /* StorageEngineBehavior.swift */,
@@ -1582,6 +1585,7 @@
 				D8079A73251656A200826E8F /* SyncEventEmitter.swift in Sources */,
 				2149E5D42388684F00873955 /* DataStorePublisher.swift in Sources */,
 				FA3841E723889D340070AD5B /* ReconcileAndLocalSaveOperation.swift in Sources */,
+				6B6B30B22590347400BACB70 /* StorageEngine+DeleteTransaction.swift in Sources */,
 				FADD728F238B0F10005AA69A /* IncomingAsyncSubscriptionEventPublisher.swift in Sources */,
 				6B4693E923A5645F006BE2C5 /* MutationRetryNotifier.swift in Sources */,
 				FACBA78B2394950C006349C8 /* MutationEventSource.swift in Sources */,

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		6B64027923E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B64027823E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift */; };
 		6B64027B23E38B9900001FD7 /* MockOutgoingMutationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */; };
 		6B91DEBF238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */; };
+		6B92A876258D7DEC0023B9C6 /* MockRemoteSyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B92A875258D7DEC0023B9C6 /* MockRemoteSyncEngine.swift */; };
 		6BB01630255B1B4D00190897 /* DataStoreSyncExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB0162F255B1B4D00190897 /* DataStoreSyncExpression.swift */; };
 		6BB93F07244BA44B00ED1FC3 /* MutationEventClearState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB93F06244BA44B00ED1FC3 /* MutationEventClearState.swift */; };
 		6BB93F09244BA8ED00ED1FC3 /* MutationEventClearStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB93F08244BA8ED00ED1FC3 /* MutationEventClearStateTests.swift */; };
@@ -320,6 +321,7 @@
 		6B64027823E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSIncomingEventReconciliationQueue.swift; sourceTree = "<group>"; };
 		6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOutgoingMutationQueue.swift; sourceTree = "<group>"; };
 		6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcileAndLocalSaveOperationTests.swift; sourceTree = "<group>"; };
+		6B92A875258D7DEC0023B9C6 /* MockRemoteSyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteSyncEngine.swift; sourceTree = "<group>"; };
 		6BB0162F255B1B4D00190897 /* DataStoreSyncExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreSyncExpression.swift; sourceTree = "<group>"; };
 		6BB93F06244BA44B00ED1FC3 /* MutationEventClearState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEventClearState.swift; sourceTree = "<group>"; };
 		6BB93F08244BA8ED00ED1FC3 /* MutationEventClearStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEventClearStateTests.swift; sourceTree = "<group>"; };
@@ -967,6 +969,7 @@
 				6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */,
 				6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */,
 				FAF5287A2399814F0053A717 /* MockReconciliationQueue.swift */,
+				6B92A875258D7DEC0023B9C6 /* MockRemoteSyncEngine.swift */,
 				6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */,
 				6B4E3DF52397327E00AD962B /* MockStateMachine.swift */,
 				FA8D932E239EA5C4001ED336 /* NoOpInitialSyncOrchestrator.swift */,
@@ -1656,6 +1659,7 @@
 				FA3B3F09238F39DE002EFDB3 /* AWSMutationEventIngesterTests.swift in Sources */,
 				6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */,
 				FA4B8E962391C609009FC10F /* XCTest+AmplifyExtensions.swift in Sources */,
+				6B92A876258D7DEC0023B9C6 /* MockRemoteSyncEngine.swift in Sources */,
 				FAE4146C239AA40600CE94C2 /* MockSQLiteStorageEngineAdapter.swift in Sources */,
 				B4D9B9E424DF90CD0049484F /* DynamicModel.swift in Sources */,
 				B912D1BA242984D10028F05C /* QueryPaginationInputTests.swift in Sources */,

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		6BB01630255B1B4D00190897 /* DataStoreSyncExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB0162F255B1B4D00190897 /* DataStoreSyncExpression.swift */; };
 		6BB93F07244BA44B00ED1FC3 /* MutationEventClearState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB93F06244BA44B00ED1FC3 /* MutationEventClearState.swift */; };
 		6BB93F09244BA8ED00ED1FC3 /* MutationEventClearStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB93F08244BA8ED00ED1FC3 /* MutationEventClearStateTests.swift */; };
+		6BC03145258BEB5E003FDFBD /* StorageEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC03144258BEB5E003FDFBD /* StorageEngineTests.swift */; };
 		6BC4FDA823A899180027D20C /* RequestRetryablePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC4FDA723A899180027D20C /* RequestRetryablePolicyTests.swift */; };
 		6BC4FDAA23A899680027D20C /* MockRequestRetryablePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */; };
 		6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */; };
@@ -322,6 +323,7 @@
 		6BB0162F255B1B4D00190897 /* DataStoreSyncExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreSyncExpression.swift; sourceTree = "<group>"; };
 		6BB93F06244BA44B00ED1FC3 /* MutationEventClearState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEventClearState.swift; sourceTree = "<group>"; };
 		6BB93F08244BA8ED00ED1FC3 /* MutationEventClearStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEventClearStateTests.swift; sourceTree = "<group>"; };
+		6BC03144258BEB5E003FDFBD /* StorageEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageEngineTests.swift; sourceTree = "<group>"; };
 		6BC4FDA723A899180027D20C /* RequestRetryablePolicyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestRetryablePolicyTests.swift; sourceTree = "<group>"; };
 		6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRequestRetryablePolicy.swift; sourceTree = "<group>"; };
 		6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSyncEngineTests.swift; sourceTree = "<group>"; };
@@ -617,6 +619,7 @@
 				2149E5E72388692E00873955 /* Info.plist */,
 				FAD2BDF423957F35006EB065 /* Core */,
 				B996FC4523FF3C41006D0F68 /* Models */,
+				6BC03143258BEB38003FDFBD /* Storage */,
 				FAD2BDF223957EE8006EB065 /* Sync */,
 				2149E5EE238869CF00873955 /* TestSupport */,
 			);
@@ -678,6 +681,14 @@
 				217D62282579E15F009F0639 /* DataStoreConnectionScenario5Tests.swift */,
 			);
 			path = Connection;
+			sourceTree = "<group>";
+		};
+		6BC03143258BEB38003FDFBD /* Storage */ = {
+			isa = PBXGroup;
+			children = (
+				6BC03144258BEB5E003FDFBD /* StorageEngineTests.swift */,
+			);
+			path = Storage;
 			sourceTree = "<group>";
 		};
 		9B5889A231ECAD33B03B5DF6 /* Pods */ = {
@@ -1670,6 +1681,7 @@
 				B4B3794B2551CF87007781D6 /* QuerySortDescriptorTests.swift in Sources */,
 				2149E5FE238869CF00873955 /* RemoteSyncAPIInvocationTests.swift in Sources */,
 				B9FAA142238C6082009414B4 /* BaseDataStoreTests.swift in Sources */,
+				6BC03145258BEB5E003FDFBD /* StorageEngineTests.swift in Sources */,
 				6B52DC9624478E75007F5AD3 /* MockModelReconciliationQueue.swift in Sources */,
 				FA4A955B239AD3F4008E876E /* Foundation+TestExtensions.swift in Sources */,
 				FA1C819F25868D17006160E9 /* AWSDataStorePluginAmplifyVersionableTests.swift in Sources */,

--- a/AmplifyTestCommon/Models/Restaurant/Dish+Schema.swift
+++ b/AmplifyTestCommon/Models/Restaurant/Dish+Schema.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Dish {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case dishName
+    case menu
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let dish = Dish.keys
+    
+    model.pluralName = "Dishes"
+    
+    model.fields(
+      .id(),
+      .field(dish.dishName, is: .optional, ofType: .string),
+      .belongsTo(dish.menu, is: .optional, ofType: Menu.self, targetName: "dishMenuId")
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/Restaurant/Dish.swift
+++ b/AmplifyTestCommon/Models/Restaurant/Dish.swift
@@ -1,0 +1,17 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Dish: Model {
+  public let id: String
+  public var dishName: String?
+  public var menu: Menu?
+  
+  public init(id: String = UUID().uuidString,
+      dishName: String? = nil,
+      menu: Menu? = nil) {
+      self.id = id
+      self.dishName = dishName
+      self.menu = menu
+  }
+}

--- a/AmplifyTestCommon/Models/Restaurant/Menu+Schema.swift
+++ b/AmplifyTestCommon/Models/Restaurant/Menu+Schema.swift
@@ -1,0 +1,31 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Menu {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case name
+    case menuType
+    case restaurant
+    case dishes
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let menu = Menu.keys
+    
+    model.pluralName = "Menus"
+    
+    model.fields(
+      .id(),
+      .field(menu.name, is: .required, ofType: .string),
+      .field(menu.menuType, is: .optional, ofType: .enum(type: MenuType.self)),
+      .belongsTo(menu.restaurant, is: .optional, ofType: Restaurant.self, targetName: "menuRestaurantId"),
+      .hasMany(menu.dishes, is: .optional, ofType: Dish.self, associatedWith: Dish.keys.menu)
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/Restaurant/Menu.swift
+++ b/AmplifyTestCommon/Models/Restaurant/Menu.swift
@@ -1,0 +1,23 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Menu: Model {
+  public let id: String
+  public var name: String
+  public var menuType: MenuType?
+  public var restaurant: Restaurant?
+  public var dishes: List<Dish>?
+  
+  public init(id: String = UUID().uuidString,
+      name: String,
+      menuType: MenuType? = nil,
+      restaurant: Restaurant? = nil,
+      dishes: List<Dish>? = []) {
+      self.id = id
+      self.name = name
+      self.menuType = menuType
+      self.restaurant = restaurant
+      self.dishes = dishes
+  }
+}

--- a/AmplifyTestCommon/Models/Restaurant/MenuType.swift
+++ b/AmplifyTestCommon/Models/Restaurant/MenuType.swift
@@ -1,0 +1,9 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public enum MenuType: String, EnumPersistable {
+  case breakfast = "BREAKFAST"
+  case lunch = "LUNCH"
+  case dinner = "DINNER"
+}

--- a/AmplifyTestCommon/Models/Restaurant/Restaurant+Schema.swift
+++ b/AmplifyTestCommon/Models/Restaurant/Restaurant+Schema.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Restaurant {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case restaurantName
+    case menus
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let restaurant = Restaurant.keys
+    
+    model.pluralName = "Restaurants"
+    
+    model.fields(
+      .id(),
+      .field(restaurant.restaurantName, is: .required, ofType: .string),
+      .hasMany(restaurant.menus, is: .optional, ofType: Menu.self, associatedWith: Menu.keys.restaurant)
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/Restaurant/Restaurant.swift
+++ b/AmplifyTestCommon/Models/Restaurant/Restaurant.swift
@@ -1,0 +1,17 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Restaurant: Model {
+  public let id: String
+  public var restaurantName: String
+  public var menus: List<Menu>?
+  
+  public init(id: String = UUID().uuidString,
+      restaurantName: String,
+      menus: List<Menu>? = []) {
+      self.id = id
+      self.restaurantName = restaurantName
+      self.menus = menus
+  }
+}

--- a/AmplifyTestCommon/Models/Restaurant/schema.graphql
+++ b/AmplifyTestCommon/Models/Restaurant/schema.graphql
@@ -1,0 +1,26 @@
+enum MenuType {
+  BREAKFAST
+  LUNCH
+  DINNER
+}
+
+type Restaurant @model {
+  id: ID!
+  restaurantName: String!
+  menus: [Menu] @connection(name: "RestaurantMenu")
+}
+
+type Menu @model {
+  id: ID!
+  name: String!
+  menuType: MenuType
+
+  restaurant: Restaurant @connection(name: "RestaurantMenu")
+  entrees: [Entree] @connection(name: "MenuEntree")
+}
+
+type Entree @model {
+  id: ID!
+  dishName: String
+  menu: Menu @connection(name: "MenuEntree")
+}


### PR DESCRIPTION
**tldr; -- Don't review this PR**.  This PR is superseded by:
https://github.com/aws-amplify/amplify-ios/pull/986
https://github.com/aws-amplify/amplify-ios/pull/987


~This PR started out as demonstrating synchronous unit tests to demonstrate improved readability.  Notice:~
* ~Absence of parent base class~
* ~XCTAsserts ONLY belong in the actual test~
* ~Ability to linearly read from the top of the function to the bottom~

~However, this PR has grown into the first version of cascade delete, to address [issue #993](https://github.com/aws-amplify/amplify-ios/issues/933). This PR will be here for historical purposes, but will work on breaking this PR up into separate PRs in order to make it easier to review.  I will break this up into two PRs:
**1st PR:** Refactor - move `queryAndDeleteTransaction` and `collpaseResults`, `syncDeletion`, into an extension (with no functional changes) 
**2nd PR:**
a.  Addition of `recurseQueryAssociatedModels` w/ unit tests
b.  Removing `private` from  `submitToSyncEngine` -- i prefer not to do this, but StorageEngine is getting large, and syncDeletion methods need to be able to call this function.~

~Main reason for doing splitting up this PR is to clearly see the diff of the implementation of `queryAndDeleteTransaction` and `collapseResults` in a single file.~

~Note that this PR relies on: https://github.com/aws-amplify/amplify-ios/pull/965~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
