### PR TITLE
[OLD] feat: Support lazy load and pagination for API

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -122,6 +122,8 @@
 		2183A56723EA4A8B00232880 /* GraphQLCreateMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212CE71623EA1839007D8E71 /* GraphQLCreateMutationTests.swift */; };
 		2183A56823EA4A8E00232880 /* GraphQLDeleteMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212CE71423EA1838007D8E71 /* GraphQLDeleteMutationTests.swift */; };
 		2183A56923EA4A9100232880 /* GraphQLUpdateMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212CE71523EA1839007D8E71 /* GraphQLUpdateMutationTests.swift */; };
+		218DC96A258A73AF00D59FC6 /* CoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218DC969258A73AF00D59FC6 /* CoreError.swift */; };
+		218DC97A258A73CA00D59FC6 /* Paginatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218DC979258A73CA00D59FC6 /* Paginatable.swift */; };
 		219A887F23EB627100BBC5F2 /* ModelBasedGraphQLDocumentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219A887E23EB627100BBC5F2 /* ModelBasedGraphQLDocumentBuilder.swift */; };
 		219A888123EB629800BBC5F2 /* ModelBasedGraphQLDocumentDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219A888023EB629800BBC5F2 /* ModelBasedGraphQLDocumentDecorator.swift */; };
 		219A888523EB897700BBC5F2 /* GraphQLRequest+AnyModelWithSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219A888423EB897700BBC5F2 /* GraphQLRequest+AnyModelWithSync.swift */; };
@@ -899,6 +901,8 @@
 		217D5EAF2577F9DF009F0639 /* Project2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Project2.swift; sourceTree = "<group>"; };
 		217D5ECD2577FA1B009F0639 /* connection-schema.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = "connection-schema.graphql"; sourceTree = "<group>"; };
 		217D5F63257830C2009F0639 /* ModelField+GraphQL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ModelField+GraphQL.swift"; sourceTree = "<group>"; };
+		218DC969258A73AF00D59FC6 /* CoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreError.swift; sourceTree = "<group>"; };
+		218DC979258A73CA00D59FC6 /* Paginatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paginatable.swift; sourceTree = "<group>"; };
 		219A887E23EB627100BBC5F2 /* ModelBasedGraphQLDocumentBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelBasedGraphQLDocumentBuilder.swift; sourceTree = "<group>"; };
 		219A888023EB629800BBC5F2 /* ModelBasedGraphQLDocumentDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelBasedGraphQLDocumentDecorator.swift; sourceTree = "<group>"; };
 		219A888423EB897700BBC5F2 /* GraphQLRequest+AnyModelWithSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLRequest+AnyModelWithSync.swift"; sourceTree = "<group>"; };
@@ -1983,6 +1987,14 @@
 			path = 5;
 			sourceTree = "<group>";
 		};
+		218DC968258A739E00D59FC6 /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				218DC969258A73AF00D59FC6 /* CoreError.swift */,
+			);
+			path = Error;
+			sourceTree = "<group>";
+		};
 		21A3FDAD24630D4200E76120 /* Decorator */ = {
 			isa = PBXGroup;
 			children = (
@@ -2850,6 +2862,7 @@
 			children = (
 				B9FAA1242388BE48009414B4 /* List+Model.swift */,
 				21644B7B2588258100C548A5 /* ModelList.swift */,
+				218DC979258A73CA00D59FC6 /* Paginatable.swift */,
 			);
 			path = Collection;
 			sourceTree = "<group>";
@@ -3342,6 +3355,7 @@
 			children = (
 				FAC2358C227A4A1D00424678 /* Category */,
 				FAC23582227A3C2E00424678 /* Configuration */,
+				218DC968258A739E00D59FC6 /* Error */,
 				FAC23534227A055200424678 /* Internal */,
 				FAC2358D227A4A2B00424678 /* Plugin */,
 				FA56F72122B14AEB0039754A /* Support */,
@@ -4712,6 +4726,7 @@
 				B9FAA10B23878122009414B4 /* ModelField+Association.swift in Sources */,
 				FAEF832124CF277F0068912D /* DataStoreCategory+Behavior+Combine.swift in Sources */,
 				95DAAB22237E63370028544F /* SpeechType.swift in Sources */,
+				218DC96A258A73AF00D59FC6 /* CoreError.swift in Sources */,
 				95DAAB8C237F13D10028544F /* PredictionsTextToSpeechRequest.swift in Sources */,
 				B493E69124524D3200D9E521 /* DeliveryDestination.swift in Sources */,
 				21644B7D2588258100C548A5 /* ModelList.swift in Sources */,
@@ -4758,6 +4773,7 @@
 				FAC2353F227A055200424678 /* PluginError.swift in Sources */,
 				974FF18724B54E590050D01B /* DeviceInfoItem.swift in Sources */,
 				97CB860624ABA023000C65FB /* LongPressGestureRecognizer.swift in Sources */,
+				218DC97A258A73CA00D59FC6 /* Paginatable.swift in Sources */,
 				FA5704C7245F368200392C19 /* ProgressListener.swift in Sources */,
 				FA76A2D32342B47100B91ADB /* HubPayloadEventName.swift in Sources */,
 				FA5704C9245F3C6900392C19 /* AmplifyInProcessReportingOperation.swift in Sources */,

--- a/Amplify/Categories/DataStore/Model/Collection/List+Model.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+Model.swift
@@ -105,8 +105,19 @@ open class List<ModelType: Model>: ModelList {
     /// Use to initialize the collection.
     ///
     /// - seealso: `load()`
+    @available(*, deprecated, message: "Use `fetch(_)` instead.")
     open func load(_ completion: DataStoreCallback<Elements>) {
         fatalError("Not implemented.")
+    }
+
+    /// Trigger a query to initialize the collection. This function always
+    /// fetches data from the backing data store if the collection has not yet been loaded.
+    /// Consumers must be aware of the implementation details that that accessing the collection
+    /// may be blocked on this call until data is ready.
+    ///
+    /// - Returns: result of querying for the data. On `.success` will have loaded the data into the current object.
+    open func fetch(_ completion: @escaping (Result<Void, CoreError>) -> Void) {
+        fatalError("Not implemented")
     }
 
     // MARK: - Synchronous API
@@ -117,6 +128,7 @@ open class List<ModelType: Model>: ModelList {
     ///
     /// - Returns: the current instance after data was loaded.
     /// - seealso: `load(completion:)`
+    @available(*, deprecated, message: "Use `fetch(_)` instead.")
     open func load() -> Self {
         fatalError("Not implemented.")
     }
@@ -129,8 +141,18 @@ open class List<ModelType: Model>: ModelList {
     ///
     /// - Returns: a type-erased Combine publisher
     @available(iOS 13.0, *)
-    @available(*, deprecated, message: "Use `load` instead.")
+    @available(*, deprecated, message: "Use `fetch(_)` instead.")
     open func loadAsPublisher() -> LazyListPublisher {
         fatalError("Not implemented")
+    }
+
+    // MARK: Paginatable
+
+    open func hasNextPage() -> Bool {
+        return false
+    }
+
+    open func getNextPage(completion: @escaping PageResultCallback) {
+        fatalError("Not supported")
     }
 }

--- a/Amplify/Categories/DataStore/Model/Collection/ModelList.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/ModelList.swift
@@ -8,8 +8,11 @@
 /// `ModelList` defines conformance to `Collection` for a list of `Model` items.
 public protocol ModelList: Collection,
                            Codable,
-                           ExpressibleByArrayLiteral where Index == Int,
-                                                           ArrayLiteralElement == Element, Element: Model {
+                           ExpressibleByArrayLiteral,
+                           Paginatable,
+                           ModelListMarker where Index == Int,
+                                                 ArrayLiteralElement == Element {
+
     init(factory: () -> Self)
 }
 
@@ -19,3 +22,6 @@ extension ModelList {
         self = factory()
     }
 }
+
+/// Empty protocol used as a marker to detect `ModelList` conformance.
+public protocol ModelListMarker { }

--- a/Amplify/Categories/DataStore/Model/Collection/Paginatable.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/Paginatable.swift
@@ -1,0 +1,20 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public protocol Paginatable {
+
+    typealias PageResultCallback = (Result<List<Element>, CoreError>) -> Void
+    associatedtype Element: Model
+
+    /// Checks if there is subsequent data to retrieve. If True, retrieve the next page using `getNextPage`
+    func hasNextPage() -> Bool
+
+    /// Retrieves the next page as a new in-memory List object asynchronously.
+    func getNextPage(completion: @escaping PageResultCallback)
+}

--- a/Amplify/Core/Error/CoreError.swift
+++ b/Amplify/Core/Error/CoreError.swift
@@ -1,0 +1,61 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// Errors associated with operations provided by Amplify
+public enum CoreError {
+
+    /// A related operation performed on `List` resulted in an error.
+    case listOperation(ErrorDescription, RecoverySuggestion, Error? = nil)
+
+    /// A client side validation error occured.
+    case validation(ErrorDescription, RecoverySuggestion, Error? = nil)
+
+    /// An unknown error occurred
+    case unknown(ErrorDescription, RecoverySuggestion, Error?)
+}
+
+extension CoreError: AmplifyError {
+    public var errorDescription: ErrorDescription {
+        switch self {
+        case .listOperation(let description, _, _),
+             .validation(let description, _, _),
+             .unknown(let description, _, _):
+            return description
+        }
+    }
+
+    public var recoverySuggestion: RecoverySuggestion {
+        switch self {
+        case .listOperation(_, let recoverySuggestion, _),
+             .validation(_, let recoverySuggestion, _),
+             .unknown(_, let recoverySuggestion, _):
+            return recoverySuggestion
+        }
+    }
+
+    public var underlyingError: Error? {
+        switch self {
+        case .listOperation(_, _, let underlyingError),
+             .validation(_, _, let underlyingError),
+             .unknown(_, _, let underlyingError):
+            return underlyingError
+        }
+    }
+
+    public init(
+        errorDescription: ErrorDescription = "An unknown error occurred",
+        recoverySuggestion: RecoverySuggestion = "See `underlyingError` for more details",
+        error: Error
+    ) {
+        if let error = error as? Self {
+            self = error
+        } else {
+            self = .unknown(errorDescription, recoverySuggestion, error)
+        }
+    }
+
+}

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
@@ -15,6 +15,12 @@
 		21233D0D2469EBBE00039337 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 21233D0C2469EBBE00039337 /* README.md */; };
 		21233DC8246F571100039337 /* GraphQLAuthDirectiveIntegrationTests+Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21233DC6246F560A00039337 /* GraphQLAuthDirectiveIntegrationTests+Auth.swift */; };
 		2129BE3E239486D2006363A1 /* AnyModel+JSONInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2129BE3D239486D2006363A1 /* AnyModel+JSONInit.swift */; };
+		212B28F0259240AB00593ED5 /* AppSyncList+Paginatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212B28EF259240AB00593ED5 /* AppSyncList+Paginatable.swift */; };
+		212B28FB2592410900593ED5 /* AppSyncList+LazyLoad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212B28FA2592410900593ED5 /* AppSyncList+LazyLoad.swift */; };
+		212B29212592454400593ED5 /* AppSyncListPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212B29202592454400593ED5 /* AppSyncListPayload.swift */; };
+		212B298B2592519800593ED5 /* GraphQLConnectionScenario3Tests+List.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212B298A2592519800593ED5 /* GraphQLConnectionScenario3Tests+List.swift */; };
+		212B299F259251F100593ED5 /* GraphQLModelBasedTests+List.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212B299E259251F100593ED5 /* GraphQLModelBasedTests+List.swift */; };
+		212B2A46259401DF00593ED5 /* AppSyncListGraphQLRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212B2A45259401DF00593ED5 /* AppSyncListGraphQLRequestTests.swift */; };
 		21409C4F2384BA7E000A53C9 /* APIOperationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21409C4E2384BA7E000A53C9 /* APIOperationResponse.swift */; };
 		21409C602384DF17000A53C9 /* RESTOperationRequest+RESTRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21409C5F2384DF17000A53C9 /* RESTOperationRequest+RESTRequest.swift */; };
 		21409C7223850BEE000A53C9 /* Todo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21409C7123850BEE000A53C9 /* Todo.swift */; };
@@ -95,10 +101,10 @@
 		21F40A2B23A0423C0074678E /* GraphQLSyncBasedTests-amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21F40A2923A0423C0074678E /* GraphQLSyncBasedTests-amplifyconfiguration.json */; };
 		21F40A2E23A0707E0074678E /* GraphQLModelBasedTests-amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21F40A2D23A0707E0074678E /* GraphQLModelBasedTests-amplifyconfiguration.json */; };
 		21FDBB762587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FDBB752587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift */; };
-		21FE04BB25894F8800B81D72 /* GraphQLConnectionScenario3Tests+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FE04B825894F8800B81D72 /* GraphQLConnectionScenario3Tests+Helpers.swift */; };
-		21FE04BD25894F8800B81D72 /* GraphQLConnectionScenario3Tests+Subscribe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FE04BA25894F8800B81D72 /* GraphQLConnectionScenario3Tests+Subscribe.swift */; };
 		21FE04262589295D00B81D72 /* AppSyncList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FE04252589295D00B81D72 /* AppSyncList.swift */; };
 		21FE044C25894C5300B81D72 /* AppSyncListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FE044B25894C5300B81D72 /* AppSyncListTests.swift */; };
+		21FE04BB25894F8800B81D72 /* GraphQLConnectionScenario3Tests+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FE04B825894F8800B81D72 /* GraphQLConnectionScenario3Tests+Helpers.swift */; };
+		21FE04BD25894F8800B81D72 /* GraphQLConnectionScenario3Tests+Subscribe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FE04BA25894F8800B81D72 /* GraphQLConnectionScenario3Tests+Subscribe.swift */; };
 		241355B5778C3B2C3826CE96 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithIAMIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D57635393A9898E665C00A1 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithIAMIntegrationTests.framework */; };
 		2CEBACDFF438BD3D3C28A92E /* Pods_HostApp_AWSAPICategoryPluginTestCommon_GraphQLWithIAMIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5B78DFE063D156DDD5BC634 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_GraphQLWithIAMIntegrationTests.framework */; };
 		34AC2D987AA9068173601F3A /* Pods_HostApp_AWSAPICategoryPluginTestCommon_AWSAPICategoryPluginFunctionalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CAC5A88BE3D8AAD8B926A28 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_AWSAPICategoryPluginFunctionalTests.framework */; };
