### PR TITLE
fix(DataStore): Generate mutation events for associatedModels

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		2CFB61C7E80D065C0A885A2F /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsTestCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5363CAF9EFAA822FED56808 /* Pods_Amplify_AWSPluginsCore_AWSPluginsTestConfigs_AWSPluginsTestCommon.framework */; };
 		3263D332138415AF42E64FF7 /* Pods_AmplifyTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC7F1C368154B364CB74742 /* Pods_AmplifyTestApp.framework */; };
 		6B33896823AAACC900561E5B /* ReachabilityUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B33896723AAACC900561E5B /* ReachabilityUpdate.swift */; };
+		6B452B8225A7D0F600A1A811 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B452B8125A7D0F600A1A811 /* Array+Extensions.swift */; };
 		6B5087BD2565E5AD000AB673 /* QueryPredicateEvaluateGeneratedDoubleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5087BC2565E5AD000AB673 /* QueryPredicateEvaluateGeneratedDoubleTests.swift */; };
 		6B5087C125662DC3000AB673 /* QueryPredicateEvaluateGeneratedDoubleIntTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5087C025662DC3000AB673 /* QueryPredicateEvaluateGeneratedDoubleIntTests.swift */; };
 		6B5087C3256630DB000AB673 /* QueryPredicateEvaluateGeneratedIntTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5087C2256630DB000AB673 /* QueryPredicateEvaluateGeneratedIntTests.swift */; };
@@ -181,6 +182,13 @@
 		6B597A0B2565D3E50038C3E2 /* QPredGen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B597A092565D3E50038C3E2 /* QPredGen.swift */; };
 		6B767FB723AC092800C683ED /* AmplifyAPICategory+ReachabilityBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B767FB623AC092800C683ED /* AmplifyAPICategory+ReachabilityBehavior.swift */; };
 		6B767FB923AC0A0D00C683ED /* APICategoryReachabilityBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B767FB823AC0A0D00C683ED /* APICategoryReachabilityBehavior.swift */; };
+		6B7743DE25906FD3001469F5 /* Menu+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7743D725906FD2001469F5 /* Menu+Schema.swift */; };
+		6B7743DF25906FD3001469F5 /* Dish.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7743D825906FD2001469F5 /* Dish.swift */; };
+		6B7743E025906FD3001469F5 /* Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7743D925906FD2001469F5 /* Menu.swift */; };
+		6B7743E125906FD3001469F5 /* MenuType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7743DA25906FD2001469F5 /* MenuType.swift */; };
+		6B7743E225906FD3001469F5 /* Dish+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7743DB25906FD2001469F5 /* Dish+Schema.swift */; };
+		6B7743E325906FD3001469F5 /* Restaurant+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7743DC25906FD2001469F5 /* Restaurant+Schema.swift */; };
+		6B7743E425906FD3001469F5 /* Restaurant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7743DD25906FD2001469F5 /* Restaurant.swift */; };
 		6B9F7C5225267E1500F1F71C /* MockAWSAuthUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9F7C5125267E1500F1F71C /* MockAWSAuthUser.swift */; };
 		6B9F7C552526864800F1F71C /* ScenarioATest6Post+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9F7C532526864800F1F71C /* ScenarioATest6Post+Schema.swift */; };
 		6B9F7C562526864800F1F71C /* ScenarioATest6Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9F7C542526864800F1F71C /* ScenarioATest6Post.swift */; };
@@ -192,6 +200,16 @@
 		6BDD6320256353F0008D70DF /* Evaluable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDD631F256353F0008D70DF /* Evaluable.swift */; };
 		6BDF15B62541262000B5BE69 /* ModelWithOwnerAuthAndGroupWithGroupClaim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDF15B52541262000B5BE69 /* ModelWithOwnerAuthAndGroupWithGroupClaim.swift */; };
 		6BDF15B825412DE600B5BE69 /* ModelWithOwnerAuthAndMultiGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDF15B725412DE600B5BE69 /* ModelWithOwnerAuthAndMultiGroup.swift */; };
+		6BE9D6EC25A6622000AB5C9A /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D6E825A6621F00AB5C9A /* Project.swift */; };
+		6BE9D6ED25A6622000AB5C9A /* Project+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D6E925A6621F00AB5C9A /* Project+Schema.swift */; };
+		6BE9D6EE25A6622000AB5C9A /* Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D6EA25A6621F00AB5C9A /* Team.swift */; };
+		6BE9D6EF25A6622000AB5C9A /* Team+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D6EB25A6622000AB5C9A /* Team+Schema.swift */; };
+		6BE9D73725A67F7400AB5C9A /* M2MPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D73125A67F7300AB5C9A /* M2MPost.swift */; };
+		6BE9D73825A67F7400AB5C9A /* M2MPostEditor+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D73225A67F7300AB5C9A /* M2MPostEditor+Schema.swift */; };
+		6BE9D73925A67F7400AB5C9A /* M2MPost+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D73325A67F7400AB5C9A /* M2MPost+Schema.swift */; };
+		6BE9D73A25A67F7400AB5C9A /* M2MUser+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D73425A67F7400AB5C9A /* M2MUser+Schema.swift */; };
+		6BE9D73B25A67F7400AB5C9A /* M2MPostEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D73525A67F7400AB5C9A /* M2MPostEditor.swift */; };
+		6BE9D73C25A67F7400AB5C9A /* M2MUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D73625A67F7400AB5C9A /* M2MUser.swift */; };
 		6BEE0817253114FD00133961 /* AWSAuthServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE0816253114FD00133961 /* AWSAuthServiceTests.swift */; };
 		6BEE08192533CAA600133961 /* GraphQLRequestOwnerAndGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE08182533CAA600133961 /* GraphQLRequestOwnerAndGroupTests.swift */; };
 		6BEE081C2533CCFA00133961 /* OGCScenarioBPost+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE081A2533CCFA00133961 /* OGCScenarioBPost+Schema.swift */; };
