### PR TITLE
feat(auth): Fix cancelling hostedUI returning a generic error

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -148,7 +148,7 @@ extension AuthenticationProviderAdapter {
                         guard let self = self else { return }
 
                         if let error = error {
-                            let authError = self.convertSignUIErrorToAuthError(error)
+                            let authError = self.convertSignInUIErrorToAuthError(error)
                             completionHandler(.failure(authError))
                             return
                         }
@@ -182,7 +182,13 @@ extension AuthenticationProviderAdapter {
         return .failure(authError)
     }
 
-    private func convertSignUIErrorToAuthError(_ error: Error) -> AuthError {
+    private func convertSignInUIErrorToAuthError(_ error: Error) -> AuthError {
+        if AuthErrorHelper.didUserCancelHostedUI(error) {
+            return AuthError.service(
+                AuthPluginErrorConstants.hostedUIUserCancelledError.errorDescription,
+                AuthPluginErrorConstants.hostedUIUserCancelledError.recoverySuggestion,
+                AWSCognitoAuthError.userCancelled)
+        }
         if let awsMobileClientError = error as? AWSMobileClientError {
             switch awsMobileClientError {
             case .securityFailed(message: _):
@@ -207,7 +213,6 @@ extension AuthenticationProviderAdapter {
             default:
                 break
             }
-
         }
         let authError = AuthErrorHelper.toAuthError(error)
         return authError

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAttributeResendConfirmationCodeOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAttributeResendConfirmationCodeOptions.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+// swiftlint:disable type_name
 public struct AWSAttributeResendConfirmationCodeOptions {
 
     public let metadata: [String: String]?

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Constants/AuthPluginErrorConstants.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Constants/AuthPluginErrorConstants.swift
@@ -36,6 +36,10 @@ struct AuthPluginErrorConstants {
         "User cancelled the signIn flow and could not be completed.",
         "Present the signIn UI again for the user to sign in.")
 
+    static let hostedUIUserCancelledSignOutError: AuthPluginErrorString = (
+        "User cancelled the signOut flow and could not be completed.",
+        "Present the signOut UI again for the user to sign out.")
+
     static let userInvalidError: AuthPluginErrorString = (
         "Could not validate the user",
         "Get the current user Auth.getCurrentUser() and make the request")

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AuthErrorHelper.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AuthErrorHelper.swift
@@ -7,6 +7,8 @@
 
 import Amplify
 import AWSMobileClient
+import SafariServices
+import AuthenticationServices
 
 struct AuthErrorHelper {
 
@@ -164,5 +166,22 @@ struct AuthErrorHelper {
         }
         return AuthError.unknown("An unknown error occurred", error)
 
+    }
+
+    static func didUserCancelHostedUI(_ error: Error) -> Bool {
+        if let sfAuthError = error as? SFAuthenticationError,
+           case SFAuthenticationError.Code.canceledLogin = sfAuthError.code {
+            return true
+        }
+
+        if #available(iOS 12.0, *) {
+
+            if let asWebAuthError = error as? ASWebAuthenticationSessionError,
+               case ASWebAuthenticationSessionError.Code.canceledLogin = asWebAuthError.code {
+                return true
+            }
+        }
+
+        return false
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithSocialWebUITests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithSocialWebUITests.swift
@@ -95,13 +95,49 @@ class AuthenticationProviderSigninWithSocialWebUITests: BaseAuthenticationProvid
     /// - Given: an auth plugin with mocked service.
     ///
     /// - When:
-    ///    - I invoke signInWithWebUI and mock cancel
+    ///    - I invoke signInWithWebUI and mock cancel using SFAuthenticationError
     /// - Then:
-    ///    - I should get a SFAuthenticationError.canceledLogin error
+    ///    - I should get a AWSCognitoAuthError.userCancelled error
     ///
     func testCancelSignIn() {
-        let mockError = NSError(domain: "com.apple.SafariServices.Authentication",
+        let mockError = NSError(domain: SFAuthenticationErrorDomain,
                                 code: SFAuthenticationError.canceledLogin.rawValue,
+                                userInfo: nil)
+        mockAWSMobileClient?.showSignInMockResult = .failure(mockError)
+        let options = AuthWebUISignInRequest.Options()
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signInWithWebUI(for: .amazon, presentationAnchor: window, options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should throw user cancelled error, instead - \(signinResult)")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .userCancelled = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce SFAuthenticationError error but instead produced \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signInWithWebUI when the user cancel
+    ///
+    /// - Given: an auth plugin with mocked service.
+    ///
+    /// - When:
+    ///    - I invoke signInWithWebUI and mock cancel using ASWebAuthenticationSessionError
+    /// - Then:
+    ///    - I should get a AWSCognitoAuthError.userCancelled error
+    ///
+    @available(iOS 12.0, *)
+    func testASWebAuthenticationSessionError() {
+        let mockError = NSError(domain: ASWebAuthenticationSessionErrorDomain,
+                                code: ASWebAuthenticationSessionError.canceledLogin.rawValue,
                                 userInfo: nil)
         mockAWSMobileClient?.showSignInMockResult = .failure(mockError)
         let options = AuthWebUISignInRequest.Options()

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithSocialWebUITests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithSocialWebUITests.swift
@@ -153,7 +153,7 @@ class AuthenticationProviderSigninWithSocialWebUITests: BaseAuthenticationProvid
             case .failure(let error):
                 guard case .service(_, _, let underlyingError) = error,
                       case .userCancelled = (underlyingError as? AWSCognitoAuthError) else {
-                    XCTFail("Should produce SFAuthenticationError error but instead produced \(error)")
+                    XCTFail("Should produce AWSCognitoAuthError error but instead produced \(error)")
                     return
                 }
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithSocialWebUITests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithSocialWebUITests.swift
@@ -117,7 +117,7 @@ class AuthenticationProviderSigninWithSocialWebUITests: BaseAuthenticationProvid
             case .failure(let error):
                 guard case .service(_, _, let underlyingError) = error,
                       case .userCancelled = (underlyingError as? AWSCognitoAuthError) else {
-                    XCTFail("Should produce SFAuthenticationError error but instead produced \(error)")
+                    XCTFail("Should produce AWSCognitoAuthError error but instead produced \(error)")
                     return
                 }
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithSocialWebUITests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithSocialWebUITests.swift
@@ -115,8 +115,8 @@ class AuthenticationProviderSigninWithSocialWebUITests: BaseAuthenticationProvid
             case .success(let signinResult):
                 XCTFail("Should throw user cancelled error, instead - \(signinResult)")
             case .failure(let error):
-                guard case .unknown(_, let underlyingError) = error,
-                      case .canceledLogin = (underlyingError as? SFAuthenticationError)?.code else {
+                guard case .service(_, _, let underlyingError) = error,
+                      case .userCancelled = (underlyingError as? AWSCognitoAuthError) else {
                     XCTFail("Should produce SFAuthenticationError error but instead produced \(error)")
                     return
                 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithWebUITests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithWebUITests.swift
@@ -115,9 +115,9 @@ class AuthenticationProviderSigninWithWebUITests: BaseAuthenticationProviderTest
             case .success(let signinResult):
                 XCTFail("Should throw user cancelled error, instead - \(signinResult)")
             case .failure(let error):
-                guard case .unknown(_, let underlyingError) = error,
-                      case .canceledLogin = (underlyingError as? SFAuthenticationError)?.code else {
-                    XCTFail("Should produce SFAuthenticationError error but instead produced \(error)")
+                guard case .service(_, _, let underlyingError) = error,
+                      case .userCancelled = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce userCancelled error but instead produced \(error)")
                     return
                 }
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignoutTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignoutTests.swift
@@ -293,9 +293,9 @@ class AuthenticationProviderSignoutTests: BaseAuthenticationProviderTest {
             case .success:
                 XCTFail("Should not get success")
             case .failure(let error):
-                guard case .unknown(_, let underlyingError) = error,
-                      case .canceledLogin = (underlyingError as? SFAuthenticationError)?.code else {
-                    XCTFail("Should produce SFAuthenticationError error instead of \(error)")
+                guard case .service(_, _, let underlyingError) = error,
+                      case .userCancelled = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce userCancelled error instead of \(error)")
                     return
                 }
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignoutTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignoutTests.swift
@@ -275,14 +275,51 @@ class AuthenticationProviderSignoutTests: BaseAuthenticationProviderTest {
     /// - When:
     ///    - I invoke signOut
     /// - Then:
-    ///    - I should get a SFAuthenticationError.canceledLogin error
+    ///    - I should get a AWSCognitoAuthError.userCancelled error
     ///
     func testSignOutWithUserCancel() {
-        let error = NSError(domain: "com.apple.SafariServices.Authentication",
+        let error = NSError(domain: SFAuthenticationErrorDomain,
                             code: SFAuthenticationError.canceledLogin.rawValue,
                             userInfo: nil)
         let options = AuthSignOutRequest.Options()
         mockAWSMobileClient.signOutMockError = error
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signOut(options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+
+            switch result {
+            case .success:
+                XCTFail("Should not get success")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error,
+                      case .userCancelled = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Should produce userCancelled error instead of \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signOut with userCancelled from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   ASWeb UserCancelled response
+    ///
+    /// - When:
+    ///    - I invoke signOut
+    /// - Then:
+    ///    - I should get a AWSCognitoAuthError.userCancelled error
+    ///
+    @available(iOS 12.0, *)
+    func testASWebAuthSignOutWithUserCancel() {
+        let mockError = NSError(domain: ASWebAuthenticationSessionErrorDomain,
+                                code: ASWebAuthenticationSessionError.canceledLogin.rawValue,
+                                userInfo: nil)
+        let options = AuthSignOutRequest.Options()
+        mockAWSMobileClient.signOutMockError = mockError
         let resultExpectation = expectation(description: "Should receive a result")
         _ = plugin.signOut(options: options) { result in
             defer {

--- a/AmplifyPlugins/Auth/Podfile.lock
+++ b/AmplifyPlugins/Auth/Podfile.lock
@@ -10,18 +10,18 @@ PODS:
     - AWSCore (~> 2.22.0)
     - AWSMobileClient (~> 2.22.0)
     - AWSPluginsCore (= 1.5.5)
-  - AWSAuthCore (2.22.0):
-    - AWSCore (= 2.22.0)
-  - AWSCognitoIdentityProvider (2.22.0):
-    - AWSCognitoIdentityProviderASF (= 2.22.0)
-    - AWSCore (= 2.22.0)
-  - AWSCognitoIdentityProviderASF (2.22.0)
-  - AWSCore (2.22.0)
-  - AWSMobileClient (2.22.0):
-    - AWSAuthCore (= 2.22.0)
-    - AWSCognitoIdentityProvider (= 2.22.0)
-    - AWSCognitoIdentityProviderASF (= 2.22.0)
-    - AWSCore (= 2.22.0)
+  - AWSAuthCore (2.22.1):
+    - AWSCore (= 2.22.1)
+  - AWSCognitoIdentityProvider (2.22.1):
+    - AWSCognitoIdentityProviderASF (= 2.22.1)
+    - AWSCore (= 2.22.1)
+  - AWSCognitoIdentityProviderASF (2.22.1)
+  - AWSCore (2.22.1)
+  - AWSMobileClient (2.22.1):
+    - AWSAuthCore (= 2.22.1)
+    - AWSCognitoIdentityProvider (= 2.22.1)
+    - AWSCognitoIdentityProviderASF (= 2.22.1)
+    - AWSCore (= 2.22.1)
   - AWSPluginsCore (1.5.5):
     - Amplify (= 1.5.5)
     - AWSCore (~> 2.22.0)
@@ -76,11 +76,11 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Amplify: 975fe3981790cf06e605353d2e704fc0985a45f3
   AmplifyTestCommon: 4e33dad284eca69acdb7511418c877967c0fc5da
-  AWSAuthCore: b54e2008da479e5a6ffdb6b482821d8f5a9afaa4
-  AWSCognitoIdentityProvider: 32a91ad644e49e40235a408a8fbb96ea74891f19
-  AWSCognitoIdentityProviderASF: 8b92721c17f2951ecd5bcfb749d5534f2851c2c7
-  AWSCore: 8bd1def9cb0b6770c65b6d394f1c1cbc0a5562b7
-  AWSMobileClient: bba690cc09c6569cc1111141beaa4e2f789f536b
+  AWSAuthCore: ad355f72d2d3e56939fb3b2965b796a93091cdf1
+  AWSCognitoIdentityProvider: 33e00e930891f899c27c007b33863e79b4b896af
+  AWSCognitoIdentityProviderASF: ac1574ea9fda4877400ecef9004e4e5759eb4961
+  AWSCore: f3f2e25cf5b4cb58b9561b48987d4fdd019227c2
+  AWSMobileClient: 70c694a0399c37084edaaebe8e1f1b6f21fd299f
   AWSPluginsCore: 358365037f62d5bc995037d6eb687f39582d90d0
   CwlCatchException: 70a52ae44ea5d46db7bd385f801a94942420cd8c
   CwlPreconditionTesting: d33a4e4f285c0b885fddcae5dfedfbb34d4f3961


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-ios/issues/967

*Description of changes:*

- This is a behavior change and potential break the current customers, please see Before and After effect below
- Cancelling HostedUI signOut now returns `userCancelled` similar to the cancelling signIn
- Added unit test for the hostedUI flow

*Other platform behavior:*

**Android**

Android currently returns AuthException that contains AWSMobileClient error AuthNavigationException. This certainly needs to change because Amplify apis should not return AWSMobileClient specific errors. 

```
AuthException{
  message=Sign in with web UI failed
  cause=AuthNavigationException{
    message=user cancelled
  }
  recoverySuggestion=See attached exception for more details
}
```
Android PR to fix - https://github.com/aws-amplify/amplify-android/pull/1073

**Flutter**

Flutter has not implemented hostedUI yet and currently in PR - https://github.com/aws-amplify/amplify-flutter/pull/154 So, if we can push this change sooner Flutter can support this.

---
Before this PR

```swift
        Amplify.Auth.signInWithWebUI(presentationAnchor: self.view.window!) { (result) in
            
            switch result {
            case .success(let result):
                print(result)
            case .failure(let error):
                if case AuthError.unknown(_, let underlyingError) = error,
                   case .canceledLogin = (underlyingError as? SFAuthenticationError)?.code {
                       print("User cancelled")
                }
            }
        }

         // SignOut
        Amplify.Auth.signOut(listener: { (result) in
            
            switch result {
            case .success:
                print("SignOut")
            case .failure(let error):
                if case AuthError.unknown(_, let underlyingError) = error,
                   case .canceledLogin = (underlyingError as? SFAuthenticationError)?.code {
                       print("User cancelled")
                }
            }
        })
```

---
After this PR

```swift

Amplify.Auth.signInWithWebUI(presentationAnchor: self.view.window!) { (result) in
            
            switch result {
            case .success(let result):
                print(result)
            case .failure(let error):
                if case AuthError.service(_, _, let underlyingError) = error,
                   case .userCancelled = (underlyingError as? AWSCognitoAuthError) {
                    print("User cancelled")
                }
            }
        }

// SignOut

Amplify.Auth.signOut(listener: { (result) in
            
            switch result {
            case .success:
                print("SignOut")
            case .failure(let error):
                if case AuthError.service(_, _, let underlyingError) = error,
                   case .userCancelled = (underlyingError as? AWSCognitoAuthError) {
                    print("User cancelled")
                }
            }
        })

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