@@ -296,6 +302,12 @@
 		21233D0C2469EBBE00039337 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		21233DC6246F560A00039337 /* GraphQLAuthDirectiveIntegrationTests+Auth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLAuthDirectiveIntegrationTests+Auth.swift"; sourceTree = "<group>"; };
 		2129BE3D239486D2006363A1 /* AnyModel+JSONInit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AnyModel+JSONInit.swift"; sourceTree = "<group>"; };
+		212B28EF259240AB00593ED5 /* AppSyncList+Paginatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSyncList+Paginatable.swift"; sourceTree = "<group>"; };
+		212B28FA2592410900593ED5 /* AppSyncList+LazyLoad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSyncList+LazyLoad.swift"; sourceTree = "<group>"; };
+		212B29202592454400593ED5 /* AppSyncListPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncListPayload.swift; sourceTree = "<group>"; };
+		212B298A2592519800593ED5 /* GraphQLConnectionScenario3Tests+List.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLConnectionScenario3Tests+List.swift"; sourceTree = "<group>"; };
+		212B299E259251F100593ED5 /* GraphQLModelBasedTests+List.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLModelBasedTests+List.swift"; sourceTree = "<group>"; };
+		212B2A45259401DF00593ED5 /* AppSyncListGraphQLRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncListGraphQLRequestTests.swift; sourceTree = "<group>"; };
 		21409C4E2384BA7E000A53C9 /* APIOperationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIOperationResponse.swift; sourceTree = "<group>"; };
 		21409C5F2384DF17000A53C9 /* RESTOperationRequest+RESTRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RESTOperationRequest+RESTRequest.swift"; sourceTree = "<group>"; };
 		21409C6723850A9E000A53C9 /* AWSAPICategoryPluginTestCommon.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSAPICategoryPluginTestCommon.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -389,10 +401,10 @@
 		21F40A2923A0423C0074678E /* GraphQLSyncBasedTests-amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GraphQLSyncBasedTests-amplifyconfiguration.json"; sourceTree = "<group>"; };
 		21F40A2D23A0707E0074678E /* GraphQLModelBasedTests-amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GraphQLModelBasedTests-amplifyconfiguration.json"; sourceTree = "<group>"; };
 		21FDBB752587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQLConnectionScenario6Tests.swift; sourceTree = "<group>"; };
-		21FE04B825894F8800B81D72 /* GraphQLConnectionScenario3Tests+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQLConnectionScenario3Tests+Helpers.swift"; sourceTree = "<group>"; };
-		21FE04BA25894F8800B81D72 /* GraphQLConnectionScenario3Tests+Subscribe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQLConnectionScenario3Tests+Subscribe.swift"; sourceTree = "<group>"; };
 		21FE04252589295D00B81D72 /* AppSyncList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncList.swift; sourceTree = "<group>"; };
 		21FE044B25894C5300B81D72 /* AppSyncListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncListTests.swift; sourceTree = "<group>"; };
+		21FE04B825894F8800B81D72 /* GraphQLConnectionScenario3Tests+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQLConnectionScenario3Tests+Helpers.swift"; sourceTree = "<group>"; };
+		21FE04BA25894F8800B81D72 /* GraphQLConnectionScenario3Tests+Subscribe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQLConnectionScenario3Tests+Subscribe.swift"; sourceTree = "<group>"; };
 		226F79D02FF47C0A8AE75467 /* Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests/Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithUserPoolIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		2A9C1061115A6639265D6C9C /* Pods-GraphQLWithIAMIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GraphQLWithIAMIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-GraphQLWithIAMIntegrationTests/Pods-GraphQLWithIAMIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		2D57635393A9898E665C00A1 /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithIAMIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithIAMIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -670,12 +682,14 @@
 				217D5FE825783559009F0639 /* GraphQLConnectionScenario2Tests.swift */,
 				217D5FFF2578369F009F0639 /* GraphQLConnectionScenario3Tests.swift */,
 				21FE04B825894F8800B81D72 /* GraphQLConnectionScenario3Tests+Helpers.swift */,
+				212B298A2592519800593ED5 /* GraphQLConnectionScenario3Tests+List.swift */,
 				21FE04BA25894F8800B81D72 /* GraphQLConnectionScenario3Tests+Subscribe.swift */,
 				217D5FFC2578369E009F0639 /* GraphQLConnectionScenario4Tests.swift */,
 				217D5FFD2578369E009F0639 /* GraphQLConnectionScenario5Tests.swift */,
 				21FDBB752587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift */,
 				21F40A2D23A0707E0074678E /* GraphQLModelBasedTests-amplifyconfiguration.json */,
 				217856C12383339D00A30D19 /* GraphQLModelBasedTests.swift */,
+				212B299E259251F100593ED5 /* GraphQLModelBasedTests+List.swift */,
 				21598CEF23A00F8400529F29 /* README.md */,
 			);
 			path = GraphQLModelBased;