@@ -982,6 +1000,7 @@
 		687B09E9348F8D29979A2404 /* Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests/Pods-Amplify-AmplifyAWSPlugins-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6AF0E4775809F0866F9C44D9 /* Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig"; path = "Target Support Files/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6B33896723AAACC900561E5B /* ReachabilityUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReachabilityUpdate.swift; sourceTree = "<group>"; };
+		6B452B8125A7D0F600A1A811 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		6B5087BC2565E5AD000AB673 /* QueryPredicateEvaluateGeneratedDoubleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPredicateEvaluateGeneratedDoubleTests.swift; sourceTree = "<group>"; };
 		6B5087C025662DC3000AB673 /* QueryPredicateEvaluateGeneratedDoubleIntTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPredicateEvaluateGeneratedDoubleIntTests.swift; sourceTree = "<group>"; };
 		6B5087C2256630DB000AB673 /* QueryPredicateEvaluateGeneratedIntTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPredicateEvaluateGeneratedIntTests.swift; sourceTree = "<group>"; };
@@ -999,6 +1018,13 @@
 		6B597A092565D3E50038C3E2 /* QPredGen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QPredGen.swift; sourceTree = "<group>"; };
 		6B767FB623AC092800C683ED /* AmplifyAPICategory+ReachabilityBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AmplifyAPICategory+ReachabilityBehavior.swift"; sourceTree = "<group>"; };
 		6B767FB823AC0A0D00C683ED /* APICategoryReachabilityBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICategoryReachabilityBehavior.swift; sourceTree = "<group>"; };
+		6B7743D725906FD2001469F5 /* Menu+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Menu+Schema.swift"; sourceTree = "<group>"; };
+		6B7743D825906FD2001469F5 /* Dish.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dish.swift; sourceTree = "<group>"; };
+		6B7743D925906FD2001469F5 /* Menu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Menu.swift; sourceTree = "<group>"; };
+		6B7743DA25906FD2001469F5 /* MenuType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuType.swift; sourceTree = "<group>"; };
+		6B7743DB25906FD2001469F5 /* Dish+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dish+Schema.swift"; sourceTree = "<group>"; };
+		6B7743DC25906FD2001469F5 /* Restaurant+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Restaurant+Schema.swift"; sourceTree = "<group>"; };
+		6B7743DD25906FD2001469F5 /* Restaurant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Restaurant.swift; sourceTree = "<group>"; };
 		6B9F7C5125267E1500F1F71C /* MockAWSAuthUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSAuthUser.swift; sourceTree = "<group>"; };
 		6B9F7C532526864800F1F71C /* ScenarioATest6Post+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ScenarioATest6Post+Schema.swift"; sourceTree = "<group>"; };
 		6B9F7C542526864800F1F71C /* ScenarioATest6Post.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScenarioATest6Post.swift; sourceTree = "<group>"; };
@@ -1011,6 +1037,16 @@
 		6BDD631F256353F0008D70DF /* Evaluable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Evaluable.swift; sourceTree = "<group>"; };
 		6BDF15B52541262000B5BE69 /* ModelWithOwnerAuthAndGroupWithGroupClaim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelWithOwnerAuthAndGroupWithGroupClaim.swift; sourceTree = "<group>"; };
 		6BDF15B725412DE600B5BE69 /* ModelWithOwnerAuthAndMultiGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelWithOwnerAuthAndMultiGroup.swift; sourceTree = "<group>"; };
+		6BE9D6E825A6621F00AB5C9A /* Project.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
+		6BE9D6E925A6621F00AB5C9A /* Project+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Project+Schema.swift"; sourceTree = "<group>"; };
+		6BE9D6EA25A6621F00AB5C9A /* Team.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Team.swift; sourceTree = "<group>"; };
+		6BE9D6EB25A6622000AB5C9A /* Team+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Team+Schema.swift"; sourceTree = "<group>"; };
+		6BE9D73125A67F7300AB5C9A /* M2MPost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = M2MPost.swift; sourceTree = "<group>"; };
+		6BE9D73225A67F7300AB5C9A /* M2MPostEditor+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "M2MPostEditor+Schema.swift"; sourceTree = "<group>"; };
+		6BE9D73325A67F7400AB5C9A /* M2MPost+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "M2MPost+Schema.swift"; sourceTree = "<group>"; };
+		6BE9D73425A67F7400AB5C9A /* M2MUser+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "M2MUser+Schema.swift"; sourceTree = "<group>"; };
+		6BE9D73525A67F7400AB5C9A /* M2MPostEditor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = M2MPostEditor.swift; sourceTree = "<group>"; };
+		6BE9D73625A67F7400AB5C9A /* M2MUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = M2MUser.swift; sourceTree = "<group>"; };
 		6BEE0816253114FD00133961 /* AWSAuthServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAuthServiceTests.swift; sourceTree = "<group>"; };
 		6BEE08182533CAA600133961 /* GraphQLRequestOwnerAndGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRequestOwnerAndGroupTests.swift; sourceTree = "<group>"; };
 		6BEE081A2533CCFA00133961 /* OGCScenarioBPost+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OGCScenarioBPost+Schema.swift"; sourceTree = "<group>"; };
@@ -2274,6 +2310,20 @@
 			path = Query;
 			sourceTree = "<group>";
 		};
+		6B7743D625906F7E001469F5 /* Restaurant */ = {
+			isa = PBXGroup;
+			children = (
+				6B7743D825906FD2001469F5 /* Dish.swift */,
+				6B7743DB25906FD2001469F5 /* Dish+Schema.swift */,
+				6B7743D925906FD2001469F5 /* Menu.swift */,
+				6B7743D725906FD2001469F5 /* Menu+Schema.swift */,
+				6B7743DA25906FD2001469F5 /* MenuType.swift */,
+				6B7743DD25906FD2001469F5 /* Restaurant.swift */,
+				6B7743DC25906FD2001469F5 /* Restaurant+Schema.swift */,
+			);
+			path = Restaurant;
+			sourceTree = "<group>";
+		};
 		6BBECD6F23ADA7C100C8DFBE /* ServiceConfiguration */ = {
 			isa = PBXGroup;
 			children = (
@@ -2289,6 +2339,30 @@
 				6BBECD7323ADA9D100C8DFBE /* AmplifyAWSServiceConfigurationTests.swift */,
 			);
 			path = ServiceConfiguration;
+			sourceTree = "<group>";
+		};
+		6BE9D6E725A6620B00AB5C9A /* TeamProject */ = {
+			isa = PBXGroup;
+			children = (
+				6BE9D6E825A6621F00AB5C9A /* Project.swift */,
+				6BE9D6E925A6621F00AB5C9A /* Project+Schema.swift */,
+				6BE9D6EA25A6621F00AB5C9A /* Team.swift */,
+				6BE9D6EB25A6622000AB5C9A /* Team+Schema.swift */,
+			);
+			path = TeamProject;
+			sourceTree = "<group>";
+		};
+		6BE9D73025A67F5A00AB5C9A /* M2MPostEditorUser */ = {
+			isa = PBXGroup;
+			children = (
+				6BE9D73125A67F7300AB5C9A /* M2MPost.swift */,
+				6BE9D73325A67F7400AB5C9A /* M2MPost+Schema.swift */,
+				6BE9D73525A67F7400AB5C9A /* M2MPostEditor.swift */,
+				6BE9D73225A67F7300AB5C9A /* M2MPostEditor+Schema.swift */,
+				6BE9D73625A67F7400AB5C9A /* M2MUser.swift */,
+				6BE9D73425A67F7400AB5C9A /* M2MUser+Schema.swift */,
+			);
+			path = M2MPostEditorUser;
 			sourceTree = "<group>";
 		};
 		6BEE0815253114E600133961 /* Auth */ = {
@@ -2737,6 +2811,7 @@
 				B9521830237E21B900F53237 /* Comment.swift */,
 				B952182E237E21B900F53237 /* Comment+Schema.swift */,
 				21AD4255249BFFDF0016FE95 /* DeprecatedTodo.swift */,
+				6BE9D73025A67F5A00AB5C9A /* M2MPostEditorUser */,
 				FAA2E8BB239FFC7700E420EA /* MockModels.swift */,
 				216E45E9248E91420035E3CE /* NonModel */,
 				6BEE08222533D30800133961 /* OGCScenarioBMGroupPost.swift */,
@@ -2749,9 +2824,11 @@
 				B9AA09F02473CA29000E6FBB /* PostStatus.swift */,
 				6B597A092565D3E50038C3E2 /* QPredGen.swift */,
 				6B597A082565D3E40038C3E2 /* QPredGen+Schema.swift */,
+				6B7743D625906F7E001469F5 /* Restaurant */,
 				6B9F7C542526864800F1F71C /* ScenarioATest6Post.swift */,
 				6B9F7C532526864800F1F71C /* ScenarioATest6Post+Schema.swift */,
 				B952182F237E21B900F53237 /* schema.graphql */,
+				6BE9D6E725A6620B00AB5C9A /* TeamProject */,
 				214F49742486D8A200DA616C /* User.swift */,
 				214F49752486D8A200DA616C /* User+Schema.swift */,
 				214F49762486D8A200DA616C /* UserFollowers.swift */,
@@ -3055,6 +3132,7 @@
 				FAA7A5A524C0CC8F00CA863F /* AmplifyOperation+Combine.swift */,
 				FA5704CA245F58C600392C19 /* AmplifyOperation+Hub.swift */,
 				FAB9D810233BF5F600928AA9 /* AmplifyOperationContext.swift */,
+				6B452B8125A7D0F600A1A811 /* Array+Extensions.swift */,
 				21FFF986230B7A5D005878EA /* AsychronousOperation.swift */,
 				FAAFAF36239051E6002CF932 /* AtomicDictionary.swift */,
 				FAC6792C2329B267004DDFE8 /* AtomicValue.swift */,
@@ -4832,6 +4910,7 @@
 				95DAAB2D237E63370028544F /* EmotionType.swift in Sources */,
 				B4BD6B392370932300A1F0A7 /* PredictionsIdentifyRequest.swift in Sources */,
 				21409C5B2384C57D000A53C9 /* GraphQLQueryType.swift in Sources */,
+				6B452B8225A7D0F600A1A811 /* Array+Extensions.swift in Sources */,
 				B91A87A223D641570049A12F /* Temporal+Comparable.swift in Sources */,
 				95DAAB29237E63370028544F /* EntityDetectionResult.swift in Sources */,
 				FA31529E233D645800DE78E7 /* StorageUploadDataRequest.swift in Sources */,
@@ -5086,20 +5165,25 @@
 				21FDBB632587D7A30086FCDC /* Comment6.swift in Sources */,
 				217D5EC52577F9DF009F0639 /* Project2.swift in Sources */,
 				B4F3543525361E0E0050FEE0 /* DynamicModel.swift in Sources */,
+				6B7743E025906FD3001469F5 /* Menu.swift in Sources */,
 				217D5EC02577F9DF009F0639 /* Post3.swift in Sources */,
 				217D5EB02577F9DF009F0639 /* Post4.swift in Sources */,
 				217D5EB22577F9DF009F0639 /* PostEditor5+Schema.swift in Sources */,
 				21F40A3A23A294770074678E /* TestConfigHelper.swift in Sources */,
 				B4BD6B3723708C6700A1F0A7 /* MockPredictionsCategoryPlugin.swift in Sources */,
 				B4F3542C25361BC80050FEE0 /* DynamicEmbedded.swift in Sources */,
+				6B7743E125906FD3001469F5 /* MenuType.swift in Sources */,
 				FACA361C2327FC7D000E74F6 /* MockHubCategoryPlugin.swift in Sources */,
 				FAD3937F23820DAE00463F5E /* MockDataStoreCategoryPlugin.swift in Sources */,
 				217D5EBB2577F9DF009F0639 /* Team1.swift in Sources */,
 				6BEE08252533D30800133961 /* OGCScenarioBMGroupPost+Schema.swift in Sources */,
 				21FDBB662587D7A30086FCDC /* Blog6+Schema.swift in Sources */,
 				21FDBB612587D7A30086FCDC /* Blog6.swift in Sources */,
+				6BE9D73B25A67F7400AB5C9A /* M2MPostEditor.swift in Sources */,
+				6BE9D73A25A67F7400AB5C9A /* M2MUser+Schema.swift in Sources */,
 				FACA361A2327FC69000E74F6 /* MockStorageCategoryPlugin.swift in Sources */,
 				217D5EB92577F9DF009F0639 /* Post3+Schema.swift in Sources */,
+				6BE9D73925A67F7400AB5C9A /* M2MPost+Schema.swift in Sources */,
 				B9521837237E21BA00F53237 /* Post.swift in Sources */,
 				B9FAA11A23879AC8009414B4 /* BookAuthor.swift in Sources */,
 				217D5EBF2577F9DF009F0639 /* Comment4.swift in Sources */,
@@ -5113,6 +5197,7 @@
 				216E460824913D430035E3CE /* Color.swift in Sources */,
 				B9FAA11823879A57009414B4 /* Author+Schema.swift in Sources */,
 				B9521836237E21BA00F53237 /* Post+Schema.swift in Sources */,
+				6B7743DE25906FD3001469F5 /* Menu+Schema.swift in Sources */,
 				217D5EB72577F9DF009F0639 /* Project1+Schema.swift in Sources */,
 				FA4A955F239ADEBD008E876E /* MockResponder.swift in Sources */,
 				214F497A2486D8A200DA616C /* User.swift in Sources */,
@@ -5120,17 +5205,21 @@
 				FACA36152327FC39000E74F6 /* MessageReporter.swift in Sources */,
 				FAF512AE23986791001ADF4E /* AmplifyModels.swift in Sources */,
 				217D5EC42577F9DF009F0639 /* Team1+Schema.swift in Sources */,
+				6BE9D73725A67F7400AB5C9A /* M2MPost.swift in Sources */,
 				B9FAA11C23879B35009414B4 /* Book.swift in Sources */,
 				6B597A0B2565D3E50038C3E2 /* QPredGen.swift in Sources */,
 				975751B424D21DE000FA0A6E /* MockDevMenuContextProvider.swift in Sources */,
 				6B597A0A2565D3E50038C3E2 /* QPredGen+Schema.swift in Sources */,
 				214F49772486D8A200DA616C /* UserFollowers+Schema.swift in Sources */,
 				B9FAA11423878CEA009414B4 /* UserProfile+Schema.swift in Sources */,
+				6BE9D6EF25A6622000AB5C9A /* Team+Schema.swift in Sources */,
 				217D5EBC2577F9DF009F0639 /* User5.swift in Sources */,
+				6B7743DF25906FD3001469F5 /* Dish.swift in Sources */,
 				217D5EB82577F9DF009F0639 /* Project2+Schema.swift in Sources */,
 				214F49792486D8A200DA616C /* UserFollowing+Schema.swift in Sources */,
 				FACA361D2327FC84000E74F6 /* MockAPICategoryPlugin.swift in Sources */,
 				B9FAA11023878C5E009414B4 /* UserProfile.swift in Sources */,
+				6BE9D6EE25A6622000AB5C9A /* Team.swift in Sources */,
 				B9AA09F12473CA29000E6FBB /* PostStatus.swift in Sources */,
 				6BEE081C2533CCFA00133961 /* OGCScenarioBPost+Schema.swift in Sources */,
 				214F497B2486D8A200DA616C /* User+Schema.swift in Sources */,
@@ -5142,10 +5231,13 @@
 				217D5EB62577F9DF009F0639 /* Comment3+Schema.swift in Sources */,
 				B9521835237E21BA00F53237 /* Comment.swift in Sources */,
 				21AD4257249BFFE00016FE95 /* DeprecatedTodo.swift in Sources */,
+				6B7743E325906FD3001469F5 /* Restaurant+Schema.swift in Sources */,
 				216E45EF248E914F0035E3CE /* Todo+Schema.swift in Sources */,
 				FACA361E2327FC8E000E74F6 /* MockAnalyticsCategoryPlugin.swift in Sources */,
 				2129BE012394627B006363A1 /* PostCommentModelRegistration.swift in Sources */,
 				217D5EB42577F9DF009F0639 /* Comment4+Schema.swift in Sources */,
+				6BE9D73C25A67F7400AB5C9A /* M2MUser.swift in Sources */,
+				6BE9D73825A67F7400AB5C9A /* M2MPostEditor+Schema.swift in Sources */,
 				B9FAA10E23878BF3009414B4 /* UserAccount.swift in Sources */,
 				217D5EC12577F9DF009F0639 /* Team2.swift in Sources */,
 				217D5EBE2577F9DF009F0639 /* Post5+Schema.swift in Sources */,
@@ -5162,9 +5254,13 @@
 				21FDBB622587D7A30086FCDC /* Post6.swift in Sources */,
 				217D5EBA2577F9DF009F0639 /* Post4+Schema.swift in Sources */,
 				217D5EBD2577F9DF009F0639 /* Post5.swift in Sources */,
+				6B7743E425906FD3001469F5 /* Restaurant.swift in Sources */,
 				FA1846EE23998E44009B9D01 /* MockAPIResponders.swift in Sources */,
+				6B7743E225906FD3001469F5 /* Dish+Schema.swift in Sources */,
 				217D5EC32577F9DF009F0639 /* PostEditor5.swift in Sources */,
 				216E45ED248E914F0035E3CE /* Category.swift in Sources */,
+				6BE9D6ED25A6622000AB5C9A /* Project+Schema.swift in Sources */,
+				6BE9D6EC25A6622000AB5C9A /* Project.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Amplify/Core/Support/Array+Extensions.swift
+++ b/Amplify/Core/Support/Array+Extensions.swift
@@ -1,0 +1,17 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+//Inspired from: https://www.hackingwithswift.com/example-code/language/how-to-split-an-array-into-chunks
+extension Array {
+    public func chunked(into size: Int) -> [[Element]] {
+        return stride(from: 0, to: count, by: size).map {
+            Array(self[$0 ..< Swift.min($0 + size, count)])
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+DeleteTransaction.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+DeleteTransaction.swift
@@ -13,21 +13,26 @@ import AWSPluginsCore
 extension StorageEngine {
     func queryAndDeleteTransaction<M: Model>(_ modelType: M.Type,
                                              modelSchema: ModelSchema,
-                                             predicate: QueryPredicate) -> DataStoreResult<[M]> {
+                                             predicate: QueryPredicate) -> DataStoreResult<([M], [Model])> {
         var queriedResult: DataStoreResult<[M]>?
         var deletedResult: DataStoreResult<[M]>?
+        var associatedModels: [Model] = []
 
         let queryCompletionBlock: DataStoreCallback<[M]> = { queryResult in
             queriedResult = queryResult
-            if case .success = queryResult {
-                let deleteCompletionWrapper: DataStoreCallback<[M]> = { deleteResult in
-                    deletedResult = deleteResult
-                }
-                self.storageAdapter.delete(modelType,
-                                           modelSchema: modelSchema,
-                                           predicate: predicate,
-                                           completion: deleteCompletionWrapper)
+            guard case .success(let queriedModels) = queryResult else {
+                return
             }
+            let modelIds = queriedModels.map {$0.id}
+            associatedModels = self.recurseQueryAssociatedModels(modelSchema: modelSchema, ids: modelIds)
+
+            let deleteCompletionWrapper: DataStoreCallback<[M]> = { deleteResult in
+                deletedResult = deleteResult
+            }
+            self.storageAdapter.delete(modelType,
+                                       modelSchema: modelSchema,
+                                       predicate: predicate,
+                                       completion: deleteCompletionWrapper)
         }
 
         do {
@@ -43,18 +48,78 @@ extension StorageEngine {
             return .failure(causedBy: error)
         }
 
-        return collapseResults(queryResult: queriedResult, deleteResult: deletedResult)
+        return collapseResults(queryResult: queriedResult, deleteResult: deletedResult, associatedModels: associatedModels)
     }
 
-    func collapseResults<M: Model>(queryResult: DataStoreResult<[M]>?,
-                                   deleteResult: DataStoreResult<[M]>?) -> DataStoreResult<[M]> {
+    func recurseQueryAssociatedModels(modelSchema: ModelSchema, ids: [Model.Identifier]) -> [Model] {
+        var associatedModels: [Model] = []
+        for (_, modelField) in modelSchema.fields {
+            guard modelField.hasAssociation,
+                modelField.isOneToOne || modelField.isOneToMany,
+                let associatedModelName = modelField.associatedModelName,
+                let associatedField = modelField.associatedField,
+                let associatedModelSchema = ModelRegistry.modelSchema(from: associatedModelName) else {
+                    continue
+            }
+            let queriedModels = queryAssociatedModels(modelName: associatedModelName,
+                                                      associatedField: associatedField,
+                                                      ids: ids)
+            let associatedModelIds = queriedModels.map {$0.id}
+            associatedModels.append(contentsOf: queriedModels)
+            associatedModels.append(contentsOf: recurseQueryAssociatedModels(modelSchema: associatedModelSchema, ids: associatedModelIds))
+        }
+        return associatedModels
+    }
+
+    func queryAssociatedModels(modelName: ModelName, associatedField: ModelField, ids: [Model.Identifier]) -> [Model] {
+        guard let modelType = ModelRegistry.modelType(from: modelName) else {
+            log.error("Failed to lookup \(modelName)")
+            return []
+        }
+
+        // SQLite supports up to 1000 expressions per SQLStatement. We have chosen to use 50 expressions
+        // less (equaling 950) than the maximum because it is possible that our SQLStatement already has
+        // some expressions.  If we encounter performance problems in the future, we will want to profile
+        // our system and find an optimal value.
+        let maxNumberOfPredicates = 950
+        var queriedModels: [Model] = []
+        let chunkedArrays = ids.chunked(into: maxNumberOfPredicates)
+        for chunkedArray in chunkedArrays {
+            // TODO: Add conveinence to queryPredicate where we have a list of items, to be all or'ed
+            var queryPredicates: [QueryPredicateOperation] = []
+            for id in chunkedArray {
+                queryPredicates.append(QueryPredicateOperation(field: associatedField.name, operator: .equals(id)))
+            }
+            let groupedQueryPredicates =  QueryPredicateGroup(type: .or, predicates: queryPredicates)
+
+            let sempahore = DispatchSemaphore(value: 0)
+            storageAdapter.query(untypedModel: modelType, predicate: groupedQueryPredicates) { result in
+                defer {
+                    sempahore.signal()
+                }
+                switch result {
+                case .success(let models):
+                    queriedModels.append(contentsOf: models)
+
+                case .failure(let error):
+                    log.error("Failed to query \(modelType) on mutation event generation: \(error)")
+                }
+            }
+            sempahore.wait()
+        }
+        return queriedModels
+    }
+
+    private func collapseResults<M: Model>(queryResult: DataStoreResult<[M]>?,
+                                           deleteResult: DataStoreResult<[M]>?,
+                                           associatedModels: [Model]) -> DataStoreResult<([M], [Model])> {
         if let queryResult = queryResult {
             switch queryResult {
             case .success(let models):
                 if let deleteResult = deleteResult {
                     switch deleteResult {
                     case .success:
-                        return .success(models)
+                        return .success((models, associatedModels))
                     case .failure(let error):
                         return .failure(error)
                     }
@@ -66,6 +131,24 @@ extension StorageEngine {
             }
         } else {
             return .failure(.unknown("queryResult not set during transaction", "coding error", nil))
+        }
+    }
+
+    func collapseMResult<M: Model>(_ result: DataStoreResult<([M], [Model])>) -> DataStoreResult<[M]> {
+        switch result {
+        case .success(let results):
+            return .success(results.0)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    func resolveAssociatedModels<M: Model>(_ result: DataStoreResult<([M], [Model])>) -> [Model] {
+        switch result {
+        case .success(let results):
+            return results.1
+        case .failure:
+            return []
         }
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/StorageEngineTestsBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/StorageEngineTestsBase.swift
@@ -1,0 +1,104 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import SQLite
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+class StorageEngineTestsBase: XCTestCase {
+    let defaultTimeout = 0.3
+    var connection: Connection!
+    var storageEngine: StorageEngine!
+    var storageAdapter: SQLiteStorageEngineAdapter!
+    var syncEngine: MockRemoteSyncEngine!
+
+    /**
+     * Below are synchronous conveinence methods.  Please do not add any calls to XCTFail()
+     * in these conveinence methods.  Failures should be handled in the body of the unit test.
+     */
+    func saveModelSynchronous<M: Model>(model: M) -> DataStoreResult<M> {
+        let saveFinished = expectation(description: "Save finished")
+        var result: DataStoreResult<M>?
+
+        storageEngine.save(model) { sResult in
+            result = sResult
+            saveFinished.fulfill()
+        }
+        wait(for: [saveFinished], timeout: defaultTimeout)
+        guard let saveResult = result else {
+            return .failure(causedBy: "Save operation timed out")
+        }
+        return saveResult
+    }
+
+    func querySingleModelSynchronous<M: Model>(modelType: M.Type, predicate: QueryPredicate) -> DataStoreResult<M> {
+        let result = queryModelSynchronous(modelType: modelType, predicate: predicate)
+
+        switch result {
+        case .success(let models):
+            if models.isEmpty {
+                return .failure(causedBy: "Found no models, of type \(modelType.modelName)")
+            } else if models.count > 1 {
+                return .failure(causedBy: "Found more than one model of type \(modelType.modelName)")
+            } else {
+                return .success(models.first!)
+            }
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    func queryModelSynchronous<M: Model>(modelType: M.Type, predicate: QueryPredicate) -> DataStoreResult<[M]> {
+        let queryFinished = expectation(description: "Query Finished")
+        var result: DataStoreResult<[M]>?
+
+        storageEngine.query(modelType, predicate: predicate) { qResult in
+            result = qResult
+            queryFinished.fulfill()
+        }
+
+        wait(for: [queryFinished], timeout: defaultTimeout)
+        guard let queryResult = result else {
+            return .failure(causedBy: "Query operation timed out")
+        }
+        return queryResult
+    }
+
+    func deleteModelSynchronousOrFailOtherwise<M: Model>(modelType: M.Type, withId id: String, timeout: TimeInterval = 1) -> DataStoreResult<M> {
+        let result = deleteModelSynchronous(modelType: modelType, withId: id, timeout: timeout)
+        switch result {
+        case .success(let model):
+            if let model = model {
+                return .success(model)
+            } else {
+                return .failure(causedBy: "")
+            }
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    func deleteModelSynchronous<M: Model>(modelType: M.Type, withId id: String, timeout: TimeInterval = 1) -> DataStoreResult<M?> {
+        let deleteFinished = expectation(description: "Delete Finished")
+        var result: DataStoreResult<M?>?
+
+        storageEngine.delete(modelType, modelSchema: modelType.schema, withId: id, completion: { dResult in
+            result = dResult
+            deleteFinished.fulfill()
+        })
+
+        wait(for: [deleteFinished], timeout: timeout)
+        guard let deleteResult = result else {
+            return .failure(causedBy: "Delete operation timed out")
+        }
+        return deleteResult
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/StorageEngineTestsHasMany.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/StorageEngineTestsHasMany.swift
@@ -1,0 +1,256 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Combine
+import Foundation
+import SQLite
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+class StorageEngineTestsHasMany: StorageEngineTestsBase {
+
+    override func setUp() {
+        super.setUp()
+        Amplify.Logging.logLevel = .warn
+
+        let validAPIPluginKey = "MockAPICategoryPlugin"
+        let validAuthPluginKey = "MockAuthCategoryPlugin"
+        do {
+            connection = try Connection(.inMemory)
+            storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
+            try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
+
+            syncEngine = MockRemoteSyncEngine()
+            storageEngine = StorageEngine(storageAdapter: storageAdapter,
+                                          dataStoreConfiguration: .default,
+                                          syncEngine: syncEngine,
+                                          validAPIPluginKey: validAPIPluginKey,
+                                          validAuthPluginKey: validAuthPluginKey)
+            ModelRegistry.register(modelType: Restaurant.self)
+            ModelRegistry.register(modelType: Menu.self)
+            ModelRegistry.register(modelType: Dish.self)
+            do {
+                try storageEngine.setUp(modelSchemas: [Restaurant.schema])
+                try storageEngine.setUp(modelSchemas: [Menu.schema])
+                try storageEngine.setUp(modelSchemas: [Dish.schema])
+
+            } catch {
+                XCTFail("Failed to setup storage engine")
+            }
+        } catch {
+            XCTFail(String(describing: error))
+            return
+        }
+    }
+
+    func testDeleteParentEmitsMutationEventsForParentAndChild() {
+        let dreamRestaurant = Restaurant(restaurantName: "Dream Cafe")
+        let lunchSpecialMenu = Menu(name: "Specials", menuType: .lunch, restaurant: dreamRestaurant)
+        let lunchStandardMenu = Menu(name: "Standard", menuType: .lunch, restaurant: dreamRestaurant)
+        let oysters = Dish(dishName: "Fried oysters", menu: lunchSpecialMenu)
+        let katsuCurry = Dish(dishName: "Katsu Curry", menu: lunchStandardMenu)
+        let uniPasta = Dish(dishName: "Uni Pasta", menu: lunchStandardMenu)
+
+        let smoneysRestaurant = Restaurant(restaurantName: "Smoney's")
+        let smoneysMenu = Menu(name: "official menu", menuType: .breakfast, restaurant: smoneysRestaurant)
+        let eggsAndSausage = Dish(dishName: "Eggs and Sausage", menu: smoneysMenu)
+
+        let mkDonaldsRestaurant = Restaurant(restaurantName: "MkDonald's")
+        let mkDonaldsMenu = Menu(name: "All day", menuType: .lunch, restaurant: mkDonaldsRestaurant)
+        let szechuanSauce = Dish(dishName: "10-piece MkNugget and a bunch of the Szechuan Sauce", menu: mkDonaldsMenu)
+
+        guard case .success = saveModelSynchronous(model: dreamRestaurant),
+            case .success = saveModelSynchronous(model: lunchSpecialMenu),
+            case .success = saveModelSynchronous(model: lunchStandardMenu),
+            case .success = saveModelSynchronous(model: oysters),
+            case .success = saveModelSynchronous(model: katsuCurry),
+            case .success = saveModelSynchronous(model: uniPasta),
+            case .success = saveModelSynchronous(model: smoneysRestaurant),
+            case .success = saveModelSynchronous(model: smoneysMenu),
+            case .success = saveModelSynchronous(model: eggsAndSausage),
+            case .success = saveModelSynchronous(model: mkDonaldsRestaurant),
+            case .success = saveModelSynchronous(model: mkDonaldsMenu),
+            case .success = saveModelSynchronous(model: szechuanSauce) else {
+                XCTFail("Failed to save hierarchy")
+                return
+        }
+
+        guard case .success =
+            querySingleModelSynchronous(modelType: Restaurant.self,
+                                        predicate: Restaurant.keys.id == dreamRestaurant.id) else {
+                XCTFail("Failed to query Restaurant")
+                return
+        }
+        guard case .success =
+            queryModelSynchronous(modelType: Menu.self, predicate: Menu.keys.restaurant == dreamRestaurant.id) else {
+                XCTFail("Failed to query Menu")
+                return
+        }
+        guard case .success(let dishes) =
+            queryModelSynchronous(modelType: Dish.self, predicate: Dish.keys.menu == lunchStandardMenu.id) else {
+                XCTFail("Failed to query Dishes")
+                return
+        }
+        XCTAssertEqual(dishes.count, 2)
+
+        let recievedMutationEvent = expectation(description: "Mutation Events submitted to sync engine")
+        recievedMutationEvent.expectedFulfillmentCount = 6
+        syncEngine.setCallbackOnSubmit(callback: { _ in
+            recievedMutationEvent.fulfill()
+        })
+        guard case .success = deleteModelSynchronousOrFailOtherwise(modelType: Restaurant.self,
+                                                                    withId: dreamRestaurant.id) else {
+            XCTFail("Failed to delete restaurant")
+            return
+        }
+        wait(for: [recievedMutationEvent], timeout: defaultTimeout)
+    }
+
+    /*
+     *  Running on Core i9 2.3ghz (in-memory, theoretical performance)
+     *  100    iterations (~200 expressions)  - .8716s
+     *  200    iterations (~400 expressions)  - 2.08s
+     *  400    iterations (~800 expressions)  - 3.8s
+     *  1000   iterations (~2000 expressions) - 12.14s
+     *  5000   iterations (~10000 expressions) - 110.62s
+     *
+     *  A delete can be an expensive operation because when we delete models of "Dish" we need to create
+     *  a query expression comprised of a number of equality expressions, in order to figure out what
+     *  MutationEvents to send to the backend.
+
+     *  In this use case, one of the query expressions we would need to generate would be something like this:
+     *  '''
+     *  Give me all of the dishes, which have an (dishMenuId == id1) || (dishmenuId == id2) || .. etc..
+     *  '''
+     *  The result of this query is used to generate MutationEvent(s) to send to the backend.
+     *
+     *  Note that because the maximum number of expressions that SQLite supports is 1000, we work around this
+     *  by chunking this expression into chunks of 950.  For example, if you have 951 expressions, we will
+     *  make two queries: One query with 950 expressions, and one query with 1 expression.
+     *
+     */
+    func testStressDeleteTopLevelMultiLevelHasManyRelationship() {
+        let iterations = 500
+        let numberOfMenus = iterations * 2
+        let numberOfDishes = iterations * 4
+
+        let restaurant1 = Restaurant(restaurantName: "Cafe1")
+        guard case .success = saveModelSynchronous(model: restaurant1) else {
+            XCTFail("Failed to save restaurant")
+            return
+        }
+
+        for iteration in 0 ..< iterations {
+            let menu1 = Menu(name: "Specials\(iteration)", menuType: .lunch, restaurant: restaurant1)
+            let menu2 = Menu(name: "Standard\(iteration)", menuType: .lunch, restaurant: restaurant1)
+            let oysters = Dish(dishName: "Fried oysters\(iteration)", menu: menu1)
+            let tataki = Dish(dishName: "Tuna tataki\(iteration)", menu: menu1)
+            let katsuCurry = Dish(dishName: "Katsu Curry\(iteration)", menu: menu2)
+            let katsuDon = Dish(dishName: "Katsu don\(iteration)", menu: menu2)
+
+            guard case .success = saveModelSynchronous(model: menu1),
+                case .success = saveModelSynchronous(model: menu2),
+                case .success = saveModelSynchronous(model: oysters),
+                case .success = saveModelSynchronous(model: tataki),
+                case .success = saveModelSynchronous(model: katsuCurry),
+                case .success = saveModelSynchronous(model: katsuDon) else {
+
+                    XCTFail("Failed to save hierarchy")
+                    return
+            }
+        }
+        // Query individually without lazy loading and verify counts.
+        guard case .success(let savedRestaurant) =
+            querySingleModelSynchronous(modelType: Restaurant.self,
+                                        predicate: Restaurant.keys.id == restaurant1.id) else {
+                                            XCTFail("Failed to query Restaurant")
+                                            return
+        }
+        XCTAssertEqual(savedRestaurant.id, restaurant1.id)
+        guard case .success(let menus) =
+            queryModelSynchronous(modelType: Menu.self,
+                                  predicate: QueryPredicateConstant.all) else {
+                                    XCTFail("Failed to query menus")
+                                    return
+        }
+        XCTAssertEqual(menus.count, numberOfMenus)
+        guard case .success(let dishes) =
+            queryModelSynchronous(modelType: Dish.self,
+                                  predicate: QueryPredicateConstant.all) else {
+                                    XCTFail("Failed to query dishes")
+                                    return
+        }
+        XCTAssertEqual(dishes.count, numberOfDishes)
+
+        //let startTime = CFAbsoluteTimeGetCurrent()
+        // Delete Top level of restaurant
+        let recievedMutationEvent = expectation(description: "Mutation Events submitted to sync engine")
+        recievedMutationEvent.expectedFulfillmentCount = numberOfMenus + numberOfDishes + 1
+        syncEngine.setCallbackOnSubmit(callback: { _ in
+            recievedMutationEvent.fulfill()
+        })
+        guard case .success = deleteModelSynchronousOrFailOtherwise(modelType: Restaurant.self,
+                                                                    withId: restaurant1.id,
+                                                                    timeout: 10) else {
+                                                                        XCTFail("Failed to delete restaurant")
+                                                                        return
+        }
+        wait(for: [recievedMutationEvent], timeout: 10)
+        //let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
+        //print("Time elapsed time to delete: \(timeElapsed) s.")
+    }
+
+    func testErrorOnSingleSubmissionToSyncEngine() {
+         let restaurant1 = Restaurant(restaurantName: "restaurant1")
+         let lunchStandardMenu = Menu(name: "Standard", menuType: .lunch, restaurant: restaurant1)
+         let oysters = Dish(dishName: "Fried oysters", menu: lunchStandardMenu)
+
+         guard case .success = saveModelSynchronous(model: restaurant1),
+             case .success = saveModelSynchronous(model: lunchStandardMenu),
+             case .success = saveModelSynchronous(model: oysters) else {
+                 XCTFail("Failed to save hierarchy")
+                 return
+         }
+
+        let recievedMutationEvent = expectation(description: "Mutation Events submitted to sync engine")
+        recievedMutationEvent.expectedFulfillmentCount = 3
+        let expectedFailures = expectation(description: "Simulated failure on mutation event submitted to sync engine")
+        expectedFailures.expectedFulfillmentCount = 2
+        let expectedSuccess = expectation(description: "Simulated success on mutation event submitted to sync engine")
+        expectedSuccess.expectedFulfillmentCount = 1
+
+        syncEngine.setCallbackOnSubmit(callback: { _ in
+            recievedMutationEvent.fulfill()
+        })
+
+        syncEngine.setReturnOnSubmit { submittedMutationEvent in
+            if submittedMutationEvent.modelId == lunchStandardMenu.id ||
+                submittedMutationEvent.modelId == oysters.id {
+                expectedFailures.fulfill()
+                return Future<MutationEvent, DataStoreError> { promise in
+                    promise(.failure(.internalOperation("mockError", "", nil)))
+                }
+            }
+            expectedSuccess.fulfill()
+            return Future<MutationEvent, DataStoreError> { promise in
+                promise(.success(submittedMutationEvent))
+            }
+        }
+
+        guard case .failure(let error) = deleteModelSynchronousOrFailOtherwise(modelType: Restaurant.self,
+                                                                               withId: restaurant1.id) else {
+                                                                                XCTFail("Deleting should have failed due to our mock")
+                                                                                return
+        }
+        wait(for: [recievedMutationEvent, expectedFailures, expectedSuccess], timeout: defaultTimeout)
+        XCTAssertEqual(error.errorDescription, "mockError")
+    }
+
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/StorageEngineTestsHasOne.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/StorageEngineTestsHasOne.swift
@@ -1,0 +1,92 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import SQLite
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+class StorageEngineTestsHasOne: StorageEngineTestsBase {
+
+    override func setUp() {
+        super.setUp()
+        Amplify.Logging.logLevel = .warn
+
+        let validAPIPluginKey = "MockAPICategoryPlugin"
+        let validAuthPluginKey = "MockAuthCategoryPlugin"
+        do {
+            connection = try Connection(.inMemory)
+            storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
+            try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
+
+            syncEngine = MockRemoteSyncEngine()
+            storageEngine = StorageEngine(storageAdapter: storageAdapter,
+                                          dataStoreConfiguration: .default,
+                                          syncEngine: syncEngine,
+                                          validAPIPluginKey: validAPIPluginKey,
+                                          validAuthPluginKey: validAuthPluginKey)
+            ModelRegistry.register(modelType: Team.self)
+            ModelRegistry.register(modelType: Project.self)
+
+            do {
+                try storageEngine.setUp(modelSchemas: [Team.schema])
+                try storageEngine.setUp(modelSchemas: [Project.schema])
+
+            } catch {
+                XCTFail("Failed to setup storage engine")
+            }
+        } catch {
+            XCTFail(String(describing: error))
+            return
+        }
+    }
+
+    func testBelongsToRelationshipWithoutOwner() {
+        let teamA = Team(name: "A-Team")
+        let projectA = Project(name: "ProjectA", team: teamA)
+
+        let teamB = Team(name: "B-Team")
+        let projectB = Project(name: "ProjectB", team: teamB)
+
+        let teamC = Team(name: "C-Team")
+        let projectC = Project(name: "ProjectC", team: teamC)
+
+        guard case .success = saveModelSynchronous(model: teamA),
+            case .success = saveModelSynchronous(model: projectA),
+            case .success = saveModelSynchronous(model: teamB),
+            case .success = saveModelSynchronous(model: projectB),
+            case .success = saveModelSynchronous(model: teamC),
+            case .success = saveModelSynchronous(model: projectC) else {
+                XCTFail("Failed to save hierachy")
+                return
+        }
+        guard case .success =
+            querySingleModelSynchronous(modelType: Project.self, predicate: Project.keys.id == projectA.id) else {
+                XCTFail("Failed to query ProjectA")
+                return
+        }
+        guard case .success =
+            querySingleModelSynchronous(modelType: Team.self, predicate: Project.keys.id == teamA.id) else {
+                XCTFail("Failed to query TeamA")
+                return
+        }
+
+        let mutationEventOnProject = expectation(description: "Mutation Events submitted to sync engine")
+        syncEngine.setCallbackOnSubmit(callback: { _ in
+            mutationEventOnProject.fulfill()
+        })
+        guard case .success = deleteModelSynchronousOrFailOtherwise(modelType: Project.self,
+                                                                    withId: projectA.id) else {
+            XCTFail("Failed to delete projectA")
+            return
+        }
+        wait(for: [mutationEventOnProject], timeout: defaultTimeout)
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/StorageEngineTestsManyToMany.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/StorageEngineTestsManyToMany.swift
@@ -1,0 +1,163 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import SQLite
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+class StorageEngineTestsManyToMany: StorageEngineTestsBase {
+
+    override func setUp() {
+        super.setUp()
+        Amplify.Logging.logLevel = .warn
+
+        let validAPIPluginKey = "MockAPICategoryPlugin"
+        let validAuthPluginKey = "MockAuthCategoryPlugin"
+        do {
+            connection = try Connection(.inMemory)
+            storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
+            try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
+
+            syncEngine = MockRemoteSyncEngine()
+            storageEngine = StorageEngine(storageAdapter: storageAdapter,
+                                          dataStoreConfiguration: .default,
+                                          syncEngine: syncEngine,
+                                          validAPIPluginKey: validAPIPluginKey,
+                                          validAuthPluginKey: validAuthPluginKey)
+            ModelRegistry.register(modelType: M2MPost.self)
+            ModelRegistry.register(modelType: M2MPostEditor.self)
+            ModelRegistry.register(modelType: M2MUser.self)
+            do {
+                try storageEngine.setUp(modelSchemas: [M2MPost.schema])
+                try storageEngine.setUp(modelSchemas: [M2MPostEditor.schema])
+                try storageEngine.setUp(modelSchemas: [M2MUser.schema])
+
+            } catch {
+                XCTFail("Failed to setup storage engine")
+            }
+        } catch {
+            XCTFail(String(describing: error))
+            return
+        }
+    }
+
+    func testDeletePostAndPostEditor() {
+        var post1 = M2MPost(title: "Post1")
+        var user1 = M2MUser(username: "User1")
+        let postEditors1 = M2MPostEditor(post: post1, editor: user1)
+        post1.editors = [postEditors1]
+        user1.posts = [postEditors1]
+
+        var post2 = M2MPost(title: "Post2")
+        var user2 = M2MUser(username: "User2")
+        let postEditors2 = M2MPostEditor(post: post2, editor: user2)
+        post2.editors = [postEditors2]
+        user2.posts = [postEditors2]
+
+        guard case .success = saveModelSynchronous(model: user1),
+            case .success = saveModelSynchronous(model: post1),
+            case .success = saveModelSynchronous(model: postEditors1),
+            case .success = saveModelSynchronous(model: user2),
+            case .success = saveModelSynchronous(model: post2),
+            case .success = saveModelSynchronous(model: postEditors2) else {
+                XCTFail("Failed to save hierachy")
+                return
+        }
+
+        guard case .success =
+            querySingleModelSynchronous(modelType: M2MPost.self,
+                                        predicate: M2MPost.keys.id == post1.id) else {
+                                            XCTFail("Failed to query M2MPost")
+                                            return
+        }
+        guard case .success =
+            querySingleModelSynchronous(modelType: M2MPostEditor.self,
+                                        predicate: M2MPostEditor.keys.id == postEditors1.id) else {
+                                            XCTFail("Failed to query M2MPostEditor")
+                                            return
+        }
+        guard case .success =
+            querySingleModelSynchronous(modelType: M2MUser.self,
+                                        predicate: M2MUser.keys.id == user1.id) else {
+                                            XCTFail("Failed to query M2MUser")
+                                            return
+        }
+
+        let mutationEvents = expectation(description: "Mutation Events submitted to sync engine")
+        mutationEvents.expectedFulfillmentCount = 2
+
+        syncEngine.setCallbackOnSubmit(callback: { _ in
+            mutationEvents.fulfill()
+        })
+        guard case .success = deleteModelSynchronousOrFailOtherwise(modelType: M2MPost.self,
+                                                                    withId: post1.id) else {
+            XCTFail("Failed to delete post1")
+            return
+        }
+        wait(for: [mutationEvents], timeout: defaultTimeout)
+    }
+
+    func testDeleteUserAndPostEditor() {
+        var post1 = M2MPost(title: "Post1")
+        var user1 = M2MUser(username: "User1")
+        let postEditors1 = M2MPostEditor(post: post1, editor: user1)
+        post1.editors = [postEditors1]
+        user1.posts = [postEditors1]
+
+        var post2 = M2MPost(title: "Post2")
+        var user2 = M2MUser(username: "User2")
+        let postEditors2 = M2MPostEditor(post: post2, editor: user2)
+        post2.editors = [postEditors2]
+        user2.posts = [postEditors2]
+
+        guard case .success = saveModelSynchronous(model: user1),
+            case .success = saveModelSynchronous(model: post1),
+            case .success = saveModelSynchronous(model: postEditors1),
+            case .success = saveModelSynchronous(model: user2),
+            case .success = saveModelSynchronous(model: post2),
+            case .success = saveModelSynchronous(model: postEditors2) else {
+                XCTFail("Failed to save hierachy")
+                return
+        }
+
+        guard case .success =
+            querySingleModelSynchronous(modelType: M2MPost.self,
+                                        predicate: M2MPost.keys.id == post1.id) else {
+                                            XCTFail("Failed to query M2MPost")
+                                            return
+        }
+        guard case .success =
+            querySingleModelSynchronous(modelType: M2MPostEditor.self,
+                                        predicate: M2MPostEditor.keys.id == postEditors1.id) else {
+                                            XCTFail("Failed to query M2MPostEditor")
+                                            return
+        }
+        guard case .success =
+            querySingleModelSynchronous(modelType: M2MUser.self,
+                                        predicate: M2MUser.keys.id == user1.id) else {
+                                            XCTFail("Failed to query M2MUser")
+                                            return
+        }
+
+        let mutationEvents = expectation(description: "Mutation Events submitted to sync engine")
+        mutationEvents.expectedFulfillmentCount = 2
+
+        syncEngine.setCallbackOnSubmit(callback: { _ in
+            mutationEvents.fulfill()
+        })
+        guard case .success = deleteModelSynchronousOrFailOtherwise(modelType: M2MUser.self,
+                                                                    withId: user1.id) else {
+            XCTFail("Failed to delete post1")
+            return
+        }
+        wait(for: [mutationEvents], timeout: defaultTimeout)
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockRemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockRemoteSyncEngine.swift
@@ -1,0 +1,57 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import AWSPluginsCore
+import Combine
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+typealias OnSubmitCallBack = (MutationEvent) -> Void
+class MockRemoteSyncEngine: RemoteSyncEngineBehavior {
+
+    let remoteSyncTopicPublisher: PassthroughSubject<RemoteSyncEngineEvent, DataStoreError>
+    var callbackOnSubmit: OnSubmitCallBack?
+    var returnOnSubmit: ((MutationEvent) -> Future<MutationEvent, DataStoreError>)?
+
+    var publisher: AnyPublisher<RemoteSyncEngineEvent, DataStoreError> {
+        return remoteSyncTopicPublisher.eraseToAnyPublisher()
+    }
+
+    init() {
+        self.remoteSyncTopicPublisher = PassthroughSubject<RemoteSyncEngineEvent, DataStoreError>()
+    }
+    func start(api: APICategoryGraphQLBehavior, auth: AuthCategoryBehavior?) {
+
+    }
+
+    func stop(completion: @escaping DataStoreCallback<Void>) {
+
+    }
+
+    @available(iOS 13.0, *)
+    func submit(_ mutationEvent: MutationEvent) -> Future<MutationEvent, DataStoreError> {
+        if let callback = callbackOnSubmit {
+            callback(mutationEvent)
+        }
+        if let returnOnSubmit = self.returnOnSubmit {
+            return returnOnSubmit(mutationEvent)
+        }
+        return Future<MutationEvent, DataStoreError> { promise in
+            promise(.success(mutationEvent))
+        }
+    }
+
+    func setCallbackOnSubmit(callback: @escaping OnSubmitCallBack) {
+        callbackOnSubmit = callback
+    }
+    func setReturnOnSubmit(_ returnOnSubmit: @escaping (MutationEvent) -> Future<MutationEvent, DataStoreError>) {
+        self.returnOnSubmit = returnOnSubmit
+    }
+}

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		6B64027923E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B64027823E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift */; };
 		6B64027B23E38B9900001FD7 /* MockOutgoingMutationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */; };
 		6B7743D525906B6E001469F5 /* StorageEngine+DeleteTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7743D425906B6E001469F5 /* StorageEngine+DeleteTransaction.swift */; };
+		6B7743E7259071C8001469F5 /* StorageEngineTestsHasMany.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7743E6259071C8001469F5 /* StorageEngineTestsHasMany.swift */; };
+		6B7743E9259071F5001469F5 /* MockRemoteSyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7743E8259071F5001469F5 /* MockRemoteSyncEngine.swift */; };
 		6B91DEBF238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */; };
 		6BB01630255B1B4D00190897 /* DataStoreSyncExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB0162F255B1B4D00190897 /* DataStoreSyncExpression.swift */; };
 		6BB93F07244BA44B00ED1FC3 /* MutationEventClearState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB93F06244BA44B00ED1FC3 /* MutationEventClearState.swift */; };
@@ -89,6 +91,9 @@
 		6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */; };
 		6BDC224223E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */; };
 		6BE7431C2575B8B000009FCB /* AWSAPICategoryPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE7431B2575B8B000009FCB /* AWSAPICategoryPluginTests.swift */; };
