### PR TITLE
chore(AWSPluginsCore): Remove unwanted AWSMobileClient dependency from AWSPluginsCore

### DIFF
--- a/AWSPluginsCore.podspec
+++ b/AWSPluginsCore.podspec
@@ -32,10 +32,6 @@ Pod::Spec.new do |s|
   s.source_files = 'AmplifyPlugins/Core/AWSPluginsCore/**/*.swift'
 
   s.dependency 'Amplify', $AMPLIFY_VERSION
-  s.dependency 'AWSMobileClient', $OPTIMISTIC_AWS_SDK_VERSION
-
-  # This is technically redundant, but adding it here allows Xcode to find it
-  # during initial indexing and prevent build errors after a fresh install
   s.dependency 'AWSCore', $OPTIMISTIC_AWS_SDK_VERSION
 
 end

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/IAMURLRequestInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/IAMURLRequestInterceptor.swift
@@ -9,7 +9,6 @@ import Amplify
 import AWSPluginsCore
 import Foundation
 import AWSCore
-import AWSMobileClient
 
 struct IAMURLRequestInterceptor: URLRequestInterceptor {
     let iamCredentialsProvider: IAMCredentialsProvider

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/UserPoolRequestInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/UserPoolRequestInterceptor.swift
@@ -9,7 +9,6 @@ import Amplify
 import AWSPluginsCore
 import Foundation
 import AWSCore
-import AWSMobileClient
 
 struct UserPoolURLRequestInterceptor: URLRequestInterceptor {
 

--- a/AmplifyPlugins/API/Podfile.lock
+++ b/AmplifyPlugins/API/Podfile.lock
@@ -12,9 +12,11 @@ PODS:
   - AmplifyTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AmplifyTestCommon/AWSPluginsTestCommon (= 1.5.1)
+    - AWSMobileClient (~> 2.20.0)
   - AmplifyTestCommon/AWSPluginsTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
+    - AWSMobileClient (~> 2.20.0)
     - AWSPluginsCore (= 1.5.1)
   - AppSyncRealTimeClient (1.4.2):
     - Starscream (~> 3.1.0)
@@ -33,13 +35,12 @@ PODS:
   - AWSPluginsCore (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
-    - AWSMobileClient (~> 2.20.0)
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
   - Starscream (3.1.1)
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.41.0)
+  - SwiftLint (0.42.0)
 
 DEPENDENCIES:
   - Amplify (from `../../`)
@@ -92,19 +93,19 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Amplify: c55f7bf2c6ea68891d95579882172c1256f301fc
   AmplifyPlugins: 40f1051d1e8313a74c16bafe0618d460bf0479db
-  AmplifyTestCommon: 60a44eefba338d8d9809f3d2740422805bfaad9f
+  AmplifyTestCommon: 66ec23a49a2c18c722956782d0fa647f7421417a
   AppSyncRealTimeClient: 7fb160294d067b6c0c4b3c4ab91e953fd4cfba30
   AWSAuthCore: 6a5f0fdbbd65d917deab61e2f5035afecafaa687
   AWSCognitoIdentityProvider: f9031fc36af73a1e6a3c7476cbd536c1d4f7591c
   AWSCognitoIdentityProviderASF: c126563dd240709a5acf2c15910ea4c872c65df3
   AWSCore: e8748f1d2e97874ff5638fe7c3c31431ad223b4a
   AWSMobileClient: f98f4d3eb4d0f893a128b5546a31fd2cbc88e2ef
-  AWSPluginsCore: 3afe92313f5be7f002a48007e6645b5ab58e05a7
+  AWSPluginsCore: 03651a5904baf7d0e4d79addda7bcd8344d17bec
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
+  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
 
 PODFILE CHECKSUM: 857e4ea8246683593b8a7db77014aeb7340c15a5
 

--- a/AmplifyPlugins/API/Podfile.lock
+++ b/AmplifyPlugins/API/Podfile.lock
@@ -12,7 +12,6 @@ PODS:
   - AmplifyTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AmplifyTestCommon/AWSPluginsTestCommon (= 1.5.1)
-    - AWSMobileClient (~> 2.20.0)
   - AmplifyTestCommon/AWSPluginsTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
@@ -93,7 +92,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Amplify: c55f7bf2c6ea68891d95579882172c1256f301fc
   AmplifyPlugins: 40f1051d1e8313a74c16bafe0618d460bf0479db
-  AmplifyTestCommon: 66ec23a49a2c18c722956782d0fa647f7421417a
+  AmplifyTestCommon: 40a2413a5fba88dd89b99ece6d467ff0951a7c2c
   AppSyncRealTimeClient: 7fb160294d067b6c0c4b3c4ab91e953fd4cfba30
   AWSAuthCore: 6a5f0fdbbd65d917deab61e2f5035afecafaa687
   AWSCognitoIdentityProvider: f9031fc36af73a1e6a3c7476cbd536c1d4f7591c

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAdapter.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAdapter.swift
@@ -6,7 +6,7 @@
 //
 
 import Amplify
-import AWSMobileClient
+import AWSCore
 import AWSPinpoint
 import AWSPluginsCore
 import Foundation
@@ -14,7 +14,6 @@ import Foundation
 /// Conforms to `AWSPinpointBehavior` by storing an instance of the `AWSPinpoint` to expose AWS Pinpoint functionality
 class AWSPinpointAdapter: AWSPinpointBehavior {
     let pinpoint: AWSPinpoint
-    // let eventRecorder: AWSPinpointEventRecorder
 
     convenience init(pinpointAnalyticsAppId: String,
                      pinpointAnalyticsRegion: AWSRegionType,
@@ -37,7 +36,6 @@ class AWSPinpointAdapter: AWSPinpointBehavior {
 
     init(pinpoint: AWSPinpoint) {
         self.pinpoint = pinpoint
-        // self.eventRecorder = pinpoint.analyticsClient.eventRecorder
     }
 
     func getEscapeHatch() -> AWSPinpoint {

--- a/AmplifyPlugins/Analytics/Podfile.lock
+++ b/AmplifyPlugins/Analytics/Podfile.lock
@@ -12,9 +12,11 @@ PODS:
   - AmplifyTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AmplifyTestCommon/AWSPluginsTestCommon (= 1.5.1)
+    - AWSMobileClient (~> 2.20.0)
   - AmplifyTestCommon/AWSPluginsTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
+    - AWSMobileClient (~> 2.20.0)
     - AWSPluginsCore (= 1.5.1)
   - AWSAuthCore (2.20.0):
     - AWSCore (= 2.20.0)
@@ -33,12 +35,11 @@ PODS:
   - AWSPluginsCore (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
-    - AWSMobileClient (~> 2.20.0)
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.41.0)
+  - SwiftLint (0.42.0)
 
 DEPENDENCIES:
   - Amplify (from `../../`)
@@ -88,19 +89,19 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Amplify: c55f7bf2c6ea68891d95579882172c1256f301fc
-  AmplifyPlugins: 78d2e39e1d5db18ae50c215063790f300607d312
-  AmplifyTestCommon: 60a44eefba338d8d9809f3d2740422805bfaad9f
+  AmplifyPlugins: 40f1051d1e8313a74c16bafe0618d460bf0479db
+  AmplifyTestCommon: 66ec23a49a2c18c722956782d0fa647f7421417a
   AWSAuthCore: 6a5f0fdbbd65d917deab61e2f5035afecafaa687
   AWSCognitoIdentityProvider: f9031fc36af73a1e6a3c7476cbd536c1d4f7591c
   AWSCognitoIdentityProviderASF: c126563dd240709a5acf2c15910ea4c872c65df3
   AWSCore: e8748f1d2e97874ff5638fe7c3c31431ad223b4a
   AWSMobileClient: f98f4d3eb4d0f893a128b5546a31fd2cbc88e2ef
   AWSPinpoint: ad147e2b6d4f4307a118b3f1ce3b581cfd56d076
-  AWSPluginsCore: 3afe92313f5be7f002a48007e6645b5ab58e05a7
+  AWSPluginsCore: 03651a5904baf7d0e4d79addda7bcd8344d17bec
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
+  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
 
 PODFILE CHECKSUM: 48d1574dddce5cef7bdb7b05b06fc588ee22956e
 

--- a/AmplifyPlugins/Analytics/Podfile.lock
+++ b/AmplifyPlugins/Analytics/Podfile.lock
@@ -12,7 +12,6 @@ PODS:
   - AmplifyTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AmplifyTestCommon/AWSPluginsTestCommon (= 1.5.1)
-    - AWSMobileClient (~> 2.20.0)
   - AmplifyTestCommon/AWSPluginsTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
@@ -90,7 +89,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Amplify: c55f7bf2c6ea68891d95579882172c1256f301fc
   AmplifyPlugins: 40f1051d1e8313a74c16bafe0618d460bf0479db
-  AmplifyTestCommon: 66ec23a49a2c18c722956782d0fa647f7421417a
+  AmplifyTestCommon: 40a2413a5fba88dd89b99ece6d467ff0951a7c2c
   AWSAuthCore: 6a5f0fdbbd65d917deab61e2f5035afecafaa687
   AWSCognitoIdentityProvider: f9031fc36af73a1e6a3c7476cbd536c1d4f7591c
   AWSCognitoIdentityProviderASF: c126563dd240709a5acf2c15910ea4c872c65df3

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -218,7 +218,7 @@ extension AuthenticationProviderAdapter {
         let authError = AuthErrorHelper.toAuthError(error)
         return authError
     }
-    
+
     private class ModalPresentingNavigationController: UINavigationController {
 
         override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {

--- a/AmplifyPlugins/Auth/Podfile.lock
+++ b/AmplifyPlugins/Auth/Podfile.lock
@@ -5,7 +5,6 @@ PODS:
   - AmplifyTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AmplifyTestCommon/AWSPluginsTestCommon (= 1.5.1)
-    - AWSMobileClient (~> 2.20.0)
   - AmplifyTestCommon/AWSPluginsTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
@@ -76,7 +75,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Amplify: c55f7bf2c6ea68891d95579882172c1256f301fc
-  AmplifyTestCommon: 66ec23a49a2c18c722956782d0fa647f7421417a
+  AmplifyTestCommon: 40a2413a5fba88dd89b99ece6d467ff0951a7c2c
   AWSAuthCore: 6a5f0fdbbd65d917deab61e2f5035afecafaa687
   AWSCognitoIdentityProvider: f9031fc36af73a1e6a3c7476cbd536c1d4f7591c
   AWSCognitoIdentityProviderASF: c126563dd240709a5acf2c15910ea4c872c65df3

--- a/AmplifyPlugins/Auth/Podfile.lock
+++ b/AmplifyPlugins/Auth/Podfile.lock
@@ -5,9 +5,11 @@ PODS:
   - AmplifyTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AmplifyTestCommon/AWSPluginsTestCommon (= 1.5.1)
+    - AWSMobileClient (~> 2.20.0)
   - AmplifyTestCommon/AWSPluginsTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
+    - AWSMobileClient (~> 2.20.0)
     - AWSPluginsCore (= 1.5.1)
   - AWSAuthCore (2.20.0):
     - AWSCore (= 2.20.0)
@@ -24,12 +26,11 @@ PODS:
   - AWSPluginsCore (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
-    - AWSMobileClient (~> 2.20.0)
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.41.0)
+  - SwiftLint (0.42.0)
 
 DEPENDENCIES:
   - Amplify (from `../../`)
@@ -75,17 +76,17 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Amplify: c55f7bf2c6ea68891d95579882172c1256f301fc
-  AmplifyTestCommon: 60a44eefba338d8d9809f3d2740422805bfaad9f
+  AmplifyTestCommon: 66ec23a49a2c18c722956782d0fa647f7421417a
   AWSAuthCore: 6a5f0fdbbd65d917deab61e2f5035afecafaa687
   AWSCognitoIdentityProvider: f9031fc36af73a1e6a3c7476cbd536c1d4f7591c
   AWSCognitoIdentityProviderASF: c126563dd240709a5acf2c15910ea4c872c65df3
   AWSCore: e8748f1d2e97874ff5638fe7c3c31431ad223b4a
   AWSMobileClient: f98f4d3eb4d0f893a128b5546a31fd2cbc88e2ef
-  AWSPluginsCore: 3afe92313f5be7f002a48007e6645b5ab58e05a7
+  AWSPluginsCore: 03651a5904baf7d0e4d79addda7bcd8344d17bec
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
+  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
 
 PODFILE CHECKSUM: 371cf67fe35ebb5167d0880bad12b01618a0fb0e
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import Amplify
-import AWSMobileClient
+import AWSCore
 
 public class AWSAuthService: AWSAuthServiceBehavior {
 

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -16,7 +16,7 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
     var getTokenClaimsError: AuthError?
     var identityId: String?
     var token: String?
-    var tokenClaims: [String : AnyObject]?
+    var tokenClaims: [String: AnyObject]?
 
     public func configure() {
     }
@@ -45,10 +45,10 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
         return .success(token ?? "token")
     }
 
-    public func getTokenClaims(tokenString: String) -> Result<[String : AnyObject], AuthError> {
+    public func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
         if let error = getTokenClaimsError {
             return .failure(error)
         }
-        return .success(tokenClaims ?? ["":"" as AnyObject])
+        return .success(tokenClaims ?? ["": "" as AnyObject])
     }
 }

--- a/AmplifyPlugins/DataStore/Podfile.lock
+++ b/AmplifyPlugins/DataStore/Podfile.lock
@@ -16,9 +16,11 @@ PODS:
   - AmplifyTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AmplifyTestCommon/AWSPluginsTestCommon (= 1.5.1)
+    - AWSMobileClient (~> 2.20.0)
   - AmplifyTestCommon/AWSPluginsTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
+    - AWSMobileClient (~> 2.20.0)
     - AWSPluginsCore (= 1.5.1)
   - AppSyncRealTimeClient (1.4.2):
     - Starscream (~> 3.1.0)
@@ -37,7 +39,6 @@ PODS:
   - AWSPluginsCore (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
-    - AWSMobileClient (~> 2.20.0)
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
@@ -46,7 +47,7 @@ PODS:
   - SQLite.swift/standard (0.12.2)
   - Starscream (3.1.1)
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.41.0)
+  - SwiftLint (0.42.0)
 
 DEPENDENCIES:
   - Amplify (from `../../`)
@@ -101,20 +102,20 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Amplify: c55f7bf2c6ea68891d95579882172c1256f301fc
   AmplifyPlugins: 40f1051d1e8313a74c16bafe0618d460bf0479db
-  AmplifyTestCommon: 60a44eefba338d8d9809f3d2740422805bfaad9f
+  AmplifyTestCommon: 66ec23a49a2c18c722956782d0fa647f7421417a
   AppSyncRealTimeClient: 7fb160294d067b6c0c4b3c4ab91e953fd4cfba30
   AWSAuthCore: 6a5f0fdbbd65d917deab61e2f5035afecafaa687
   AWSCognitoIdentityProvider: f9031fc36af73a1e6a3c7476cbd536c1d4f7591c
   AWSCognitoIdentityProviderASF: c126563dd240709a5acf2c15910ea4c872c65df3
   AWSCore: e8748f1d2e97874ff5638fe7c3c31431ad223b4a
   AWSMobileClient: f98f4d3eb4d0f893a128b5546a31fd2cbc88e2ef
-  AWSPluginsCore: 3afe92313f5be7f002a48007e6645b5ab58e05a7
+  AWSPluginsCore: 03651a5904baf7d0e4d79addda7bcd8344d17bec
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
   Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
+  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
 
 PODFILE CHECKSUM: 04860e414d616b67d24ed3346a60700f427764b9
 

--- a/AmplifyPlugins/DataStore/Podfile.lock
+++ b/AmplifyPlugins/DataStore/Podfile.lock
@@ -16,7 +16,6 @@ PODS:
   - AmplifyTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AmplifyTestCommon/AWSPluginsTestCommon (= 1.5.1)
-    - AWSMobileClient (~> 2.20.0)
   - AmplifyTestCommon/AWSPluginsTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
@@ -102,7 +101,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Amplify: c55f7bf2c6ea68891d95579882172c1256f301fc
   AmplifyPlugins: 40f1051d1e8313a74c16bafe0618d460bf0479db
-  AmplifyTestCommon: 66ec23a49a2c18c722956782d0fa647f7421417a
+  AmplifyTestCommon: 40a2413a5fba88dd89b99ece6d467ff0951a7c2c
   AppSyncRealTimeClient: 7fb160294d067b6c0c4b3c4ab91e953fd4cfba30
   AWSAuthCore: 6a5f0fdbbd65d917deab61e2f5035afecafaa687
   AWSCognitoIdentityProvider: f9031fc36af73a1e6a3c7476cbd536c1d4f7591c

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Operation/AWSTranscribeOperation.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Operation/AWSTranscribeOperation.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import Amplify
-import AWSMobileClient
 import AWSPluginsCore
 
 public class AWSTranscribeOperation: AmplifyOperation<

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Operation/IdentifyOperation.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Operation/IdentifyOperation.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import Amplify
-import AWSMobileClient
 import AWSPluginsCore
 
 public class IdentifyOperation: AmplifyOperation<

--- a/AmplifyPlugins/Predictions/Podfile.lock
+++ b/AmplifyPlugins/Predictions/Podfile.lock
@@ -12,9 +12,11 @@ PODS:
   - AmplifyTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AmplifyTestCommon/AWSPluginsTestCommon (= 1.5.1)
+    - AWSMobileClient (~> 2.20.0)
   - AmplifyTestCommon/AWSPluginsTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
+    - AWSMobileClient (~> 2.20.0)
     - AWSPluginsCore (= 1.5.1)
   - AWSAuthCore (2.20.0):
     - AWSCore (= 2.20.0)
@@ -33,7 +35,6 @@ PODS:
   - AWSPluginsCore (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
-    - AWSMobileClient (~> 2.20.0)
   - AWSPolly (2.20.0):
     - AWSCore (= 2.20.0)
   - AWSRekognition (2.20.0):
@@ -48,7 +49,7 @@ PODS:
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.41.0)
+  - SwiftLint (0.42.0)
 
 DEPENDENCIES:
   - Amplify (from `../../`)
@@ -108,15 +109,15 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Amplify: c55f7bf2c6ea68891d95579882172c1256f301fc
-  AmplifyPlugins: 78d2e39e1d5db18ae50c215063790f300607d312
-  AmplifyTestCommon: 60a44eefba338d8d9809f3d2740422805bfaad9f
+  AmplifyPlugins: 40f1051d1e8313a74c16bafe0618d460bf0479db
+  AmplifyTestCommon: 66ec23a49a2c18c722956782d0fa647f7421417a
   AWSAuthCore: 6a5f0fdbbd65d917deab61e2f5035afecafaa687
   AWSCognitoIdentityProvider: f9031fc36af73a1e6a3c7476cbd536c1d4f7591c
   AWSCognitoIdentityProviderASF: c126563dd240709a5acf2c15910ea4c872c65df3
   AWSComprehend: 694b52d7dc4bfd1ffd4467cec3c17186c5a3f52d
   AWSCore: e8748f1d2e97874ff5638fe7c3c31431ad223b4a
   AWSMobileClient: f98f4d3eb4d0f893a128b5546a31fd2cbc88e2ef
-  AWSPluginsCore: 3afe92313f5be7f002a48007e6645b5ab58e05a7
+  AWSPluginsCore: 03651a5904baf7d0e4d79addda7bcd8344d17bec
   AWSPolly: 85134dee8a97c2c84012cd1436ac9a6e0a34602b
   AWSRekognition: b9807a9a019637a15caaaf4c377683f156f3e431
   AWSTextract: f9080ea05cd5319e6de2c10a3db54f5c8f3f6b3c
@@ -125,7 +126,7 @@ SPEC CHECKSUMS:
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
+  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
 
 PODFILE CHECKSUM: 65cca76c6059f8ccc8628936971fb9e4b035fb10
 

--- a/AmplifyPlugins/Predictions/Podfile.lock
+++ b/AmplifyPlugins/Predictions/Podfile.lock
@@ -12,7 +12,6 @@ PODS:
   - AmplifyTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AmplifyTestCommon/AWSPluginsTestCommon (= 1.5.1)
-    - AWSMobileClient (~> 2.20.0)
   - AmplifyTestCommon/AWSPluginsTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
@@ -110,7 +109,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Amplify: c55f7bf2c6ea68891d95579882172c1256f301fc
   AmplifyPlugins: 40f1051d1e8313a74c16bafe0618d460bf0479db
-  AmplifyTestCommon: 66ec23a49a2c18c722956782d0fa647f7421417a
+  AmplifyTestCommon: 40a2413a5fba88dd89b99ece6d467ff0951a7c2c
   AWSAuthCore: 6a5f0fdbbd65d917deab61e2f5035afecafaa687
   AWSCognitoIdentityProvider: f9031fc36af73a1e6a3c7476cbd536c1d4f7591c
   AWSCognitoIdentityProviderASF: c126563dd240709a5acf2c15910ea4c872c65df3

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
@@ -8,7 +8,6 @@
 import Foundation
 import AWSS3
 import Amplify
-import AWSMobileClient
 import AWSPluginsCore
 
 class AWSS3StorageService: AWSS3StorageServiceBehaviour {

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Utils/StorageErrorHelper.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Utils/StorageErrorHelper.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import AWSMobileClient
 import Amplify
 import AWSS3
 

--- a/AmplifyPlugins/Storage/Podfile.lock
+++ b/AmplifyPlugins/Storage/Podfile.lock
@@ -12,9 +12,11 @@ PODS:
   - AmplifyTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AmplifyTestCommon/AWSPluginsTestCommon (= 1.5.1)
+    - AWSMobileClient (~> 2.20.0)
   - AmplifyTestCommon/AWSPluginsTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
+    - AWSMobileClient (~> 2.20.0)
     - AWSPluginsCore (= 1.5.1)
   - AWSAuthCore (2.20.0):
     - AWSCore (= 2.20.0)
@@ -31,14 +33,13 @@ PODS:
   - AWSPluginsCore (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
-    - AWSMobileClient (~> 2.20.0)
   - AWSS3 (2.20.0):
     - AWSCore (= 2.20.0)
   - CwlCatchException (1.0.2)
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.41.0)
+  - SwiftLint (0.42.0)
 
 DEPENDENCIES:
   - Amplify (from `../../`)
@@ -88,19 +89,19 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Amplify: c55f7bf2c6ea68891d95579882172c1256f301fc
-  AmplifyPlugins: 78d2e39e1d5db18ae50c215063790f300607d312
-  AmplifyTestCommon: 60a44eefba338d8d9809f3d2740422805bfaad9f
+  AmplifyPlugins: 40f1051d1e8313a74c16bafe0618d460bf0479db
+  AmplifyTestCommon: 66ec23a49a2c18c722956782d0fa647f7421417a
   AWSAuthCore: 6a5f0fdbbd65d917deab61e2f5035afecafaa687
   AWSCognitoIdentityProvider: f9031fc36af73a1e6a3c7476cbd536c1d4f7591c
   AWSCognitoIdentityProviderASF: c126563dd240709a5acf2c15910ea4c872c65df3
   AWSCore: e8748f1d2e97874ff5638fe7c3c31431ad223b4a
   AWSMobileClient: f98f4d3eb4d0f893a128b5546a31fd2cbc88e2ef
-  AWSPluginsCore: 3afe92313f5be7f002a48007e6645b5ab58e05a7
+  AWSPluginsCore: 03651a5904baf7d0e4d79addda7bcd8344d17bec
   AWSS3: ad208d641f06eaf57e01db2071c09c9e50e17b0f
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
+  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
 
 PODFILE CHECKSUM: 23c3028505a2f56c001d01c66c1622dff6f8dd8e
 

--- a/AmplifyPlugins/Storage/Podfile.lock
+++ b/AmplifyPlugins/Storage/Podfile.lock
@@ -12,7 +12,6 @@ PODS:
   - AmplifyTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AmplifyTestCommon/AWSPluginsTestCommon (= 1.5.1)
-    - AWSMobileClient (~> 2.20.0)
   - AmplifyTestCommon/AWSPluginsTestCommon (1.5.1):
     - Amplify (= 1.5.1)
     - AWSCore (~> 2.20.0)
@@ -90,7 +89,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Amplify: c55f7bf2c6ea68891d95579882172c1256f301fc
   AmplifyPlugins: 40f1051d1e8313a74c16bafe0618d460bf0479db
-  AmplifyTestCommon: 66ec23a49a2c18c722956782d0fa647f7421417a
+  AmplifyTestCommon: 40a2413a5fba88dd89b99ece6d467ff0951a7c2c
   AWSAuthCore: 6a5f0fdbbd65d917deab61e2f5035afecafaa687
   AWSCognitoIdentityProvider: f9031fc36af73a1e6a3c7476cbd536c1d4f7591c
   AWSCognitoIdentityProviderASF: c126563dd240709a5acf2c15910ea4c872c65df3

--- a/AmplifyTestCommon.podspec
+++ b/AmplifyTestCommon.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
   s.subspec 'AWSPluginsTestCommon' do |ss|
     ss.source_files = 'AmplifyPlugins/Core/AWSPluginsTestCommon/**/*.swift'
     ss.dependency 'AWSPluginsCore', $AMPLIFY_VERSION
-    s.dependency 'AWSMobileClient', $OPTIMISTIC_AWS_SDK_VERSION
+    ss.dependency 'AWSMobileClient', $OPTIMISTIC_AWS_SDK_VERSION
     ss.dependency 'AWSCore', $OPTIMISTIC_AWS_SDK_VERSION
   end
 

--- a/AmplifyTestCommon.podspec
+++ b/AmplifyTestCommon.podspec
@@ -35,6 +35,7 @@ Pod::Spec.new do |s|
   s.subspec 'AWSPluginsTestCommon' do |ss|
     ss.source_files = 'AmplifyPlugins/Core/AWSPluginsTestCommon/**/*.swift'
     ss.dependency 'AWSPluginsCore', $AMPLIFY_VERSION
+    s.dependency 'AWSMobileClient', $OPTIMISTIC_AWS_SDK_VERSION
     ss.dependency 'AWSCore', $OPTIMISTIC_AWS_SDK_VERSION
   end
 

--- a/Podfile
+++ b/Podfile
@@ -27,7 +27,7 @@ target "Amplify" do
     inherit! :complete
     use_frameworks!
 
-    pod "AWSMobileClient", $OPTIMISTIC_AWS_SDK_VERSION
+    pod "AWSCore", $OPTIMISTIC_AWS_SDK_VERSION
 
     abstract_target "AWSPluginsTestConfigs" do
       include_test_utilities!

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,9 +15,10 @@ PODS:
   - CwlPreconditionTesting (1.1.1):
     - CwlCatchException
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.41.0)
+  - SwiftLint (0.42.0)
 
 DEPENDENCIES:
+  - AWSCore (~> 2.20.0)
   - AWSMobileClient (~> 2.20.0)
   - CwlCatchException (from `https://github.com/mattgallagher/CwlCatchException.git`, tag `1.2.0`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `1.2.0`)
@@ -59,8 +60,8 @@ SPEC CHECKSUMS:
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
+  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
 
-PODFILE CHECKSUM: a2acde35ab1bc6b80b362106cfda70905a6a840f
+PODFILE CHECKSUM: 1d9ff7be63820d403791eafdd9293066f537344a
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
*Description of changes:* AWSPluginsCore has a dependency on AWSMobileClient which is not required. This PR removes the dependency from AWSMobileClient to the test package.

These are the changes in this PR:

- AWSPluginsCore depend on AWSCore instead of AWSMobileClient
- AmplifyTestCommon to depend on AWSMobileClient
- Remove AWSMobileClient import from unwanted places
- Code cleanup

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
