### PR TITLE
chore: Update copyright year to 2021

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -10,7 +10,7 @@
   --elseposition same-line
 
 --enable fileHeader
-  --header "//\n// Copyright 2018-{created.year} Amazon.com,\n// Inc. or its affiliates. All Rights Reserved.\n//\n// SPDX-License-Identifier: Apache-2.0\n//"
+  --header "//\n// Copyright 2018-{year} Amazon.com,\n// Inc. or its affiliates. All Rights Reserved.\n//\n// SPDX-License-Identifier: Apache-2.0\n//"
 
 --disable hoistPatternLet
   --patternlet inline

--- a/Amplify/Amplify.swift
+++ b/Amplify/Amplify.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/APICategory+HubPayloadEventName.swift
+++ b/Amplify/Categories/API/APICategory+HubPayloadEventName.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/APICategory.swift
+++ b/Amplify/Categories/API/APICategory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/APICategoryConfiguration.swift
+++ b/Amplify/Categories/API/APICategoryConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/APICategoryPlugin.swift
+++ b/Amplify/Categories/API/APICategoryPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/AmplifyAPICategory+APICategory.swift
+++ b/Amplify/Categories/API/AmplifyAPICategory+APICategory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/AmplifyAPICategory.swift
+++ b/Amplify/Categories/API/AmplifyAPICategory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
+++ b/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/ClientBehavior/APICategoryAuthProviderFactoryBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategoryAuthProviderFactoryBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/ClientBehavior/APICategoryBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategoryBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/ClientBehavior/APICategoryGraphQLBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategoryGraphQLBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/ClientBehavior/APICategoryInterceptorBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategoryInterceptorBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/ClientBehavior/APICategoryRESTBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategoryRESTBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/ClientBehavior/APICategoryReachabilityBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategoryReachabilityBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+AuthProviderFactoryBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+AuthProviderFactoryBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+GraphQLBehavior+Combine.swift
+++ b/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+GraphQLBehavior+Combine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+GraphQLBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+GraphQLBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+InterceptorBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+InterceptorBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+RESTBehavior+Combine.swift
+++ b/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+RESTBehavior+Combine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+RESTBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+RESTBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+ReachabilityBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+ReachabilityBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Error/APIError.swift
+++ b/Amplify/Categories/API/Error/APIError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Interceptor/URLRequestInterceptor.swift
+++ b/Amplify/Categories/API/Interceptor/URLRequestInterceptor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Internal/APICategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/API/Internal/APICategory+CategoryConfigurable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Internal/APICategory+Resettable.swift
+++ b/Amplify/Categories/API/Internal/APICategory+Resettable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Operation/AmplifyOperation+APIPublishers.swift
+++ b/Amplify/Categories/API/Operation/AmplifyOperation+APIPublishers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Operation/GraphQLOperation.swift
+++ b/Amplify/Categories/API/Operation/GraphQLOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Operation/RESTOperation.swift
+++ b/Amplify/Categories/API/Operation/RESTOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Reachability/ReachabilityUpdate.swift
+++ b/Amplify/Categories/API/Reachability/ReachabilityUpdate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Request/GraphQLOperationRequest.swift
+++ b/Amplify/Categories/API/Request/GraphQLOperationRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Request/GraphQLOperationType.swift
+++ b/Amplify/Categories/API/Request/GraphQLOperationType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Request/GraphQLRequest.swift
+++ b/Amplify/Categories/API/Request/GraphQLRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Request/RESTOperationRequest.swift
+++ b/Amplify/Categories/API/Request/RESTOperationRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Request/RESTOperationType.swift
+++ b/Amplify/Categories/API/Request/RESTOperationType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Request/RESTRequest.swift
+++ b/Amplify/Categories/API/Request/RESTRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Response/GraphQLError.swift
+++ b/Amplify/Categories/API/Response/GraphQLError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Response/GraphQLResponse.swift
+++ b/Amplify/Categories/API/Response/GraphQLResponse.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Response/SubscriptionConnectionState.swift
+++ b/Amplify/Categories/API/Response/SubscriptionConnectionState.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/API/Response/SubscriptionEvent.swift
+++ b/Amplify/Categories/API/Response/SubscriptionEvent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Analytics/AnalyticsCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Analytics/AnalyticsCategory+ClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Analytics/AnalyticsCategory+HubPayloadEventName.swift
+++ b/Amplify/Categories/Analytics/AnalyticsCategory+HubPayloadEventName.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Analytics/AnalyticsCategory.swift
+++ b/Amplify/Categories/Analytics/AnalyticsCategory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Analytics/AnalyticsCategoryBehavior.swift
+++ b/Amplify/Categories/Analytics/AnalyticsCategoryBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Analytics/AnalyticsCategoryConfiguration.swift
+++ b/Amplify/Categories/Analytics/AnalyticsCategoryConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Analytics/AnalyticsCategoryPlugin.swift
+++ b/Amplify/Categories/Analytics/AnalyticsCategoryPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Analytics/AnalyticsProfile.swift
+++ b/Amplify/Categories/Analytics/AnalyticsProfile.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Analytics/AnalyticsPropertyValue.swift
+++ b/Amplify/Categories/Analytics/AnalyticsPropertyValue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Analytics/Error/AnalyticsError.swift
+++ b/Amplify/Categories/Analytics/Error/AnalyticsError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Analytics/Event/AnalyticsEvent.swift
+++ b/Amplify/Categories/Analytics/Event/AnalyticsEvent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Analytics/Event/BasicAnalyticsEvent.swift
+++ b/Amplify/Categories/Analytics/Event/BasicAnalyticsEvent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Analytics/Internal/AnalyticsCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Analytics/Internal/AnalyticsCategory+CategoryConfigurable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Analytics/Internal/AnalyticsCategory+Resettable.swift
+++ b/Amplify/Categories/Analytics/Internal/AnalyticsCategory+Resettable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/AuthCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategory+ClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/AuthCategory+DeviceBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategory+DeviceBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/AuthCategory+HubPayloadEventName.swift
+++ b/Amplify/Categories/Auth/AuthCategory+HubPayloadEventName.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/AuthCategory+UserBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategory+UserBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/AuthCategory.swift
+++ b/Amplify/Categories/Auth/AuthCategory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/AuthCategoryBehavior+Combine.swift
+++ b/Amplify/Categories/Auth/AuthCategoryBehavior+Combine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/AuthCategoryBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategoryBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/AuthCategoryConfiguration.swift
+++ b/Amplify/Categories/Auth/AuthCategoryConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/AuthCategoryDeviceBehavior+Combine.swift
+++ b/Amplify/Categories/Auth/AuthCategoryDeviceBehavior+Combine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/AuthCategoryDeviceBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategoryDeviceBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/AuthCategoryPlugin.swift
+++ b/Amplify/Categories/Auth/AuthCategoryPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/AuthCategoryUserBehavior+Combine.swift
+++ b/Amplify/Categories/Auth/AuthCategoryUserBehavior+Combine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/AuthCategoryUserBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategoryUserBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Error/AuthError.swift
+++ b/Amplify/Categories/Auth/Error/AuthError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Internal/AuthCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Auth/Internal/AuthCategory+CategoryConfigurable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Internal/AuthCategory+Resettable.swift
+++ b/Amplify/Categories/Auth/Internal/AuthCategory+Resettable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Models/AuthCodeDeliveryDetails.swift
+++ b/Amplify/Categories/Auth/Models/AuthCodeDeliveryDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Models/AuthDevice.swift
+++ b/Amplify/Categories/Auth/Models/AuthDevice.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Models/AuthEventName.swift
+++ b/Amplify/Categories/Auth/Models/AuthEventName.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Models/AuthProvider.swift
+++ b/Amplify/Categories/Auth/Models/AuthProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Models/AuthSession.swift
+++ b/Amplify/Categories/Auth/Models/AuthSession.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Models/AuthSignInStep.swift
+++ b/Amplify/Categories/Auth/Models/AuthSignInStep.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Models/AuthSignUpStep.swift
+++ b/Amplify/Categories/Auth/Models/AuthSignUpStep.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Models/AuthUpdateAttributeStep.swift
+++ b/Amplify/Categories/Auth/Models/AuthUpdateAttributeStep.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Models/AuthUser.swift
+++ b/Amplify/Categories/Auth/Models/AuthUser.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Models/AuthUserAttribute.swift
+++ b/Amplify/Categories/Auth/Models/AuthUserAttribute.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Models/DeliveryDestination.swift
+++ b/Amplify/Categories/Auth/Models/DeliveryDestination.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/AmplifyOperation+AuthPublishers.swift
+++ b/Amplify/Categories/Auth/Operation/AmplifyOperation+AuthPublishers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/AuthChangePasswordOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthChangePasswordOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/AuthConfirmResetPasswordOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthConfirmResetPasswordOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/AuthConfirmSignInOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthConfirmSignInOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/AuthConfirmSignUpOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthConfirmSignUpOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/AuthFetchDevicesOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthFetchDevicesOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/AuthFetchSessionOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthFetchSessionOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/AuthForgetDeviceOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthForgetDeviceOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/AuthRememberDeviceOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthRememberDeviceOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/AuthResendSignUpCodeOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthResendSignUpCodeOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/AuthResetPasswordOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthResetPasswordOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/AuthSignInOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthSignInOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/AuthSignOutOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthSignOutOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/AuthSignUpOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthSignUpOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/AuthSocialWebUISignInOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthSocialWebUISignInOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/AuthWebUISignInOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthWebUISignInOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/UserOperations/AuthAttributeResendConfirmationCodeOperation.swift
+++ b/Amplify/Categories/Auth/Operation/UserOperations/AuthAttributeResendConfirmationCodeOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/UserOperations/AuthConfirmUserAttributeOperation.swift
+++ b/Amplify/Categories/Auth/Operation/UserOperations/AuthConfirmUserAttributeOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/UserOperations/AuthFetchUserAttributeOperation.swift
+++ b/Amplify/Categories/Auth/Operation/UserOperations/AuthFetchUserAttributeOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/UserOperations/AuthUpdateUserAttributeOperation.swift
+++ b/Amplify/Categories/Auth/Operation/UserOperations/AuthUpdateUserAttributeOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Operation/UserOperations/AuthUpdateUserAttributesOperation.swift
+++ b/Amplify/Categories/Auth/Operation/UserOperations/AuthUpdateUserAttributesOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthAttributeResendConfirmationCodeRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthAttributeResendConfirmationCodeRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthChangePasswordRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthChangePasswordRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthConfirmResetPasswordRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthConfirmResetPasswordRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthConfirmSignInRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthConfirmSignInRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthConfirmSignUpRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthConfirmSignUpRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthConfirmUserAttributeRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthConfirmUserAttributeRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthFetchDevicesRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthFetchDevicesRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthFetchSessionRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthFetchSessionRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthFetchUserAttributesRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthFetchUserAttributesRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthForgetDeviceRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthForgetDeviceRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthRememberDeviceRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthRememberDeviceRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthResendSignUpCodeRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthResendSignUpCodeRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthResetPasswordRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthResetPasswordRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthSignInRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthSignInRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthSignOutRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthSignOutRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthSignUpRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthSignUpRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthUpdateUserAttributeRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthUpdateUserAttributeRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthUpdateUserAttributesRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthUpdateUserAttributesRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Request/AuthWebUISignInRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthWebUISignInRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Result/AuthResetPasswordResult.swift
+++ b/Amplify/Categories/Auth/Result/AuthResetPasswordResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Result/AuthSignInResult.swift
+++ b/Amplify/Categories/Auth/Result/AuthSignInResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Result/AuthSignUpResult.swift
+++ b/Amplify/Categories/Auth/Result/AuthSignUpResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Auth/Result/AuthUpdateAttributeResult.swift
+++ b/Amplify/Categories/Auth/Result/AuthUpdateAttributeResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/DataStoreCallback+Combine.swift
+++ b/Amplify/Categories/DataStore/DataStoreCallback+Combine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/DataStoreCallback.swift
+++ b/Amplify/Categories/DataStore/DataStoreCallback.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior+Combine.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior+Combine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/DataStoreCategory+HubPayloadEventName.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+HubPayloadEventName.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/DataStoreCategory.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/DataStoreCategoryConfiguration.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/DataStoreCategoryPlugin.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/DataStoreConflict.swift
+++ b/Amplify/Categories/DataStore/DataStoreConflict.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/DataStoreError.swift
+++ b/Amplify/Categories/DataStore/DataStoreError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/DataStoreStatement.swift
+++ b/Amplify/Categories/DataStore/DataStoreStatement.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/GraphQL/GraphQLMutationType.swift
+++ b/Amplify/Categories/DataStore/GraphQL/GraphQLMutationType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/GraphQL/GraphQLQueryType.swift
+++ b/Amplify/Categories/DataStore/GraphQL/GraphQLQueryType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/GraphQL/GraphQLSubscriptionType.swift
+++ b/Amplify/Categories/DataStore/GraphQL/GraphQLSubscriptionType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Internal/DataStoreCategory+Configurable.swift
+++ b/Amplify/Categories/DataStore/Internal/DataStoreCategory+Configurable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Internal/DataStoreCategory+Resettable.swift
+++ b/Amplify/Categories/DataStore/Internal/DataStoreCategory+Resettable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/AmplifyModelRegistration.swift
+++ b/Amplify/Categories/DataStore/Model/AmplifyModelRegistration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Collection/List+Combine.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+Combine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Collection/List+LazyLoad.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+LazyLoad.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Collection/List+Model.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+Model.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Internal/Embedded.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Embedded.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Internal/Model+Array.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Model+Array.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Internal/Model+Codable.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Model+Codable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Internal/Model+DateFormatting.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Model+DateFormatting.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Internal/Model+Enum.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Model+Enum.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Internal/Model+Subscript.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Model+Subscript.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry+Syncable.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry+Syncable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Internal/Persistable.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Persistable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/AuthRule.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/AuthRule.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/Model+Schema.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/Model+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Attributes.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Attributes.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelValueConverter.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelValueConverter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/JSONHelper/JSONValueHolder.swift
+++ b/Amplify/Categories/DataStore/Model/JSONHelper/JSONValueHolder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Model+ModelName.swift
+++ b/Amplify/Categories/DataStore/Model/Model+ModelName.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Model.swift
+++ b/Amplify/Categories/DataStore/Model/Model.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Temporal/DataStoreError+Temporal.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/DataStoreError+Temporal.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Temporal/Date+Operation.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/Date+Operation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Temporal/Date.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/Date.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Temporal/DateTime.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/DateTime.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Temporal/Temporal+Codable.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/Temporal+Codable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Temporal/Temporal+Comparable.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/Temporal+Comparable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Temporal/Temporal+Hashable.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/Temporal+Hashable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Temporal/Temporal.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/Temporal.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Temporal/TemporalFormat+Date.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/TemporalFormat+Date.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Temporal/TemporalFormat+DateTime.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/TemporalFormat+DateTime.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Temporal/TemporalFormat+Time.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/TemporalFormat+Time.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Temporal/TemporalFormat.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/TemporalFormat.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Temporal/TemporalOperation.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/TemporalOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Temporal/Time+Operation.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/Time+Operation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Model/Temporal/Time.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/Time.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Query/Evaluable.swift
+++ b/Amplify/Categories/DataStore/Query/Evaluable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Query/ModelKey.swift
+++ b/Amplify/Categories/DataStore/Query/ModelKey.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Query/QueryField.swift
+++ b/Amplify/Categories/DataStore/Query/QueryField.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Query/QueryOperator+Equatable.swift
+++ b/Amplify/Categories/DataStore/Query/QueryOperator+Equatable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Query/QueryOperator.swift
+++ b/Amplify/Categories/DataStore/Query/QueryOperator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Query/QueryPaginationInput.swift
+++ b/Amplify/Categories/DataStore/Query/QueryPaginationInput.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Query/QueryPredicate+Equatable.swift
+++ b/Amplify/Categories/DataStore/Query/QueryPredicate+Equatable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Query/QueryPredicate.swift
+++ b/Amplify/Categories/DataStore/Query/QueryPredicate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Query/QuerySortInput.swift
+++ b/Amplify/Categories/DataStore/Query/QuerySortInput.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Subscribe/DataStoreCategory+Subscribe.swift
+++ b/Amplify/Categories/DataStore/Subscribe/DataStoreCategory+Subscribe.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Subscribe/MutationEvent+Model.swift
+++ b/Amplify/Categories/DataStore/Subscribe/MutationEvent+Model.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Subscribe/MutationEvent+MutationType.swift
+++ b/Amplify/Categories/DataStore/Subscribe/MutationEvent+MutationType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Subscribe/MutationEvent+Schema.swift
+++ b/Amplify/Categories/DataStore/Subscribe/MutationEvent+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/DataStore/Subscribe/MutationEvent.swift
+++ b/Amplify/Categories/DataStore/Subscribe/MutationEvent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Hub/HubCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Hub/HubCategory+ClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Hub/HubCategory.swift
+++ b/Amplify/Categories/Hub/HubCategory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Hub/HubCategoryBehavior+Combine.swift
+++ b/Amplify/Categories/Hub/HubCategoryBehavior+Combine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Hub/HubCategoryBehavior.swift
+++ b/Amplify/Categories/Hub/HubCategoryBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Hub/HubCategoryConfiguration.swift
+++ b/Amplify/Categories/Hub/HubCategoryConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Hub/HubCategoryPlugin.swift
+++ b/Amplify/Categories/Hub/HubCategoryPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Hub/HubChannel.swift
+++ b/Amplify/Categories/Hub/HubChannel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Hub/HubError.swift
+++ b/Amplify/Categories/Hub/HubError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Hub/HubFilter.swift
+++ b/Amplify/Categories/Hub/HubFilter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Hub/HubPayload.swift
+++ b/Amplify/Categories/Hub/HubPayload.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Hub/HubPayloadEventName.swift
+++ b/Amplify/Categories/Hub/HubPayloadEventName.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Hub/Internal/HubCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Hub/Internal/HubCategory+CategoryConfigurable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Hub/Internal/HubCategory+Resettable.swift
+++ b/Amplify/Categories/Hub/Internal/HubCategory+Resettable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Hub/UnsubscribeToken.swift
+++ b/Amplify/Categories/Hub/UnsubscribeToken.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Logging/DefaultLogger.swift
+++ b/Amplify/Categories/Logging/DefaultLogger.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Logging/Internal/LoggingCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Logging/Internal/LoggingCategory+CategoryConfigurable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Logging/Internal/LoggingCategory+Resettable.swift
+++ b/Amplify/Categories/Logging/Internal/LoggingCategory+Resettable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Logging/LogLevel.swift
+++ b/Amplify/Categories/Logging/LogLevel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Logging/LoggingCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Logging/LoggingCategory+ClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Logging/LoggingCategory+Logger.swift
+++ b/Amplify/Categories/Logging/LoggingCategory+Logger.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Logging/LoggingCategory.swift
+++ b/Amplify/Categories/Logging/LoggingCategory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Logging/LoggingCategoryClientBehavior.swift
+++ b/Amplify/Categories/Logging/LoggingCategoryClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Logging/LoggingCategoryConfiguration.swift
+++ b/Amplify/Categories/Logging/LoggingCategoryConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Logging/LoggingCategoryPlugin.swift
+++ b/Amplify/Categories/Logging/LoggingCategoryPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Logging/LoggingError.swift
+++ b/Amplify/Categories/Logging/LoggingError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Error/PredictionsError.swift
+++ b/Amplify/Categories/Predictions/Error/PredictionsError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Internal/DefaultNetworkPolicy.swift
+++ b/Amplify/Categories/Predictions/Internal/DefaultNetworkPolicy.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Internal/PredictionsCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Predictions/Internal/PredictionsCategory+CategoryConfigurable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Internal/PredictionsCategory+Resettable.swift
+++ b/Amplify/Categories/Predictions/Internal/PredictionsCategory+Resettable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/AgeRange.swift
+++ b/Amplify/Categories/Predictions/Models/AgeRange.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/Attribute.swift
+++ b/Amplify/Categories/Predictions/Models/Attribute.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/BoundedKeyValue.swift
+++ b/Amplify/Categories/Predictions/Models/BoundedKeyValue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/Celebrity.swift
+++ b/Amplify/Categories/Predictions/Models/Celebrity.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/Emotion.swift
+++ b/Amplify/Categories/Predictions/Models/Emotion.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/EmotionType.swift
+++ b/Amplify/Categories/Predictions/Models/EmotionType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/Entity.swift
+++ b/Amplify/Categories/Predictions/Models/Entity.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/EntityDetectionResult.swift
+++ b/Amplify/Categories/Predictions/Models/EntityDetectionResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/EntityMatch.swift
+++ b/Amplify/Categories/Predictions/Models/EntityMatch.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/EntityType.swift
+++ b/Amplify/Categories/Predictions/Models/EntityType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/GenderType.swift
+++ b/Amplify/Categories/Predictions/Models/GenderType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/IdentifiedLine.swift
+++ b/Amplify/Categories/Predictions/Models/IdentifiedLine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/IdentifiedText.swift
+++ b/Amplify/Categories/Predictions/Models/IdentifiedText.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/IdentifiedWord.swift
+++ b/Amplify/Categories/Predictions/Models/IdentifiedWord.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/IdentifyAction.swift
+++ b/Amplify/Categories/Predictions/Models/IdentifyAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/KeyPhrase.swift
+++ b/Amplify/Categories/Predictions/Models/KeyPhrase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/LabelType.swift
+++ b/Amplify/Categories/Predictions/Models/LabelType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/Landmark.swift
+++ b/Amplify/Categories/Predictions/Models/Landmark.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/LanguageDetectionResult.swift
+++ b/Amplify/Categories/Predictions/Models/LanguageDetectionResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/LanguageType.swift
+++ b/Amplify/Categories/Predictions/Models/LanguageType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/PartOfSpeech.swift
+++ b/Amplify/Categories/Predictions/Models/PartOfSpeech.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/Polygon.swift
+++ b/Amplify/Categories/Predictions/Models/Polygon.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/Pose.swift
+++ b/Amplify/Categories/Predictions/Models/Pose.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/Selection.swift
+++ b/Amplify/Categories/Predictions/Models/Selection.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/Sentiment.swift
+++ b/Amplify/Categories/Predictions/Models/Sentiment.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/SpeechType.swift
+++ b/Amplify/Categories/Predictions/Models/SpeechType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/SyntaxToken.swift
+++ b/Amplify/Categories/Predictions/Models/SyntaxToken.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/Table.swift
+++ b/Amplify/Categories/Predictions/Models/Table.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/TextFormatType.swift
+++ b/Amplify/Categories/Predictions/Models/TextFormatType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Models/VoiceType.swift
+++ b/Amplify/Categories/Predictions/Models/VoiceType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Operation/AmplifyOperation+PredictionsPublishers.swift
+++ b/Amplify/Categories/Predictions/Operation/AmplifyOperation+PredictionsPublishers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Operation/PredictionsIdentifyOperation.swift
+++ b/Amplify/Categories/Predictions/Operation/PredictionsIdentifyOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Operation/PredictionsInterpretOperation.swift
+++ b/Amplify/Categories/Predictions/Operation/PredictionsInterpretOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Operation/PredictionsSpeechToTextOperation.swift
+++ b/Amplify/Categories/Predictions/Operation/PredictionsSpeechToTextOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Operation/PredictionsTextToSpeechOperation.swift
+++ b/Amplify/Categories/Predictions/Operation/PredictionsTextToSpeechOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Operation/PredictionsTranslateTextOperation.swift
+++ b/Amplify/Categories/Predictions/Operation/PredictionsTranslateTextOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/PredictionsCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Predictions/PredictionsCategory+ClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/PredictionsCategory+HubPayloadEventName.swift
+++ b/Amplify/Categories/Predictions/PredictionsCategory+HubPayloadEventName.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/PredictionsCategory.swift
+++ b/Amplify/Categories/Predictions/PredictionsCategory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/PredictionsCategoryBehavior+Combine.swift
+++ b/Amplify/Categories/Predictions/PredictionsCategoryBehavior+Combine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/PredictionsCategoryBehavior.swift
+++ b/Amplify/Categories/Predictions/PredictionsCategoryBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/PredictionsCategoryConfiguration.swift
+++ b/Amplify/Categories/Predictions/PredictionsCategoryConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/PredictionsCategoryPlugin.swift
+++ b/Amplify/Categories/Predictions/PredictionsCategoryPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Request/PredictionsIdentifyRequest.swift
+++ b/Amplify/Categories/Predictions/Request/PredictionsIdentifyRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Request/PredictionsInterpretRequest.swift
+++ b/Amplify/Categories/Predictions/Request/PredictionsInterpretRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Request/PredictionsSpeechToTextRequest.swift
+++ b/Amplify/Categories/Predictions/Request/PredictionsSpeechToTextRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Request/PredictionsTextToSpeechRequest.swift
+++ b/Amplify/Categories/Predictions/Request/PredictionsTextToSpeechRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Request/PredictionsTranslateTextRequest.swift
+++ b/Amplify/Categories/Predictions/Request/PredictionsTranslateTextRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Result/ConvertResult.swift
+++ b/Amplify/Categories/Predictions/Result/ConvertResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Result/IdentifyCelebritiesResult.swift
+++ b/Amplify/Categories/Predictions/Result/IdentifyCelebritiesResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Result/IdentifyDocumentTextResult.swift
+++ b/Amplify/Categories/Predictions/Result/IdentifyDocumentTextResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Result/IdentifyEntitiesResult.swift
+++ b/Amplify/Categories/Predictions/Result/IdentifyEntitiesResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Result/IdentifyEntityMatchesResult.swift
+++ b/Amplify/Categories/Predictions/Result/IdentifyEntityMatchesResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Result/IdentifyLabelsResult.swift
+++ b/Amplify/Categories/Predictions/Result/IdentifyLabelsResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Result/IdentifyResult.swift
+++ b/Amplify/Categories/Predictions/Result/IdentifyResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Result/IdentifyTextResult.swift
+++ b/Amplify/Categories/Predictions/Result/IdentifyTextResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Result/InterpretResult.swift
+++ b/Amplify/Categories/Predictions/Result/InterpretResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Result/SpeechToTextResult.swift
+++ b/Amplify/Categories/Predictions/Result/SpeechToTextResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Result/TextToSpeechResult.swift
+++ b/Amplify/Categories/Predictions/Result/TextToSpeechResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Predictions/Result/TranslateTextResult.swift
+++ b/Amplify/Categories/Predictions/Result/TranslateTextResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Error/StorageError.swift
+++ b/Amplify/Categories/Storage/Error/StorageError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Internal/StorageCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Storage/Internal/StorageCategory+CategoryConfigurable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Internal/StorageCategory+Resettable.swift
+++ b/Amplify/Categories/Storage/Internal/StorageCategory+Resettable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Operation/Operation+StoragePublishers.swift
+++ b/Amplify/Categories/Storage/Operation/Operation+StoragePublishers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Operation/Request/StorageDownloadDataRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageDownloadDataRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Operation/Request/StorageGetURLRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageGetURLRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Operation/Request/StorageListRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageListRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Operation/Request/StorageRemoveRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageRemoveRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Operation/Request/StorageUploadDataRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageUploadDataRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Operation/Request/StorageUploadFileRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageUploadFileRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Operation/StorageDownloadDataOperation.swift
+++ b/Amplify/Categories/Storage/Operation/StorageDownloadDataOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Operation/StorageDownloadFileOperation.swift
+++ b/Amplify/Categories/Storage/Operation/StorageDownloadFileOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Operation/StorageGetURLOperation.swift
+++ b/Amplify/Categories/Storage/Operation/StorageGetURLOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Operation/StorageListOperation.swift
+++ b/Amplify/Categories/Storage/Operation/StorageListOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Operation/StorageRemoveOperation.swift
+++ b/Amplify/Categories/Storage/Operation/StorageRemoveOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Operation/StorageUploadDataOperation.swift
+++ b/Amplify/Categories/Storage/Operation/StorageUploadDataOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Operation/StorageUploadFileOperation.swift
+++ b/Amplify/Categories/Storage/Operation/StorageUploadFileOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Request/StorageDownloadFileRequest.swift
+++ b/Amplify/Categories/Storage/Request/StorageDownloadFileRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Result/ProgressListener.swift
+++ b/Amplify/Categories/Storage/Result/ProgressListener.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/Result/StorageListResult.swift
+++ b/Amplify/Categories/Storage/Result/StorageListResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/StorageAccessLevel.swift
+++ b/Amplify/Categories/Storage/StorageAccessLevel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/StorageCategory+ClientBehavior+Combine.swift
+++ b/Amplify/Categories/Storage/StorageCategory+ClientBehavior+Combine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/StorageCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Storage/StorageCategory+ClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/StorageCategory+HubPayloadEventName.swift
+++ b/Amplify/Categories/Storage/StorageCategory+HubPayloadEventName.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/StorageCategory.swift
+++ b/Amplify/Categories/Storage/StorageCategory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/StorageCategoryBehavior.swift
+++ b/Amplify/Categories/Storage/StorageCategoryBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/StorageCategoryConfiguration.swift
+++ b/Amplify/Categories/Storage/StorageCategoryConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Categories/Storage/StorageCategoryPlugin.swift
+++ b/Amplify/Categories/Storage/StorageCategoryPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Category/Category+Logging.swift
+++ b/Amplify/Core/Category/Category+Logging.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Category/Category.swift
+++ b/Amplify/Core/Category/Category.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Category/CategoryType.swift
+++ b/Amplify/Core/Category/CategoryType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Configuration/AmplifyConfiguration.swift
+++ b/Amplify/Core/Configuration/AmplifyConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Configuration/CategoryConfiguration.swift
+++ b/Amplify/Core/Configuration/CategoryConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Configuration/ConfigurationError.swift
+++ b/Amplify/Core/Configuration/ConfigurationError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Configuration/Internal/Amplify+Reset.swift
+++ b/Amplify/Core/Configuration/Internal/Amplify+Reset.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Configuration/Internal/Amplify+Resolve.swift
+++ b/Amplify/Core/Configuration/Internal/Amplify+Resolve.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Configuration/Internal/AmplifyConfigurationInitialization.swift
+++ b/Amplify/Core/Configuration/Internal/AmplifyConfigurationInitialization.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Configuration/Internal/Category+Configuration.swift
+++ b/Amplify/Core/Configuration/Internal/Category+Configuration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Configuration/Internal/CategoryConfigurable.swift
+++ b/Amplify/Core/Configuration/Internal/CategoryConfigurable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Internal/Foundation+Utils.swift
+++ b/Amplify/Core/Internal/Foundation+Utils.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Plugin/Internal/Resettable.swift
+++ b/Amplify/Core/Plugin/Internal/Resettable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Plugin/Plugin.swift
+++ b/Amplify/Core/Plugin/Plugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Plugin/PluginError.swift
+++ b/Amplify/Core/Plugin/PluginError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/AccessLevel.swift
+++ b/Amplify/Core/Support/AccessLevel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/Amplify+HubPayloadEventName.swift
+++ b/Amplify/Core/Support/Amplify+HubPayloadEventName.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/AmplifyError.swift
+++ b/Amplify/Core/Support/AmplifyError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/AmplifyErrorMessages.swift
+++ b/Amplify/Core/Support/AmplifyErrorMessages.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/AmplifyInProcessReportingOperation+Combine.swift
+++ b/Amplify/Core/Support/AmplifyInProcessReportingOperation+Combine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/AmplifyInProcessReportingOperation.swift
+++ b/Amplify/Core/Support/AmplifyInProcessReportingOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/AmplifyOperation+Combine.swift
+++ b/Amplify/Core/Support/AmplifyOperation+Combine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/AmplifyOperation+Hub.swift
+++ b/Amplify/Core/Support/AmplifyOperation+Hub.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/AmplifyOperation.swift
+++ b/Amplify/Core/Support/AmplifyOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/AmplifyOperationContext.swift
+++ b/Amplify/Core/Support/AmplifyOperationContext.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/AsychronousOperation.swift
+++ b/Amplify/Core/Support/AsychronousOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/AtomicDictionary.swift
+++ b/Amplify/Core/Support/AtomicDictionary.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/AtomicValue+Bool.swift
+++ b/Amplify/Core/Support/AtomicValue+Bool.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/AtomicValue+Numeric.swift
+++ b/Amplify/Core/Support/AtomicValue+Numeric.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/AtomicValue+RangeReplaceableCollection.swift
+++ b/Amplify/Core/Support/AtomicValue+RangeReplaceableCollection.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/AtomicValue.swift
+++ b/Amplify/Core/Support/AtomicValue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/BasicClosure.swift
+++ b/Amplify/Core/Support/BasicClosure.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/Cancellable.swift
+++ b/Amplify/Core/Support/Cancellable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/DispatchSource+MakeOneOff.swift
+++ b/Amplify/Core/Support/DispatchSource+MakeOneOff.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/Encodable+AnyEncodable.swift
+++ b/Amplify/Core/Support/Encodable+AnyEncodable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/JSONValue+KeyPath.swift
+++ b/Amplify/Core/Support/JSONValue+KeyPath.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/JSONValue+Subscript.swift
+++ b/Amplify/Core/Support/JSONValue+Subscript.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/JSONValue.swift
+++ b/Amplify/Core/Support/JSONValue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/Result+Void.swift
+++ b/Amplify/Core/Support/Result+Void.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/Resumable.swift
+++ b/Amplify/Core/Support/Resumable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/String+Extensions.swift
+++ b/Amplify/Core/Support/String+Extensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/TimeInterval+Helper.swift
+++ b/Amplify/Core/Support/TimeInterval+Helper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/Core/Support/Tree.swift
+++ b/Amplify/Core/Support/Tree.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DefaultPlugins/AWSHubPlugin/AWSHubPlugin.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/AWSHubPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DefaultPlugins/AWSHubPlugin/Internal/ConcurrentDispatcher.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/Internal/ConcurrentDispatcher.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DefaultPlugins/AWSHubPlugin/Internal/FilteredListener.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/Internal/FilteredListener.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DefaultPlugins/AWSHubPlugin/Internal/HubChannelDispatcher.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/Internal/HubChannelDispatcher.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DefaultPlugins/AWSHubPlugin/Internal/SerialDispatcher.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/Internal/SerialDispatcher.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/AWSUnifiedLoggingPlugin.swift
+++ b/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/AWSUnifiedLoggingPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/Internal/OSLogWrapper.swift
+++ b/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/Internal/OSLogWrapper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Amplify+DevMenu.swift
+++ b/Amplify/DevMenu/Amplify+DevMenu.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/AmplifyDevMenu.swift
+++ b/Amplify/DevMenu/AmplifyDevMenu.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/AmplifyVersionable.swift
+++ b/Amplify/DevMenu/AmplifyVersionable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Data/DevMenuItem.swift
+++ b/Amplify/DevMenu/Data/DevMenuItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Data/DevMenuItemType.swift
+++ b/Amplify/DevMenu/Data/DevMenuItemType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Data/DeviceInfoHelper.swift
+++ b/Amplify/DevMenu/Data/DeviceInfoHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Data/DeviceInfoItem.swift
+++ b/Amplify/DevMenu/Data/DeviceInfoItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Data/DeviceInfoItemType.swift
+++ b/Amplify/DevMenu/Data/DeviceInfoItemType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Data/EnvironmentInfoHelper.swift
+++ b/Amplify/DevMenu/Data/EnvironmentInfoHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Data/EnvironmentInfoItem.swift
+++ b/Amplify/DevMenu/Data/EnvironmentInfoItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Data/EnvironmentInfoItemType.swift
+++ b/Amplify/DevMenu/Data/EnvironmentInfoItemType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Data/InfoItemProvider.swift
+++ b/Amplify/DevMenu/Data/InfoItemProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Data/IssueInfo.swift
+++ b/Amplify/DevMenu/Data/IssueInfo.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Data/IssueInfoHelper.swift
+++ b/Amplify/DevMenu/Data/IssueInfoHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Data/LogEntryHelper.swift
+++ b/Amplify/DevMenu/Data/LogEntryHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Data/LogEntryItem.swift
+++ b/Amplify/DevMenu/Data/LogEntryItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Data/PluginInfoHelper.swift
+++ b/Amplify/DevMenu/Data/PluginInfoHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Data/PluginInfoItem.swift
+++ b/Amplify/DevMenu/Data/PluginInfoItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/DevEnvironmentInfo.swift
+++ b/Amplify/DevMenu/DevEnvironmentInfo.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/DevMenuBehavior.swift
+++ b/Amplify/DevMenu/DevMenuBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/DevMenuPresentationContextProvider.swift
+++ b/Amplify/DevMenu/DevMenuPresentationContextProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/DevMenuStringConstants.swift
+++ b/Amplify/DevMenu/DevMenuStringConstants.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Logging/PersistentLogWrapper.swift
+++ b/Amplify/DevMenu/Logging/PersistentLogWrapper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Logging/PersistentLoggingPlugin.swift
+++ b/Amplify/DevMenu/Logging/PersistentLoggingPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Trigger/LongPressGestureRecognizer.swift
+++ b/Amplify/DevMenu/Trigger/LongPressGestureRecognizer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Trigger/TriggerDelegate.swift
+++ b/Amplify/DevMenu/Trigger/TriggerDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/Trigger/TriggerRecognizer.swift
+++ b/Amplify/DevMenu/Trigger/TriggerRecognizer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/View/DetailViewFactory.swift
+++ b/Amplify/DevMenu/View/DetailViewFactory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/View/DevMenuList.swift
+++ b/Amplify/DevMenu/View/DevMenuList.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/View/DevMenuRow.swift
+++ b/Amplify/DevMenu/View/DevMenuRow.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/View/DeviceInfoDetailView.swift
+++ b/Amplify/DevMenu/View/DeviceInfoDetailView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/View/EnvironmentInfoDetailView.swift
+++ b/Amplify/DevMenu/View/EnvironmentInfoDetailView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/View/InfoRow.swift
+++ b/Amplify/DevMenu/View/InfoRow.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/View/IssueReporter.swift
+++ b/Amplify/DevMenu/View/IssueReporter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/View/LogEntryRow.swift
+++ b/Amplify/DevMenu/View/LogEntryRow.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/Amplify/DevMenu/View/LogViewer.swift
+++ b/Amplify/DevMenu/View/LogViewer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyFunctionalTests/AmplifyConfigurationInitFromFileTests.swift
+++ b/AmplifyFunctionalTests/AmplifyConfigurationInitFromFileTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyFunctionalTests/AmplifyConfigurationTests.swift
+++ b/AmplifyFunctionalTests/AmplifyConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyFunctionalTests/Hub/ConcurrentDispatcherPerformanceTests.swift
+++ b/AmplifyFunctionalTests/Hub/ConcurrentDispatcherPerformanceTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyFunctionalTests/Hub/DefaultHubPluginPerformanceTestHelpers.swift
+++ b/AmplifyFunctionalTests/Hub/DefaultHubPluginPerformanceTestHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyFunctionalTests/Hub/SerialDispatcherPerformanceTests.swift
+++ b/AmplifyFunctionalTests/Hub/SerialDispatcherPerformanceTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+APIAuthProviderFactoryBehavior.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+APIAuthProviderFactoryBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Configure.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Configure.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+GraphQLBehavior.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+GraphQLBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+InterceptorBehavior.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+InterceptorBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Log.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Log.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+RESTBehavior.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+RESTBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Reachability.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Reachability.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Resettable.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Resettable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+URLSessionBehaviorDelegate.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+URLSessionBehaviorDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+URLSessionDelegate.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+URLSessionDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginConfiguration+EndpointConfig.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginConfiguration+EndpointConfig.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginConfiguration.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginEndpointType.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginEndpointType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/AWSAPICategoryPluginError.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/AWSAPICategoryPluginError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/APIKeyURLRequestInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/APIKeyURLRequestInterceptor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/IAMURLRequestInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/IAMURLRequestInterceptor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/UserPoolRequestInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/UserPoolRequestInterceptor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/OIDCAuthProviderWrapper.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/OIDCAuthProviderWrapper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/APIOperation.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/APIOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/APIOperationResponse.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/APIOperationResponse.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSAPIOperation+APIOperation.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSAPIOperation+APIOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLOperation+APIOperation.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLOperation+APIOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLOperation.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLSubscriptionOperation.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLSubscriptionOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSRESTOperation.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSRESTOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Reachability/NetworkReachability.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Reachability/NetworkReachability.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Reachability/NetworkReachabilityNotifier.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Reachability/NetworkReachabilityNotifier.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSSubscriptionConnectionFactory.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSSubscriptionConnectionFactory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/SubscriptionConnectionFactory.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/SubscriptionConnectionFactory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Constants/URLRequestConstants.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Constants/URLRequestConstants.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Decode/GraphQLErrorDecoder.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Decode/GraphQLErrorDecoder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Decode/GraphQLResponseDecoder+DecodeData.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Decode/GraphQLResponseDecoder+DecodeData.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Decode/GraphQLResponseDecoder.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Decode/GraphQLResponseDecoder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Internal/AWSAppSyncGraphQLResponse.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Internal/AWSAppSyncGraphQLResponse.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/APIError+DecodingError.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/APIError+DecodingError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/AnyModel+JSONInit.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/AnyModel+JSONInit.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/AppSyncJSONValue+toJSONValue.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/AppSyncJSONValue+toJSONValue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/GraphQLOperationRequest+Validate.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/GraphQLOperationRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/GraphQLOperationRequestUtils+Validator.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/GraphQLOperationRequestUtils+Validator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/GraphQLOperationRequestUtils.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/GraphQLOperationRequestUtils.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/GraphQLRequest+toOperationRequest.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/GraphQLRequest+toOperationRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequest+RESTRequest.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequest+RESTRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequest+Validate.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequestUtils+Validator.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequestUtils+Validator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequestUtils.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequestUtils.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/OperationTaskMapper.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/OperationTaskMapper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/URLSession+URLSessionBehavior.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/URLSession+URLSessionBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/URLSessionBehavior.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/URLSessionBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/URLSessionBehaviorDelegate.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/URLSessionBehaviorDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/URLSessionDataTaskBehavior.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/URLSessionDataTaskBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/URLSessionFactory.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/URLSessionFactory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/URLSessionTask+URLSessionTaskBehavior.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/URLSessionTask+URLSessionTaskBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/APICategoryPluginConcurrencyTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/APICategoryPluginConcurrencyTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/AnyModelIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/AnyModelIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario1Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario1Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario2Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario2Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests+Helpers.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests+Helpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests+Subscribe.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests+Subscribe.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario4Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario4Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario5Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario5Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario6Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLModelBasedTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLModelBasedTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncBasedTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncBasedTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginGraphQLAPIKeyIntegrationTests/AWSAPICategoryPluginGraphQLAPIKeyIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginGraphQLAPIKeyIntegrationTests/AWSAPICategoryPluginGraphQLAPIKeyIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithIAMIntegrationTests/GraphQLWithIAMIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithIAMIntegrationTests/GraphQLWithIAMIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/GraphQLAuthDirectiveIntegrationTests+Auth.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/GraphQLAuthDirectiveIntegrationTests+Auth.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/GraphQLAuthDirectiveIntegrationTests+Support.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/GraphQLAuthDirectiveIntegrationTests+Support.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/GraphQLAuthDirectiveIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/GraphQLAuthDirectiveIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/SocialNote.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/SocialNote.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/GraphQLWithUserPoolIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/GraphQLWithUserPoolIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithIAMIntegrationTests/RESTWithIAMIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithIAMIntegrationTests/RESTWithIAMIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/RESTWithUserPoolIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/RESTWithUserPoolIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTestCommon/Model/Todo.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTestCommon/Model/Todo.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ConfigureTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ConfigureTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+GraphQLBehaviorTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+GraphQLBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+InterceptorBehaviorTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+InterceptorBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+RESTClientBehaviorTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+RESTClientBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ResetTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ResetTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+URLSessionBehaviorDelegateTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+URLSessionBehaviorDelegateTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+URLSessionDelegateTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+URLSessionDelegateTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPluginAmplifyVersionableTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPluginTestBase.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPluginTestBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationEndpointConfigTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationEndpointConfigTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/APIKeyURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/APIKeyURLRequestInterceptorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/IAMURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/IAMURLRequestInterceptorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/UserPoolRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/UserPoolRequestInterceptorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Mocks/MockReachability.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Mocks/MockReachability.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Mocks/MockSessionFactory.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Mocks/MockSessionFactory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Mocks/MockSubscription.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Mocks/MockSubscription.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Mocks/MockURLSession.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Mocks/MockURLSession.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Mocks/MockURLSessionTask.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Mocks/MockURLSessionTask.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSGraphQLOperationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSGraphQLOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSRESTOperationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSRESTOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLMutateCombineTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLMutateCombineTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLQueryCombineTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLQueryCombineTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLSubscribeCombineTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLSubscribeCombineTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLSubscribeTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLSubscribeTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/OperationTestBase.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/OperationTestBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/RESTCombineTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/RESTCombineTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Reachability/NetworkReachabilityNotifierTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Reachability/NetworkReachabilityNotifierTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Request/GraphQLOperationRequestValidateTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Request/GraphQLOperationRequestValidateTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Request/RESTOperationRequestValidateTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Request/RESTOperationRequestValidateTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Decode/GraphQLErrorDecoderTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Decode/GraphQLErrorDecoderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Decode/GraphQLResponseDecoder+DecodeDataTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Decode/GraphQLResponseDecoder+DecodeDataTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Decode/GraphQLResponseDecoderTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Decode/GraphQLResponseDecoderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Internal/AWSAppSyncGrpahQLResponseTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Internal/AWSAppSyncGrpahQLResponseTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Utils/GraphQLRequestUtils+ValidatorTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Utils/GraphQLRequestUtils+ValidatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Utils/GraphQLRequestUtilsTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Utils/GraphQLRequestUtilsTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Utils/RESTRequestUtils+ValidatorTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Utils/RESTRequestUtils+ValidatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Utils/RESTRequestUtilsTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Utils/RESTRequestUtilsTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Utils/XCTestExpectation+ShouldTrigger.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Utils/XCTestExpectation+ShouldTrigger.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/HostApp/Source/AppDelegate.swift
+++ b/AmplifyPlugins/API/HostApp/Source/AppDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/HostApp/Source/SceneDelegate.swift
+++ b/AmplifyPlugins/API/HostApp/Source/SceneDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/API/HostApp/Source/ViewController.swift
+++ b/AmplifyPlugins/API/HostApp/Source/ViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+ClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Configure.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Configure.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+DefaultLogger.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+DefaultLogger.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Reset.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Reset.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Configuration/AWSPinpointAnalyticsPluginConfiguration.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Configuration/AWSPinpointAnalyticsPluginConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAdapter+AnalyticsClientBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAdapter+AnalyticsClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAdapter+TargetingClientBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAdapter+TargetingClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAdapter.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAnalyticsClientBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAnalyticsClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointTargetingClientBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointTargetingClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Constants/AnalyticsErrorConstants.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Constants/AnalyticsErrorConstants.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Extensions/AWSPinpointAnalyticsPlugin+AWSPinpointEndpointProfile.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Extensions/AWSPinpointAnalyticsPlugin+AWSPinpointEndpointProfile.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Extensions/AWSPinpointAnalyticsPlugin+AWSPinpointEndpointProfileLocation.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Extensions/AWSPinpointAnalyticsPlugin+AWSPinpointEndpointProfileLocation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Extensions/AWSPinpointAnalyticsPlugin+AWSPinpointEvent.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Extensions/AWSPinpointAnalyticsPlugin+AWSPinpointEvent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Extensions/AWSPinpointAnalyticsPlugin+HubCategory.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Extensions/AWSPinpointAnalyticsPlugin+HubCategory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Utils/AnalyticsErrorHelper.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Utils/AnalyticsErrorHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Utils/RepeatingTimer.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Utils/RepeatingTimer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Tracker/AppSessionTracker.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Tracker/AppSessionTracker.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Tracker/Tracker.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Tracker/Tracker.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginIntegrationTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginTestBase.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginTestBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginAmplifyVersionableTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginClientBehaviorTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginClientBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginConfigureTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginConfigureTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginResetTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginResetTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginTestBase.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginTestBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Configuration/AWSPinpointAnalyticsPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Configuration/AWSPinpointAnalyticsPluginConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSPinpoint+AnalyticsClientBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSPinpoint+AnalyticsClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSPinpoint+TargetingClientBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSPinpoint+TargetingClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSPinpoint.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSPinpoint.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAppSessionTracker.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAppSessionTracker.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Support/Utils/RepeatingTimerTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Support/Utils/RepeatingTimerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/HostApp/Source/AppDelegate.swift
+++ b/AmplifyPlugins/Analytics/HostApp/Source/AppDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/HostApp/Source/SceneDelegate.swift
+++ b/AmplifyPlugins/Analytics/HostApp/Source/SceneDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Analytics/HostApp/Source/ViewController.swift
+++ b/AmplifyPlugins/Analytics/HostApp/Source/ViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+InvalidateCredentials.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+InvalidateCredentials.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Reset.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Reset.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+DeviceBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+DeviceBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+UserBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+UserBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthDeviceServiceAdapter.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthDeviceServiceAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthDeviceServiceBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthDeviceServiceBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthUserServiceAdapter.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthUserServiceAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthUserServiceBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthUserServiceBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+Password.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+Password.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignOut.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignOut.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignUp.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignUp.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+Reset.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+Reset.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedInSession.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedInSession.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedOutSession.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedOutSession.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/HubEvents/AuthHubEventBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/HubEvents/AuthHubEventBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/HubEvents/AuthHubEventHandler.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/HubEvents/AuthHubEventHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/AWSAuthCognitoSession.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/AWSAuthCognitoSession.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/AWSAuthDevice.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/AWSAuthDevice.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/AWSAuthUser.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/AWSAuthUser.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/AWSCognitoAuthService.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/AWSCognitoAuthService.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/AWSCognitoUserPoolTokens.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/AWSCognitoUserPoolTokens.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Error/AWSCognitoAuthError.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Error/AWSCognitoAuthError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAttributeResendConfirmationCodeOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAttributeResendConfirmationCodeOptions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmResetPasswordOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmResetPasswordOptions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmSignInOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmSignInOptions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmSignUpOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmSignUpOptions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthResendSignUpCodeOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthResendSignUpCodeOptions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthResetPasswordOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthResetPasswordOptions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignInOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignInOptions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignUpOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignUpOptions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthWebUISignInOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthWebUISignInOptions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSUpdateUserAttributeOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSUpdateUserAttributeOptions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSUpdateUserAttributesOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSUpdateUserAttributesOptions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/SignInResult+Extension.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/SignInResult+Extension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthConfirmResetPasswordOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthConfirmResetPasswordOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthConfirmSignInOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthConfirmSignInOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthConfirmSignUpOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthConfirmSignUpOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthFetchDevicesOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthFetchDevicesOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthFetchSessionOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthFetchSessionOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthForgetDeviceOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthForgetDeviceOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthRememberDeviceOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthRememberDeviceOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthResendSignUpCodeOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthResendSignUpCodeOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthResetPasswordOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthResetPasswordOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthSignInOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthSignInOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthSignOutOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthSignOutOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthSignUpOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthSignUpOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthSocialWebUISignInOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthSocialWebUISignInOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthWebUISignInOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthWebUISignInOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthAttributeResendConfirmationCodeOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthAttributeResendConfirmationCodeOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthChangePasswordOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthChangePasswordOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthConfirmUserAttributeOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthConfirmUserAttributeOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthFetchUserAttributeOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthFetchUserAttributeOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthUpdateUserAttributeOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthUpdateUserAttributeOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthUpdateUserAttributesOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthUpdateUserAttributesOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Request/AuthConfirmResetPasswordRequest+Validate.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Request/AuthConfirmResetPasswordRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Request/AuthConfirmSignInRequest+Validate.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Request/AuthConfirmSignInRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Request/AuthConfirmSignUpRequest+Validate.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Request/AuthConfirmSignUpRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Request/AuthResendSignUpCodeRequest+Validate.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Request/AuthResendSignUpCodeRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Request/AuthResetPasswordRequest+Validate.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Request/AuthResetPasswordRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Request/AuthSignInRequest+Validate.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Request/AuthSignInRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Request/AuthSignUpRequest+Validate.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Request/AuthSignUpRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Service/AWSMobileClient/AWSMobileClientAdapter+Reset.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Service/AWSMobileClient/AWSMobileClientAdapter+Reset.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Service/AWSMobileClient/AWSMobileClientAdapter.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Service/AWSMobileClient/AWSMobileClientAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Service/AWSMobileClient/AWSMobileClientBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Service/AWSMobileClient/AWSMobileClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Constants/AuthPluginErrorConstants.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Constants/AuthPluginErrorConstants.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AWSCredentials+Extension.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AWSCredentials+Extension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AWSMobileClient+Reset.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AWSMobileClient+Reset.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AuthCognitoSignedInSessionHelper.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AuthCognitoSignedInSessionHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AuthCognitoSignedOutSessionHelper.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AuthCognitoSignedOutSessionHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AuthErrorHelper.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AuthErrorHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AuthProvider+AWSMobileClient.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AuthProvider+AWSMobileClient.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AuthUserAttributeKey+Extension.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AuthUserAttributeKey+Extension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/Device+Extension.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/Device+Extension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/Tokens+Extension.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/Tokens+Extension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/UserCodeDeliveryDetails+Extension.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/UserCodeDeliveryDetails+Extension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AWSAuthBaseTest.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AWSAuthBaseTest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthDeviceTests/AuthDeviceOperationTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthDeviceTests/AuthDeviceOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSessionTests/SignedInAuthSessionTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSessionTests/SignedInAuthSessionTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSessionTests/SignedOutAuthSessionTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSessionTests/SignedOutAuthSessionTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignInTests/AuthUsernamePasswordSignInTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignInTests/AuthUsernamePasswordSignInTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignOutTests/AuthSignOutTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignOutTests/AuthSignOutTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthConfirmSignUpTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthConfirmSignUpTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthResendSignUpCodeTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthResendSignUpCodeTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthSignUpTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthSignUpTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthUserAttributesTests/AuthUserAttributesTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthUserAttributesTests/AuthUserAttributesTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthUserTests/AuthUserTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthUserTests/AuthUserTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/Support/AuthConfigurationHelper.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/Support/AuthConfigurationHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/Support/AuthSessionHelper.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/Support/AuthSessionHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/Support/AuthSignInHelper.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/Support/AuthSignInHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthDeviceBehaviorTests/AuthDeviceFetchDevicesTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthDeviceBehaviorTests/AuthDeviceFetchDevicesTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthDeviceBehaviorTests/AuthDeviceForgetDeviceTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthDeviceBehaviorTests/AuthDeviceForgetDeviceTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthDeviceBehaviorTests/AuthDeviceRememberDeviceTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthDeviceBehaviorTests/AuthDeviceRememberDeviceTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthDeviceBehaviorTests/BaseAuthDeviceTest.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthDeviceBehaviorTests/BaseAuthDeviceTest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/BaseUserBehaviorTest.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/BaseUserBehaviorTest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorChangePasswordTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorChangePasswordTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorConfirmAttributeTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorConfirmAttributeTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorFetchAttributeTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorFetchAttributeTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorResendCodeTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorResendCodeTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorUpdateAttributeTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorUpdateAttributeTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderConfirmResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderConfirmResetPasswordTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderConfirmSigninTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderConfirmSigninTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderConfirmSignupTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderConfirmSignupTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderResendSignupCodeTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderResendSignupCodeTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderResetPasswordTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithSocialWebUITests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithSocialWebUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithWebUITests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithWebUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignoutTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignoutTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignupTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignupTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/BaseAuthenticationProviderTest.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/BaseAuthenticationProviderTest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthorizationProviderTests/AuthorizationProviderSessionSignInTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthorizationProviderTests/AuthorizationProviderSessionSignInTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthorizationProviderTests/AuthorizationProviderSessionSignoutTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthorizationProviderTests/AuthorizationProviderSessionSignoutTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthorizationProviderTests/BaseAuthorizationProviderTest.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthorizationProviderTests/BaseAuthorizationProviderTest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ClientBehaviorAPITests/AWSCognitoAuthClientBehaviorTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ClientBehaviorAPITests/AWSCognitoAuthClientBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ClientBehaviorAPITests/AWSCognitoAuthDeviceBehaviorTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ClientBehaviorAPITests/AWSCognitoAuthDeviceBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ClientBehaviorAPITests/AWSCognitoAuthUserBehaviorTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ClientBehaviorAPITests/AWSCognitoAuthUserBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ConfigurationTests/AWSCognitoAuthPluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ConfigurationTests/AWSCognitoAuthPluginAmplifyVersionableTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/HubEventTests/AuthHubEventHandlerTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/HubEventTests/AuthHubEventHandlerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAWSMobileClient.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAWSMobileClient.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthDeviceServiceBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthDeviceServiceBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthHubEventBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthHubEventBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthUserServiceBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthUserServiceBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthenticationProviderBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthenticationProviderBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthorizationProviderBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthorizationProviderBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Utils/AuthUserAttributeKeyTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Utils/AuthUserAttributeKeyTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/HostApp/Source/AppDelegate.swift
+++ b/AmplifyPlugins/Auth/HostApp/Source/AppDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/HostApp/Source/SceneDelegate.swift
+++ b/AmplifyPlugins/Auth/HostApp/Source/SceneDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Auth/HostApp/Source/ViewController.swift
+++ b/AmplifyPlugins/Auth/HostApp/Source/ViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/API/AppSyncErrorType.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/API/AppSyncErrorType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/AWSPluginsCore.h
+++ b/AmplifyPlugins/Core/AWSPluginsCore/AWSPluginsCore.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthorizationType.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthorizationType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AuthPluginBehavior/AuthInvalidateCredentialBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AuthPluginBehavior/AuthInvalidateCredentialBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Configuration/APIKeyConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Configuration/APIKeyConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Configuration/AWSAuthorizationConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Configuration/AWSAuthorizationConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Configuration/AWSIAMConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Configuration/AWSIAMConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Configuration/CognitoUserPoolsConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Configuration/CognitoUserPoolsConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Configuration/OIDCConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Configuration/OIDCConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/APIKeyProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/APIKeyProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AmplifyAWSCredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AmplifyAWSCredentialsProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthAWSCredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthAWSCredentialsProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthCognitoIdentityProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthCognitoIdentityProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthCognitoTokensProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthCognitoTokensProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/IAMCredentialProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/IAMCredentialProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/AnyModel/AnyModel+Codable.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/AnyModel/AnyModel+Codable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/AnyModel/AnyModel+Schema.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/AnyModel/AnyModel+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/AnyModel/AnyModel+Subscript.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/AnyModel/AnyModel+Subscript.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/AnyModel/AnyModel.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/AnyModel/AnyModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/AnyModel/Model+AnyModel.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/AnyModel/Model+AnyModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/DirectiveNameDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/DirectiveNameDecorator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/FilterDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/FilterDecorator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelBasedGraphQLDocumentDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelBasedGraphQLDocumentDecorator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelDecorator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelIdDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelIdDecorator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/PaginationDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/PaginationDecorator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLMutation.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLMutation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLQuery.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLQuery.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLSubscription.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLSubscription.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/ModelBasedGraphQLDocumentBuilder.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/ModelBasedGraphQLDocumentBuilder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/SingleDirectiveGraphQLDocument.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/SingleDirectiveGraphQLDocument.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/AuthRule+Extension.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/AuthRule+Extension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/GraphQLDocumentInput.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/GraphQLDocumentInput.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/GraphQLDocumentnputValue.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/GraphQLDocumentnputValue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/ModelField+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/ModelField+GraphQL.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/ModelSchema+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/ModelSchema+GraphQL.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration+Platform.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration+Platform.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata+Schema.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSync.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata+Schema.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/PaginatedList.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/PaginatedList.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AWSAuthServiceTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AWSAuthServiceTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/AnyModel/AnyModelTester.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/AnyModel/AnyModelTester.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/AnyModel/AnyModelTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/AnyModel/AnyModelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelMultipleOwnerAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelMultipleOwnerAuthRuleTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelReadUpdateAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelReadUpdateAuthRuleTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerAuthAndGroupWithGroupClaim.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerAuthAndGroupWithGroupClaim.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerAuthAndMultiGroup.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerAuthAndMultiGroup.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerFieldAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerFieldAuthRuleTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDeleteMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDeleteMutationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLGetQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLGetQueryTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLListQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLListQueryTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSubscriptionTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSubscriptionTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSyncQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSyncQueryTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLUpdateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLUpdateMutationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAnyModelWithSyncTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAnyModelWithSyncTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthIdentityClaimTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthIdentityClaimTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthRuleTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestEmbeddableTypeJSONTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestEmbeddableTypeJSONTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestEmbeddableTypeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestEmbeddableTypeTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestModelTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestModelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestOptionalAssociationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestOptionalAssociationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestOwnerAndGroupTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestOwnerAndGroupTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/MockAWSAuthUser.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/MockAWSAuthUser.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/ModelGraphQLTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/ModelGraphQLTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/QueryPredicateGraphQLTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/QueryPredicateGraphQLTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedBoolTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedBoolTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTimeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTimeTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleIntTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleIntTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntDoubleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntDoubleTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedStringTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedStringTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedTimeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedTimeTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGenerator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGenerator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/MutationSync/MutationSyncMetadataTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/MutationSync/MutationSyncMetadataTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/PaginatedListTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/PaginatedListTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/AWSPluginsTestCommon.h
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/AWSPluginsTestCommon.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DefaultLogger.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DefaultLogger.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/DataStoreConfiguration.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/DataStoreConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/DataStoreSyncExpression.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/DataStoreSyncExpression.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/ModelSchema+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/ModelSchema+SQLite.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/ModelValueConverter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/ModelValueConverter+SQLite.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QueryPaginationInput+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QueryPaginationInput+SQLite.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QueryPredicate+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QueryPredicate+SQLite.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QuerySort+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QuerySort+SQLite.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QuerySortDescriptor.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QuerySortDescriptor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Delete.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Delete.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Select.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Select.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Update.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Update.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Statement+AnyModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Statement+AnyModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Statement+Model.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Statement+Model.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+SyncRequirement.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+SyncRequirement.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStorePublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStorePublisher.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/ModelSyncedEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/ModelSyncedEvent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/NetworkStatusEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/NetworkStatusEvent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/OutboxMutationEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/OutboxMutationEvent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/OutboxStatusEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/OutboxStatusEvent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/SyncQueriesStartedEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Events/SyncQueriesStartedEvent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperationEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperationEvent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ReadyEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ReadyEventEmitter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/SyncEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/SyncEventEmitter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventSource.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventSource.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/AWSMutationEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/AWSMutationEventPublisher.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventClearState.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventClearState.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventIngester.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventPublisher.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventSource.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventSource.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventSubscriber.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventSubscriber.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventSubscription.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventSubscription.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/MutationRetryNotifier.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/MutationRetryNotifier.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Action.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Resolver.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+State.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Retryable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Retryable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+State.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RequestRetryable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RequestRetryable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RequestRetryablePolicy.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RequestRetryablePolicy.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Action.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Resolver.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+State.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/RemoteSyncReconciler.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/RemoteSyncReconciler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/CancelAwareBlockOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/CancelAwareBlockOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Cancellable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Cancellable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/DataStoreError+Plugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/DataStoreError+Plugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Query.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Query.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/StateMachine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/StateMachine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/AWSDataStoreCategoryPluginAuthIntegrationTests+Auth.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/AWSDataStoreCategoryPluginAuthIntegrationTests+Auth.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/AWSDataStoreCategoryPluginAuthIntegrationTests+Support.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/AWSDataStoreCategoryPluginAuthIntegrationTests+Support.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/AWSDataStoreCategoryPluginAuthIntegrationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/AWSDataStoreCategoryPluginAuthIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/SocialNote.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/SocialNote.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/AWSDataStorePluginConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/AWSDataStorePluginConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario1Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario1Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario2Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario2Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario3Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario3Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario4Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario4Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario5Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario5Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario6Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreHubEventsTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreHubEventsTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreLocalStoreTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreLocalStoreTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/SubscriptionEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/SubscriptionEndToEndTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/SyncMetadataTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/SyncMetadataTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/LocalStoreIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/LocalStoreIntegrationTestBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/TestModelRegistration.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/TestModelRegistration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSAPICategoryPluginTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSAPICategoryPluginTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSDataStorePluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSDataStorePluginAmplifyVersionableTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/CodableDateFormatTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/CodableDateFormatTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/ConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/ConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/DataStoreCategoryConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/DataStoreCategoryConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/ListTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/ListTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/QueryPaginationInputTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/QueryPaginationInputTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/QueryPredicateTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/QueryPredicateTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/QuerySortDescriptorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/QuerySortDescriptorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SortByDependencyOrderTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SortByDependencyOrderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/StateMachineTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/StateMachineTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/StorageAdapterMutationSyncTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/StorageAdapterMutationSyncTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/DynamicModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/DynamicModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/ExampleWithEveryType+Schema.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/ExampleWithEveryType+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/ExampleWithEveryType.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/ExampleWithEveryType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/SQLModelValueConverterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/SQLModelValueConverterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/DataStoreHubTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/DataStoreHubTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/ReadyEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/ReadyEventEmitterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/SyncEngineStartupTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/SyncEngineStartupTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionWithJSONModelTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionWithJSONModelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationDatabaseAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationDatabaseAdapterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/MutationEventClearStateTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/MutationEventClearStateTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSyncEngineTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSyncEngineTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RequestRetryablePolicyTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RequestRetryablePolicyTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/RemoteSyncReconcilerTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/RemoteSyncReconcilerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/EquatableExtensions.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/EquatableExtensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockModelReconciliationQueue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapterResponders.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapterResponders.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/ReconciliationQueueTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/ReconciliationQueueTestBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Foundation+TestExtensions.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Foundation+TestExtensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSInitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSInitialSyncOrchestrator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockFileManager.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockFileManager.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockOutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockOutgoingMutationQueue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockRequestRetryablePolicy.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockRequestRetryablePolicy.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockStateMachine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockStateMachine.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/NoOpInitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/NoOpInitialSyncOrchestrator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/NoOpMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/NoOpMutationQueue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/XCTest+AmplifyExtensions.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/XCTest+AmplifyExtensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin+ClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin+Configure.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin+Configure.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin+Reset.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin+Reset.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Configuration/ConvertConfiguration.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Configuration/ConvertConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Configuration/IdentifyConfiguration.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Configuration/IdentifyConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Configuration/InterpretConfiguration.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Configuration/InterpretConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Configuration/PredictionsPluginConfiguration.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Configuration/PredictionsPluginConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSComprehendAdapter.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSComprehendAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSComprehendBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSComprehendBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSPollyAdapter.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSPollyAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSPollyBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSPollyBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSRekognitionAdapter.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSRekognitionAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSRekognitionBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSRekognitionBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSTextractAdapter.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSTextractAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSTextractBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSTextractBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSTranscribeStreamingAdapter.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSTranscribeStreamingAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSTranscribeStreamingBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSTranscribeStreamingBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSTranslateAdapter.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSTranslateAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSTranslateBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSTranslateBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Operation/AWSPollyOperation.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Operation/AWSPollyOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Operation/AWSTranscribeOperation.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Operation/AWSTranscribeOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Operation/AWSTranslateOperation.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Operation/AWSTranslateOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Operation/IdentifyOperation.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Operation/IdentifyOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Operation/InterpretTextOperation.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Operation/InterpretTextOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Requests/PredictionsIdentifyRequest+Validate.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Requests/PredictionsIdentifyRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Requests/PredictionsSpeechToTextRequest+Validate.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Requests/PredictionsSpeechToTextRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Requests/PredictionsTextToSpeechRequest+Validate.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Requests/PredictionsTextToSpeechRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Requests/PredictionsTranslateTextRequest+Validate.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Requests/PredictionsTranslateTextRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/CoreML/CoreMLPredictionBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/CoreML/CoreMLPredictionBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/CoreML/CoreMLPredictionService.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/CoreML/CoreMLPredictionService.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/MultiService/IdentifyMultiService.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/MultiService/IdentifyMultiService.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/MultiService/InterpretTextMultiService.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/MultiService/InterpretTextMultiService.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/MultiService/MultiServiceBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/MultiService/MultiServiceBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/MultiService/TranscribeMultiService.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/MultiService/TranscribeMultiService.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSComprehendServiceBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSComprehendServiceBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPollyServiceBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPollyServiceBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Comprehend.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Comprehend.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Polly.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Polly.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Rekognition.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Rekognition.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Textract.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Textract.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Transcribe.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Transcribe.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Translate.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Translate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSRekognitionServiceBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSRekognitionServiceBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSTextractServiceBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSTextractServiceBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSTranscribeStreamingServiceBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSTranscribeStreamingServiceBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSTranslateServiceBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSTranslateServiceBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/AWSComprehendErrorMessage.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/AWSComprehendErrorMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/AWSPollyErrorMessage.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/AWSPollyErrorMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/AWSRekognitionErrorMessage.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/AWSRekognitionErrorMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/AWSServiceErrorMessage.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/AWSServiceErrorMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/AWSTextractErrorMessage.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/AWSTextractErrorMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/AWSTranscribeStreamingErrorMessage.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/AWSTranscribeStreamingErrorMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/AWSTranslateErrorMessage.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/AWSTranslateErrorMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/ConvertMultiServiceErrorMessage.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/ConvertMultiServiceErrorMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/IdentifyMultiServiceErrorMessage.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/IdentifyMultiServiceErrorMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/InterpretMultiServiceErrorMessage.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/InterpretMultiServiceErrorMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/PluginErrorMessage.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Constants/PluginErrorMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/AWSComprehendEntityTypeExtension.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/AWSComprehendEntityTypeExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/AWSComprehendPartOfSpeechTagTypeExtension.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/AWSComprehendPartOfSpeechTagTypeExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/AWSComprehendSentimentTypeExtension.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/AWSComprehendSentimentTypeExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/AWSPollyVoiceId+Extension.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/AWSPollyVoiceId+Extension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/FetchDominantLanguageEvent.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/FetchDominantLanguageEvent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/FormatType+AWSExtension.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/FormatType+AWSExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/LanguageTypeExtension.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/LanguageTypeExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/NativeWebSocketProvider.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/NativeWebSocketProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/PredictionsAWSServices.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/PredictionsAWSServices.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/PredictionsAction.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/PredictionsAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/PredictionsEvent.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/PredictionsEvent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/VoiceType+AWSExtension.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Internal/VoiceType+AWSExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/ConvertSpeechToTextTransformers.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/ConvertSpeechToTextTransformers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/IdentifyCelebritiesResultTransformers.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/IdentifyCelebritiesResultTransformers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/IdentifyEntitiesResultTransformers.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/IdentifyEntitiesResultTransformers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/IdentifyLabelsResultTransformers.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/IdentifyLabelsResultTransformers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/IdentifyResultTransformers.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/IdentifyResultTransformers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/IdentifyTextResultTransformers+KeyValueSet.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/IdentifyTextResultTransformers+KeyValueSet.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/IdentifyTextResultTransformers+Tables.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/IdentifyTextResultTransformers+Tables.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/IdentifyTextResultTransformers.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/IdentifyTextResultTransformers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/PredictionsErrorHelper.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/Utils/PredictionsErrorHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/AWSPredictionsPluginTestBase.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/AWSPredictionsPluginTestBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/ConvertBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/ConvertBasicIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/IdentifyBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/IdentifyBasicIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/InterpretBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/InterpretBasicIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/ConfigurationTests/AWSPredictionsPluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/ConfigurationTests/AWSPredictionsPluginAmplifyVersionableTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Mocks/Service/MockComprehendBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Mocks/Service/MockComprehendBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Mocks/Service/MockPollyBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Mocks/Service/MockPollyBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Mocks/Service/MockRekognitionBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Mocks/Service/MockRekognitionBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Mocks/Service/MockTextractBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Mocks/Service/MockTextractBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Mocks/Service/MockTranscribeStreamingBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Mocks/Service/MockTranscribeStreamingBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Mocks/Service/MockTranslateBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Mocks/Service/MockTranslateBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceComprehendTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceComprehendTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceRekognitionTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceRekognitionTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceTextractTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceTextractTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceTranscribeTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceTranscribeTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceTranslateTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginTests/Service/PredictionsTest/PredictionsServiceTranslateTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/CoreMLPredictionsPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/CoreMLPredictionsPlugin+ClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/CoreMLPredictionsPlugin+Configure.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/CoreMLPredictionsPlugin+Configure.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/CoreMLPredictionsPlugin+Reset.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/CoreMLPredictionsPlugin+Reset.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/CoreMLPredictionsPlugin.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/CoreMLPredictionsPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLNaturalLanguageAdapter.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLNaturalLanguageAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLNaturalLanguageBehavior.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLNaturalLanguageBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLSpeechAdapter.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLSpeechAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLSpeechBehavior.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLSpeechBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLVisionAdapter.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLVisionAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLVisionBehavior.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLVisionBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Operation/CoreMLIdentifyOperation.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Operation/CoreMLIdentifyOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Operation/CoreMLInterpretTextOperation.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Operation/CoreMLInterpretTextOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Operation/CoreMLSpeechToTextOperation.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Operation/CoreMLSpeechToTextOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Operation/CoreMLTextToSpeechOperation.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Operation/CoreMLTextToSpeechOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Operation/CoreMLTranslateTextOperation.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Operation/CoreMLTranslateTextOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Support/Constants/CoreMLPluginErrorString.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Support/Constants/CoreMLPluginErrorString.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPluginIntegrationTests/CoreMLPredictionsPluginIntegrationTest.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPluginIntegrationTests/CoreMLPredictionsPluginIntegrationTest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPluginIntegrationTests/CoreMLPredictionsPluginTestBase.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPluginIntegrationTests/CoreMLPredictionsPluginTestBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/CoreMLPredictionsPluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/CoreMLPredictionsPluginAmplifyVersionableTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/CoreMLPredictionsPluginClientBehaviorTests.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/CoreMLPredictionsPluginClientBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/CoreMLPredictionsPluginConfigTests.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/CoreMLPredictionsPluginConfigTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/CoreMLPredictionsPluginTestBase.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/CoreMLPredictionsPluginTestBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/DependencyTests/CoreMLNaturalLanguageAdapterTests.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/DependencyTests/CoreMLNaturalLanguageAdapterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/DependencyTests/CoreMLSpeechAdapterTests.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/DependencyTests/CoreMLSpeechAdapterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/DependencyTests/CoreMLVisionAdapterTests.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/DependencyTests/CoreMLVisionAdapterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/Mocks/MockCoreMLNaturalLanguageAdapter.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/Mocks/MockCoreMLNaturalLanguageAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/Mocks/MockCoreMLSpeechAdapter.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/Mocks/MockCoreMLSpeechAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/Mocks/MockCoreMLVisionAdapter.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/Mocks/MockCoreMLVisionAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/Mocks/MockOperationQueue.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPluginTests/Mocks/MockOperationQueue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/HostApp/Source/AppDelegate.swift
+++ b/AmplifyPlugins/Predictions/HostApp/Source/AppDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/HostApp/Source/SceneDelegate.swift
+++ b/AmplifyPlugins/Predictions/HostApp/Source/SceneDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Predictions/HostApp/Source/ViewController.swift
+++ b/AmplifyPlugins/Predictions/HostApp/Source/ViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin+ClientBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin+Configure.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin+Configure.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin+Reset.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin+Reset.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Dependency/AWSS3Adapter.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Dependency/AWSS3Adapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Dependency/AWSS3Behavior.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Dependency/AWSS3Behavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Dependency/AWSS3PreSignedURLBuilderAdapter.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Dependency/AWSS3PreSignedURLBuilderAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Dependency/AWSS3PreSignedURLBuilderBehavior.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Dependency/AWSS3PreSignedURLBuilderBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Dependency/AWSS3TransferUtilityAdapter.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Dependency/AWSS3TransferUtilityAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Dependency/AWSS3TransferUtilityBehavior.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Dependency/AWSS3TransferUtilityBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadDataOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadDataOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadFileOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadFileOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageGetURLOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageGetURLOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageListOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageListOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageRemoveOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageRemoveOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageUploadDataOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageUploadDataOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageUploadFileOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageUploadFileOperation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Request/StorageDownloadDataRequest+Validate.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Request/StorageDownloadDataRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Request/StorageDownloadFileRequest+Validate.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Request/StorageDownloadFileRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Request/StorageGetURLRequest+Validate.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Request/StorageGetURLRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Request/StorageListRequest+Validate.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Request/StorageListRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Request/StorageRemoveRequest+Validate.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Request/StorageRemoveRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Request/StorageUploadDataRequest+Validate.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Request/StorageUploadDataRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Request/StorageUploadFileRequest+Validate.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Request/StorageUploadFileRequest+Validate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+DeleteBehavior.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+DeleteBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+DownloadBehavior.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+DownloadBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+EscapeHatchBehavior.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+EscapeHatchBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+GetPreSignedURLBehavior.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+GetPreSignedURLBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+ListBehavior.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+ListBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+MultiPartUploadBehavior.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+MultiPartUploadBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+UploadBehavior.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+UploadBehavior.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageServiceBehaviour.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Service/Storage/AWSS3StorageServiceBehaviour.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Constants/PluginConstants.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Constants/PluginConstants.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Constants/PluginErrorConstants.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Constants/PluginErrorConstants.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Constants/StorageErrorConstants.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Constants/StorageErrorConstants.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Internal/StorageEvent.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Internal/StorageEvent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Internal/StorageOperationReference.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Internal/StorageOperationReference.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Internal/UploadSource.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Internal/UploadSource.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Utils/StorageErrorHelper.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Utils/StorageErrorHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Utils/StorageRequestUtils+Getter.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Utils/StorageRequestUtils+Getter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Utils/StorageRequestUtils+Validator.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Utils/StorageRequestUtils+Validator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Utils/StorageRequestUtils.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Utils/StorageRequestUtils.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginAccessLevelTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginAccessLevelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginBasicIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginConfigurationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginNegativeTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginNegativeTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginOptionsUsabilityTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginOptionsUsabilityTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginTestBase.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginTestBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/ResumabilityTests/AWSS3StoragePluginDownloadFileResumabilityTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/ResumabilityTests/AWSS3StoragePluginDownloadFileResumabilityTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/ResumabilityTests/AWSS3StoragePluginGetDataResumabilityTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/ResumabilityTests/AWSS3StoragePluginGetDataResumabilityTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/ResumabilityTests/AWSS3StoragePluginPutDataResumabilityTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/ResumabilityTests/AWSS3StoragePluginPutDataResumabilityTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/ResumabilityTests/AWSS3StoragePluginUploadFileResumabilityTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/ResumabilityTests/AWSS3StoragePluginUploadFileResumabilityTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginAmplifyVersionableTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginBaseConfigTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginBaseConfigTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginClientBehaviorTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginClientBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginConfigureTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginConfigureTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginResetTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginResetTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginTestBase.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginTestBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Mocks/MockAWSS3.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Mocks/MockAWSS3.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Mocks/MockAWSS3PreSignedURLBuilder.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Mocks/MockAWSS3PreSignedURLBuilder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Mocks/MockAWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Mocks/MockAWSS3StorageService.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Mocks/MockAWSS3TransferUtility.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Mocks/MockAWSS3TransferUtility.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Mocks/MockOperationQueue.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Mocks/MockOperationQueue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageDownloadFileOperationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageDownloadFileOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageGetDataOperationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageGetDataOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageGetURLOperationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageGetURLOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageListOperationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageListOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageOperationTestBase.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageOperationTestBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StoragePutDataOperationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StoragePutDataOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageRemoveOperationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageRemoveOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Request/AWSS3StorageDownloadFileRequestTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Request/AWSS3StorageDownloadFileRequestTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Request/AWSS3StorageGetDataRequestTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Request/AWSS3StorageGetDataRequestTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Request/AWSS3StorageGetURLRequestTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Request/AWSS3StorageGetURLRequestTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Request/AWSS3StorageListRequestTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Request/AWSS3StorageListRequestTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Request/AWSS3StoragePutDataRequestTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Request/AWSS3StoragePutDataRequestTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Request/AWSS3StorageRemoveRequestTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Request/AWSS3StorageRemoveRequestTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Request/AWSS3StorageUploadFileRequestTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Request/AWSS3StorageUploadFileRequestTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceConfigureTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceConfigureTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceDeleteBehaviorTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceDeleteBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceDownloadBehaviorTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceDownloadBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceEscapeHatchBehaviorTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceEscapeHatchBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceGetPreSignedURLBehaviorTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceGetPreSignedURLBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceListBehaviorTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceListBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceMultiPartUploadBehaviorTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceMultiPartUploadBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceTestBase.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceTestBase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceUploadBehaviorTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceUploadBehaviorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsGetterTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsGetterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsValidatorTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsValidatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/HostApp/Source/AppDelegate.swift
+++ b/AmplifyPlugins/Storage/HostApp/Source/AppDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/HostApp/Source/SceneDelegate.swift
+++ b/AmplifyPlugins/Storage/HostApp/Source/SceneDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyPlugins/Storage/HostApp/Source/ViewController.swift
+++ b/AmplifyPlugins/Storage/HostApp/Source/ViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestApp/AppDelegate.swift
+++ b/AmplifyTestApp/AppDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestApp/ViewController.swift
+++ b/AmplifyTestApp/ViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/AmplifyTestCommon.h
+++ b/AmplifyTestCommon/AmplifyTestCommon.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Helpers/AWSMobileClient+Message.swift
+++ b/AmplifyTestCommon/Helpers/AWSMobileClient+Message.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Helpers/AuthHelper.swift
+++ b/AmplifyTestCommon/Helpers/AuthHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Helpers/HubListenerTestUtilities.swift
+++ b/AmplifyTestCommon/Helpers/HubListenerTestUtilities.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Helpers/TestConfigHelper.swift
+++ b/AmplifyTestCommon/Helpers/TestConfigHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Mocks/MessageReporter.swift
+++ b/AmplifyTestCommon/Mocks/MessageReporter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Mocks/MockAPIResponders.swift
+++ b/AmplifyTestCommon/Mocks/MockAPIResponders.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Mocks/MockAnalyticsCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAnalyticsCategoryPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Mocks/MockDevMenuContextProvider.swift
+++ b/AmplifyTestCommon/Mocks/MockDevMenuContextProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Mocks/MockHubCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockHubCategoryPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Mocks/MockLoggingCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockLoggingCategoryPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Mocks/MockPredictionsCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockPredictionsCategoryPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Mocks/MockResponder.swift
+++ b/AmplifyTestCommon/Mocks/MockResponder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Mocks/MockStorageCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockStorageCategoryPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/AmplifyModels.swift
+++ b/AmplifyTestCommon/Models/AmplifyModels.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Article+Schema.swift
+++ b/AmplifyTestCommon/Models/Article+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Article.swift
+++ b/AmplifyTestCommon/Models/Article.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Associations/Author+Schema.swift
+++ b/AmplifyTestCommon/Models/Associations/Author+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Associations/Author.swift
+++ b/AmplifyTestCommon/Models/Associations/Author.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Associations/Book+Schema.swift
+++ b/AmplifyTestCommon/Models/Associations/Book+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Associations/Book.swift
+++ b/AmplifyTestCommon/Models/Associations/Book.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Associations/BookAuthor+Schema.swift
+++ b/AmplifyTestCommon/Models/Associations/BookAuthor+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Associations/BookAuthor.swift
+++ b/AmplifyTestCommon/Models/Associations/BookAuthor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Associations/UserAccount+Schema.swift
+++ b/AmplifyTestCommon/Models/Associations/UserAccount+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Associations/UserAccount.swift
+++ b/AmplifyTestCommon/Models/Associations/UserAccount.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Associations/UserProfile+Schema.swift
+++ b/AmplifyTestCommon/Models/Associations/UserProfile+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Associations/UserProfile.swift
+++ b/AmplifyTestCommon/Models/Associations/UserProfile.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/1/Project1+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/1/Project1+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/1/Project1.swift
+++ b/AmplifyTestCommon/Models/Collection/1/Project1.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/1/Team1+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/1/Team1+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/1/Team1.swift
+++ b/AmplifyTestCommon/Models/Collection/1/Team1.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/2/Project2+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/2/Project2+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/2/Project2.swift
+++ b/AmplifyTestCommon/Models/Collection/2/Project2.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/2/Team2+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/2/Team2+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/2/Team2.swift
+++ b/AmplifyTestCommon/Models/Collection/2/Team2.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/3/Comment3+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/3/Comment3+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/3/Comment3.swift
+++ b/AmplifyTestCommon/Models/Collection/3/Comment3.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/3/Post3+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/3/Post3+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/3/Post3.swift
+++ b/AmplifyTestCommon/Models/Collection/3/Post3.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/4/Comment4+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/4/Comment4+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/4/Comment4.swift
+++ b/AmplifyTestCommon/Models/Collection/4/Comment4.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/4/Post4+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/4/Post4+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/4/Post4.swift
+++ b/AmplifyTestCommon/Models/Collection/4/Post4.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/5/Post5+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/5/Post5+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/5/Post5.swift
+++ b/AmplifyTestCommon/Models/Collection/5/Post5.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/5/PostEditor5+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/5/PostEditor5+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/5/PostEditor5.swift
+++ b/AmplifyTestCommon/Models/Collection/5/PostEditor5.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/5/User5+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/5/User5+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/5/User5.swift
+++ b/AmplifyTestCommon/Models/Collection/5/User5.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/6/Blog6+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/6/Blog6+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/6/Blog6.swift
+++ b/AmplifyTestCommon/Models/Collection/6/Blog6.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/6/Comment6+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/6/Comment6+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/6/Comment6.swift
+++ b/AmplifyTestCommon/Models/Collection/6/Comment6.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/6/Post6+Schema.swift
+++ b/AmplifyTestCommon/Models/Collection/6/Post6+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Collection/6/Post6.swift
+++ b/AmplifyTestCommon/Models/Collection/6/Post6.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Comment+Schema.swift
+++ b/AmplifyTestCommon/Models/Comment+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Comment.swift
+++ b/AmplifyTestCommon/Models/Comment.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Deprecated/DeprecatedTodo.swift
+++ b/AmplifyTestCommon/Models/Deprecated/DeprecatedTodo.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/MockModels.swift
+++ b/AmplifyTestCommon/Models/MockModels.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/NonModel/Category.swift
+++ b/AmplifyTestCommon/Models/NonModel/Category.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/NonModel/Color.swift
+++ b/AmplifyTestCommon/Models/NonModel/Color.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/NonModel/DynamicEmbedded.swift
+++ b/AmplifyTestCommon/Models/NonModel/DynamicEmbedded.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/NonModel/DynamicModel.swift
+++ b/AmplifyTestCommon/Models/NonModel/DynamicModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/NonModel/Section.swift
+++ b/AmplifyTestCommon/Models/NonModel/Section.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/NonModel/Todo+Schema.swift
+++ b/AmplifyTestCommon/Models/NonModel/Todo+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/NonModel/Todo.swift
+++ b/AmplifyTestCommon/Models/NonModel/Todo.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/OGCScenarioBMGroupPost+Schema.swift
+++ b/AmplifyTestCommon/Models/OGCScenarioBMGroupPost+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/OGCScenarioBMGroupPost.swift
+++ b/AmplifyTestCommon/Models/OGCScenarioBMGroupPost.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/OGCScenarioBPost+Schema.swift
+++ b/AmplifyTestCommon/Models/OGCScenarioBPost+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/OGCScenarioBPost.swift
+++ b/AmplifyTestCommon/Models/OGCScenarioBPost.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Post+Schema.swift
+++ b/AmplifyTestCommon/Models/Post+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/Post.swift
+++ b/AmplifyTestCommon/Models/Post.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/PostCommentModelRegistration.swift
+++ b/AmplifyTestCommon/Models/PostCommentModelRegistration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/PostStatus.swift
+++ b/AmplifyTestCommon/Models/PostStatus.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/QPredGen+Schema.swift
+++ b/AmplifyTestCommon/Models/QPredGen+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/QPredGen.swift
+++ b/AmplifyTestCommon/Models/QPredGen.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/ScenarioATest6Post+Schema.swift
+++ b/AmplifyTestCommon/Models/ScenarioATest6Post+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/ScenarioATest6Post.swift
+++ b/AmplifyTestCommon/Models/ScenarioATest6Post.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/User+Schema.swift
+++ b/AmplifyTestCommon/Models/User+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/User.swift
+++ b/AmplifyTestCommon/Models/User.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/UserFollowers+Schema.swift
+++ b/AmplifyTestCommon/Models/UserFollowers+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/UserFollowers.swift
+++ b/AmplifyTestCommon/Models/UserFollowers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/UserFollowing+Schema.swift
+++ b/AmplifyTestCommon/Models/UserFollowing+Schema.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/Models/UserFollowing.swift
+++ b/AmplifyTestCommon/Models/UserFollowing.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/TestCommonConstants.swift
+++ b/AmplifyTestCommon/TestCommonConstants.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTestCommon/TestExtensions.swift
+++ b/AmplifyTestCommon/TestExtensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/API/APICategoryClientGraphQLTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryClientGraphQLTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/API/APICategoryClientInterceptorTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryClientInterceptorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/API/APICategoryClientRESTTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryClientRESTTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/API/APIPluginSelectorFactoryTests.swift
+++ b/AmplifyTests/CategoryTests/API/APIPluginSelectorFactoryTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryClientAPITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Analytics/AnalyticsPluginSelectorFactoryTests.swift
+++ b/AmplifyTests/CategoryTests/Analytics/AnalyticsPluginSelectorFactoryTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryClientAPITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/DataStore/JSONValueHolderTest.swift
+++ b/AmplifyTests/CategoryTests/DataStore/JSONValueHolderTest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/DataStore/ModelFieldAssociationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/ModelFieldAssociationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/DataStore/ModelRegistryTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/ModelRegistryTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/DataStore/TemporalComparableTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/TemporalComparableTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/DataStore/TemporalOperationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/TemporalOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/DataStore/TemporalTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/TemporalTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AWSHubPluginAmplifyVersionableTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AWSHubPluginAmplifyVersionableTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeHubListenToOperationTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeHubListenToOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeOperationTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeOperationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginConcurrencyTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginConcurrencyTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginCustomChannelTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginCustomChannelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Hub/HubCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubCategoryConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Hub/HubClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubClientAPITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Hub/HubCombineTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubCombineTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Hub/HubListenerTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubListenerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Hub/HubPluginSelectorFactoryTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubPluginSelectorFactoryTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Logging/DefaultLoggingPluginAmplifyVersionableTests.swift
+++ b/AmplifyTests/CategoryTests/Logging/DefaultLoggingPluginAmplifyVersionableTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Logging/DefaultLoggingPluginTests.swift
+++ b/AmplifyTests/CategoryTests/Logging/DefaultLoggingPluginTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Logging/LoggingCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Logging/LoggingCategoryClientAPITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Logging/LoggingCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Logging/LoggingCategoryConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Logging/LoggingPluginSelectorFactoryTests.swift
+++ b/AmplifyTests/CategoryTests/Logging/LoggingPluginSelectorFactoryTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Predictions/ModelsTest/LanguageTypeTest.swift
+++ b/AmplifyTests/CategoryTests/Predictions/ModelsTest/LanguageTypeTest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryClientAPITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Storage/StorageCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StorageCategoryClientAPITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CategoryTests/Storage/StoragePluginSelectorFactoryTests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StoragePluginSelectorFactoryTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/AmplifyConfigurationInitializationTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyConfigurationInitializationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/AmplifyInProcessReportingOperationChainedTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyInProcessReportingOperationChainedTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/AmplifyInProcessReportingOperationCombineTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyInProcessReportingOperationCombineTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/AmplifyOperationCombineSupportTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyOperationCombineSupportTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/AmplifyOperationCombineTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyOperationCombineTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/AnyEncodableTests.swift
+++ b/AmplifyTests/CoreTests/AnyEncodableTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/AtomicDictionaryTests.swift
+++ b/AmplifyTests/CoreTests/AtomicDictionaryTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/AtomicValue+BoolTests.swift
+++ b/AmplifyTests/CoreTests/AtomicValue+BoolTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/AtomicValue+NumericTests.swift
+++ b/AmplifyTests/CoreTests/AtomicValue+NumericTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/AtomicValue+RangeReplaceableCollectionTests.swift
+++ b/AmplifyTests/CoreTests/AtomicValue+RangeReplaceableCollectionTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/AtomicValueTests.swift
+++ b/AmplifyTests/CoreTests/AtomicValueTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/ConfigurationTests.swift
+++ b/AmplifyTests/CoreTests/ConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/FoundationUtilsTests.swift
+++ b/AmplifyTests/CoreTests/FoundationUtilsTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/JSONValue+KeyPathTests.swift
+++ b/AmplifyTests/CoreTests/JSONValue+KeyPathTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/JSONValue+SubscriptTests.swift
+++ b/AmplifyTests/CoreTests/JSONValue+SubscriptTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/JSONValueTests.swift
+++ b/AmplifyTests/CoreTests/JSONValueTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/Model+CodableTests.swift
+++ b/AmplifyTests/CoreTests/Model+CodableTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/NotificationListeningAnalyticsPlugin.swift
+++ b/AmplifyTests/CoreTests/NotificationListeningAnalyticsPlugin.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/CoreTests/TreeTests.swift
+++ b/AmplifyTests/CoreTests/TreeTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/DevMenuTests/DevMenuExtensionTests.swift
+++ b/AmplifyTests/DevMenuTests/DevMenuExtensionTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/DevMenuTests/GestureRecognizerTests.swift
+++ b/AmplifyTests/DevMenuTests/GestureRecognizerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/DevMenuTests/PersistentLogWrapperTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLogWrapperTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/DevMenuTests/PersistentLoggingPluginAmplifyVersionableTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLoggingPluginAmplifyVersionableTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTests/DevMenuTests/PersistentLoggingPluginTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLoggingPluginTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Amazon.com,
+// Copyright 2018-2021 Amazon.com,
 // Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/AmplifyTools/amplify-tools.sh
+++ b/AmplifyTools/amplify-tools.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright 2018-2020 Amazon.com,
+# Copyright 2018-2021 Amazon.com,
 # Inc. or its affiliates. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Basically ran this:
```
 for i in `find . |grep -i "\.swift$" |grep -v Pods`; do cat $i |sed 's/2018-2020/2018-2021/g' > $i.tmp; mv $i.tmp $i; done
```
Then did it for ".h" files, and manually updated amplify-tools.

Verified by doing something like this:
```
git diff --cached |grep -v Amazon\.com |grep -v "diff\ --git"|grep -v "//" |grep -v "\.swift" |grep -v "index" |grep -v "@@"
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
