### PR TITLE
fix(DataStore): support for QueryPredicateConstant.all for graphql queries

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/FilterDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/FilterDecorator.swift
@@ -25,6 +25,10 @@ public struct FilterDecorator: ModelBasedGraphQLDocumentDecorator {
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
+        guard !filter.isEmpty else {
+            return document.copy(inputs: document.inputs)
+        }
+
         var inputs = document.inputs
         let modelName = modelSchema.name
         if case .mutation = document.operationType {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
@@ -102,7 +102,7 @@ extension QueryPredicate {
 
 extension QueryPredicateConstant: GraphQLFilterConvertible {
     func graphQLFilter(for modelSchema: ModelSchema?) -> GraphQLFilter {
-        if (self == .all) {
+        if self == .all {
             return [:]
         }
         preconditionFailure("Could not find QueryPredicateConstant \(self)")

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
@@ -77,6 +77,8 @@ extension QueryPredicate {
             return operation.graphQLFilter(for: modelSchema)
         } else if let group = self as? QueryPredicateGroup {
             return group.graphQLFilter(for: modelSchema)
+        } else if let constant = self as? QueryPredicateConstant {
+            return constant.graphQLFilter(for: modelSchema)
         }
 
         preconditionFailure(
@@ -95,6 +97,15 @@ extension QueryPredicate {
 
         preconditionFailure(
             "Could not find QueryPredicateOperation or QueryPredicateGroup for \(String(describing: self))")
+    }
+}
+
+extension QueryPredicateConstant: GraphQLFilterConvertible {
+    func graphQLFilter(for modelSchema: ModelSchema?) -> GraphQLFilter {
+        if (self == .all) {
+            return [:]
+        }
+        preconditionFailure("Could not find QueryPredicateConstant \(self)")
     }
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -468,7 +468,8 @@ final class StorageEngine: StorageEngineBehavior {
         var graphQLFilterJSON: String?
         if let predicate = predicate {
             do {
-                graphQLFilterJSON = try GraphQLFilterConverter.toJSON(predicate)
+                graphQLFilterJSON = try GraphQLFilterConverter.toJSON(predicate,
+                                                                      modelSchema: modelSchema)
             } catch {
                 let dataStoreError = DataStoreError(error: error)
                 completion(.failure(dataStoreError))
@@ -519,7 +520,8 @@ final class StorageEngine: StorageEngineBehavior {
         do {
             var graphQLFilterJSON: String?
             if let predicate = predicate {
-                graphQLFilterJSON = try GraphQLFilterConverter.toJSON(predicate)
+                graphQLFilterJSON = try GraphQLFilterConverter.toJSON(predicate,
+                                                                      modelSchema: modelSchema)
             }
 
             mutationEvent = try MutationEvent(model: savedModel,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -739,8 +739,8 @@ class InitialSyncOperationTests: XCTestCase {
         let apiWasQueried = expectation(description: "API was queried with sync expression")
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { request, listener in
             XCTAssertEqual(request.document, """
-            query SyncMockSynceds($filter: ModelMockSyncedFilterInput, $limit: Int) {
-              syncMockSynceds(filter: $filter, limit: $limit) {
+            query SyncMockSynceds($limit: Int) {
+              syncMockSynceds(limit: $limit) {
                 items {
                   id
                   __typename
@@ -753,11 +753,7 @@ class InitialSyncOperationTests: XCTestCase {
               }
             }
             """)
-            guard let filter = request.variables?["filter"] as? [String: Any?] else {
-                XCTFail("Unable to get filter")
-                return nil
-            }
-            XCTAssert(filter.isEmpty)
+            XCTAssertNil(request.variables?["filter"])
 
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: nil)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -731,4 +731,80 @@ class InitialSyncOperationTests: XCTestCase {
         waitForExpectations(timeout: 1)
         sink.cancel()
     }
+
+    func testBaseQueryWithSyncExpressionConstantAll() throws {
+        let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas + [MockSynced.schema])
+
+        let apiWasQueried = expectation(description: "API was queried with sync expression")
+        let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { request, listener in
+            XCTAssertEqual(request.document, """
+            query SyncMockSynceds($filter: ModelMockSyncedFilterInput, $limit: Int) {
+              syncMockSynceds(filter: $filter, limit: $limit) {
+                items {
+                  id
+                  __typename
+                  _version
+                  _deleted
+                  _lastChangedAt
+                }
+                nextToken
+                startedAt
+              }
+            }
+            """)
+            guard let filter = request.variables?["filter"] as? [String: Any?] else {
+                XCTFail("Unable to get filter")
+                return nil
+            }
+            XCTAssert(filter.isEmpty)
+
+            let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: nil)
+            let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
+            listener?(event)
+            apiWasQueried.fulfill()
+            return nil
+        }
+
+        let apiPlugin = MockAPICategoryPlugin()
+        apiPlugin.responders[.queryRequestListener] = responder
+
+        let reconciliationQueue = MockReconciliationQueue()
+        let syncExpression = DataStoreSyncExpression.syncExpression(MockSynced.schema, where: {
+            QueryPredicateConstant.all
+        })
+        let configuration  = DataStoreConfiguration.custom(syncPageSize: 10, syncExpressions: [syncExpression])
+        let operation = InitialSyncOperation(
+            modelSchema: MockSynced.schema,
+            api: apiPlugin,
+            reconciliationQueue: reconciliationQueue,
+            storageAdapter: storageAdapter,
+            dataStoreConfiguration: configuration)
+
+        let syncStartedReceived = expectation(description: "Sync started received, sync operation started")
+        let syncCompletionReceived = expectation(description: "Sync completion received, sync operation is complete")
+        let finishedReceived = expectation(description: "InitialSyncOperation finishe offering items")
+        let sink = operation
+            .publisher
+            .sink(receiveCompletion: { _ in
+                syncCompletionReceived.fulfill()
+            }, receiveValue: { value in
+                switch value {
+                case .started(modelName: let modelName, syncType: let syncType):
+                    XCTAssertEqual(modelName, "MockSynced")
+                    XCTAssertEqual(syncType, .fullSync)
+                    syncStartedReceived.fulfill()
+                case .finished(modelName: let modelName):
+                    XCTAssertEqual(modelName, "MockSynced")
+                    finishedReceived.fulfill()
+                default:
+                    break
+                }
+            })
+
+        operation.main()
+
+        waitForExpectations(timeout: 1)
+        sink.cancel()
+    }
 }


### PR DESCRIPTION
Customers will experience a crash in the event they define a sync query with the `.all` constant.  For example:
```
  let syncExpression1 = DataStoreSyncExpression.syncExpression(Todo.schema, where: {
      return QueryPredicateConstant.all
  }
````

This code change remedies this by using `[:]` as the filter value -- effectively disabling the selective sync expression.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