+		6BE9D6F125A6643100AB5C9A /* StorageEngineTestsHasOne.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D6F025A6643100AB5C9A /* StorageEngineTestsHasOne.swift */; };
+		6BE9D6F325A665EA00AB5C9A /* StorageEngineTestsBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D6F225A665EA00AB5C9A /* StorageEngineTestsBase.swift */; };
+		6BE9D73E25A6800100AB5C9A /* StorageEngineTestsManyToMany.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D73D25A6800100AB5C9A /* StorageEngineTestsManyToMany.swift */; };
 		8141657E756CC7B2EE1CE851 /* Pods_HostApp_AWSDataStoreCategoryPluginAuthIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA320D973669D3843FDF755E /* Pods_HostApp_AWSDataStoreCategoryPluginAuthIntegrationTests.framework */; };
 		A209418EED69D7B1BB8A55C2 /* Pods_AWSDataStoreCategoryPlugin_AWSDataStoreCategoryPluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C63AE18F2569D004E94BD550 /* Pods_AWSDataStoreCategoryPlugin_AWSDataStoreCategoryPluginTests.framework */; };
 		A569484A6FBAE7EC7ADF3FD4 /* Pods_AWSDataStoreCategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A1D332BE6CF885805360B3D /* Pods_AWSDataStoreCategoryPlugin.framework */; };
