### PR TITLE
chore: pr title conventional commits validation

### DIFF
--- a/.github/workflows/pr_title_conventional_commits.yml
+++ b/.github/workflows/pr_title_conventional_commits.yml
@@ -1,0 +1,16 @@
+name: Check PR title
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v3.2.6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
*Description of changes:*
Adds check to validate that PRs title matches [Conventional Commits](https://www.conventionalcommits.org/) specs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
