### PR TITLE
chore(auth): Updated the signInWithWebUI to use ASWebAuthenticationSession

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		B43DC74F2410572400D40275 /* AWSCognitoAuthPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B43DC7452410572400D40275 /* AWSCognitoAuthPlugin.framework */; };
 		B44373A1247C869100DEF43C /* AuthSessionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44373A0247C869100DEF43C /* AuthSessionHelper.swift */; };
 		B44373A4247C8CCE00DEF43C /* AuthSignOutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44373A3247C8CCE00DEF43C /* AuthSignOutTests.swift */; };
+		B458316825C8C31500414DCC /* AWSCognitoAuthPluginUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = B458316725C8C31500414DCC /* AWSCognitoAuthPluginUserDefaults.swift */; };
 		B4D5411B256F2C8A00436E5C /* BaseAuthorizationProviderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D5411A256F2C8A00436E5C /* BaseAuthorizationProviderTest.swift */; };
 		B4F3EA47243A776800F23296 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B4F3EA41243A776800F23296 /* Assets.xcassets */; };
 		B4F3EA48243A776800F23296 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B4F3EA42243A776800F23296 /* LaunchScreen.storyboard */; };
@@ -332,6 +333,7 @@
 		B43DC74E2410572400D40275 /* AWSCognitoAuthPluginTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSCognitoAuthPluginTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B44373A0247C869100DEF43C /* AuthSessionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSessionHelper.swift; sourceTree = "<group>"; };
 		B44373A3247C8CCE00DEF43C /* AuthSignOutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSignOutTests.swift; sourceTree = "<group>"; };
+		B458316725C8C31500414DCC /* AWSCognitoAuthPluginUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSCognitoAuthPluginUserDefaults.swift; sourceTree = "<group>"; };
 		B4672B5524777C7500C83E96 /* Amplify.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Amplify.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4672B5624777C7500C83E96 /* AmplifyTestCommon.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AmplifyTestCommon.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4672B5724777C7500C83E96 /* AWSAuthCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AWSAuthCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -621,6 +623,7 @@
 		B41D0F422475A3960049D08D /* Options */ = {
 			isa = PBXGroup;
 			children = (
+				21621E0D24DE1FC300497A24 /* AWSAttributeResendConfirmationCodeOptions.swift */,
 				B41D0F492475A3960049D08D /* AWSAuthConfirmResetPasswordOptions.swift */,
 				B41D0F432475A3960049D08D /* AWSAuthConfirmSignInOptions.swift */,
 				B41D0F442475A3960049D08D /* AWSAuthConfirmSignUpOptions.swift */,
@@ -629,7 +632,6 @@
 				B41D0F462475A3960049D08D /* AWSAuthSignInOptions.swift */,
 				B41D0F472475A3960049D08D /* AWSAuthSignUpOptions.swift */,
 				B41D0F482475A3960049D08D /* AWSAuthWebUISignInOptions.swift */,
-				21621E0D24DE1FC300497A24 /* AWSAttributeResendConfirmationCodeOptions.swift */,
 				21621E1124DE2D6100497A24 /* AWSUpdateUserAttributeOptions.swift */,
 				21621E0F24DE2D5600497A24 /* AWSUpdateUserAttributesOptions.swift */,
 			);
@@ -704,6 +706,7 @@
 				B41D0F762475A3960049D08D /* AuthErrorHelper.swift */,
 				B41D0F772475A3960049D08D /* AuthProvider+AWSMobileClient.swift */,
 				B41D0F722475A3960049D08D /* AuthUserAttributeKey+Extension.swift */,
+				B458316725C8C31500414DCC /* AWSCognitoAuthPluginUserDefaults.swift */,
 				B41D0F742475A3960049D08D /* AWSCredentials+Extension.swift */,
 				B41D0F732475A3960049D08D /* AWSMobileClient+Reset.swift */,
 				B41D0F752475A3960049D08D /* Device+Extension.swift */,
@@ -1456,6 +1459,7 @@
 				B41D0F8B2475A3960049D08D /* AuthHubEventBehavior.swift in Sources */,
 				B41D0FBE2475A3960049D08D /* AWSAuthForgetDeviceOperation.swift in Sources */,
 				B41D0FB42475A3960049D08D /* AWSAuthFetchUserAttributeOperation.swift in Sources */,
+				B458316825C8C31500414DCC /* AWSCognitoAuthPluginUserDefaults.swift in Sources */,
 				B41D0F9E2475A3960049D08D /* AWSAuthConfirmSignUpOptions.swift in Sources */,
 				21621E1224DE2D6100497A24 /* AWSUpdateUserAttributeOptions.swift in Sources */,
 				B41D0FB22475A3960049D08D /* AWSAuthUpdateUserAttributeOperation.swift in Sources */,

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		B4136E8E256D7B500011210B /* AuthDeviceFetchDevicesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4136E8D256D7B500011210B /* AuthDeviceFetchDevicesTests.swift */; };
 		B4136E94256D7B630011210B /* AuthDeviceForgetDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4136E93256D7B630011210B /* AuthDeviceForgetDeviceTests.swift */; };
 		B4136E9A256D7B700011210B /* AuthDeviceRememberDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4136E99256D7B700011210B /* AuthDeviceRememberDeviceTests.swift */; };
+		B415ACFE25CB2A7F0033090D /* AWSCognitoAuthPluginUserDefaultsBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = B415ACFD25CB2A7F0033090D /* AWSCognitoAuthPluginUserDefaultsBehavior.swift */; };
 		B41D0F8A2475A3960049D08D /* AuthHubEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41D0F2C2475A3960049D08D /* AuthHubEventHandler.swift */; };
 		B41D0F8B2475A3960049D08D /* AuthHubEventBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41D0F2D2475A3960049D08D /* AuthHubEventBehavior.swift */; };
 		B41D0F8E2475A3960049D08D /* AuthenticationProviderAdapter+SignOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41D0F322475A3960049D08D /* AuthenticationProviderAdapter+SignOut.swift */; };