@@ -322,6 +327,8 @@
 		6B64027823E3584300001FD7 /* MockAWSIncomingEventReconciliationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSIncomingEventReconciliationQueue.swift; sourceTree = "<group>"; };
 		6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOutgoingMutationQueue.swift; sourceTree = "<group>"; };
 		6B7743D425906B6E001469F5 /* StorageEngine+DeleteTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StorageEngine+DeleteTransaction.swift"; sourceTree = "<group>"; };
+		6B7743E6259071C8001469F5 /* StorageEngineTestsHasMany.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageEngineTestsHasMany.swift; sourceTree = "<group>"; };
+		6B7743E8259071F5001469F5 /* MockRemoteSyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteSyncEngine.swift; sourceTree = "<group>"; };
 		6B91DEBE238B9CE0004D6BEE /* ReconcileAndLocalSaveOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcileAndLocalSaveOperationTests.swift; sourceTree = "<group>"; };
 		6BB0162F255B1B4D00190897 /* DataStoreSyncExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreSyncExpression.swift; sourceTree = "<group>"; };
 		6BB93F06244BA44B00ED1FC3 /* MutationEventClearState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEventClearState.swift; sourceTree = "<group>"; };
@@ -331,6 +338,9 @@
 		6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSyncEngineTests.swift; sourceTree = "<group>"; };
 		6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSInitialSyncOrchestrator.swift; sourceTree = "<group>"; };
 		6BE7431B2575B8B000009FCB /* AWSAPICategoryPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAPICategoryPluginTests.swift; sourceTree = "<group>"; };
+		6BE9D6F025A6643100AB5C9A /* StorageEngineTestsHasOne.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageEngineTestsHasOne.swift; sourceTree = "<group>"; };
+		6BE9D6F225A665EA00AB5C9A /* StorageEngineTestsBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageEngineTestsBase.swift; sourceTree = "<group>"; };
+		6BE9D73D25A6800100AB5C9A /* StorageEngineTestsManyToMany.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageEngineTestsManyToMany.swift; sourceTree = "<group>"; };
 		9D42A96449A4B73735566C07 /* Pods-AWSDataStoreCategoryPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSDataStoreCategoryPlugin/Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; sourceTree = "<group>"; };
 		9F987EC33AAD7C0904A598CA /* Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B40EF02724BF68C900F2264C /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
@@ -622,6 +632,7 @@
 				2149E5E72388692E00873955 /* Info.plist */,
 				FAD2BDF423957F35006EB065 /* Core */,
 				B996FC4523FF3C41006D0F68 /* Models */,