@@ -940,6 +954,9 @@
 			isa = PBXGroup;
 			children = (
 				21FE04252589295D00B81D72 /* AppSyncList.swift */,
+				212B28FA2592410900593ED5 /* AppSyncList+LazyLoad.swift */,
+				212B28EF259240AB00593ED5 /* AppSyncList+Paginatable.swift */,
+				212B29202592454400593ED5 /* AppSyncListPayload.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -948,6 +965,7 @@
 			isa = PBXGroup;
 			children = (
 				21FE044B25894C5300B81D72 /* AppSyncListTests.swift */,
+				212B2A45259401DF00593ED5 /* AppSyncListGraphQLRequestTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -2210,7 +2228,9 @@
 				217D60012578369F009F0639 /* GraphQLConnectionScenario5Tests.swift in Sources */,
 				217D5FE925783559009F0639 /* GraphQLConnectionScenario2Tests.swift in Sources */,
 				217856C22383339D00A30D19 /* GraphQLModelBasedTests.swift in Sources */,
+				212B298B2592519800593ED5 /* GraphQLConnectionScenario3Tests+List.swift in Sources */,
 				217D60022578369F009F0639 /* GraphQLConnectionScenario1Tests.swift in Sources */,
+				212B299F259251F100593ED5 /* GraphQLModelBasedTests+List.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2248,6 +2268,7 @@
 			files = (
 				21D7A102237B54D90057D00D /* URLSessionBehaviorDelegate.swift in Sources */,
 				21D7A0FD237B54D90057D00D /* URLSession+URLSessionBehavior.swift in Sources */,
+				212B29212592454400593ED5 /* AppSyncListPayload.swift in Sources */,
 				21D7A0FF237B54D90057D00D /* URLSessionBehavior.swift in Sources */,
 				21D7A101237B54D90057D00D /* OperationTaskMapper.swift in Sources */,
 				21D7A110237B54D90057D00D /* GraphQLOperationRequestUtils.swift in Sources */,
@@ -2280,6 +2301,7 @@
 				216449472587E92B00C548A5 /* GraphQLResponseDecoder+DecodeData.swift in Sources */,
 				21D7A112237B54D90057D00D /* GraphQLOperationRequestUtils+Validator.swift in Sources */,
 				21D7A0FC237B54D90057D00D /* URLSessionFactory.swift in Sources */,
+				212B28FB2592410900593ED5 /* AppSyncList+LazyLoad.swift in Sources */,
 				7632AD8A252E1E10009B5BC9 /* AppSyncJSONValue+toJSONValue.swift in Sources */,
 				21D7A103237B54D90057D00D /* URLRequestConstants.swift in Sources */,
 				21D7A118237B54D90057D00D /* APIKeyURLRequestInterceptor.swift in Sources */,
@@ -2288,6 +2310,7 @@
 				21D7A0E6237B54D90057D00D /* AWSAPICategoryPluginConfiguration+EndpointConfig.swift in Sources */,
 				21D7A0EB237B54D90057D00D /* AWSAPIPlugin+URLSessionDelegate.swift in Sources */,
 				21D7A0DF237B54D90057D00D /* AWSGraphQLOperation.swift in Sources */,
+				212B28F0259240AB00593ED5 /* AppSyncList+Paginatable.swift in Sources */,
 				6B8D479D25801DF700E841CB /* AmplifyReachability.swift in Sources */,
 				6B33897223AAD94800561E5B /* AWSAPIPlugin+Reachability.swift in Sources */,
 				FA8EE785238632620097E4F1 /* AWSAPIPlugin+Log.swift in Sources */,
@@ -2333,6 +2356,7 @@
 				B4DFA5E1237A611D0013E17B /* MockURLSessionTask.swift in Sources */,
 				FAA7A5AA24C0E01500CA863F /* AWSGraphQLSubscriptionOperationCancelTests.swift in Sources */,
 				B4DFA5F8237A611D0013E17B /* AWSAPICategoryPlugin+ConfigureTests.swift in Sources */,
+				212B2A46259401DF00593ED5 /* AppSyncListGraphQLRequestTests.swift in Sources */,
 				21FE044C25894C5300B81D72 /* AppSyncListTests.swift in Sources */,
 				B4DFA5F1237A611D0013E17B /* AWSAPICategoryPlugin+URLSessionBehaviorDelegateTests.swift in Sources */,
 				B4DFA5E7237A611D0013E17B /* AWSAPICategoryPlugin+InterceptorBehaviorTests.swift in Sources */,

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Core/AppSyncList+LazyLoad.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Core/AppSyncList+LazyLoad.swift
@@ -1,0 +1,100 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import AWSPluginsCore
+
+extension AppSyncList {
+    /// Represents the data state of the `AppSyncList`.
+    internal enum LoadState {
+        case pending
+        case loaded
+    }
+
+    internal func loadIfNeeded() {
+        if state != .loaded {
+            firstPage()
+        }
+    }
+
+    func firstPage(_ completion: @escaping (Result<Void, CoreError>) -> Void) {
+        // if the collection has no associated field, return immediately
+        guard let associatedId = associatedId,
+              let associatedField = associatedField else {
+            completion(.success(()))
+            return
+        }
+
+        let request = AppSyncList.requestForFirstPage(associatedId: associatedId,
+                                                      associatedField: associatedField)
+        Amplify.API.query(request: request) { result in
+            switch result {
+            case .success(let graphQLResponse):
+                switch graphQLResponse {
+                case .success(let list):
+                    self.elements = list.elements
+                    self.document = list.document
+                    self.variables = list.variables
+                    self.nextToken = list.nextToken
+                    self.state = .loaded
+                    completion(.success(()))
+                case .failure(let graphQLError):
+                    Amplify.API.log.error(error: graphQLError)
+                    completion(.failure(.listOperation(
+                                            "The AppSync response returned successfully with GraphQL errors.",
+                                            "Check the underlying error for the failed GraphQL response.",
+                                            graphQLError)))
+                }
+            case .failure(let apiError):
+                Amplify.API.log.error(error: apiError)
+                completion(.failure(.listOperation("The AppSync request failed",
+                                                   "Check the underlying `APIError`",
+                                                   apiError)))
+            }
+        }
+    }
+
+    func firstPage() {
+        let semaphore = DispatchSemaphore(value: 0)
+        firstPage {
+            switch $0 {
+            case .success:
+                semaphore.signal()
+            case .failure:
+                semaphore.signal()
+            }
+        }
+        semaphore.wait()
+    }
+
+    // This method will return a request to retrieve `ModelType` based on its `associatedField` by the `associatedId`.
+    // For example, if this is a Comment, which belongs to Post, the associatedField is the Post and the associatedId is
+    // the belonging to Post's ID. The request constructed will leverage existing GraphQLRequest document builders
+    // and decorators to create
+    // - A GraphQL `query` operation
+    // - A `list` type query operation
+    // - A filter on the associated field with `associatedId`
+    static func requestForFirstPage(associatedId: String,
+                                    associatedField: ModelField) -> GraphQLRequest<AppSyncList<ModelType>> {
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelType.schema, operationType: .query)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
+
+        var fieldName = associatedField.name
+        if case let .belongsTo(_, targetName) = associatedField.association {
+            // use the default service generated field name if the targetName does not exist
+            fieldName = targetName ?? ModelType.modelName.camelCased() + associatedField.name.pascalCased() + "Id"
+        }
+        let predicate: QueryPredicate = field(fieldName) == associatedId
+        documentBuilder.add(decorator: FilterDecorator(filter: predicate.graphQLFilter))
+        documentBuilder.add(decorator: PaginationDecorator())
+        let document = documentBuilder.build()
+        return GraphQLRequest<AppSyncList<ModelType>>(document: document.stringValue,
+                                                      variables: document.variables,
+                                                      responseType: AppSyncList<ModelType>.self,
+                                                      decodePath: document.name)
+    }
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Core/AppSyncList+Paginatable.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Core/AppSyncList+Paginatable.swift
@@ -1,0 +1,85 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import AWSPluginsCore
+
+extension AppSyncList {
+    func nextPage(completion: @escaping PageResultCallback) {
+        guard let nextToken = nextToken else {
+            completion(.failure(CoreError.validation("There is no next page to fetch.",
+                                                     "Check `hasNextPage()` before fetching the next page")))
+            return
+        }
+
+        let request = AppSyncList.requestForNextPage(nextToken: nextToken, variables: variables)
+
+        Amplify.API.query(request: request) { result in
+            switch result {
+            case .success(let graphQLResponse):
+                switch graphQLResponse {
+                case .success(let list):
+                    completion(.success(list))
+                case .failure(let graphQLError):
+                    completion(.failure(.listOperation(
+                                            "The AppSync response returned successfully with GraphQL errors.",
+                                            "Check the underlying error for the failed GraphQL response.",
+                                            graphQLError)))
+                }
+            case .failure(let apiError):
+                completion(.failure(.listOperation("The AppSync request failed",
+                                                   "Check the underlying `APIError`",
+                                                   apiError)))
+            }
+        }
+    }
+
+    // This method will always successfully return a new GraphQLRequest with the next token added to the input variables
+    // It leverages the existing GraphQLRequest document builders and decorators to create
+    // - A GraphQL `query` operation
+    // - A `list` type query operation
+    // - The next token added to the GraphQL request variables
+    // If the existing `variables` from current list (`Self`) contains information such as a filter and limit, they are
+    // extracted back out and added back onto the GraphQL request variables to maintain the expected behavior
+    static func requestForNextPage(nextToken: String,
+                                   variables: [String: JSONValue]?) -> GraphQLRequest<AppSyncList<ModelType>> {
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelType.schema, operationType: .query)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
+
+        // Since the original request constructed with object of type `QueryPredicate`, and the type is lost when
+        // translated to a GraphQLRequest. The following extracts the existing filter variables stored in the
+        // GraphQLRequest's variables and uses FilterDecorator to re-create the proper document.
+        if let storedVariables = variables,
+           let filters = storedVariables["filter"],
+           case let .object(filterValue) = filters {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
+            guard let filterVariablesData = try? encoder.encode(filterValue),
+                  let filterVariablesJSON = try? JSONSerialization.jsonObject(with: filterVariablesData)
+                    as? [String: Any] else {
+                fatalError("Filter variables is not valid JSON object")
+            }
+            documentBuilder.add(decorator: FilterDecorator(filter: filterVariablesJSON))
+        }
+
+        // Similar to the filter variables, limit is also stored in the variables and expected to be persisted
+        // across multiple requets, hence extract the limit from the variables if it exists.
+        if let storedVariables = variables,
+           let limit = storedVariables["limit"],
+           case let .number(limitValue) = limit {
+            documentBuilder.add(decorator: PaginationDecorator(limit: Int(limitValue), nextToken: nextToken))
+        } else {
+            documentBuilder.add(decorator: PaginationDecorator(nextToken: nextToken))
+        }
+
+        let document = documentBuilder.build()
+        return GraphQLRequest<AppSyncList<ModelType>>(document: document.stringValue,
+                                                      variables: document.variables,
+                                                      responseType: AppSyncList<ModelType>.self,
+                                                      decodePath: document.name)
+    }
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Core/AppSyncList.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Core/AppSyncList.swift
@@ -10,14 +10,77 @@ import Amplify
 
 public class AppSyncList<ModelType: Model>: List<ModelType>, ModelListDecoder {
 
+    var associatedId: Model.Identifier?
+    var associatedField: ModelField?
+    var state: LoadState = .pending
+
+    var nextToken: String?
+    var document: String?
+    var variables: [String: JSONValue]?
+
+    // MARK: - Initializers
+
+    init(_ elements: [Element],
+         nextToken: String? = nil,
+         document: String? = nil,
+         variables: [String: JSONValue]? = nil) {
+        super.init(elements)
+        self.nextToken = nextToken
+        self.document = document
+        self.variables = variables
+        self.state = .loaded
+    }
+
+    public init(_ elements: Elements,
+                associatedId: Model.Identifier?,
+                associatedField: ModelField?) {
+        super.init(elements)
+        self.associatedId = associatedId
+        self.associatedField = associatedField
+    }
+
+    required convenience public init(arrayLiteral elements: Element...) {
+        self.init(elements)
+        self.state = .loaded
+    }
+
+    // MARK: - Collection conformance
+
+    public override var startIndex: Index {
+        loadIfNeeded()
+        return elements.startIndex
+    }
+
+    public __consuming override func makeIterator() -> IndexingIterator<Elements> {
+        loadIfNeeded()
+        return elements.makeIterator()
+    }
+
     // MARK: Codable
 
     required convenience public init(from decoder: Decoder) throws {
         let json = try JSONValue(from: decoder)
-
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
 
+        // If decodable to `AppSyncListPayload`, extract the request and response
+        if let payload = try? AppSyncListPayload.init(from: decoder) {
+            // When handling the response, decode each item to the model and store the item's metadata in the array
+            // associations
+            let elements = try payload.getItems().map { (jsonElement) -> ModelType in
+                return try GraphQLResponseDecoder<ModelType>.decodeToModelWithArrayAssociations(
+                    responseType: ModelType.self,
+                    modelGraphQLData: jsonElement)
+            }
+
+            self.init(elements,
+                      nextToken: payload.getNextToken(),
+                      document: payload.document,
+                      variables: payload.variables)
+            return
+        }
+
+        // Decode to a collection of elements when detected the "items" response from AppSync
         if case let .object(jsonObject) = json,
               case let .array(jsonArray) = jsonObject["items"] {
 
@@ -32,6 +95,17 @@ public class AppSyncList<ModelType: Model>: List<ModelType>, ModelListDecoder {
             return
         }
 
+        // Decode to an empty collection with metadata about the associated field and id
+        // The metadata is useful for fetching the first page
+        if case let .object(jsonObject) = json,
+                  case let .string(associatedId) = jsonObject["associatedId"],
+                  case let .string(associatedField) = jsonObject["associatedField"],
+                  case .string = jsonObject["listType"] {
+            let field = Element.schema.field(withName: associatedField)
+            self.init([], associatedId: associatedId, associatedField: field)
+            return
+        }
+
         self.init([ModelType]())
     }
 
@@ -43,9 +117,20 @@ public class AppSyncList<ModelType: Model>: List<ModelType>, ModelListDecoder {
         if case let .object(jsonObject) = json,
            case .array = jsonObject["items"] {
             return true
+        } else if case let .object(jsonObject) = json,
+                  case .string = jsonObject["associatedId"],
+                  case .string = jsonObject["associatedField"],
+                  case .string(let listType) = jsonObject["listType"],
+                  listType == "appSyncList" {
+            return true
         }
 
-        return false
+        do {
+            _ = try AppSyncListPayload.init(from: decoder)
+            return true
+        } catch {
+            return false
+        }
     }
 
     public static func decode<ModelType: Model>(decoder: Decoder,
@@ -55,5 +140,26 @@ public class AppSyncList<ModelType: Model>: List<ModelType>, ModelListDecoder {
         } catch {
             return List([ModelType]())
         }
+    }
+
+    // MARK: - Asynchronous API
+
+    public override func fetch(_ completion: @escaping (Result<Void, CoreError>) -> Void) {
+        if state != .loaded {
+            firstPage(completion)
+        } else {
+            completion(.success(()))
+        }
+    }
+
+    // MARK: Paginatable
+
+    public override func hasNextPage() -> Bool {
+        loadIfNeeded()
+        return nextToken != nil
+    }
+
+    public override func getNextPage(completion: @escaping PageResultCallback) {
+        nextPage(completion: completion)
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Core/AppSyncListPayload.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Core/AppSyncListPayload.swift
@@ -1,0 +1,37 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+
+// A payload containing both the request and response data for AppSync, useful for custom decoding to `AppSyncList`.
+public struct AppSyncListPayload: Codable {
+    let document: String
+    let variables: [String: JSONValue]?
+    private let graphQLData: JSONValue
+
+    public init(document: String, variables: [String: JSONValue]? = nil, graphQLData: JSONValue) {
+        self.document = document
+        self.variables = variables
+        self.graphQLData = graphQLData
+    }
+
+    func getNextToken() -> String? {
+        if case let .string(nextToken) = graphQLData["nextToken"] {
+            return nextToken
+        }
+
+        return nil
+    }
+
+    func getItems() -> [JSONValue] {
+        if case let .array(jsonArray) = graphQLData["items"] {
+            return jsonArray
+        }
+
+        return []
+    }
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Decode/GraphQLResponseDecoder+DecodeData.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Decode/GraphQLResponseDecoder+DecodeData.swift
@@ -28,8 +28,96 @@ extension GraphQLResponseDecoder {
         } else {
             let serializedJSON = try encoder.encode(graphQLData)
             let responseData = try decoder.decode(request.responseType, from: serializedJSON)
+            if responseData is Model {
+                return try GraphQLResponseDecoder.decodeToModelWithArrayAssociations(responseType: request.responseType,
+                                                                                     modelGraphQLData: graphQLData)
+            } else if responseData is ModelListMarker {
+                return try decodeToAppSyncList(graphQLData: graphQLData)
+            }
             return responseData
         }
+    }
+
+    static func decodeToModelWithArrayAssociations<M: Decodable>(responseType: M.Type,
+                                                                 modelGraphQLData: JSONValue) throws -> M {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = ModelDateFormatting.decodingStrategy
+
+        guard let modelType = getModelType(modelGraphQLData: modelGraphQLData),
+              let id = getId(modelGraphQLData: modelGraphQLData),
+              case .object(var model) = modelGraphQLData else {
+            let serializedJSON = try encoder.encode(modelGraphQLData)
+            return try decoder.decode(M.self, from: serializedJSON)
+        }
+
+        // Iterate over the associations of the model and for each association, store it's association data
+        // For example, if the modelType is a Post and has a field that is an array association like Comment
+        // Store the post's id and post field in the comments as the `associationPayload`
+        modelType.schema.fields.values.forEach { modelField in
+            if modelField.isArray && modelField.hasAssociation,
+               let associatedField = modelField.associatedField {
+                let modelFieldName = modelField.name
+                let associatedFieldName = associatedField.name
+
+                if model[modelFieldName] == nil {
+                    let associationPayload: JSONValue = [
+                        "associatedId": .string(id),
+                        "associatedField": .string(associatedFieldName),
+                        "listType": "appSyncList"
+                    ]
+
+                    model.updateValue(associationPayload, forKey: modelFieldName)
+                }
+            }
+        }
+        let serializedJSON = try encoder.encode(model)
+        return try decoder.decode(M.self, from: serializedJSON)
+    }
+
+    private static func getModelType(modelGraphQLData: JSONValue) -> Model.Type? {
+        guard case .string(let modelName) = modelGraphQLData["__typename"],
+              let modelType = ModelRegistry.modelType(from: modelName) else {
+            Amplify.API.log.error("""
+                Could not retrieve the `__typename` attribute from the return value. Be sure to include __typename in \
+                the selection set of the GraphQL operation. GraphQL:
+                \(modelGraphQLData)
+                """)
+            return nil
+        }
+
+        return modelType
+    }
+
+    private static func getId(modelGraphQLData: JSONValue) -> String? {
+        guard case .string(let id) = modelGraphQLData["id"] else {
+            Amplify.API.log.error("""
+                Could not retrieve the `id` attribute from the return value. Be sure to include `id` in \
+                the selection set of the GraphQL operation. GraphQL:
+                \(modelGraphQLData)
+                """)
+            return nil
+        }
+
+        return id
+    }
+
+    func decodeToAppSyncList(graphQLData: JSONValue) throws -> R {
+        let payload: AppSyncListPayload
+        if let variables = request.variables {
+            let variablesData = try JSONSerialization.data(withJSONObject: variables)
+            let variablesJSON = try decoder.decode([String: JSONValue].self, from: variablesData)
+            payload = AppSyncListPayload(document: request.document,
+                                         variables: variablesJSON,
+                                         graphQLData: graphQLData)
+        } else {
+            payload = AppSyncListPayload(document: request.document,
+                                         graphQLData: graphQLData)
+        }
+
+        let encodedData = try encoder.encode(payload)
+        return try decoder.decode(request.responseType, from: encodedData)
     }
 
     private func valueAtDecodePath(from graphQLData: JSONValue) throws -> JSONValue {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario1Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario1Tests.swift
@@ -202,6 +202,58 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
         wait(for: [listProjectByTeamIDCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
+    func testPaginatedListProjects() {
+        guard let team = createTeam(name: "name"),
+              let projecta = createProject(team: team),
+              let projectb = createProject(team: team) else {
+            XCTFail("Could not create team and two projects")
+            return
+        }
+
+        let listProjectByTeamIDCompleted = expectation(description: "list projects completed")
+        var results: List<Project1>?
+        let predicate = Project1.keys.id == projecta.id || Project1.keys.id == projectb.id
+        Amplify.API.query(request: .paginatedList(Project1.self, where: predicate)) { result in
+            switch result {
+            case .success(let result):
+                switch result {
+                case .success(let projects):
+                    results = projects
+                    listProjectByTeamIDCompleted.fulfill()
+                case .failure(let response):
+                    XCTFail("Failed with: \(response)")
+                }
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [listProjectByTeamIDCompleted], timeout: TestCommonConstants.networkTimeout)
+        guard var subsequentResults = results else {
+            XCTFail("Could not get first results")
+            return
+        }
+        var resultsArray: [Project1] = []
+        resultsArray.append(contentsOf: subsequentResults)
+        while subsequentResults.hasNextPage() {
+            let semaphore = DispatchSemaphore(value: 0)
+            subsequentResults.getNextPage { result in
+                defer {
+                    semaphore.signal()
+                }
+                switch result {
+                case .success(let listResult):
+                    subsequentResults = listResult
+                    resultsArray.append(contentsOf: subsequentResults)
+                case .failure(let coreError):
+                    XCTFail("Unexpected error: \(coreError)")
+                }
+
+            }
+            semaphore.wait()
+        }
+        XCTAssertEqual(resultsArray.count, 2)
+    }
+
     func createTeam(id: String = UUID().uuidString, name: String) -> Team1? {
         let team = Team1(id: id, name: name)
         var result: Team1?

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests+List.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests+List.swift
@@ -1,0 +1,389 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import AWSAPICategoryPlugin
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSAPICategoryPluginTestCommon
+
+/*
+ (HasMany) A Post that can have many comments
+ ```
+ type Post3 @model {
+   id: ID!
+   title: String!
+   comments: [Comment3] @connection(keyName: "byPost3", fields: ["id"])
+ }
+
+ type Comment3 @model
+   @key(name: "byPost3", fields: ["postID", "content"]) {
+   id: ID!
+   postID: ID!
+   content: String!
+ }
+ ```
+ See https://docs.amplify.aws/cli/graphql-transformer/connection for more details
+ */
+extension GraphQLConnectionScenario3Tests {
+
+    func testGetPostThenIterateComments() {
+        guard let post = createPost(title: "title"),
+              createComment(postID: post.id, content: "content") != nil,
+              createComment(postID: post.id, content: "content") != nil else {
+            XCTFail("Could not create post and two comments")
+            return
+        }
+
+        let getPostCompleted = expectation(description: "get post complete")
+        var results: List<Comment3>?
+        Amplify.API.query(request: .get(Post3.self, byId: post.id)) { result in
+            switch result {
+            case .success(let result):
+                switch result {
+                case .success(let queriedPostOptional):
+                    guard let queriedPost = queriedPostOptional else {
+                        XCTFail("Could not get post")
+                        return
+                    }
+                    XCTAssertEqual(queriedPost.id, post.id)
+                    results = queriedPost.comments
+                    getPostCompleted.fulfill()
+                case .failure(let response):
+                    XCTFail("Failed with: \(response)")
+                }
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [getPostCompleted], timeout: TestCommonConstants.networkTimeout)
+        guard var comments = results else {
+            XCTFail("Could not get comments")
+            return
+        }
+        var resultsArray: [Comment3] = []
+        for comment in comments {
+            resultsArray.append(comment)
+        }
+        while comments.hasNextPage() {
+            let semaphore = DispatchSemaphore(value: 0)
+            comments.getNextPage { result in
+                defer {
+                    semaphore.signal()
+                }
+                switch result {
+                case .success(let listResult):
+                    comments = listResult
+                    resultsArray.append(contentsOf: comments)
+                case .failure(let coreError):
+                    XCTFail("Unexpected error: \(coreError)")
+                }
+
+            }
+            semaphore.wait()
+        }
+        XCTAssertEqual(resultsArray.count, 2)
+    }
+
+    func testGetPostThenFetchComments() {
+        guard let post = createPost(title: "title"),
+              createComment(postID: post.id, content: "content") != nil,
+              createComment(postID: post.id, content: "content") != nil else {
+            XCTFail("Could not create post and two comments")
+            return
+        }
+
+        let getPostCompleted = expectation(description: "get post complete")
+        var results: List<Comment3>?
+        Amplify.API.query(request: .get(Post3.self, byId: post.id)) { result in
+            switch result {
+            case .success(let result):
+                switch result {
+                case .success(let queriedPostOptional):
+                    guard let queriedPost = queriedPostOptional else {
+                        XCTFail("Could not get post")
+                        return
+                    }
+                    XCTAssertEqual(queriedPost.id, post.id)
+                    results = queriedPost.comments
+                    getPostCompleted.fulfill()
+                case .failure(let response):
+                    XCTFail("Failed with: \(response)")
+                }
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [getPostCompleted], timeout: TestCommonConstants.networkTimeout)
+        guard var comments = results else {
+            XCTFail("Could not get comments")
+            return
+        }
+        var resultsArray: [Comment3] = []
+        let fetchSemaphore = DispatchSemaphore(value: 0)
+        comments.fetch { fetchResults in
+            switch fetchResults {
+            case .success:
+                fetchSemaphore.signal()
+            case .failure(let error):
+                XCTFail("Could not fetch comments \(error)")
+            }
+        }
+        fetchSemaphore.wait()
+        resultsArray.append(contentsOf: comments)
+        while comments.hasNextPage() {
+            let semaphore = DispatchSemaphore(value: 0)
+            comments.getNextPage { result in
+                defer {
+                    semaphore.signal()
+                }
+                switch result {
+                case .success(let listResult):
+                    comments = listResult
+                    resultsArray.append(contentsOf: comments)
+                case .failure(let coreError):
+                    XCTFail("Unexpected error: \(coreError)")
+                }
+
+            }
+            semaphore.wait()
+        }
+        XCTAssertEqual(resultsArray.count, 2)
+    }
+
+    // Create a post and list the posts
+    func testListPost() {
+        guard createPost(title: "title") != nil else {
+            XCTFail("Failed to ensure at least one Post to be retrieved on the listQuery")
+            return
+        }
+
+        let requestInvokedSuccessfully = expectation(description: "request completed")
+
+        _ = Amplify.API.query(request: .list(Post3.self)) { event in
+            switch event {
+            case .success(let graphQLResponse):
+                guard case let .success(posts) = graphQLResponse else {
+                    XCTFail("Missing successful response")
+                    return
+                }
+                XCTAssertTrue(!posts.isEmpty)
+                print(posts)
+                requestInvokedSuccessfully.fulfill()
+            case .failure(let error):
+                XCTFail("Unexpected .failed event: \(error)")
+            }
+        }
+
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
+    }
+
+    func testListPostWithPredicate() {
+        let uuid = UUID().uuidString
+        let testMethodName = String("\(#function)".dropLast(2))
+        let uniqueTitle = testMethodName + uuid + "Title"
+        guard let createdPost = createPost(id: uuid, title: uniqueTitle) else {
+            XCTFail("Failed to ensure at least one Post to be retrieved on the listQuery")
+            return
+        }
+
+        let requestInvokedSuccessfully = expectation(description: "request completed")
+        let post = Post3.keys
+        let predicate = post.id == uuid && post.title == uniqueTitle
+        _ = Amplify.API.query(request: .list(Post3.self, where: predicate)) { event in
+            switch event {
+            case .success(let graphQLResponse):
+                guard case let .success(posts) = graphQLResponse else {
+                    XCTFail("Missing successful response")
+                    return
+                }
+                XCTAssertEqual(posts.count, 1)
+                guard let singlePost = posts.first else {
+                    XCTFail("Should only have a single post with the unique title")
+                    return
+                }
+                XCTAssertEqual(singlePost.id, uuid)
+                XCTAssertEqual(singlePost.title, uniqueTitle)
+                requestInvokedSuccessfully.fulfill()
+            case .failure(let error):
+                XCTFail("Unexpected .failed event: \(error)")
+            }
+        }
+
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
+    }
+
+    // Create a post and a comment with that post
+    // list the comments by postId
+    func testListCommentsByPostID() {
+        guard let post = createPost(title: "title") else {
+            XCTFail("Could not create post")
+            return
+        }
+        guard createComment(postID: post.id, content: "content") != nil else {
+            XCTFail("Could not create comment")
+            return
+        }
+        let listCommentByPostIDCompleted = expectation(description: "list projects completed")
+        let predicate = Comment3.keys.postID.eq(post.id)
+        Amplify.API.query(request: .list(Comment3.self, where: predicate)) { result in
+            switch result {
+            case .success(let result):
+                switch result {
+                case .success(let comments):
+                    print(comments)
+                    listCommentByPostIDCompleted.fulfill()
+                case .failure(let response):
+                    XCTFail("Failed with: \(response)")
+                }
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [listCommentByPostIDCompleted], timeout: TestCommonConstants.networkTimeout)
+    }
+
+    /// Test paginated list query returns a List containing pagination functionality. This test also aggregates page
+    /// results by appending to an in-memory Array, useful to backing UI components which.
+    ///
+    /// - Given: Two comments for the same post, and a query with the predicate for comments by postID with limit of 1
+    /// - When:
+    ///    - first query returns a List that provides Paginatable methods, and contains next page.
+    ///    - subsequent queries exhaust the results from the API to retrieve the remaining results
+    /// - Then:
+    ///    - the in-memory Array is a populated with exactly two comments.
+    func testPaginatedListCommentsByPostID() {
+        guard let post = createPost(title: "title") else {
+            XCTFail("Could not create post")
+            return
+        }
+        guard createComment(postID: post.id, content: "content") != nil else {
+            XCTFail("Could not create comment")
+            return
+        }
+        guard createComment(postID: post.id, content: "content") != nil else {
+            XCTFail("Could not create comment")
+            return
+        }
+        let listCommentByPostIDCompleted = expectation(description: "list projects completed")
+        var results: List<Comment3>?
+        let predicate = Comment3.keys.postID.eq(post.id)
+        Amplify.API.query(request: .paginatedList(Comment3.self, where: predicate, limit: 1)) { result in
+            switch result {
+            case .success(let result):
+                switch result {
+                case .success(let comments):
+                    results = comments
+                    listCommentByPostIDCompleted.fulfill()
+                case .failure(let response):
+                    XCTFail("Failed with: \(response)")
+                }
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [listCommentByPostIDCompleted], timeout: TestCommonConstants.networkTimeout)
+        guard var subsequentResults = results else {
+            XCTFail("Could not get first results")
+            return
+        }
+        var resultsArray: [Comment3] = []
+        resultsArray.append(contentsOf: subsequentResults)
+        while subsequentResults.hasNextPage() {
+            let semaphore = DispatchSemaphore(value: 0)
+            subsequentResults.getNextPage { result in
+                defer {
+                    semaphore.signal()
+                }
+                switch result {
+                case .success(let listResult):
+                    subsequentResults = listResult
+                    resultsArray.append(contentsOf: subsequentResults)
+                case .failure(let coreError):
+                    XCTFail("Unexpected error: \(coreError)")
+                }
+
+            }
+            semaphore.wait()
+        }
+        XCTAssertEqual(resultsArray.count, 2)
+    }
+
+    /// Test paginated list query returns a List containing pagination functionality. This test also aggregates page
+    /// results by appending to an in-memory Array, useful to backing UI components which.
+    ///
+    /// - Given: Two posts, and a query with the predicate, exhausted `fetch` calls
+    /// - When:
+    ///    - A `fetch` is made when `hasNextPage` returns false.
+    /// - Then:
+    ///    - A validation error is returned
+    func testPaginatedListFetchValidationError() throws {
+        let uuid1 = UUID().uuidString
+        guard createPost(id: uuid1, title: "title") != nil else {
+            XCTFail("Failed to create post")
+            return
+        }
+
+        let firstQueryCompleted = expectation(description: "first query completed")
+        let post = Post3.keys
+        let predicate = post.id == uuid1
+        var results: List<Post3>?
+        _ = Amplify.API.query(request: .paginatedList(Post3.self, where: predicate)) { event in
+            switch event {
+            case .success(let response):
+                guard case let .success(graphQLResponse) = response else {
+                    XCTFail("Missing successful response")
+                    return
+                }
+
+                results = graphQLResponse
+                firstQueryCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("Unexpected .failure event: \(error)")
+            }
+        }
+
+        wait(for: [firstQueryCompleted], timeout: TestCommonConstants.networkTimeout)
+        guard var subsequentResults = results else {
+            XCTFail("Could not get first results")
+            return
+        }
+        while subsequentResults.hasNextPage() {
+            let semaphore = DispatchSemaphore(value: 0)
+            subsequentResults.getNextPage { result in
+                defer {
+                    semaphore.signal()
+                }
+                switch result {
+                case .success(let listResult):
+                    subsequentResults = listResult
+                case .failure(let coreError):
+                    XCTFail("Unexpected error: \(coreError)")
+                }
+
+            }
+            semaphore.wait()
+        }
+        XCTAssertFalse(subsequentResults.hasNextPage())
+        let invalidFetchCompleted = expectation(description: "fetch completed with validation error")
+        subsequentResults.getNextPage { result in
+
+            switch result {
+            case .success(let listResult):
+                XCTFail("Unexpected .success \(listResult)")
+            case .failure(let coreError):
+                guard case .validation = coreError else {
+                    XCTFail("Unexpected CoreError \(coreError)")
+                    return
+                }
+                invalidFetchCompleted.fulfill()
+            }
+        }
+
+        wait(for: [invalidFetchCompleted], timeout: TestCommonConstants.networkTimeout)
+    }
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario4Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario4Tests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import AWSMobileClient
 @testable import AWSAPICategoryPlugin
 @testable import Amplify
 @testable import AmplifyTestCommon
@@ -86,18 +87,24 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
         wait(for: [getCommentCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    // TODO: complete this test with lazy loading of API (https://github.com/aws-amplify/amplify-ios/pull/845)
-    func testCreateCommentAndGetPostWithComments() {
+    func testGetPostThenFetchComments() {
         guard let post = createPost(title: "title") else {
             XCTFail("Could not create post")
             return
         }
-        guard let comment = createComment(content: "content", post: post) else {
+        guard createComment(content: "content", post: post) != nil else {
+            XCTFail("Could not create comment")
+            return
+        }
+
+        guard createComment(content: "content", post: post) != nil else {
             XCTFail("Could not create comment")
             return
         }
 
         let getPostCompleted = expectation(description: "get post complete")
+        let fetchCommentsCompleted = expectation(description: "fetch comments complete")
+        var results: List<Comment4>?
         Amplify.API.query(request: .get(Post4.self, byId: post.id)) { result in
             switch result {
             case .success(let result):
@@ -108,11 +115,21 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
                         return
                     }
                     XCTAssertEqual(queriedPost.id, post.id)
-                    // XCTAssertNotNil(queriedPost.comments)
-                    if let queriedComments = queriedPost.comments {
-                        // TODO: Load Comments
-                    }
                     getPostCompleted.fulfill()
+                    guard let comments = queriedPost.comments else {
+                        XCTFail("Could not get comments")
+                        return
+                    }
+                    comments.fetch { fetchResults in
+                        switch fetchResults {
+                        case .success:
+                            results = comments
+                            fetchCommentsCompleted.fulfill()
+                        case .failure(let error):
+                            XCTFail("\(error)")
+                        }
+                    }
+
                 case .failure(let response):
                     XCTFail("Failed with: \(response)")
                 }
@@ -120,7 +137,31 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
                 XCTFail("\(error)")
             }
         }
-        wait(for: [getPostCompleted], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [getPostCompleted, fetchCommentsCompleted], timeout: TestCommonConstants.networkTimeout)
+        guard var subsequentResults = results else {
+            XCTFail("Could not get first results")
+            return
+        }
+        var resultsArray: [Comment4] = []
+        resultsArray.append(contentsOf: subsequentResults)
+        while subsequentResults.hasNextPage() {
+            let semaphore = DispatchSemaphore(value: 0)
+            subsequentResults.getNextPage { result in
+                defer {
+                    semaphore.signal()
+                }
+                switch result {
+                case .success(let listResult):
+                    subsequentResults = listResult
+                    resultsArray.append(contentsOf: subsequentResults)
+                case .failure(let coreError):
+                    XCTFail("Unexpected error: \(coreError)")
+                }
+
+            }
+            semaphore.wait()
+        }
+        XCTAssertEqual(resultsArray.count, 2)
     }
 
     func testUpdateComment() {
@@ -232,49 +273,100 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
         wait(for: [listCommentByPostIDCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func createPost(id: String = UUID().uuidString, title: String) -> Post4? {
-        let post = Post4(id: id, title: title)
-        var result: Post4?
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-        Amplify.API.mutate(request: .create(post)) { event in
-            switch event {
-            case .success(let data):
-                switch data {
-                case .success(let post):
-                    result = post
-                default:
-                    XCTFail("Could not get data back")
+    func testPaginatedListCommentsByPostID() {
+        guard let post = createPost(title: "title"),
+              createComment(content: "content", post: post) != nil,
+              createComment(content: "content", post: post) != nil else {
+            XCTFail("Could not create post and two comments")
+            return
+        }
+        let listCommentByPostIDCompleted = expectation(description: "list projects completed")
+        let predicate = field("postID").eq(post.id)
+        var results: List<Comment4>?
+        Amplify.API.query(request: .paginatedList(Comment4.self, where: predicate, limit: 1)) { result in
+            switch result {
+            case .success(let result):
+                switch result {
+                case .success(let comments):
+                    results = comments
+                    listCommentByPostIDCompleted.fulfill()
+                case .failure(let response):
+                    XCTFail("Failed with: \(response)")
                 }
-                requestInvokedSuccessfully.fulfill()
             case .failure(let error):
-                XCTFail("Failed \(error)")
+                XCTFail("\(error)")
             }
         }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
-        return result
+        wait(for: [listCommentByPostIDCompleted], timeout: TestCommonConstants.networkTimeout)
+        guard var subsequentResults = results else {
+            XCTFail("Could not get first results")
+            return
+        }
+        var resultsArray: [Comment4] = []
+        resultsArray.append(contentsOf: subsequentResults)
+        while subsequentResults.hasNextPage() {
+            let semaphore = DispatchSemaphore(value: 0)
+            subsequentResults.getNextPage { result in
+                defer {
+                    semaphore.signal()
+                }
+                switch result {
+                case .success(let listResult):
+                    subsequentResults = listResult
+                    resultsArray.append(contentsOf: subsequentResults)
+                case .failure(let coreError):
+                    XCTFail("Unexpected error: \(coreError)")
+                }
+
+            }
+            semaphore.wait()
+        }
+        XCTAssertEqual(resultsArray.count, 2)
     }
 
-    func createComment(id: String = UUID().uuidString, content: String, post: Post4) -> Comment4? {
-        let comment = Comment4(id: id, content: content, post: post)
-        var result: Comment4?
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-        Amplify.API.mutate(request: .create(comment)) { event in
-            switch event {
-            case .success(let data):
-                switch data {
-                case .success(let comment):
-                    result = comment
-                default:
-                    XCTFail("Could not get data back")
+    func createPost(id: String = UUID().uuidString, title: String) -> Post4? {
+            let post = Post4(id: id, title: title)
+            var result: Post4?
+            let requestInvokedSuccessfully = expectation(description: "request completed")
+            Amplify.API.mutate(request: .create(post)) { event in
+                switch event {
+                case .success(let data):
+                    switch data {
+                    case .success(let post):
+                        result = post
+                    default:
+                        XCTFail("Could not get data back")
+                    }
+                    requestInvokedSuccessfully.fulfill()
+                case .failure(let error):
+                    XCTFail("Failed \(error)")
                 }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("Failed \(error)")
             }
+            wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
+            return result
         }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
-        return result
-    }
+
+        func createComment(id: String = UUID().uuidString, content: String, post: Post4) -> Comment4? {
+            let comment = Comment4(id: id, content: content, post: post)
+            var result: Comment4?
+            let requestInvokedSuccessfully = expectation(description: "request completed")
+            Amplify.API.mutate(request: .create(comment)) { event in
+                switch event {
+                case .success(let data):
+                    switch data {
+                    case .success(let comment):
+                        result = comment
+                    default:
+                        XCTFail("Could not get data back")
+                    }
+                    requestInvokedSuccessfully.fulfill()
+                case .failure(let error):
+                    XCTFail("Failed \(error)")
+                }
+            }
+            wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
+            return result
+        }
 }
 
 extension Post4: Equatable {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario5Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario5Tests.swift
@@ -131,8 +131,10 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
         wait(for: [listPostEditorByEditorIdCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    // TODO: complete this test with lazy loading of API (https://github.com/aws-amplify/amplify-ios/pull/845)
-    func testGetPostThenLoadPostEditors() {
+    // Create a Post and a User, Create a PostEditor with the post and user
+    // Get the post and fetch the PostEditors for that post
+    // The Posteditor contains the user which is connected the post
+    func testGetPostThenFetchPostEditorsToRetrieveUser() {
         guard let post = createPost(title: "title") else {
             XCTFail("Could not create post")
             return
@@ -141,22 +143,37 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
             XCTFail("Could not create user")
             return
         }
-        guard let postEditor = createPostEditor(post: post, editor: user) else {
+        guard createPostEditor(post: post, editor: user) != nil else {
             XCTFail("Could not create user")
             return
         }
         let getPostCompleted = expectation(description: "get post complete")
+        let fetchPostEditorCompleted = expectation(description: "fetch postEditors complete")
+        var results: List<PostEditor5>?
         Amplify.API.query(request: .get(Post5.self, byId: post.id)) { result in
             switch result {
             case .success(let result):
                 switch result {
-                case .success(let queriedPost):
-                    XCTAssertNotNil(queriedPost)
-                    XCTAssertEqual(queriedPost!.id, post.id)
-                    if let editors = queriedPost?.editors {
-                        // TODO: Lazy load editors
+                case .success(let queriedPostOptional):
+                    guard let queriedPost = queriedPostOptional else {
+                        XCTFail("Could not get post")
+                        return
                     }
+                    XCTAssertEqual(queriedPost.id, post.id)
                     getPostCompleted.fulfill()
+                    guard let editors = queriedPost.editors else {
+                        XCTFail("Could not get postEditors")
+                        return
+                    }
+                    editors.fetch { fetchResults in
+                        switch fetchResults {
+                        case .success:
+                            results = editors
+                            fetchPostEditorCompleted.fulfill()
+                        case .failure(let error):
+                            XCTFail("Could not fetch postEditors \(error)")
+                        }
+                    }
                 case .failure(let response):
                     XCTFail("Failed with: \(response)")
                 }
@@ -164,12 +181,48 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
                 XCTFail("\(error)")
             }
         }
-        wait(for: [getPostCompleted], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [getPostCompleted, fetchPostEditorCompleted], timeout: TestCommonConstants.networkTimeout)
+        guard var subsequentResults = results else {
+            XCTFail("Could not get first results")
+            return
+        }
+        var resultsArray: [PostEditor5] = []
+        resultsArray.append(contentsOf: subsequentResults)
+        while subsequentResults.hasNextPage() {
+            let semaphore = DispatchSemaphore(value: 0)
+            subsequentResults.getNextPage { result in
+                defer {
+                    semaphore.signal()
+                }
+                switch result {
+                case .success(let listResult):
+                    subsequentResults = listResult
+                    resultsArray.append(contentsOf: subsequentResults)
+                case .failure(let coreError):
+                    XCTFail("Unexpected error: \(coreError)")
+                }
+
+            }
+            semaphore.wait()
+        }
+        XCTAssertEqual(resultsArray.count, 1)
+        guard let postEditor = resultsArray.first else {
+            XCTFail("Could not get editor")
+            return
+        }
+        XCTAssertEqual(postEditor.editor.id, user.id)
     }
 
-    // TODO: complete this test with lazy loading of API (https://github.com/aws-amplify/amplify-ios/pull/845)
-    func testGetUserThenLoadPosts() {
-        guard let post = createPost(title: "title") else {
+    // Create two posts (`post1` and `post2`) and a user
+    // create first PostEditor with the `post1` and user and create second postEditor with `post2` and user.
+    // Get the user and fetch the PostEditors for that user
+    // The PostEditors should contain the two posts `post1` and `post2`
+    func testGetUserThenFetchPostEditorsToRetrievePosts() {
+        guard let post1 = createPost(title: "title") else {
+            XCTFail("Could not create post")
+            return
+        }
+        guard let post2 = createPost(title: "title") else {
             XCTFail("Could not create post")
             return
         }
@@ -177,22 +230,41 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
             XCTFail("Could not create user")
             return
         }
-        guard let postEditor = createPostEditor(post: post, editor: user) else {
-            XCTFail("Could not create user")
+        guard createPostEditor(post: post1, editor: user) != nil else {
+            XCTFail("Could not create postEditor with `post1`")
+            return
+        }
+        guard createPostEditor(post: post2, editor: user) != nil else {
+            XCTFail("Could not create postEditor with `post2`")
             return
         }
         let getUserCompleted = expectation(description: "get user complete")
+        let fetchPostEditorCompleted = expectation(description: "fetch postEditors complete")
+        var results: List<PostEditor5>?
         Amplify.API.query(request: .get(User5.self, byId: user.id)) { result in
             switch result {
             case .success(let result):
                 switch result {
-                case .success(let queriedUser):
-                    XCTAssertNotNil(queriedUser)
-                    XCTAssertEqual(queriedUser!.id, user.id)
-                    if let posts = queriedUser?.posts {
-                        // TODO: Lazy load editors
+                case .success(let queriedUserOptional):
+                    guard let queriedUser = queriedUserOptional else {
+                        XCTFail("Could not get post")
+                        return
                     }
+                    XCTAssertEqual(queriedUser.id, user.id)
                     getUserCompleted.fulfill()
+                    guard let posts = queriedUser.posts else {
+                        XCTFail("Could not get postEditors")
+                        return
+                    }
+                    posts.fetch { fetchResults in
+                        switch fetchResults {
+                        case .success:
+                            results = posts
+                            fetchPostEditorCompleted.fulfill()
+                        case .failure(let error):
+                            XCTFail("Could not fetch postEditors \(error)")
+                        }
+                    }
                 case .failure(let response):
                     XCTFail("Failed with: \(response)")
                 }
@@ -200,7 +272,38 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
                 XCTFail("\(error)")
             }
         }
-        wait(for: [getUserCompleted], timeout: TestCommonConstants.networkTimeout)
+        wait(for: [getUserCompleted, fetchPostEditorCompleted], timeout: TestCommonConstants.networkTimeout)
+
+        guard var subsequentResults = results else {
+            XCTFail("Could not get first results")
+            return
+        }
+        var resultsArray: [PostEditor5] = []
+        resultsArray.append(contentsOf: subsequentResults)
+        while subsequentResults.hasNextPage() {
+            let semaphore = DispatchSemaphore(value: 0)
+            subsequentResults.getNextPage { result in
+                defer {
+                    semaphore.signal()
+                }
+                switch result {
+                case .success(let listResult):
+                    subsequentResults = listResult
+                    resultsArray.append(contentsOf: subsequentResults)
+                case .failure(let coreError):
+                    XCTFail("Unexpected error: \(coreError)")
+                }
+
+            }
+            semaphore.wait()
+        }
+        XCTAssertEqual(resultsArray.count, 2)
+        XCTAssertTrue(resultsArray.contains(where: { (postEditor) -> Bool in
+            postEditor.post.id == post1.id
+        }))
+        XCTAssertTrue(resultsArray.contains(where: { (postEditor) -> Bool in
+            postEditor.post.id == post2.id
+        }))
     }
 
     func createPost(id: String = UUID().uuidString, title: String) -> Post5? {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario6Tests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import AWSMobileClient
 @testable import AWSAPICategoryPlugin
 @testable import Amplify
 @testable import AmplifyTestCommon
@@ -58,6 +59,102 @@ class GraphQLConnectionScenario6Tests: XCTestCase {
 
     override func tearDown() {
         Amplify.reset()
+    }
+
+    func testGetBlogThenFetchPostsThenFetchComments() {
+        guard let blog = createBlog(name: "name"),
+              let post1 = createPost(title: "title", blog: blog),
+              let post2 = createPost(title: "title", blog: blog),
+              let comment1post1 = createComment(post: post1, content: "content"),
+              let comment2post1 = createComment(post: post1, content: "content") else {
+            XCTFail("Could not create blog, posts, and comments")
+            return
+        }
+        let getBlogCompleted = expectation(description: "get blog complete")
+        let fetchPostCompleted = expectation(description: "fetch post complete")
+        var resultPosts: List<Post6>?
+        Amplify.API.query(request: .get(Blog6.self, byId: blog.id)) { result in
+            switch result {
+            case .success(let result):
+                switch result {
+                case .success(let queriedBlogOptional):
+                    guard let queriedBlog = queriedBlogOptional else {
+                        XCTFail("Could not get blog")
+                        return
+                    }
+                    XCTAssertEqual(queriedBlog.id, blog.id)
+                    getBlogCompleted.fulfill()
+                    guard let posts = queriedBlog.posts else {
+                        XCTFail("Could not get comments")
+                        return
+                    }
+                    posts.fetch { fetchResults in
+                        switch fetchResults {
+                        case .success:
+                            resultPosts = posts
+                            fetchPostCompleted.fulfill()
+                        case .failure(let error):
+                            XCTFail("Could not fetch posts \(error)")
+                        }
+                    }
+                case .failure(let response): XCTFail("Failed with: \(response)")
+                }
+            case .failure(let error): XCTFail("\(error)")
+            }
+        }
+        wait(for: [getBlogCompleted, fetchPostCompleted], timeout: TestCommonConstants.networkTimeout)
+
+        let allPosts = getAll(list: resultPosts)
+        XCTAssertEqual(allPosts.count, 2)
+        guard let fetchedPost = allPosts.first(where: { (post) -> Bool in
+            post.id == post1.id
+        }), let comments = fetchedPost.comments else {
+            XCTFail("Could not set up - failed to get a post and its comments")
+            return
+        }
+
+        let fetchCommentsCompleted = expectation(description: "fetch post complete")
+        var resultComments: List<Comment6>?
+        comments.fetch { fetchResults in
+            switch fetchResults {
+            case .success:
+                resultComments = comments
+                fetchCommentsCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("Could not fetch comments \(error)")
+            }
+        }
+        wait(for: [fetchCommentsCompleted], timeout: TestCommonConstants.networkTimeout)
+        let allComments = getAll(list: resultComments)
+        XCTAssertEqual(allComments.count, 2)
+        XCTAssertTrue(allComments.contains(where: { (comment) -> Bool in
+            comment.id == comment1post1.id
+        }))
+        XCTAssertTrue(allComments.contains(where: { (comment) -> Bool in
+            comment.id == comment2post1.id
+        }))
+    }
+
+    func getAll<M>(list: List<M>?) -> [M] {
+        guard var list = list else {
+            return []
+        }
+        var results = [M]()
+        while list.hasNextPage() {
+            let semaphore = DispatchSemaphore(value: 0)
+            list.getNextPage { result in
+                switch result {
+                case .success(let nextList):
+                    list = nextList
+                    results.append(contentsOf: nextList.elements)
+                    semaphore.signal()
+                case .failure(let error):
+                    XCTFail("\(error)")
+                }
+            }
+            semaphore.wait()
+        }
+        return list.elements
     }
 
     func createBlog(id: String = UUID().uuidString, name: String) -> Blog6? {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLModelBasedTests+List.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLModelBasedTests+List.swift
@@ -1,0 +1,217 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AWSMobileClient
+import AWSPluginsCore
+@testable import AWSAPICategoryPlugin
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSAPICategoryPluginTestCommon
+
+extension GraphQLModelBasedTests {
+
+    /// Test paginated list query returns a List containing pagination functionality. This test also aggregates page
+    /// results by appending to an in-memory Array, useful to backing UI components which.
+    ///
+    /// - Given: Two posts, and a query with the predicate for the two posts and a limit of 1
+    /// - When:
+    ///    - first query returns a List that provides Paginatable methods, and contains next page.
+    ///    - subsequent queries exhaust the results from the API to retrieve the remaining results
+    /// - Then:
+    ///    - the in-memory Array is a populated with all expected items.
+    func testPaginatedListFetch() throws {
+        var resultsArray: [Post] = []
+        let uuid1 = UUID().uuidString
+        let uuid2 = UUID().uuidString
+        let testMethodName = String("\(#function)".dropLast(2))
+        let title = testMethodName + "Title"
+        guard createPost(id: uuid1, title: title) != nil,
+              createPost(id: uuid2, title: title) != nil else {
+            XCTFail("Failed to ensure at least two Posts to be retrieved on the listQuery")
+            return
+        }
+
+        let firstQueryCompleted = expectation(description: "first query completed")
+        let post = Post.keys
+        let predicate = post.id == uuid1 || post.id == uuid2
+        var results: List<Post>?
+        _ = Amplify.API.query(request: .paginatedList(Post.self, where: predicate, limit: 1)) { event in
+            switch event {
+            case .success(let response):
+                guard case let .success(graphQLResponse) = response else {
+                    XCTFail("Missing successful response")
+                    return
+                }
+
+                results = graphQLResponse
+                firstQueryCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("Unexpected .failure event: \(error)")
+            }
+        }
+
+        wait(for: [firstQueryCompleted], timeout: TestCommonConstants.networkTimeout)
+        guard var subsequentResults = results else {
+            XCTFail("Could not get first results")
+            return
+        }
+
+        resultsArray.append(contentsOf: subsequentResults)
+
+        while subsequentResults.hasNextPage() {
+            let semaphore = DispatchSemaphore(value: 0)
+            subsequentResults.getNextPage { result in
+                defer {
+                    semaphore.signal()
+                }
+                switch result {
+                case .success(let listResult):
+                    subsequentResults = listResult
+                    resultsArray.append(contentsOf: subsequentResults)
+                case .failure(let coreError):
+                    XCTFail("Unexpected error: \(coreError)")
+                }
+
+            }
+            semaphore.wait()
+        }
+        XCTAssertEqual(resultsArray.count, 2)
+    }
+
+    /// Test paginated list query returns a List containing pagination functionality.
+    ///
+    /// - Given: Two posts, and a query with the predicate, exhausted `getNextPage` calls
+    /// - When:
+    ///    - A `getNextPage` is made when `hasNextPage` returns false.
+    /// - Then:
+    ///    - A validation error is returned
+    func testPaginatedListFetchValidationError() throws {
+        let uuid1 = UUID().uuidString
+        let testMethodName = String("\(#function)".dropLast(2))
+        let title = testMethodName + "Title"
+        guard createPost(id: uuid1, title: title) != nil else {
+            XCTFail("Failed to create post")
+            return
+        }
+
+        let firstQueryCompleted = expectation(description: "first query completed")
+        let post = Post.keys
+        let predicate = post.id == uuid1
+        var results: List<Post>?
+        _ = Amplify.API.query(request: .paginatedList(Post.self, where: predicate)) { event in
+            switch event {
+            case .success(let response):
+                guard case let .success(graphQLResponse) = response else {
+                    XCTFail("Missing successful response")
+                    return
+                }
+
+                results = graphQLResponse
+                firstQueryCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("Unexpected .failure event: \(error)")
+            }
+        }
+
+        wait(for: [firstQueryCompleted], timeout: TestCommonConstants.networkTimeout)
+        guard var subsequentResults = results else {
+            XCTFail("Could not get first results")
+            return
+        }
+        while subsequentResults.hasNextPage() {
+            let semaphore = DispatchSemaphore(value: 0)
+            subsequentResults.getNextPage { result in
+                defer {
+                    semaphore.signal()
+                }
+                switch result {
+                case .success(let listResult):
+                    subsequentResults = listResult
+                case .failure(let coreError):
+                    XCTFail("Unexpected error: \(coreError)")
+                }
+            }
+            semaphore.wait()
+        }
+        XCTAssertFalse(subsequentResults.hasNextPage())
+        let invalidFetchCompleted = expectation(description: "fetch completed with validation error")
+        subsequentResults.getNextPage { result in
+
+            switch result {
+            case .success(let listResult):
+                XCTFail("Unexpected .success \(listResult)")
+            case .failure(let coreError):
+                guard case .validation = coreError else {
+                    XCTFail("Unexpected CoreError \(coreError)")
+                    return
+                }
+                invalidFetchCompleted.fulfill()
+            }
+        }
+
+        wait(for: [invalidFetchCompleted], timeout: TestCommonConstants.networkTimeout)
+    }
+
+
+    /// This test shows the issue with retrieving comments by postId. The schema used to create `Post.swift` and
+    /// `Comment.swift` provisions an AppSync API that does not provide a list query operation for comments by postId.
+    ///
+    /// - Given: A post with a comment, query for the post, and traverse to the comments
+    /// - When:
+    ///    - `comments.fetch` is called
+    /// - Then:
+    ///    - `CoreError` is returned
+    func testFetchListOfCommentsFromPostFails() {
+        let uuid1 = UUID().uuidString
+        let testMethodName = String("\(#function)".dropLast(2))
+        let title = testMethodName + "Title"
+        guard let createdPost = createPost(id: uuid1, title: title) else {
+            XCTFail("Failed to create post")
+            return
+        }
+        guard let createdComment = createComment(content: title, post: createdPost) else {
+            XCTFail("Failed to create comment")
+            return
+        }
+
+        let firstQueryCompleted = expectation(description: "first query completed")
+        var results: Post?
+        _ = Amplify.API.query(request: .get(Post.self, byId: createdPost.id)) { event in
+            switch event {
+            case .success(let response):
+                guard case let .success(graphQLResponse) = response else {
+                    XCTFail("Missing successful response")
+                    return
+                }
+
+                results = graphQLResponse
+                firstQueryCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("Unexpected .failure event: \(error)")
+            }
+        }
+
+        wait(for: [firstQueryCompleted], timeout: TestCommonConstants.networkTimeout)
+        guard let retrievedPost = results else {
+            XCTFail("Could not get post")
+            return
+        }
+        XCTAssertTrue(retrievedPost.comments.isEmpty)
+        let fetchCommentsFailed = expectation(description: "Fetch comments failed")
+        retrievedPost.comments?.fetch { result in
+            switch result {
+            case .success(let comments):
+                XCTFail("Should have failed to fetch comments \(comments)")
+            case .failure(let coreError):
+                XCTAssertNotNil(coreError)
+                fetchCommentsFailed.fulfill()
+            }
+        }
+        wait(for: [fetchCommentsFailed], timeout: TestCommonConstants.networkTimeout)
+    }
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListGraphQLRequestTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListGraphQLRequestTests.swift
@@ -1,0 +1,171 @@
+//
+// Copyright 2018-2020 Amazon.com,
+// Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+@testable import AWSPluginsCore
+@testable import AmplifyTestCommon
+@testable import AWSAPICategoryPlugin
+
+class AppSyncListGraphQLRequestTests: XCTestCase {
+
+    override func setUp() {
+        Amplify.reset()
+        ModelRegistry.register(modelType: Post4.self)
+        ModelRegistry.register(modelType: Comment4.self)
+    }
+
+    func testAppSyncListRequestForFirstPage() {
+        guard let commentSchema = ModelRegistry.modelSchema(from: "Comment4") else {
+            XCTFail("Fail")
+            return
+        }
+        guard let postModelField = commentSchema.field(withName: Comment4.keys.post.rawValue) else {
+            XCTFail("Fail")
+            return
+        }
+        let request = AppSyncList<Comment4>.requestForFirstPage(associatedId: "postId123",
+                                                                associatedField: postModelField)
+        XCTAssertNotNil(request)
+        let expectedDocument = """
+        query ListComment4s($filter: ModelComment4FilterInput, $limit: Int) {
+          listComment4s(filter: $filter, limit: $limit) {
+            items {
+              id
+              content
+              post {
+                id
+                title
+                __typename
+              }
+              __typename
+            }
+            nextToken
+          }
+        }
+        """
+        XCTAssertEqual(request.document, expectedDocument)
+        XCTAssertEqual(request.decodePath, "listComment4s")
+        guard let variables = request.variables else {
+            XCTFail("The document doesn't contain variables")
+            return
+        }
+        XCTAssertNotNil(variables["limit"])
+        XCTAssertEqual(variables["limit"] as? Int, 1_000)
+        guard let filter = variables["filter"] as? GraphQLFilter,
+              let filterJSON = try? JSONSerialization.data(withJSONObject: filter,
+                                                                 options: .prettyPrinted) else {
+            XCTFail("variables should contain a valid filter JSON")
+            return
+        }
+        let expectedFilterJSON = """
+        {
+          "postID" : {
+            "eq" : "postId123"
+          }
+        }
+        """
+        XCTAssertEqual(String(data: filterJSON, encoding: .utf8), expectedFilterJSON)
+    }
+
+    func testAppSyncListRequestForNextPage() {
+        let request = AppSyncList<Comment4>.requestForNextPage(nextToken: "nextToken", variables: nil)
+        XCTAssertNotNil(request)
+        let expectedDocument = """
+        query ListComment4s($limit: Int, $nextToken: String) {
+          listComment4s(limit: $limit, nextToken: $nextToken) {
+            items {
+              id
+              content
+              post {
+                id
+                title
+                __typename
+              }
+              __typename
+            }
+            nextToken
+          }
+        }
+        """
+        XCTAssertEqual(request.document, expectedDocument)
+        XCTAssertEqual(request.decodePath, "listComment4s")
+        guard let variables = request.variables else {
+            XCTFail("The document doesn't contain variables")
+            return
+        }
+        XCTAssertNotNil(variables["limit"])
+        XCTAssertEqual(variables["limit"] as? Int, 1_000)
+        XCTAssertNotNil(variables["nextToken"])
+        XCTAssertEqual(variables["nextToken"] as? String, "nextToken")
+    }
+
+    func testAppSyncListRequestForNextPageWithSameLimitAndFilter() {
+        let previousVariables: [String: JSONValue] = [
+            "limit": 1_000,
+            "filter": [
+                "and": [
+                    "postID": [
+                        "eq": "postId123"
+                    ],
+                    "content": [
+                        "beginWith": "hello"
+                    ]
+                ]
+            ]
+        ]
+        let request = AppSyncList<Comment4>.requestForNextPage(nextToken: "nextToken", variables: previousVariables)
+        XCTAssertNotNil(request)
+        let expectedDocument = """
+        query ListComment4s($filter: ModelComment4FilterInput, $limit: Int, $nextToken: String) {
+          listComment4s(filter: $filter, limit: $limit, nextToken: $nextToken) {
+            items {
+              id
+              content
+              post {
+                id
+                title
+                __typename
+              }
+              __typename
+            }
+            nextToken
+          }
+        }
+        """
+        XCTAssertEqual(request.document, expectedDocument)
+        XCTAssertEqual(request.decodePath, "listComment4s")
+        guard let variables = request.variables else {
+            XCTFail("The document doesn't contain variables")
+            return
+        }
+        XCTAssertNotNil(variables["limit"])
+        XCTAssertEqual(variables["limit"] as? Int, 1_000)
+        XCTAssertNotNil(variables["nextToken"])
+        XCTAssertEqual(variables["nextToken"] as? String, "nextToken")
+        guard let filter = variables["filter"] as? GraphQLFilter,
+              let filterJSON = try? JSONSerialization.data(withJSONObject: filter,
+                                                                 options: .prettyPrinted) else {
+            XCTFail("variables should contain a valid filter JSON")
+            return
+        }
+        let expectedFilterJSON = """
+        {
+          "and" : {
+            "content" : {
+              "beginWith" : "hello"
+            },
+            "postID" : {
+              "eq" : "postId123"
+            }
+          }
+        }
+        """
+        XCTAssertEqual(String(data: filterJSON, encoding: .utf8), expectedFilterJSON)
+    }
+
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListTests.swift
@@ -13,9 +13,12 @@ import XCTest
 
 class AppSyncListTests: XCTestCase {
 
+    var mockAPIPlugin: MockAPICategoryPlugin!
+
     override func setUp() {
         Amplify.reset()
-        ModelRegistry.register(modelType: Post.self)
+        ModelRegistry.register(modelType: Post4.self)
+        ModelRegistry.register(modelType: Comment4.self)
         ModelListDecoderRegistry.registerDecoder(AppSyncList<AnyModel>.self)
         do {
             let configWithAPI = try setUpAPICategory()
@@ -25,48 +28,402 @@ class AppSyncListTests: XCTestCase {
         }
     }
 
-    func testAppSyncListDeserializeFromGraphQLResponse() throws {
+    func testAppSyncListDecodeFromGraphQLResponse() throws {
+        let graphQLData: JSONValue = [
+            "items": [[
+                "id": "1",
+                "title": JSONValue.init(stringLiteral: "title")
+            ], [
+                "id": "2",
+                "title": JSONValue.init(stringLiteral: "title"),
+            ]],
+            "nextToken": "nextToken"
+        ]
+        let data = try AppSyncListTests.encode(json: graphQLData)
+
+        let list = try AppSyncListTests.decode(data, responseType: Post4.self)
+        XCTAssertEqual(list.count, 2)
+        guard let appSyncList = list as? AppSyncList else {
+            XCTFail("Could not cast to AppSyncList")
+            return
+        }
+        XCTAssertNil(appSyncList.associatedId)
+        XCTAssertNil(appSyncList.associatedField)
+        XCTAssertNil(appSyncList.nextToken)
+        XCTAssertNil(appSyncList.document)
+        XCTAssertNil(appSyncList.variables)
+        XCTAssertEqual(appSyncList.state, .loaded)
+    }
+
+    func testAppSyncListDecodeFromAppSyncListPayload() throws {
         let graphQLData: JSONValue = [
             "items": [[
                 "id": "1",
                 "title": JSONValue.init(stringLiteral: "title"),
-                "content": JSONValue.init(stringLiteral: "content"),
-                "createdAt": JSONValue.init(stringLiteral: Temporal.DateTime.now().iso8601String)
+                "__typename": "Post4"
             ], [
                 "id": "2",
                 "title": JSONValue.init(stringLiteral: "title"),
-                "content": JSONValue.init(stringLiteral: "content"),
-                "createdAt": JSONValue.init(stringLiteral: Temporal.DateTime.now().iso8601String)
+                "__typename": "Post4"
             ]],
             "nextToken": "nextToken"
         ]
-        let serializedData = try AppSyncListTests.serialize(json: graphQLData)
+        let variables: [String: JSONValue] = [
+            "filter": [
+                "id": [
+                    "eq": "123"
+                ]
+            ],
+            "limit": 1_000
+        ]
+        let appSyncListPayload = AppSyncListPayload(document: "document",
+                                                    variables: variables,
+                                                    graphQLData: graphQLData)
+        let data = try AppSyncListTests.encode(payload: appSyncListPayload)
 
-        let list = try AppSyncListTests.deserialize(serializedData, responseType: Post.self)
-        XCTAssertNotNil(list)
+        let list = try AppSyncListTests.decode(data, responseType: Post4.self)
+        XCTAssertEqual(list.count, 2)
+        guard let appSyncList = list as? AppSyncList else {
+            XCTFail("Could not cast to AppSyncList")
+            return
+        }
+        XCTAssertNil(appSyncList.associatedId)
+        XCTAssertNil(appSyncList.associatedField)
+        XCTAssertEqual(appSyncList.nextToken, "nextToken")
+        XCTAssertEqual(appSyncList.document, "document")
+        XCTAssertNotNil(appSyncList.variables)
+        XCTAssertEqual(appSyncList.state, .loaded)
+        for post in list {
+            let comments = post.comments
+            guard let appSyncComments = comments as? AppSyncList else {
+                XCTFail("Could not cast to AppSyncList")
+                return
+            }
+            XCTAssertEqual(appSyncComments.associatedId, post.id)
+            XCTAssertNotNil(appSyncComments.associatedField)
+            XCTAssertEqual(appSyncComments.associatedField!.name, "post")
+            XCTAssertNil(appSyncComments.nextToken)
+            XCTAssertNil(appSyncComments.document)
+            XCTAssertNil(appSyncComments.variables)
+            XCTAssertEqual(appSyncComments.state, .pending)
+        }
     }
 
-    private static func serialize(json: JSONValue) throws -> Data {
+    func testAppSyncListDecodeFromAssociatedDataThenFetch() throws {
+        mockAPIPlugin.responders[.queryRequestListener] =
+            QueryRequestListenerResponder<AppSyncList<Comment4>> { _, listener in
+                let list = AppSyncList<Comment4>()
+                list.elements = [Comment4(content: "content", post: Post4(title: "title"))]
+                let event: GraphQLOperation<AppSyncList<Comment4>>.OperationResult = .success(.success(list))
+                listener?(event)
+                return nil
+        }
+
+        let associatedData: JSONValue = [
+            "associatedId": "postId123",
+            "associatedField": "post",
+            "listType": "appSyncList"
+        ]
+        let data = try AppSyncListTests.encode(json: associatedData)
+        let list = try AppSyncListTests.decode(data, responseType: Comment4.self)
+        guard let appSyncList = list as? AppSyncList else {
+            XCTFail("Could not cast to AppSyncList")
+            return
+        }
+        XCTAssertEqual(appSyncList.associatedId, "postId123")
+        XCTAssertNotNil(appSyncList.associatedField)
+        XCTAssertEqual(appSyncList.associatedField!.name, "post")
+        XCTAssertNil(appSyncList.nextToken)
+        XCTAssertNil(appSyncList.document)
+        XCTAssertNil(appSyncList.variables)
+        XCTAssertEqual(appSyncList.state, .pending)
+        XCTAssertEqual(appSyncList.elements.count, 0)
+
+        let fetchCompleted = expectation(description: "fetch completed")
+        list.fetch { result in
+            switch result {
+            case .success:
+                fetchCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [fetchCompleted], timeout: 1)
+        XCTAssertEqual(list.count, 1)
+        XCTAssertEqual(appSyncList.state, .loaded)
+        XCTAssertEqual(appSyncList.elements.count, 1)
+    }
+
+    func testAppSyncListFetchFails() throws {
+        mockAPIPlugin.responders[.queryRequestListener] =
+            QueryRequestListenerResponder<AppSyncList<Comment4>> { _, listener in
+                let event: GraphQLOperation<AppSyncList<Comment4>>.OperationResult =
+                    .failure(APIError.unknown("", "", nil))
+                listener?(event)
+                return nil
+        }
+
+        let associatedData: JSONValue = [
+            "associatedId": "postId123",
+            "associatedField": "post",
+            "listType": "appSyncList"
+        ]
+        let data = try AppSyncListTests.encode(json: associatedData)
+        let list = try AppSyncListTests.decode(data, responseType: Comment4.self)
+        guard let appSyncList = list as? AppSyncList else {
+            XCTFail("Could not cast to AppSyncList")
+            return
+        }
+        XCTAssertEqual(appSyncList.state, .pending)
+        XCTAssertEqual(appSyncList.elements.count, 0)
+
+        let fetchCompleted = expectation(description: "fetch completed")
+        list.fetch { result in
+            switch result {
+            case .success:
+                XCTFail("Should have failed")
+            case .failure:
+                fetchCompleted.fulfill()
+            }
+        }
+        wait(for: [fetchCompleted], timeout: 1)
+        XCTAssertEqual(appSyncList.state, .pending)
+        XCTAssertEqual(appSyncList.elements.count, 0)
+    }
+
+    func testAppSyncListImplicitFetchOnCount() throws {
+        mockAPIPlugin.responders[.queryRequestListener] =
+            QueryRequestListenerResponder<AppSyncList<Comment4>> { _, listener in
+                let list = AppSyncList<Comment4>()
+                list.elements = [Comment4(content: "content", post: Post4(title: "title"))]
+                let event: GraphQLOperation<AppSyncList<Comment4>>.OperationResult = .success(.success(list))
+                listener?(event)
+                return nil
+        }
+
+        let associatedData: JSONValue = [
+            "associatedId": "postId123",
+            "associatedField": "post",
+            "listType": "appSyncList"
+        ]
+        let data = try AppSyncListTests.encode(json: associatedData)
+        let list = try AppSyncListTests.decode(data, responseType: Comment4.self)
+        guard let appSyncList = list as? AppSyncList else {
+            XCTFail("Could not cast to AppSyncList")
+            return
+        }
+        XCTAssertEqual(appSyncList.state, .pending)
+        XCTAssertEqual(appSyncList.elements.count, 0)
+
+        if list.count != 1 {
+            XCTFail("Implicit fetch failed")
+        }
+
+        XCTAssertEqual(appSyncList.state, .loaded)
+        XCTAssertEqual(appSyncList.elements.count, 1)
+    }
+
+    func testAppSyncListImplicitFetchOnEnumerated() throws {
+        mockAPIPlugin.responders[.queryRequestListener] =
+            QueryRequestListenerResponder<AppSyncList<Comment4>> { _, listener in
+                let list = AppSyncList<Comment4>()
+                list.elements = [Comment4(content: "content", post: Post4(title: "title"))]
+                let event: GraphQLOperation<AppSyncList<Comment4>>.OperationResult = .success(.success(list))
+                listener?(event)
+                return nil
+        }
+
+        let associatedData: JSONValue = [
+            "associatedId": "postId123",
+            "associatedField": "post",
+            "listType": "appSyncList"
+        ]
+        let data = try AppSyncListTests.encode(json: associatedData)
+        let list = try AppSyncListTests.decode(data, responseType: Comment4.self)
+        guard let appSyncList = list as? AppSyncList else {
+            XCTFail("Could not cast to AppSyncList")
+            return
+        }
+        XCTAssertEqual(appSyncList.state, .pending)
+        XCTAssertEqual(appSyncList.elements.count, 0)
+        for (index, comment) in list.enumerated() {
+            XCTAssertEqual(index, 0)
+            XCTAssertNotNil(comment)
+        }
+        XCTAssertEqual(appSyncList.state, .loaded)
+        XCTAssertEqual(appSyncList.elements.count, 1)
+    }
+
+    func testAppSyncListMulitpleFetchReturnsSameResult() throws {
+        let apiCalledOnce = expectation(description: "API is called only once for multiple fetch")
+        apiCalledOnce.assertForOverFulfill = true
+        mockAPIPlugin.responders[.queryRequestListener] =
+            QueryRequestListenerResponder<AppSyncList<Comment4>> { _, listener in
+                apiCalledOnce.fulfill()
+                let list = AppSyncList<Comment4>()
+                list.elements = [Comment4(content: "content", post: Post4(title: "title"))]
+                let event: GraphQLOperation<AppSyncList<Comment4>>.OperationResult = .success(.success(list))
+                listener?(event)
+                return nil
+            }
+
+        let associatedData: JSONValue = [
+            "associatedId": "postId123",
+            "associatedField": "post",
+            "listType": "appSyncList"
+        ]
+        let data = try AppSyncListTests.encode(json: associatedData)
+        let list = try AppSyncListTests.decode(data, responseType: Comment4.self)
+        guard let appSyncList = list as? AppSyncList else {
+            XCTFail("Could not cast to AppSyncList")
+            return
+        }
+        XCTAssertEqual(appSyncList.state, .pending)
+        XCTAssertEqual(appSyncList.elements.count, 0)
+        XCTAssertEqual(list.count, 1)
+        XCTAssertEqual(appSyncList.state, .loaded)
+        for (index, comment) in list.enumerated() {
+            XCTAssertEqual(index, 0)
+            XCTAssertNotNil(comment)
+        }
+        for comment in list {
+            XCTAssertNotNil(comment)
+        }
+        wait(for: [apiCalledOnce], timeout: 1)
+    }
+
+    func testAppSyncListImplicitFetchFails() throws {
+        mockAPIPlugin.responders[.queryRequestListener] =
+            QueryRequestListenerResponder<AppSyncList<Comment4>> { _, listener in
+                let event: GraphQLOperation<AppSyncList<Comment4>>.OperationResult =
+                    .failure(APIError.unknown("", "", nil))
+                listener?(event)
+                return nil
+        }
+
+        let associatedData: JSONValue = [
+            "associatedId": "postId123",
+            "associatedField": "post",
+            "listType": "appSyncList"
+        ]
+        let data = try AppSyncListTests.encode(json: associatedData)
+        let list = try AppSyncListTests.decode(data, responseType: Comment4.self)
+        guard let appSyncList = list as? AppSyncList else {
+            XCTFail("Could not cast to AppSyncList")
+            return
+        }
+        XCTAssertEqual(appSyncList.state, .pending)
+        XCTAssertEqual(appSyncList.elements.count, 0)
+        for (index, comment) in list.enumerated() {
+            XCTAssertEqual(index, 0)
+            XCTAssertNotNil(comment)
+        }
+        XCTAssertEqual(appSyncList.state, .pending)
+        XCTAssertEqual(list.count, 0)
+
+    }
+
+    func testAppSyncListImplicitFetchOnHasNextPage() throws {
+        mockAPIPlugin.responders[.queryRequestListener] =
+            QueryRequestListenerResponder<AppSyncList<Comment4>> { _, listener in
+                let list = AppSyncList<Comment4>()
+                list.elements = [Comment4(content: "content", post: Post4(title: "title"))]
+                let event: GraphQLOperation<AppSyncList<Comment4>>.OperationResult = .success(.success(list))
+                listener?(event)
+                return nil
+            }
+
+        let associatedData: JSONValue = [
+            "associatedId": "postId123",
+            "associatedField": "post",
+            "listType": "appSyncList"
+        ]
+        let data = try AppSyncListTests.encode(json: associatedData)
+        let list = try AppSyncListTests.decode(data, responseType: Comment4.self)
+        guard let appSyncList = list as? AppSyncList else {
+            XCTFail("Could not cast to AppSyncList")
+            return
+        }
+        XCTAssertEqual(appSyncList.state, .pending)
+        XCTAssertEqual(appSyncList.elements.count, 0)
+
+        if list.hasNextPage() {
+            XCTFail("Implicit fetch completed, however expected single page of results")
+        }
+
+        XCTAssertEqual(appSyncList.state, .loaded)
+        XCTAssertEqual(list.count, 1)
+    }
+
+    func testAppSyncListGetNextPage() throws {
+        mockAPIPlugin.responders[.queryRequestListener] =
+            QueryRequestListenerResponder<AppSyncList<Comment4>> { _, listener in
+                let list = AppSyncList<Comment4>()
+                list.nextToken = "nextToken"
+                list.elements = [Comment4(id: "commentId",
+                                         content: "content",
+                                         post: Post4(title: "title"))]
+                let event: GraphQLOperation<AppSyncList<Comment4>>.OperationResult = .success(.success(list))
+                listener?(event)
+                return nil
+            }
+
+        let associatedData: JSONValue = [
+            "associatedId": "postId123",
+            "associatedField": "post",
+            "listType": "appSyncList"
+        ]
+        let data = try AppSyncListTests.encode(json: associatedData)
+        let list = try AppSyncListTests.decode(data, responseType: Comment4.self)
+        guard let appSyncList = list as? AppSyncList else {
+            XCTFail("Could not cast to AppSyncList")
+            return
+        }
+        XCTAssertNil(appSyncList.nextToken)
+        XCTAssertEqual(appSyncList.state, .pending)
+        XCTAssertEqual(appSyncList.elements.count, 0)
+
+        for comment in list {
+            XCTAssertEqual(comment.id, "commentId")
+        }
+        XCTAssertEqual(appSyncList.state, .loaded)
+        XCTAssertEqual(appSyncList.nextToken, "nextToken")
+        XCTAssertTrue(list.hasNextPage())
+        let getNextPageCompleted = expectation(description: "getNextPage completed")
+        list.getNextPage { result in
+            switch result {
+            case .success(let list):
+                XCTAssertNotNil(list)
+                getNextPageCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [getNextPageCompleted], timeout: 1)
+    }
+
+
+    private static func encode(json: JSONValue) throws -> Data {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
         return try encoder.encode(json)
     }
 
-    private static func deserialize<R: Decodable>(_ data: Data, responseType: R.Type) throws -> List<R> {
+    private static func encode(payload: AppSyncListPayload) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
+        return try encoder.encode(payload)
+    }
+
+    private static func decode<R: Decodable>(_ data: Data, responseType: R.Type) throws -> List<R> {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = ModelDateFormatting.decodingStrategy
         return try decoder.decode(List<R>.self, from: data)
     }
 
     private func setUpAPICategory() throws -> AmplifyConfiguration {
-        let apiPlugin = MockAPICategoryPlugin()
-        apiPlugin.responders[.queryRequestListener] = QueryRequestListenerResponder<AppSyncList<Post>> { _, listener in
-            let list = AppSyncList<Post>()
-            let event: GraphQLOperation<AppSyncList<Post>>.OperationResult = .success(.success(list))
-            listener?(event)
-            return nil
-        }
-        try Amplify.add(plugin: apiPlugin)
+        mockAPIPlugin = MockAPICategoryPlugin()
+        try Amplify.add(plugin: mockAPIPlugin)
 
         let apiConfig = APICategoryConfiguration(plugins: [
             "MockAPICategoryPlugin": true

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
@@ -31,6 +31,21 @@ protocol ModelGraphQLRequestFactory {
     static func list<M: Model>(_ modelType: M.Type,
                                where predicate: QueryPredicate?) -> GraphQLRequest<[M]>
 
+    /// Creates a `GraphQLRequest` that represents a query that expects multiple values as a result.
+    /// The request will be created with the correct document based on the `ModelSchema` and
+    /// variables based on the the predicate.
+    ///
+    /// - Parameters:
+    ///   - modelType: the metatype of the model
+    ///   - predicate: an optional predicate containing the criteria for the query
+    ///   - limit: the maximum number of results to be retrieved. The result list may be less than the `limit`
+    /// - Returns: a valid `GraphQLRequest` instance
+    ///
+    /// - seealso: `GraphQLQuery`, `GraphQLQueryType.list`
+    static func paginatedList<M: Model>(_ modelType: M.Type,
+                                        where predicate: QueryPredicate?,
+                                        limit: Int?) -> GraphQLRequest<List<M>>
+
     /// Creates a `GraphQLRequest` that represents a query that expects a single value as a result.
     /// The request will be created with the correct correct document based on the `ModelSchema` and
     /// variables based on given `id`.
@@ -216,6 +231,25 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
                                    variables: document.variables,
                                    responseType: [M].self,
                                    decodePath: document.name + ".items")
+    }
+
+    public static func paginatedList<M: Model>(_ modelType: M.Type,
+                                               where predicate: QueryPredicate? = nil,
+                                               limit: Int? = nil) -> GraphQLRequest<List<M>> {
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: modelType, operationType: .query)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
+
+        if let predicate = predicate {
+            documentBuilder.add(decorator: FilterDecorator(filter: predicate.graphQLFilter))
+        }
+
+        documentBuilder.add(decorator: PaginationDecorator(limit: limit))
+        let document = documentBuilder.build()
+
+        return GraphQLRequest<List<M>>(document: document.stringValue,
+                                       variables: document.variables,
+                                       responseType: List<M>.self,
+                                       decodePath: document.name)
     }
 
     public static func subscription<M: Model>(of modelType: M.Type,

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestEmbeddableTypeJSONTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestEmbeddableTypeJSONTests.swift
@@ -5,4 +5,126 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Foundation
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSPluginsCore
+
+class GraphQLRequestEmbeddableTypeJSONTests: XCTestCase {
+
+    override func setUp() {
+        let sectionName =  ModelField(name: "name", type: .string, isRequired: true)
+        let sectionNumber =  ModelField(name: "number", type: .double, isRequired: true)
+        let sectionSchema = ModelSchema(name: "Section",
+                                        fields: [sectionName.name: sectionName,
+                                                 sectionNumber.name: sectionNumber])
+
+        let colorName =  ModelField(name: "name", type: .string, isRequired: true)
+        let colorR =  ModelField(name: "red", type: .int, isRequired: true)
+        let colorG =  ModelField(name: "green", type: .int, isRequired: true)
+        let colorB =  ModelField(name: "blue", type: .int, isRequired: true)
+        let colorSchema = ModelSchema(name: "Color", pluralName: "Colors",
+                                      fields: [colorName.name: colorName,
+                                               colorR.name: colorR,
+                                               colorG.name: colorG,
+                                               colorB.name: colorB])
+
+        let categoryName = ModelField(name: "name", type: .string, isRequired: true)
+        let categoryColor = ModelField(name: "color",
+                                       type: .embeddedCollection(of: DynamicEmbedded.self, schema: colorSchema),
+                                       isRequired: true)
+        let categorySchema = ModelSchema(name: "Category", pluralName: "Categories",
+                                         fields: [categoryName.name: categoryName,
+                                                  categoryColor.name: categoryColor])
+
+        let todoId = ModelFieldDefinition.id("id").modelField
+        let todoName = ModelField(name: "name", type: .string, isRequired: true)
+        let todoDescription = ModelField(name: "description", type: .string)
+        let todoCategories = ModelField(name: "categories",
+                                        type: .embeddedCollection(of: DynamicEmbedded.self, schema: categorySchema))
+        let todoSection = ModelField(name: "section",
+                                     type: .embedded(type: DynamicEmbedded.self, schema: sectionSchema))
+        let todoStickies = ModelField(name: "stickies", type: .embedded(type: String.self))
+        let todoSchema = ModelSchema(name: "Todo",
+                                     pluralName: "Todos",
+                                     fields: [todoId.name: todoId,
+                                              todoName.name: todoName,
+                                              todoDescription.name: todoDescription,
+                                              todoCategories.name: todoCategories,
+                                              todoSection.name: todoSection,
+                                              todoStickies.name: todoStickies])
+
+        ModelRegistry.register(modelType: DynamicModel.self,
+                               modelSchema: todoSchema) { (_, _) -> Model in
+            return DynamicModel(id: "1", map: [:])
+        }
+    }
+
+    override func tearDown() {
+        ModelRegistry.reset()
+    }
+
+    func testCreateTodoGraphQLRequest() {
+        let color1 = ["name": JSONValue.string("color1"),
+                      "red": JSONValue.number(1),
+                      "green": JSONValue.number(2),
+                      "blue": JSONValue.number(3)]
+        let color2 = ["name": JSONValue.string("color1"),
+                      "red": JSONValue.number(12),
+                      "green": JSONValue.number(13),
+                      "blue": JSONValue.number(14)]
+
+        let category1 = ["name": JSONValue.string("green"), "color": JSONValue.object(color1)]
+        let category2 = ["name": JSONValue.string("red"), "color": JSONValue.object(color2)]
+
+        let section = ["name": JSONValue.string("section"), "number": JSONValue.number(1.1)]
+
+        let todo = ["name": JSONValue.string("my first todo"),
+                    "description": JSONValue.string("todo description"),
+                    "categories": JSONValue.array([JSONValue.object(category1), JSONValue.object(category2)]),
+                    "section": JSONValue.object(section)]
+
+        let todoModel = DynamicModel(map: todo)
+        let documentStringValue = """
+        mutation CreateTodo($input: CreateTodoInput!) {
+          createTodo(input: $input) {
+            id
+            categories {
+              color {
+                blue
+                green
+                name
+                red
+                __typename
+              }
+              name
+              __typename
+            }
+            description
+            name
+            section {
+              name
+              number
+              __typename
+            }
+            stickies
+            __typename
+          }
+        }
+        """
+        let schema = ModelRegistry.modelSchema(from: "Todo")!
+        let request = GraphQLRequest<DynamicModel>.create(todoModel, modelSchema: schema)
+        XCTAssertEqual(documentStringValue, request.document)
+
+        guard let variables = request.variables else {
+            XCTFail("The request doesn't contain variables")
+            return
+        }
+        guard let input = variables["input"] as? [String: Any] else {
+            XCTFail("The document variables property doesn't contain a valid input")
+            return
+        }
+        XCTAssertEqual(input["id"] as? String, todoModel.id)
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestModelTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestModelTests.swift
@@ -11,120 +11,137 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class GraphQLRequestEmbeddableTypeJSONTests: XCTestCase {
+class GraphQLRequestModelTest: XCTestCase {
 
-    override func setUp() {
-        let sectionName =  ModelField(name: "name", type: .string, isRequired: true)
-        let sectionNumber =  ModelField(name: "number", type: .double, isRequired: true)
-        let sectionSchema = ModelSchema(name: "Section",
-                                        fields: [sectionName.name: sectionName,
-                                                 sectionNumber.name: sectionNumber])
+    /// - Given: a `Model` instance
+    /// - When:
+    ///   - the model is a `Post`
+    ///   - the mutation is of type `.create`
+    /// - Then:
+    ///   - check if the `GraphQLRequest` is valid:
+    ///     - the `document` has the right content
+    ///     - the `responseType` is correct
+    ///     - the `variables` is non-nil
+    func testCreateMutationGraphQLRequest() {
+        let post = Post(title: "title", content: "content", createdAt: .now())
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .mutation)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
+        documentBuilder.add(decorator: ModelDecorator(model: post))
+        let document = documentBuilder.build()
 
-        let colorName =  ModelField(name: "name", type: .string, isRequired: true)
-        let colorR =  ModelField(name: "red", type: .int, isRequired: true)
-        let colorG =  ModelField(name: "green", type: .int, isRequired: true)
-        let colorB =  ModelField(name: "blue", type: .int, isRequired: true)
-        let colorSchema = ModelSchema(name: "Color", pluralName: "Colors",
-                                      fields: [colorName.name: colorName,
-                                               colorR.name: colorR,
-                                               colorG.name: colorG,
-                                               colorB.name: colorB])
+        let request = GraphQLRequest<Post>.create(post)
 
-        let categoryName = ModelField(name: "name", type: .string, isRequired: true)
-        let categoryColor = ModelField(name: "color",
-                                       type: .embeddedCollection(of: DynamicEmbedded.self, schema: colorSchema),
-                                       isRequired: true)
-        let categorySchema = ModelSchema(name: "Category", pluralName: "Categories",
-                                         fields: [categoryName.name: categoryName,
-                                                  categoryColor.name: categoryColor])
-
-        let todoId = ModelFieldDefinition.id("id").modelField
-        let todoName = ModelField(name: "name", type: .string, isRequired: true)
-        let todoDescription = ModelField(name: "description", type: .string)
-        let todoCategories = ModelField(name: "categories",
-                                        type: .embeddedCollection(of: DynamicEmbedded.self, schema: categorySchema))
-        let todoSection = ModelField(name: "section",
-                                     type: .embedded(type: DynamicEmbedded.self, schema: sectionSchema))
-        let todoStickies = ModelField(name: "stickies", type: .embedded(type: String.self))
-        let todoSchema = ModelSchema(name: "Todo",
-                                     pluralName: "Todos",
-                                     fields: [todoId.name: todoId,
-                                              todoName.name: todoName,
-                                              todoDescription.name: todoDescription,
-                                              todoCategories.name: todoCategories,
-                                              todoSection.name: todoSection,
-                                              todoStickies.name: todoStickies])
-
-        ModelRegistry.register(modelType: DynamicModel.self,
-                               modelSchema: todoSchema) { (_, _) -> Model in
-            return DynamicModel(id: "1", map: [:])
-        }
+        XCTAssertEqual(document.stringValue, request.document)
+        XCTAssert(request.responseType == Post.self)
+        XCTAssert(request.variables != nil)
     }
 
-    override func tearDown() {
-        ModelRegistry.reset()
+    func testUpdateMutationGraphQLRequest() {
+        let post = Post(title: "title", content: "content", createdAt: .now())
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .mutation)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .update))
+        documentBuilder.add(decorator: ModelDecorator(model: post))
+        let document = documentBuilder.build()
+
+        let request = GraphQLRequest<Post>.update(post)
+
+        XCTAssertEqual(document.stringValue, request.document)
+        XCTAssert(request.responseType == Post.self)
+        XCTAssert(request.variables != nil)
     }
 
-    func testCreateTodoGraphQLRequest() {
-        let color1 = ["name": JSONValue.string("color1"),
-                      "red": JSONValue.number(1),
-                      "green": JSONValue.number(2),
-                      "blue": JSONValue.number(3)]
-        let color2 = ["name": JSONValue.string("color1"),
-                      "red": JSONValue.number(12),
-                      "green": JSONValue.number(13),
-                      "blue": JSONValue.number(14)]
+    func testDeleteMutationGraphQLRequest() {
+        let post = Post(title: "title", content: "content", createdAt: .now())
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .mutation)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .delete))
+        documentBuilder.add(decorator: ModelDecorator(model: post))
+        let document = documentBuilder.build()
 
-        let category1 = ["name": JSONValue.string("green"), "color": JSONValue.object(color1)]
-        let category2 = ["name": JSONValue.string("red"), "color": JSONValue.object(color2)]
+        let request = GraphQLRequest<Post>.delete(post)
 
-        let section = ["name": JSONValue.string("section"), "number": JSONValue.number(1.1)]
+        XCTAssertEqual(document.stringValue, request.document)
+        XCTAssert(request.responseType == Post.self)
+        XCTAssert(request.variables != nil)
+    }
 
-        let todo = ["name": JSONValue.string("my first todo"),
-                    "description": JSONValue.string("todo description"),
-                    "categories": JSONValue.array([JSONValue.object(category1), JSONValue.object(category2)]),
-                    "section": JSONValue.object(section)]
+    func testQueryByIdGraphQLRequest() {
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .query)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
+        documentBuilder.add(decorator: ModelIdDecorator(id: "id"))
+        let document = documentBuilder.build()
 
-        let todoModel = DynamicModel(map: todo)
-        let documentStringValue = """
-        mutation CreateTodo($input: CreateTodoInput!) {
-          createTodo(input: $input) {
-            id
-            categories {
-              color {
-                blue
-                green
-                name
-                red
-                __typename
-              }
-              name
-              __typename
-            }
-            description
-            name
-            section {
-              name
-              number
-              __typename
-            }
-            stickies
-            __typename
-          }
-        }
-        """
-        let schema = ModelRegistry.modelSchema(from: "Todo")!
-        let request = GraphQLRequest<DynamicModel>.create(todoModel, modelSchema: schema)
-        XCTAssertEqual(documentStringValue, request.document)
+        let request = GraphQLRequest<Post>.get(Post.self, byId: "id")
 
-        guard let variables = request.variables else {
-            XCTFail("The request doesn't contain variables")
-            return
-        }
-        guard let input = variables["input"] as? [String: Any] else {
-            XCTFail("The document variables property doesn't contain a valid input")
-            return
-        }
-        XCTAssertEqual(input["id"] as? String, todoModel.id)
+        XCTAssertEqual(document.stringValue, request.document)
+        XCTAssert(request.responseType == Post?.self)
+        XCTAssert(request.variables != nil)
+    }
+
+    func testListQueryGraphQLRequest() {
+        let post = Post.keys
+        let predicate = post.id.eq("id") && (post.title.beginsWith("Title") || post.content.contains("content"))
+
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .query)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
+        documentBuilder.add(decorator: FilterDecorator(filter: predicate.graphQLFilter))
+        documentBuilder.add(decorator: PaginationDecorator())
+        let document = documentBuilder.build()
+
+        let request = GraphQLRequest<Post>.list(Post.self, where: predicate)
+
+        XCTAssertEqual(document.stringValue, request.document)
+        XCTAssert(request.responseType == [Post].self)
+        XCTAssertNotNil(request.variables)
+    }
+
+    func testPaginatedListQueryGraphQLRequest() {
+        let post = Post.keys
+        let predicate = post.id.eq("id") && (post.title.beginsWith("Title") || post.content.contains("content"))
+
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .query)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
+        documentBuilder.add(decorator: FilterDecorator(filter: predicate.graphQLFilter))
+        documentBuilder.add(decorator: PaginationDecorator(limit: 10))
+        let document = documentBuilder.build()
+
+        let request = GraphQLRequest<Post>.paginatedList(Post.self, where: predicate, limit: 10)
+
+        XCTAssertEqual(document.stringValue, request.document)
+        XCTAssert(request.responseType == List<Post>.self)
+        XCTAssertNotNil(request.variables)
+    }
+
+    func testOnCreateSubscriptionGraphQLRequest() {
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .subscription)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
+        let document = documentBuilder.build()
+
+        let request = GraphQLRequest<Post>.subscription(of: Post.self, type: .onCreate)
+
+        XCTAssertEqual(document.stringValue, request.document)
+        XCTAssert(request.responseType == Post.self)
+
+    }
+
+    func testOnUpdateSubscriptionGraphQLRequest() {
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .subscription)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .onUpdate))
+        let document = documentBuilder.build()
+
+        let request = GraphQLRequest<Post>.subscription(of: Post.self, type: .onUpdate)
+
+        XCTAssertEqual(document.stringValue, request.document)
+        XCTAssert(request.responseType == Post.self)
+    }
+
+    func testOnDeleteSubscriptionGraphQLRequest() {
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .subscription)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .onDelete))
+        let document = documentBuilder.build()
+
+        let request = GraphQLRequest<Post>.subscription(of: Post.self, type: .onDelete)
+
+        XCTAssertEqual(document.stringValue, request.document)
+        XCTAssert(request.responseType == Post.self)
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Core/DataStoreList+LazyLoad.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Core/DataStoreList+LazyLoad.swift
@@ -74,4 +74,18 @@ extension DataStoreList {
         }
         semaphore.wait()
     }
+
+    func firstPage(_ completion: @escaping (Result<Void, CoreError>) -> Void) {
+        lazyLoad { result in
+            switch result {
+            case .success:
+                completion(.success(()))
+            case .failure(let dataStoreError):
+                completion(.failure(.listOperation(
+                                        "The SQL query failed.",
+                                        "Check the underlying `DataStoreError`",
+                                        dataStoreError)))
+            }
+        }
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Core/DataStoreList.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Core/DataStoreList.swift
@@ -129,8 +129,13 @@ public class DataStoreList<ModelType: Model>: List<ModelType>, ModelListDecoder 
     /// fetches data from the `DataStore.query`.
     ///
     /// - seealso: `load()`
+    @available(*, deprecated, message: "Use `fetch(_)` instead.")
     public override func load(_ completion: DataStoreCallback<Elements>) {
         lazyLoad(completion)
+    }
+
+    public override func fetch(_ completion: @escaping (Result<Void, CoreError>) -> Void) {
+        firstPage(completion)
     }
 
     // MARK: - Synchronous API
@@ -143,6 +148,7 @@ public class DataStoreList<ModelType: Model>: List<ModelType>, ModelListDecoder 
     ///
     /// - Returns: the current instance after data was loaded.
     /// - seealso: `load(completion:)`
+    @available(*, deprecated, message: "Use `fetch(_)` instead.")
     public override func load() -> Self {
         lazyLoad()
         return self


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**Public APIs added**
1. `.paginatedList`
```swift
extension GraphQLRequest {
    static func paginatedList<M: Model>(_ modelType: M.Type,
                                        where predicate: QueryPredicate?,
                                        limit: Int?) -> GraphQLRequest<List<M>>
}
```

2. `Paginatable` protocol 

```swift
public protocol Paginatable {

    typealias PageResultCallback = (Result<List<Element>, CoreError>) -> Void
    associatedtype Element: Model

    /// Checks if there is subsequent data to retrieve. If True, retrieve the next page using `getNextPage`
    func hasNextPage() -> Bool

    /// Retrieves the next page as a new in-memory List object asynchronously.
    func getNextPage(completion: @escaping PageResultCallback)
}
```

3. `fetch` method on `List`

```swift
open class List<ModelType: Model>: ModelList {
    open func fetch(_ completion: @escaping (Result<Void, CoreError>) -> Void)
}
```

**Developer Experience**

**How to create a List**
```swift
Amplify.API.query(.paginatedList(Comments.self, limit: 10)) { result in
   switch result {
   case .success(let graphQLResponse):
       switch graphqlResponse {
          case .success(let comments):
          case .failure(let graphQLErrorResponse):
       }
   case .failure(let apiError):
   }
}
```

**Traverse to a List**
```swift
Amplify.API.query(request: .get(Post3.self, byId: post.id)) { result in
    switch result {
    case .success(let result):
        switch result {
        case .success(let queriedPostOptional):
            guard let queriedPost = queriedPostOptional else { // Post object
                return
            }
            guard let comments = queriedPost.comments else { // instantiated List object
                return
            }
```
The comments List object is deserialized with the the associated data (post field and postId) to allow lazy loading the comments for that post. The developer can explicitly call fetch to load the comments into the List object
```swift
// Then load the data
comments.fetch { fetchResults in // fetches up to 1000
    switch fetchResults {
    case .success: 
    case .failure(let error):
    }
}

for comment in comments {
}
```
Or comments can be implicitly fetched by performing operations on the object such as
```swift
// accessing the count
comments.count 
// or iterating over the comments
for comment in comments {
}
```
**How to get next page: Pagination**

```swift
if comments.hasNextPage() {
    comments.fetch { result in
        switch result {
        case .success(let list):
            print(list)
        case .failure(let coreError):
            print("Failed to fetch next page \(coreError)")
            switch coreError {
               case .validation: break
               case .listOperation: break
               case .unknown: break
            }
        }
    }
}
```

**How to aggregate pages of data**

If you are using the results as a backing store to hydrate some UI components, you should create your own in-memory array to append new pages into it. The reason for this is because there is metadata stored in the object is used to fetch the next page, so any current page only knows how to fetch the next page from the current page. ie. If you append it to the existing page, your `fetch` call will always retrieve the subsequent page of the original page.
```swift
var resultsArray: [Post] = [] // binding to UI components
var currentPage: List<Post>?

_ = Amplify.API.query(request: .paginatedList(Post.self, limit: 1)) { event in
    switch event {
    case .success(let response):
        guard case let .success(graphQLResponse) = response else {
            XCTFail("Missing successful response")
            return
        }

        resultsArray.append(contentsOf: graphQLResponse)
        currentPage = graphQLResponse

    case .failure(let error):
        XCTFail("Unexpected .failure event: \(error)")
    }
}

// respond to UI actions to retrieve next page, ie.
func loadMore() {
    if let current = currentPage, current.hasNextPage() {
        current.fetch { result in
            switch result {
            case .success(let list):
                resultsArray.append(contentsOf: list)
                currentPage = list
                loadMore()
            case .failure(let coreError):
                print("Failed to fetch next page \(coreError)")
            }
        }
    }
}
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