@@ -150,6 +151,7 @@
 		B4F3EA4F243A782700F23296 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3EA4C243A782700F23296 /* ViewController.swift */; };
 		B4F3EA50243A782700F23296 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3EA4D243A782700F23296 /* AppDelegate.swift */; };
 		B4F3EA51243A782700F23296 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3EA4E243A782700F23296 /* SceneDelegate.swift */; };
+		B4F9F11E25CB303200742BB3 /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F9F11D25CB303200742BB3 /* MockUserDefaults.swift */; };
 		D828362C2590527F0016173F /* BaseUserBehaviorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D828362B2590527F0016173F /* BaseUserBehaviorTest.swift */; };
 		D87D5864257EF27E004617B3 /* BaseAuthDeviceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87D5863257EF27E004617B3 /* BaseAuthDeviceTest.swift */; };
 		FA1C817D25868C46006160E9 /* AWSCognitoAuthPluginAmplifyVersionableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1C817C25868C46006160E9 /* AWSCognitoAuthPluginAmplifyVersionableTests.swift */; };
@@ -238,6 +240,7 @@
 		B4136E8D256D7B500011210B /* AuthDeviceFetchDevicesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthDeviceFetchDevicesTests.swift; sourceTree = "<group>"; };
 		B4136E93256D7B630011210B /* AuthDeviceForgetDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthDeviceForgetDeviceTests.swift; sourceTree = "<group>"; };
 		B4136E99256D7B700011210B /* AuthDeviceRememberDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthDeviceRememberDeviceTests.swift; sourceTree = "<group>"; };
+		B415ACFD25CB2A7F0033090D /* AWSCognitoAuthPluginUserDefaultsBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSCognitoAuthPluginUserDefaultsBehavior.swift; sourceTree = "<group>"; };
 		B41D0F2C2475A3960049D08D /* AuthHubEventHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthHubEventHandler.swift; sourceTree = "<group>"; };
 		B41D0F2D2475A3960049D08D /* AuthHubEventBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthHubEventBehavior.swift; sourceTree = "<group>"; };
 		B41D0F302475A3960049D08D /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -351,6 +354,7 @@
 		B4F3EA4C243A782700F23296 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		B4F3EA4D243A782700F23296 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B4F3EA4E243A782700F23296 /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		B4F9F11D25CB303200742BB3 /* MockUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserDefaults.swift; sourceTree = "<group>"; };
 		C49A4C812B0F973F5536DCC8 /* Pods-AWSAuthPlugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAuthPlugin.release.xcconfig"; path = "Target Support Files/Pods-AWSAuthPlugin/Pods-AWSAuthPlugin.release.xcconfig"; sourceTree = "<group>"; };
 		C5E50D8021B9740CB511898D /* Pods-AWSAuthPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAuthPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSAuthPlugin/Pods-AWSAuthPlugin.debug.xcconfig"; sourceTree = "<group>"; };
 		D828362B2590527F0016173F /* BaseUserBehaviorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseUserBehaviorTest.swift; sourceTree = "<group>"; };
@@ -707,6 +711,7 @@
 				B41D0F772475A3960049D08D /* AuthProvider+AWSMobileClient.swift */,
 				B41D0F722475A3960049D08D /* AuthUserAttributeKey+Extension.swift */,
 				B458316725C8C31500414DCC /* AWSCognitoAuthPluginUserDefaults.swift */,
+				B415ACFD25CB2A7F0033090D /* AWSCognitoAuthPluginUserDefaultsBehavior.swift */,
 				B41D0F742475A3960049D08D /* AWSCredentials+Extension.swift */,
 				B41D0F732475A3960049D08D /* AWSMobileClient+Reset.swift */,
 				B41D0F752475A3960049D08D /* Device+Extension.swift */,
@@ -794,12 +799,13 @@
 		B43B4DD72565E803008F345D /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				B43B4E022565E95E008F345D /* MockAuthDeviceServiceBehavior.swift */,
 				B43B4DD82565E820008F345D /* MockAuthenticationProviderBehavior.swift */,
+				B43B4E082565E97D008F345D /* MockAuthHubEventBehavior.swift */,
 				B43B4DE22565E8D7008F345D /* MockAuthorizationProviderBehavior.swift */,
 				B43B4DFC2565E941008F345D /* MockAuthUserServiceBehavior.swift */,
-				B43B4E022565E95E008F345D /* MockAuthDeviceServiceBehavior.swift */,
-				B43B4E082565E97D008F345D /* MockAuthHubEventBehavior.swift */,
 				B40602A2256C230B00D23D50 /* MockAWSMobileClient.swift */,
+				B4F9F11D25CB303200742BB3 /* MockUserDefaults.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -1466,6 +1472,7 @@
 				B41D0FBA2475A3960049D08D /* AWSAuthSocialWebUISignInOperation.swift in Sources */,
 				B41D0FC42475A3960049D08D /* UserCodeDeliveryDetails+Extension.swift in Sources */,
 				B41D0FCD2475A3960049D08D /* AuthCognitoSignedOutSessionHelper.swift in Sources */,
+				B415ACFE25CB2A7F0033090D /* AWSCognitoAuthPluginUserDefaultsBehavior.swift in Sources */,
 				B41D10052475AB7E0049D08D /* AWSCognitoAuthPlugin.swift in Sources */,
 				B41D0FB52475A3960049D08D /* AWSAuthUpdateUserAttributesOperation.swift in Sources */,
 				B41D0FBB2475A3960049D08D /* AWSAuthSignInOperation.swift in Sources */,