+				6B7743E5259071AB001469F5 /* Storage */,
 				FAD2BDF223957EE8006EB065 /* Sync */,
 				2149E5EE238869CF00873955 /* TestSupport */,
 			);
@@ -684,6 +695,17 @@
 				21FDBBDA2587DB7A0086FCDC /* DataStoreConnectionScenario6Tests.swift */,
 			);
 			path = Connection;
+			sourceTree = "<group>";
+		};
+		6B7743E5259071AB001469F5 /* Storage */ = {
+			isa = PBXGroup;
+			children = (
+				6BE9D6F225A665EA00AB5C9A /* StorageEngineTestsBase.swift */,
+				6B7743E6259071C8001469F5 /* StorageEngineTestsHasMany.swift */,
+				6BE9D6F025A6643100AB5C9A /* StorageEngineTestsHasOne.swift */,
+				6BE9D73D25A6800100AB5C9A /* StorageEngineTestsManyToMany.swift */,
+			);
+			path = Storage;
 			sourceTree = "<group>";
 		};
 		9B5889A231ECAD33B03B5DF6 /* Pods */ = {
@@ -962,6 +984,7 @@
 				6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */,
 				6B64027A23E38B9900001FD7 /* MockOutgoingMutationQueue.swift */,
 				FAF5287A2399814F0053A717 /* MockReconciliationQueue.swift */,
+				6B7743E8259071F5001469F5 /* MockRemoteSyncEngine.swift */,
 				6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */,
 				6B4E3DF52397327E00AD962B /* MockStateMachine.swift */,
 				FA8D932E239EA5C4001ED336 /* NoOpInitialSyncOrchestrator.swift */,
@@ -1652,6 +1675,7 @@
 				FA3B3F09238F39DE002EFDB3 /* AWSMutationEventIngesterTests.swift in Sources */,
 				6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */,
 				FA4B8E962391C609009FC10F /* XCTest+AmplifyExtensions.swift in Sources */,
+				6B7743E9259071F5001469F5 /* MockRemoteSyncEngine.swift in Sources */,
 				FAE4146C239AA40600CE94C2 /* MockSQLiteStorageEngineAdapter.swift in Sources */,
 				B4D9B9E424DF90CD0049484F /* DynamicModel.swift in Sources */,
 				B912D1BA242984D10028F05C /* QueryPaginationInputTests.swift in Sources */,
@@ -1675,10 +1699,14 @@
 				6B4E3DF42397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift in Sources */,
 				FAE4146A239AA2B700CE94C2 /* RemoteSyncReconcilerTests.swift in Sources */,
 				B4B3794B2551CF87007781D6 /* QuerySortDescriptorTests.swift in Sources */,
+				6BE9D73E25A6800100AB5C9A /* StorageEngineTestsManyToMany.swift in Sources */,
 				2149E5FE238869CF00873955 /* RemoteSyncAPIInvocationTests.swift in Sources */,
 				B9FAA142238C6082009414B4 /* BaseDataStoreTests.swift in Sources */,
+				6B7743E7259071C8001469F5 /* StorageEngineTestsHasMany.swift in Sources */,
+				6BE9D6F125A6643100AB5C9A /* StorageEngineTestsHasOne.swift in Sources */,
 				6B52DC9624478E75007F5AD3 /* MockModelReconciliationQueue.swift in Sources */,
 				FA4A955B239AD3F4008E876E /* Foundation+TestExtensions.swift in Sources */,
+				6BE9D6F325A665EA00AB5C9A /* StorageEngineTestsBase.swift in Sources */,
 				FA1C819F25868D17006160E9 /* AWSDataStorePluginAmplifyVersionableTests.swift in Sources */,
 				B4D9B9E224DF85580049484F /* SQLiteStorageEngineAdapterJsonTests.swift in Sources */,
 				6B64027B23E38B9900001FD7 /* MockOutgoingMutationQueue.swift in Sources */,

--- a/AmplifyTestCommon/Models/M2MPostEditorUser/M2MPost+Schema.swift
+++ b/AmplifyTestCommon/Models/M2MPostEditorUser/M2MPost+Schema.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension M2MPost {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case title
+    case editors
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let m2MPost = M2MPost.keys
+    
+    model.pluralName = "M2MPosts"
+    
+    model.fields(
+      .id(),
+      .field(m2MPost.title, is: .required, ofType: .string),
+      .hasMany(m2MPost.editors, is: .optional, ofType: M2MPostEditor.self, associatedWith: M2MPostEditor.keys.post)
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/M2MPostEditorUser/M2MPost.swift
+++ b/AmplifyTestCommon/Models/M2MPostEditorUser/M2MPost.swift
@@ -1,0 +1,17 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct M2MPost: Model {
+  public let id: String
+  public var title: String
+  public var editors: List<M2MPostEditor>?
+  
+  public init(id: String = UUID().uuidString,
+      title: String,
+      editors: List<M2MPostEditor>? = []) {
+      self.id = id
+      self.title = title
+      self.editors = editors
+  }
+}

--- a/AmplifyTestCommon/Models/M2MPostEditorUser/M2MPostEditor+Schema.swift
+++ b/AmplifyTestCommon/Models/M2MPostEditorUser/M2MPostEditor+Schema.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension M2MPostEditor {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case post
+    case editor
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let m2MPostEditor = M2MPostEditor.keys
+    
+    model.pluralName = "M2MPostEditors"
+    
+    model.fields(
+      .id(),
+      .belongsTo(m2MPostEditor.post, is: .required, ofType: M2MPost.self, targetName: "postID"),
+      .belongsTo(m2MPostEditor.editor, is: .required, ofType: M2MUser.self, targetName: "editorID")
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/M2MPostEditorUser/M2MPostEditor.swift
+++ b/AmplifyTestCommon/Models/M2MPostEditorUser/M2MPostEditor.swift
@@ -1,0 +1,17 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct M2MPostEditor: Model {
+  public let id: String
+  public var post: M2MPost
+  public var editor: M2MUser
+  
+  public init(id: String = UUID().uuidString,
+      post: M2MPost,
+      editor: M2MUser) {
+      self.id = id
+      self.post = post
+      self.editor = editor
+  }
+}

--- a/AmplifyTestCommon/Models/M2MPostEditorUser/M2MUser+Schema.swift
+++ b/AmplifyTestCommon/Models/M2MPostEditorUser/M2MUser+Schema.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension M2MUser {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case username
+    case posts
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let m2MUser = M2MUser.keys
+    
+    model.pluralName = "M2MUsers"
+    
+    model.fields(
+      .id(),
+      .field(m2MUser.username, is: .required, ofType: .string),
+      .hasMany(m2MUser.posts, is: .optional, ofType: M2MPostEditor.self, associatedWith: M2MPostEditor.keys.editor)
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/M2MPostEditorUser/M2MUser.swift
+++ b/AmplifyTestCommon/Models/M2MPostEditorUser/M2MUser.swift
@@ -1,0 +1,17 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct M2MUser: Model {
+  public let id: String
+  public var username: String
+  public var posts: List<M2MPostEditor>?
+  
+  public init(id: String = UUID().uuidString,
+      username: String,
+      posts: List<M2MPostEditor>? = []) {
+      self.id = id
+      self.username = username
+      self.posts = posts
+  }
+}

--- a/AmplifyTestCommon/Models/M2MPostEditorUser/schema.graphql
+++ b/AmplifyTestCommon/Models/M2MPostEditorUser/schema.graphql
@@ -1,0 +1,23 @@
+type M2MPost @model {
+  id: ID!
+  title: String!
+  editors: [M2MPostEditor] @connection(keyName: "byPost", fields: ["id"])
+}
+
+
+type M2MPostEditor
+  @model(queries: null)
+  @key(name: "byPost", fields: ["postID", "editorID"])
+  @key(name: "byEditor", fields: ["editorID", "postID"]) {
+  id: ID!
+  postID: ID!
+  editorID: ID!
+  post: M2MPost! @connection(fields: ["postID"])
+  editor: M2MUser! @connection(fields: ["editorID"])
+}
+
+type M2MUser @model {
+  id: ID!
+  username: String!
+  posts: [M2MPostEditor] @connection(keyName: "byEditor", fields: ["id"])
+}

--- a/AmplifyTestCommon/Models/Restaurant/Dish+Schema.swift
+++ b/AmplifyTestCommon/Models/Restaurant/Dish+Schema.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Dish {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case dishName
+    case menu
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let dish = Dish.keys
+    
+    model.pluralName = "Dishes"
+    
+    model.fields(
+      .id(),
+      .field(dish.dishName, is: .optional, ofType: .string),
+      .belongsTo(dish.menu, is: .optional, ofType: Menu.self, targetName: "dishMenuId")
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/Restaurant/Dish.swift
+++ b/AmplifyTestCommon/Models/Restaurant/Dish.swift
@@ -1,0 +1,17 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Dish: Model {
+  public let id: String
+  public var dishName: String?
+  public var menu: Menu?
+  
+  public init(id: String = UUID().uuidString,
+      dishName: String? = nil,
+      menu: Menu? = nil) {
+      self.id = id
+      self.dishName = dishName
+      self.menu = menu
+  }
+}

--- a/AmplifyTestCommon/Models/Restaurant/Menu+Schema.swift
+++ b/AmplifyTestCommon/Models/Restaurant/Menu+Schema.swift
@@ -1,0 +1,31 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Menu {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case name
+    case menuType
+    case restaurant
+    case dishes
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let menu = Menu.keys
+    
+    model.pluralName = "Menus"
+    
+    model.fields(
+      .id(),
+      .field(menu.name, is: .required, ofType: .string),
+      .field(menu.menuType, is: .optional, ofType: .enum(type: MenuType.self)),
+      .belongsTo(menu.restaurant, is: .optional, ofType: Restaurant.self, targetName: "menuRestaurantId"),
+      .hasMany(menu.dishes, is: .optional, ofType: Dish.self, associatedWith: Dish.keys.menu)
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/Restaurant/Menu.swift
+++ b/AmplifyTestCommon/Models/Restaurant/Menu.swift
@@ -1,0 +1,23 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Menu: Model {
+  public let id: String
+  public var name: String
+  public var menuType: MenuType?
+  public var restaurant: Restaurant?
+  public var dishes: List<Dish>?
+  
+  public init(id: String = UUID().uuidString,
+      name: String,
+      menuType: MenuType? = nil,
+      restaurant: Restaurant? = nil,
+      dishes: List<Dish>? = []) {
+      self.id = id
+      self.name = name
+      self.menuType = menuType
+      self.restaurant = restaurant
+      self.dishes = dishes
+  }
+}

--- a/AmplifyTestCommon/Models/Restaurant/MenuType.swift
+++ b/AmplifyTestCommon/Models/Restaurant/MenuType.swift
@@ -1,0 +1,9 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public enum MenuType: String, EnumPersistable {
+  case breakfast = "BREAKFAST"
+  case lunch = "LUNCH"
+  case dinner = "DINNER"
+}

--- a/AmplifyTestCommon/Models/Restaurant/Restaurant+Schema.swift
+++ b/AmplifyTestCommon/Models/Restaurant/Restaurant+Schema.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Restaurant {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case restaurantName
+    case menus
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let restaurant = Restaurant.keys
+    
+    model.pluralName = "Restaurants"
+    
+    model.fields(
+      .id(),
+      .field(restaurant.restaurantName, is: .required, ofType: .string),
+      .hasMany(restaurant.menus, is: .optional, ofType: Menu.self, associatedWith: Menu.keys.restaurant)
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/Restaurant/Restaurant.swift
+++ b/AmplifyTestCommon/Models/Restaurant/Restaurant.swift
@@ -1,0 +1,17 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Restaurant: Model {
+  public let id: String
+  public var restaurantName: String
+  public var menus: List<Menu>?
+  
+  public init(id: String = UUID().uuidString,
+      restaurantName: String,
+      menus: List<Menu>? = []) {
+      self.id = id
+      self.restaurantName = restaurantName
+      self.menus = menus
+  }
+}

--- a/AmplifyTestCommon/Models/Restaurant/schema.graphql
+++ b/AmplifyTestCommon/Models/Restaurant/schema.graphql
@@ -1,0 +1,26 @@
+enum MenuType {
+  BREAKFAST
+  LUNCH
+  DINNER
+}
+
+type Restaurant @model {
+  id: ID!
+  restaurantName: String!
+  menus: [Menu] @connection(name: "RestaurantMenu")
+}
+
+type Menu @model {
+  id: ID!
+  name: String!
+  menuType: MenuType
+
+  restaurant: Restaurant @connection(name: "RestaurantMenu")
+  entrees: [Entree] @connection(name: "MenuEntree")
+}
+
+type Entree @model {
+  id: ID!
+  dishName: String
+  menu: Menu @connection(name: "MenuEntree")
+}

--- a/AmplifyTestCommon/Models/TeamProject/Project+Schema.swift
+++ b/AmplifyTestCommon/Models/TeamProject/Project+Schema.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Project {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case name
+    case team
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let project = Project.keys
+    
+    model.pluralName = "Projects"
+    
+    model.fields(
+      .id(),
+      .field(project.name, is: .optional, ofType: .string),
+      .belongsTo(project.team, is: .optional, ofType: Team.self, targetName: "projectTeamId")
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/TeamProject/Project.swift
+++ b/AmplifyTestCommon/Models/TeamProject/Project.swift
@@ -1,0 +1,17 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Project: Model {
+  public let id: String
+  public var name: String?
+  public var team: Team?
+  
+  public init(id: String = UUID().uuidString,
+      name: String? = nil,
+      team: Team? = nil) {
+      self.id = id
+      self.name = name
+      self.team = team
+  }
+}

--- a/AmplifyTestCommon/Models/TeamProject/Team+Schema.swift
+++ b/AmplifyTestCommon/Models/TeamProject/Team+Schema.swift
@@ -1,0 +1,25 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Team {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case name
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let team = Team.keys
+    
+    model.pluralName = "Teams"
+    
+    model.fields(
+      .id(),
+      .field(team.name, is: .required, ofType: .string)
+    )
+    }
+}

--- a/AmplifyTestCommon/Models/TeamProject/Team.swift
+++ b/AmplifyTestCommon/Models/TeamProject/Team.swift
@@ -1,0 +1,14 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Team: Model {
+  public let id: String
+  public var name: String
+  
+  public init(id: String = UUID().uuidString,
+      name: String) {
+      self.id = id
+      self.name = name
+  }
+}

--- a/AmplifyTestCommon/Models/TeamProject/schema.graphql
+++ b/AmplifyTestCommon/Models/TeamProject/schema.graphql
@@ -1,0 +1,10 @@
+type Project @model {
+  id: ID!
+  name: String
+  team: Team @connection
+}
+
+type Team @model {
+  id: ID!
+  name: String!
+}


### PR DESCRIPTION
This PR addresses issue [#933](https://github.com/aws-amplify/amplify-ios/issues/933)

This PR relies on:
~~[965](https://github.com/aws-amplify/amplify-ios/pull/965) - Addressing columns~~ -- pushed to mainline
[986](https://github.com/aws-amplify/amplify-ios/pull/986) - minor refactor

(For reference only, the precursor to this pr is located here: https://github.com/aws-amplify/amplify-ios/pull/979 )

Did a high level overview/review with @palpatim -- two items that came up:

**Stress test case**
- See unit test `testStressDeleteTopLevelMultiLevelHasManyRelationship`

**Edge case with regards to foreign key constraints**
Tested an edge case where we have a `Blog` -> `Post` - > `Comment`
Steps:
1.  Updated the storageEngine's code to not send sync deletions for Post
```
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -432,6 +432,12 @@ final class StorageEngine: StorageEngineBehavior {
         }
         var mutationEvents: Set<Model.Identifier> = []
         for associatedModel in associatedModels {
+            if associatedModel.modelName == "Post" {
+                print("SKIPPING Post!!")
+                continue
+            }
+
```
2. Created 1 blog, 2 posts, and 4 comments
3. Delete the Blog ( notice that only 5 delete mutation events were sent out )
4.  `clear()` and `start()` -- effectively forcing the initial sync operation to run.

**Observed**: ReconcileAndLocalSaveOperation fails with a Foreign Key constraint coming from SQLite3.  This is expected since its parent Blog(owner), no longer exists.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