@@ -1529,6 +1536,7 @@
 				B4136E44256D795B0011210B /* AuthenticationProviderResetPasswordTests.swift in Sources */,
 				B402C916257700610020B83B /* BaseAuthenticationProviderTest.swift in Sources */,
 				B43B4E092565E97D008F345D /* MockAuthHubEventBehavior.swift in Sources */,
+				B4F9F11E25CB303200742BB3 /* MockUserDefaults.swift in Sources */,
 				B4060295256C21BC00D23D50 /* AuthenticationProviderSignupTests.swift in Sources */,
 				B41D0FE22475A3A10049D08D /* AuthUserAttributeKeyTests.swift in Sources */,
 				B4136E26256D76300011210B /* AuthenticationProviderConfirmSigninTests.swift in Sources */,

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -49,7 +49,7 @@ extension AuthenticationProviderAdapter {
                 completionHandler(.failure(error))
                 return
             }
-            AWSCognitoAuthPluginUserDefaults.storePreferredBrowserSession(privateSessionPrefered: false)
+            self.userdefaults.storePreferredBrowserSession(privateSessionPrefered: false)
             let authResult = AuthSignInResult(nextStep: signInNextStep)
             completionHandler(.success(authResult))
         }
@@ -205,7 +205,7 @@ extension AuthenticationProviderAdapter {
             completionHandler(.failure(error))
             return
         }
-        AWSCognitoAuthPluginUserDefaults.storePreferredBrowserSession(privateSessionPrefered: preferPrivateSession)
+        userdefaults.storePreferredBrowserSession(privateSessionPrefered: preferPrivateSession)
         let authResult = AuthSignInResult(nextStep: .done)
         completionHandler(.success(authResult))
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -59,11 +59,11 @@ extension AuthenticationProviderAdapter {
     func signInWithWebUI(request: AuthWebUISignInRequest,
                          completionHandler: @escaping SigInResultCompletion) {
 
-        let window = request.presentationAnchor
+        let presentationAnchor = request.presentationAnchor
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
 
-            self.showSignInWebView(window: window,
+            self.showSignInWebView(presentationAnchor: presentationAnchor,
                                    request: request,
                                    completionHandler: completionHandler)
         }
@@ -109,7 +109,7 @@ extension AuthenticationProviderAdapter {
     }
 
     // MARK: - Internal methods
-    private func showSignInWebView(window: UIWindow,
+    private func showSignInWebView(presentationAnchor: AuthUIPresentationAnchor,
                                    request: AuthWebUISignInRequest,
                                    completionHandler: @escaping SigInResultCompletion) {
 
@@ -133,19 +133,19 @@ extension AuthenticationProviderAdapter {
                                               signInPrivateSession: preferPrivateSession)
 
         if #available(iOS 13, *) {
-            launchASWebAuthenticationSession(window: window,
+            launchASWebAuthenticationSession(presentationAnchor: presentationAnchor,
                                              hostedUIOptions: hostedUIOptions,
                                              preferPrivateSession: preferPrivateSession,
                                              completionHandler: completionHandler)
         } else {
-            launchSFAuthenticationSession(window: window,
+            launchSFAuthenticationSession(presentationAnchor: presentationAnchor,
                                           hostedUIOptions: hostedUIOptions,
                                           completionHandler: completionHandler)
         }
 
     }
 
-    private func launchSFAuthenticationSession(window: UIWindow,
+    private func launchSFAuthenticationSession(presentationAnchor: AuthUIPresentationAnchor,
                                                hostedUIOptions: HostedUIOptions,
                                                completionHandler: @escaping SigInResultCompletion) {
         let navController = ModalPresentingNavigationController(rootViewController: UIViewController())
@@ -153,7 +153,7 @@ extension AuthenticationProviderAdapter {
         navController.modalPresentationStyle = .overCurrentContext
 
         // Get top most view controller to present a navController
-        var parentViewController = window.rootViewController
+        var parentViewController = presentationAnchor.rootViewController
         while (parentViewController?.presentedViewController) != nil {
             parentViewController = parentViewController?.presentedViewController
         }
@@ -175,11 +175,11 @@ extension AuthenticationProviderAdapter {
     }
 
     @available(iOS 13, *)
-    private func launchASWebAuthenticationSession(window: UIWindow,
+    private func launchASWebAuthenticationSession(presentationAnchor: AuthUIPresentationAnchor,
                                                   hostedUIOptions: HostedUIOptions,
                                                   preferPrivateSession: Bool,
                                                   completionHandler: @escaping SigInResultCompletion) {
-        awsMobileClient.showSignIn(uiwindow: window,
+        awsMobileClient.showSignIn(uiwindow: presentationAnchor,
                                    hostedUIOptions: hostedUIOptions) { [weak self] state, error in
             guard let self = self else { return }
             self.handleHostedUIResult(state: state,
@@ -199,9 +199,9 @@ extension AuthenticationProviderAdapter {
             return
         }
 
-        guard let state = state, state == .signedIn else {
+        guard let signedInState = state, signedInState == .signedIn else {
 
-            let error = AuthError.unknown("signInWithWebUI did not produce a valid result.")
+            let error = AuthError.unknown("signInWithWebUI did not produce a valid result \(state?.rawValue ?? "").")
             completionHandler(.failure(error))
             return
         }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignOut.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignOut.swift
@@ -12,6 +12,15 @@ extension AuthenticationProviderAdapter {
 
     func signOut(request: AuthSignOutRequest, completionHandler: @escaping (Result<Void, AuthError>) -> Void) {
 
+        // If developer had signed in using private session, we just need to signout the user locally.
+        guard AWSCognitoAuthPluginUserDefaults.isPrivateSessionPreferred() == false else {
+            awsMobileClient.signOutLocally()
+            // Reset the user defaults.
+            AWSCognitoAuthPluginUserDefaults.storePreferredBrowserSession(privateSessionPrefered: false)
+            completionHandler(.success(()))
+            return
+        }
+
         // If user is signed in through HostedUI the signout require UI to complete. So calling this in main thread.
         DispatchQueue.main.async { [weak self] in
             guard let self = self else {

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignOut.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignOut.swift
@@ -13,7 +13,7 @@ extension AuthenticationProviderAdapter {
     func signOut(request: AuthSignOutRequest, completionHandler: @escaping (Result<Void, AuthError>) -> Void) {
 
         // If developer had signed in using private session, we just need to signout the user locally.
-        guard userdefaults.isPrivateSessionPreferred() == false else {
+        guard !userdefaults.isPrivateSessionPreferred() else {
             awsMobileClient.signOutLocally()
             // Reset the user defaults.
             userdefaults.storePreferredBrowserSession(privateSessionPrefered: false)

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignOut.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignOut.swift
@@ -13,10 +13,10 @@ extension AuthenticationProviderAdapter {
     func signOut(request: AuthSignOutRequest, completionHandler: @escaping (Result<Void, AuthError>) -> Void) {
 
         // If developer had signed in using private session, we just need to signout the user locally.
-        guard AWSCognitoAuthPluginUserDefaults.isPrivateSessionPreferred() == false else {
+        guard userdefaults.isPrivateSessionPreferred() == false else {
             awsMobileClient.signOutLocally()
             // Reset the user defaults.
-            AWSCognitoAuthPluginUserDefaults.storePreferredBrowserSession(privateSessionPrefered: false)
+            userdefaults.storePreferredBrowserSession(privateSessionPrefered: false)
             completionHandler(.success(()))
             return
         }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter.swift
@@ -12,8 +12,12 @@ class AuthenticationProviderAdapter: AuthenticationProviderBehavior {
 
     let awsMobileClient: AWSMobileClientBehavior
 
-    init(awsMobileClient: AWSMobileClientBehavior) {
+    let userdefaults: AWSCognitoAuthPluginUserDefaultsBehavior
+
+    init(awsMobileClient: AWSMobileClientBehavior,
+         userdefaults: AWSCognitoAuthPluginUserDefaultsBehavior = AWSCognitoAuthPluginUserDefaults()) {
         self.awsMobileClient = awsMobileClient
+        self.userdefaults = userdefaults
     }
 
     func getCurrentUser() -> AuthUser? {

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthWebUISignInOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthWebUISignInOptions.swift
@@ -25,7 +25,7 @@ public struct AWSAuthWebUISignInOptions {
     /// are using Auth0, specify the `federationProviderName` as <your_domain>.auth0.com.
     public let federationProviderName: String?
 
-    /// Start the webUI signin in a private browser session.
+    /// Starts the webUI signin in a private browser session, if supported by the current browser.
     ///
     /// Internally this sets the ASWebAuthentication session's prefersEphemeralWebBrowserSession = true.
     /// Note that this value internally set `prefersEphemeralWebBrowserSession` in ASWebAuthenticationSession.

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthWebUISignInOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthWebUISignInOptions.swift
@@ -27,8 +27,7 @@ public struct AWSAuthWebUISignInOptions {
 
     /// Starts the webUI signin in a private browser session, if supported by the current browser.
     ///
-    /// Internally this sets the ASWebAuthentication session's prefersEphemeralWebBrowserSession = true.
-    /// Note that this value internally set `prefersEphemeralWebBrowserSession` in ASWebAuthenticationSession.
+    /// Note that this value internally sets `prefersEphemeralWebBrowserSession` in ASWebAuthenticationSession.
     /// As per Apple documentation, Whether the request is honored depends on the user’s default web browser.
     /// Safari always honors the request.
     public let preferPrivateSession: Bool

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthWebUISignInOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthWebUISignInOptions.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Amplify
 
 public struct AWSAuthWebUISignInOptions {
 
@@ -24,8 +25,28 @@ public struct AWSAuthWebUISignInOptions {
     /// are using Auth0, specify the `federationProviderName` as <your_domain>.auth0.com.
     public let federationProviderName: String?
 
-    public init(idpIdentifier: String? = nil, federationProviderName: String? = nil) {
+    /// Start the webUI signin in a private browser session.
+    ///
+    /// Internally this sets the ASWebAuthentication session's prefersEphemeralWebBrowserSession = true.
+    /// Note that this value internally set `prefersEphemeralWebBrowserSession` in ASWebAuthenticationSession.
+    /// As per Apple documentation, Whether the request is honored depends on the user’s default web browser.
+    /// Safari always honors the request.
+    public let preferPrivateSession: Bool
+
+    public init(idpIdentifier: String? = nil,
+                federationProviderName: String? = nil,
+                preferPrivateSession: Bool = false) {
         self.idpIdentifier = idpIdentifier
         self.federationProviderName = federationProviderName
+        self.preferPrivateSession = preferPrivateSession
+    }
+}
+
+extension AuthWebUISignInRequest {
+
+    public static func optionWithPrivateSession() -> AuthWebUISignInOperation.Request.Options {
+        let pluginOptions = AWSAuthWebUISignInOptions(preferPrivateSession: true)
+        let options = AuthWebUISignInOperation.Request.Options(pluginOptions: pluginOptions)
+        return options
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthWebUISignInOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthWebUISignInOptions.swift
@@ -41,9 +41,9 @@ public struct AWSAuthWebUISignInOptions {
     }
 }
 
-extension AuthWebUISignInRequest {
+extension AuthWebUISignInRequest.Options {
 
-    public static func optionWithPrivateSession() -> AuthWebUISignInOperation.Request.Options {
+    public static func preferPrivateSession() -> AuthWebUISignInOperation.Request.Options {
         let pluginOptions = AWSAuthWebUISignInOptions(preferPrivateSession: true)
         let options = AuthWebUISignInOperation.Request.Options(pluginOptions: pluginOptions)
         return options

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Service/AWSMobileClient/AWSMobileClientAdapter.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Service/AWSMobileClient/AWSMobileClientAdapter.swift
@@ -100,6 +100,15 @@ class AWSMobileClientAdapter: AWSMobileClientBehavior {
                                    completionHandler)
     }
 
+    @available(iOS 13, *)
+    func showSignIn(uiwindow: UIWindow,
+                    hostedUIOptions: HostedUIOptions,
+                    _ completionHandler: @escaping (UserState?, Error?) -> Void) {
+        awsMobileClient.showSignIn(presentationAnchor: uiwindow,
+                                   hostedUIOptions: hostedUIOptions,
+                                   completionHandler)
+    }
+
     func confirmSignIn(challengeResponse: String,
                        userAttributes: [String: String] = [:],
                        clientMetaData: [String: String] = [:],
@@ -112,6 +121,15 @@ class AWSMobileClientAdapter: AWSMobileClientBehavior {
 
     func signOut(options: SignOutOptions = SignOutOptions(), completionHandler: @escaping ((Error?) -> Void)) {
         awsMobileClient.signOut(options: options, completionHandler: completionHandler)
+    }
+
+    @available(iOS 13, *)
+    func signOut(uiwindow: UIWindow,
+                 options: SignOutOptions = SignOutOptions(),
+                 completionHandler: @escaping ((Error?) -> Void)) {
+        awsMobileClient.signOut(presentationAnchor: uiwindow,
+                                options: options,
+                                completionHandler: completionHandler)
     }
 
     func signOutLocally() {

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Service/AWSMobileClient/AWSMobileClientBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Service/AWSMobileClient/AWSMobileClientBehavior.swift
@@ -44,12 +44,22 @@ protocol AWSMobileClientBehavior {
                     hostedUIOptions: HostedUIOptions?,
                     _ completionHandler: @escaping (UserState?, Error?) -> Void)
 
+    @available(iOS 13, *)
+    func showSignIn(uiwindow: UIWindow,
+                    hostedUIOptions: HostedUIOptions,
+                    _ completionHandler: @escaping (UserState?, Error?) -> Void)
+
     func confirmSignIn(challengeResponse: String,
                        userAttributes: [String: String],
                        clientMetaData: [String: String],
                        completionHandler: @escaping ((SignInResult?, Error?) -> Void))
 
     func signOut(options: SignOutOptions,
+                 completionHandler: @escaping ((Error?) -> Void))
+
+    @available(iOS 13, *)
+    func signOut(uiwindow: UIWindow,
+                 options: SignOutOptions,
                  completionHandler: @escaping ((Error?) -> Void))
 
     func signOutLocally()

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AWSCognitoAuthPluginUserDefaults.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AWSCognitoAuthPluginUserDefaults.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct AWSCognitoAuthPluginUserDefaults {
 
-    private static let preferPrivateSessionKey = "privateSessionKey"
+    private static let preferPrivateSessionKey = "AWSCognitoAuthPluginUserDefaults.privateSessionKey"
 
     static func storePreferredBrowserSession(privateSessionPrefered: Bool) {
         UserDefaults.standard.setValue(privateSessionPrefered, forKey: preferPrivateSessionKey)

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AWSCognitoAuthPluginUserDefaults.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AWSCognitoAuthPluginUserDefaults.swift
@@ -1,0 +1,21 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+struct AWSCognitoAuthPluginUserDefaults {
+
+    private static let preferPrivateSessionKey = "privateSessionKey"
+
+    static func storePreferredBrowserSession(privateSessionPrefered: Bool) {
+        UserDefaults.standard.setValue(privateSessionPrefered, forKey: preferPrivateSessionKey)
+    }
+
+    static func isPrivateSessionPreferred() -> Bool {
+        return UserDefaults.standard.bool(forKey: preferPrivateSessionKey)
+    }
+}

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AWSCognitoAuthPluginUserDefaults.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AWSCognitoAuthPluginUserDefaults.swift
@@ -7,15 +7,15 @@
 
 import Foundation
 
-struct AWSCognitoAuthPluginUserDefaults {
+struct AWSCognitoAuthPluginUserDefaults: AWSCognitoAuthPluginUserDefaultsBehavior {
 
-    private static let preferPrivateSessionKey = "AWSCognitoAuthPluginUserDefaults.privateSessionKey"
+    private let preferPrivateSessionKey = "AWSCognitoAuthPluginUserDefaults.privateSessionKey"
 
-    static func storePreferredBrowserSession(privateSessionPrefered: Bool) {
+    func storePreferredBrowserSession(privateSessionPrefered: Bool) {
         UserDefaults.standard.setValue(privateSessionPrefered, forKey: preferPrivateSessionKey)
     }
 
-    static func isPrivateSessionPreferred() -> Bool {
+    func isPrivateSessionPreferred() -> Bool {
         return UserDefaults.standard.bool(forKey: preferPrivateSessionKey)
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AWSCognitoAuthPluginUserDefaultsBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AWSCognitoAuthPluginUserDefaultsBehavior.swift
@@ -1,0 +1,15 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+protocol AWSCognitoAuthPluginUserDefaultsBehavior {
+
+    func storePreferredBrowserSession(privateSessionPrefered: Bool)
+
+    func isPrivateSessionPreferred() -> Bool
+}

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
@@ -46,7 +46,7 @@ class AuthenticationProviderSigninTests: BaseAuthenticationProviderTest {
                     return
                 }
                 XCTAssertTrue(signinResult.isSignedIn, "Signin result should be complete")
-                XCTAssertFalse(AWSCognitoAuthPluginUserDefaults.isPrivateSessionPreferred(),
+                XCTAssertFalse(self.mockUserDefault.isPrivateSessionPreferred(),
                               "Prefer private session userdefaults should not be set.")
             case .failure(let error):
                 XCTFail("Received failure with error \(error)")

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
@@ -47,7 +47,7 @@ class AuthenticationProviderSigninTests: BaseAuthenticationProviderTest {
                 }
                 XCTAssertTrue(signinResult.isSignedIn, "Signin result should be complete")
                 XCTAssertFalse(self.mockUserDefault.isPrivateSessionPreferred(),
-                              "Prefer private session userdefaults should not be set.")
+                               "Prefer private session userdefaults should not be set.")
             case .failure(let error):
                 XCTFail("Received failure with error \(error)")
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
@@ -46,6 +46,8 @@ class AuthenticationProviderSigninTests: BaseAuthenticationProviderTest {
                     return
                 }
                 XCTAssertTrue(signinResult.isSignedIn, "Signin result should be complete")
+                XCTAssertFalse(AWSCognitoAuthPluginUserDefaults.isPrivateSessionPreferred(),
+                              "Prefer private session userdefaults should not be set.")
             case .failure(let error):
                 XCTFail("Received failure with error \(error)")
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithWebUITests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithWebUITests.swift
@@ -237,10 +237,9 @@ class AuthenticationProviderSigninWithWebUITests: BaseAuthenticationProviderTest
 
         let mockSigninResult = UserState.signedIn
         mockAWSMobileClient?.showSignInMockResult = .success(mockSigninResult)
-        let options = AuthWebUISignInRequest.optionWithPrivateSession()
 
         let resultExpectation = expectation(description: "Should receive a result")
-        _ = plugin.signInWithWebUI(presentationAnchor: window, options: options) { result in
+        _ = plugin.signInWithWebUI(presentationAnchor: window, options: .preferPrivateSession()) { result in
             defer {
                 resultExpectation.fulfill()
             }
@@ -273,10 +272,9 @@ class AuthenticationProviderSigninWithWebUITests: BaseAuthenticationProviderTest
 
         let error = AWSMobileClientError.securityFailed(message: "")
         mockAWSMobileClient?.showSignInMockResult = .failure(error)
-        let options = AuthWebUISignInRequest.optionWithPrivateSession()
 
         let resultExpectation = expectation(description: "Should receive a result")
-        _ = plugin.signInWithWebUI(presentationAnchor: window, options: options) { result in
+        _ = plugin.signInWithWebUI(presentationAnchor: window, options: .preferPrivateSession()) { result in
 
             defer {
                 resultExpectation.fulfill()

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithWebUITests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithWebUITests.swift
@@ -251,20 +251,13 @@ class AuthenticationProviderSigninWithWebUITests: BaseAuthenticationProviderTest
                     return
                 }
                 XCTAssertTrue(signinResult.isSignedIn, "Signin result should be complete")
-                XCTAssertTrue(AWSCognitoAuthPluginUserDefaults.isPrivateSessionPreferred(),
+                XCTAssertTrue(self.mockUserDefault.isPrivateSessionPreferred(),
                               "Prefer private session userdefaults should be set.")
             case .failure(let error):
                 XCTFail("Received failure with error \(error)")
             }
         }
         wait(for: [resultExpectation], timeout: apiTimeout)
-
-        // Signout to clear the userdefaults so that this value do not affect other test
-        let signOutResultExpectation = expectation(description: "Should receive a result")
-        _ = plugin.signOut(options: AuthSignOutRequest.Options(), listener: { _ in
-            signOutResultExpectation.fulfill()
-        })
-        wait(for: [signOutResultExpectation], timeout: apiTimeout)
     }
 
     /// Test a signIn with error and private session
@@ -296,7 +289,7 @@ class AuthenticationProviderSigninWithWebUITests: BaseAuthenticationProviderTest
                     XCTFail("Should produce service error but instead produced \(error)")
                     return
                 }
-                XCTAssertFalse(AWSCognitoAuthPluginUserDefaults.isPrivateSessionPreferred(),
+                XCTAssertFalse(self.mockUserDefault.isPrivateSessionPreferred(),
                               "Prefer private session userdefaults should not be set.")
             }
         }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithWebUITests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninWithWebUITests.swift
@@ -223,6 +223,85 @@ class AuthenticationProviderSigninWithWebUITests: BaseAuthenticationProviderTest
         }
         wait(for: [resultExpectation], timeout: apiTimeout)
     }
+
+    /// Test a signIn with valid inputs and private session
+    ///
+    /// - Given: Given an auth plugin with mocked service.
+    ///
+    /// - When:
+    ///    - I invoke signIn with valid values and private session as option
+    /// - Then:
+    ///    - I should get a .done response and user defaults should store private session
+    ///
+    func testSuccessfulSignInWithPrivateSession() {
+
+        let mockSigninResult = UserState.signedIn
+        mockAWSMobileClient?.showSignInMockResult = .success(mockSigninResult)
+        let options = AuthWebUISignInRequest.optionWithPrivateSession()
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signInWithWebUI(presentationAnchor: window, options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                guard case .done = signinResult.nextStep else {
+                    XCTFail("Result should be .done for next step")
+                    return
+                }
+                XCTAssertTrue(signinResult.isSignedIn, "Signin result should be complete")
+                XCTAssertTrue(AWSCognitoAuthPluginUserDefaults.isPrivateSessionPreferred(),
+                              "Prefer private session userdefaults should be set.")
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+
+        // Signout to clear the userdefaults so that this value do not affect other test
+        let signOutResultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signOut(options: AuthSignOutRequest.Options(), listener: { _ in
+            signOutResultExpectation.fulfill()
+        })
+        wait(for: [signOutResultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with error and private session
+    ///
+    /// - Given: Given an auth plugin with mocked service.
+    ///
+    /// - When:
+    ///    - I invoke signIn and mock securityFailed
+    /// - Then:
+    ///    - I should get a .service error and private session should not be set.
+    ///
+    func testSignInWithPrivateSessionServiceError() {
+
+        let error = AWSMobileClientError.securityFailed(message: "")
+        mockAWSMobileClient?.showSignInMockResult = .failure(error)
+        let options = AuthWebUISignInRequest.optionWithPrivateSession()
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signInWithWebUI(presentationAnchor: window, options: options) { result in
+
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                XCTFail("Should throw user cancelled error, instead - \(signinResult)")
+            case .failure(let error):
+                guard case .service = error else {
+                    XCTFail("Should produce service error but instead produced \(error)")
+                    return
+                }
+                XCTAssertFalse(AWSCognitoAuthPluginUserDefaults.isPrivateSessionPreferred(),
+                              "Prefer private session userdefaults should not be set.")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
 }
 
 class MockRootUIViewController: UIViewController {

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignoutTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignoutTests.swift
@@ -353,10 +353,9 @@ class AuthenticationProviderSignoutTests: BaseAuthenticationProviderTest {
 
         let mockSigninResult = UserState.signedIn
         mockAWSMobileClient?.showSignInMockResult = .success(mockSigninResult)
-        let options = AuthWebUISignInRequest.optionWithPrivateSession()
 
         let resultExpectation = expectation(description: "Should receive a result")
-        _ = plugin.signInWithWebUI(presentationAnchor: window, options: options) { result in
+        _ = plugin.signInWithWebUI(presentationAnchor: window, options: .preferPrivateSession()) { result in
             defer {
                 resultExpectation.fulfill()
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignoutTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignoutTests.swift
@@ -367,7 +367,7 @@ class AuthenticationProviderSignoutTests: BaseAuthenticationProviderTest {
                     return
                 }
                 XCTAssertTrue(signinResult.isSignedIn, "Signin result should be complete")
-                XCTAssertTrue(AWSCognitoAuthPluginUserDefaults.isPrivateSessionPreferred(),
+                XCTAssertTrue(self.mockUserDefault.isPrivateSessionPreferred(),
                               "Prefer private session userdefaults should be set.")
             case .failure(let error):
                 XCTFail("Received failure with error \(error)")
@@ -384,7 +384,7 @@ class AuthenticationProviderSignoutTests: BaseAuthenticationProviderTest {
 
             switch result {
             case .success:
-                XCTAssertFalse(AWSCognitoAuthPluginUserDefaults.isPrivateSessionPreferred(),
+                XCTAssertFalse(self.mockUserDefault.isPrivateSessionPreferred(),
                               "Prefer private session userdefaults should be set to false.")
             case .failure(let error):
                 guard case .unknown(_, let underlyingError) = error,
@@ -402,5 +402,4 @@ class AuthenticationProviderSignoutTests: BaseAuthenticationProviderTest {
         window.rootViewController = MockRootUIViewController()
         return window
     }
-
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignoutTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSignoutTests.swift
@@ -340,4 +340,67 @@ class AuthenticationProviderSignoutTests: BaseAuthenticationProviderTest {
         wait(for: [resultExpectation], timeout: apiTimeout)
     }
 
+    /// Test a signout clears private session after signin via privatesession
+    ///
+    /// - Given: Given an auth plugin with mocked service.
+    ///
+    /// - When:
+    ///    - I invoke signout on a private session
+    /// - Then:
+    ///    - I should get a successful response and user defaults should clear the private session
+    ///
+    func testSuccessfulSignOutWithPrivateSession() {
+
+        let mockSigninResult = UserState.signedIn
+        mockAWSMobileClient?.showSignInMockResult = .success(mockSigninResult)
+        let options = AuthWebUISignInRequest.optionWithPrivateSession()
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signInWithWebUI(presentationAnchor: window, options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                guard case .done = signinResult.nextStep else {
+                    XCTFail("Result should be .done for next step")
+                    return
+                }
+                XCTAssertTrue(signinResult.isSignedIn, "Signin result should be complete")
+                XCTAssertTrue(AWSCognitoAuthPluginUserDefaults.isPrivateSessionPreferred(),
+                              "Prefer private session userdefaults should be set.")
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+
+        let signOutOptions = AuthSignOutRequest.Options()
+        let signOutResultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signOut(options: signOutOptions) { result in
+            defer {
+                signOutResultExpectation.fulfill()
+            }
+
+            switch result {
+            case .success:
+                XCTAssertFalse(AWSCognitoAuthPluginUserDefaults.isPrivateSessionPreferred(),
+                              "Prefer private session userdefaults should be set to false.")
+            case .failure(let error):
+                guard case .unknown(_, let underlyingError) = error,
+                      case .canceledLogin = (underlyingError as? SFAuthenticationError)?.code else {
+                    XCTFail("Should produce SFAuthenticationError error instead of \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [signOutResultExpectation], timeout: apiTimeout)
+    }
+
+    var window: UIWindow {
+        let window = UIWindow()
+        window.rootViewController = MockRootUIViewController()
+        return window
+    }
+
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/BaseAuthenticationProviderTest.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/BaseAuthenticationProviderTest.swift
@@ -34,7 +34,6 @@ class BaseAuthenticationProviderTest: XCTestCase {
     }
 
     override func tearDown() {
-        mockUserDefault.clearDefaults()
         mockUserDefault = nil
         plugin = nil
         mockAWSMobileClient = nil

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/BaseAuthenticationProviderTest.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/BaseAuthenticationProviderTest.swift
@@ -17,11 +17,14 @@ class BaseAuthenticationProviderTest: XCTestCase {
     let apiTimeout = 2.0
     var authenticationProvider: AuthenticationProviderAdapter!
     var mockAWSMobileClient: MockAWSMobileClient!
+    var mockUserDefault: MockUserDefaults!
     var plugin: AWSCognitoAuthPlugin!
 
     override func setUp() {
         mockAWSMobileClient = MockAWSMobileClient()
-        authenticationProvider = AuthenticationProviderAdapter(awsMobileClient: mockAWSMobileClient!)
+        mockUserDefault = MockUserDefaults()
+        authenticationProvider = AuthenticationProviderAdapter(awsMobileClient: mockAWSMobileClient!,
+                                                               userdefaults: mockUserDefault)
         plugin = AWSCognitoAuthPlugin()
         plugin?.configure(authenticationProvider: authenticationProvider,
                          authorizationProvider: MockAuthorizationProviderBehavior(),
@@ -31,6 +34,8 @@ class BaseAuthenticationProviderTest: XCTestCase {
     }
 
     override func tearDown() {
+        mockUserDefault.clearDefaults()
+        mockUserDefault = nil
         plugin = nil
         mockAWSMobileClient = nil
         authenticationProvider = nil

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAWSMobileClient.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAWSMobileClient.swift
@@ -9,6 +9,10 @@
 import AWSMobileClient
 
 class MockAWSMobileClient: AWSMobileClientBehavior {
+    func signOut(uiwindow: UIWindow, options: SignOutOptions, completionHandler: @escaping ((Error?) -> Void)) {
+
+    }
+
 
     var signupMockResult: Result<SignUpResult, Error>?
     var confirmSignUpMockResult: Result<SignUpResult, Error>?
@@ -85,6 +89,12 @@ class MockAWSMobileClient: AWSMobileClientBehavior {
     func showSignIn(navigationController: UINavigationController,
                     signInUIOptions: SignInUIOptions,
                     hostedUIOptions: HostedUIOptions?,
+                    _ completionHandler: @escaping (UserState?, Error?) -> Void) {
+        prepareResult(mockResult: showSignInMockResult, completionHandler: completionHandler)
+    }
+
+    func showSignIn(uiwindow: UIWindow,
+                    hostedUIOptions: HostedUIOptions,
                     _ completionHandler: @escaping (UserState?, Error?) -> Void) {
         prepareResult(mockResult: showSignInMockResult, completionHandler: completionHandler)
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockUserDefaults.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockUserDefaults.swift
@@ -10,23 +10,19 @@ import Foundation
 
 struct MockUserDefaults: AWSCognitoAuthPluginUserDefaultsBehavior {
 
-    let userDefaults: UserDefaults
-    let suiteName = "AWSCognitoAuthPluginUnitTest"
+    var userDefaultsDict: NSMutableDictionary
+
     let privateSessionKey = "AWSCognitoAuthPluginUnitTest.privateSessionKey"
 
     init() {
-        self.userDefaults = UserDefaults.init(suiteName: suiteName)!
+        self.userDefaultsDict = NSMutableDictionary()
     }
 
     func storePreferredBrowserSession(privateSessionPrefered: Bool) {
-        userDefaults.setValue(privateSessionPrefered, forKey: privateSessionKey)
+        userDefaultsDict.setValue(privateSessionPrefered, forKey: privateSessionKey)
     }
 
     func isPrivateSessionPreferred() -> Bool {
-        return userDefaults.bool(forKey: privateSessionKey)
-    }
-
-    func clearDefaults() {
-        userDefaults.removeObject(forKey: privateSessionKey)
+        return userDefaultsDict[privateSessionKey] as? Bool ?? false
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockUserDefaults.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockUserDefaults.swift
@@ -1,0 +1,32 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+@testable import AWSCognitoAuthPlugin
+
+struct MockUserDefaults: AWSCognitoAuthPluginUserDefaultsBehavior {
+
+    let userDefaults: UserDefaults
+    let suiteName = "AWSCognitoAuthPluginUnitTest"
+    let privateSessionKey = "AWSCognitoAuthPluginUnitTest.privateSessionKey"
+
+    init() {
+        self.userDefaults = UserDefaults.init(suiteName: suiteName)!
+    }
+
+    func storePreferredBrowserSession(privateSessionPrefered: Bool) {
+        userDefaults.setValue(privateSessionPrefered, forKey: privateSessionKey)
+    }
+
+    func isPrivateSessionPreferred() -> Bool {
+        return userDefaults.bool(forKey: privateSessionKey)
+    }
+
+    func clearDefaults() {
+        userDefaults.removeObject(forKey: privateSessionKey)
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/aws-sdk-ios/issues/3141

*Description of changes:*

- HostedUI signIn defaults to `ASWebAuthenticationSession` in iOS 13.0+
- Added a new parameter in `AWSAuthWebUISignInOptions` called `preferPrivateSession` which will start the hostedUI in `prefersEphemeralWebBrowserSession` of `ASWebAuthenticationSession`.

_*Developer Experience*_

1. There is no change in the signIn or signOut api for existing developers if they do not need to add the new feature of preferPrivateSession.
2. Existing developer (including Flutter) need to update the userCancelled error if they are dependent on it, explained here - https://github.com/aws-amplify/amplify-ios/pull/982
3. New feature is only available for iOS >= 13.0, so if the app runs in a iOS version lesser than 13.0, the `preferPrivateSession` will not have any effect and the signOut will see the popup.
4. PrivateSession is guaranteed to work in Safari, and might not work if the default browser of the user is different, developer should be aware of this. 
5. Developer code after the new properties are added:

```swift
// Sign in With private session
let pluginOption = AWSAuthWebUISignInOptions(preferPrivateSession: true)
let webUISignInoptions = AuthWebUISignInRequest.Options(pluginOptions: pluginOption)
Amplify.Auth.signInWithWebUI(presentationAnchor: self.view.window!, 
                             options: webUISignInoptions) { ... }

// Using the static builder options to signin with private session
Amplify.Auth.signInWithWebUI(presentationAnchor: self.view.window!, 
                             options: .preferPrivateSession()) { ... }


// Sign in Without private session
Amplify.Auth.signInWithWebUI(presentationAnchor: self.view.window!) { ... }

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
