### PR TITLE
feat(api): fix querystring encoding according to AWS SigV4

### DIFF
--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 		6B8D479D25801DF700E841CB /* AmplifyReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8D479C25801DF700E841CB /* AmplifyReachability.swift */; };
 		6BD4620625380EA200906831 /* OIDCAuthProviderWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD4620525380EA200906831 /* OIDCAuthProviderWrapper.swift */; };
 		6BD462082538102500906831 /* AuthTokenProviderWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD462072538102500906831 /* AuthTokenProviderWrapper.swift */; };
+		76148E0925D896EA007F3F21 /* URLComponents+sigv4Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76148E0825D896EA007F3F21 /* URLComponents+sigv4Encoding.swift */; };
 		7632AD8A252E1E10009B5BC9 /* AppSyncJSONValue+toJSONValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7632AD89252E1E10009B5BC9 /* AppSyncJSONValue+toJSONValue.swift */; };
 		9B13EA5E48896E8B38883633 /* Pods_HostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 930DD773E0FB4047393CA2AD /* Pods_HostApp.framework */; };
 		A04815BCD5F9181C8AEDEF43 /* Pods_AWSAPICategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 881AB4B98B48235DEC7754C2 /* Pods_AWSAPICategoryPlugin.framework */; };
@@ -471,6 +472,7 @@
 		6BD462072538102500906831 /* AuthTokenProviderWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTokenProviderWrapper.swift; sourceTree = "<group>"; };
 		6DD6386039136045F18D44AC /* Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithUserPoolIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSAPICategoryPluginTestCommon_RESTWithUserPoolIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74EDB7008F5342ED4B38C9CA /* Pods_HostApp_AWSAPICategoryPluginIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSAPICategoryPluginIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		76148E0825D896EA007F3F21 /* URLComponents+sigv4Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLComponents+sigv4Encoding.swift"; sourceTree = "<group>"; };
 		7632AD89252E1E10009B5BC9 /* AppSyncJSONValue+toJSONValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSyncJSONValue+toJSONValue.swift"; sourceTree = "<group>"; };
 		77792DD821FC754D857FC63C /* Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithIAMIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithIAMIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithIAMIntegrationTests/Pods-HostApp-AWSAPICategoryPluginTestCommon-GraphQLWithIAMIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		7866FCFB5807C2D20219CEBE /* Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithIAMIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithIAMIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithIAMIntegrationTests/Pods-HostApp-AWSAPICategoryPluginTestCommon-RESTWithIAMIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -963,6 +965,7 @@
 			isa = PBXGroup;
 			children = (
 				21D7A0C5237B54D90057D00D /* AWSAppSyncGraphQLResponse.swift */,
+				76148E0825D896EA007F3F21 /* URLComponents+sigv4Encoding.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -2398,6 +2401,7 @@
 				6B382B452538E53700906593 /* AWSAPIPlugin+APIAuthProviderFactoryBehavior.swift in Sources */,
 				6B33897023AABF1800561E5B /* NetworkReachability.swift in Sources */,
 				21D7A0FE237B54D90057D00D /* URLSessionDataTaskBehavior.swift in Sources */,
+				76148E0925D896EA007F3F21 /* URLComponents+sigv4Encoding.swift in Sources */,
 				21A4F94C25A7ACE600E1047D /* GraphQLRequest+toListQuery.swift in Sources */,
 				216449482587E92B00C548A5 /* GraphQLResponseDecoder.swift in Sources */,
 				21D7A0E5237B54D90057D00D /* AWSAPICategoryPluginConfiguration.swift in Sources */,

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Internal/URLComponents+sigv4Encoding.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Internal/URLComponents+sigv4Encoding.swift
@@ -1,0 +1,36 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// Per AWS reference guide https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+/// URL querystring should be encoded according to the following rules::
+/// - percent-encode with %XY (X and Y are hexadecimal characters) all characters
+///   but any of the __unreserved characters__ defined by `RFC3986` (A-Za-z0-9-_.~)
+/// - encode spaces with %20
+/// - double encode any equals in params values
+///
+/// `URLComponents` encodes queryItems values by strictly following `RFC 3986`.
+/// This function encode missing characters needed to make the querystring compliant to AWS guidelines
+/// without double encoding those characters already encoded by `URLComponents`
+extension URLComponents {
+    static var sigV4UnreservedCharacters: CharacterSet = {
+        var sigV4UnreservedCharacters = CharacterSet(charactersIn: "A" ... "Z")
+        sigV4UnreservedCharacters = sigV4UnreservedCharacters.union(CharacterSet(charactersIn: "a" ... "z"))
+        sigV4UnreservedCharacters = sigV4UnreservedCharacters.union(CharacterSet(charactersIn: "0" ... "9"))
+        sigV4UnreservedCharacters = sigV4UnreservedCharacters.union(CharacterSet(charactersIn: "-_~.%=&"))
+        return sigV4UnreservedCharacters
+    }()
+
+    mutating func percentEncodeQueryBySigV4Rules() {
+        guard let percentEncodedQuery = self.percentEncodedQuery else {
+            return
+        }
+        self.percentEncodedQuery = percentEncodedQuery.addingPercentEncoding(
+            withAllowedCharacters: Self.sigV4UnreservedCharacters)
+    }
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Internal/URLComponents+sigv4Encoding.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Internal/URLComponents+sigv4Encoding.swift
@@ -45,7 +45,8 @@ extension URLComponents {
                 throw APIError.invalidURL(
                     "Invalid query parameter.",
                     """
-                    Review your API plugin configuration and make sure to pass valid query parameters in your request.
+                    Review your Amplify.API call to make sure you are passing \
+                    valid UTF-8 query parameters in your request.
                     The value passed was '\(name)=\(value)'
                     """)
             }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Internal/URLComponents+sigv4Encoding.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Internal/URLComponents+sigv4Encoding.swift
@@ -26,23 +26,22 @@ extension URLComponents {
         return sigV4UnreservedCharacters
     }()
 
-    private func encodeQueryParamValueBySigV4Rules(_ value: String) -> String {
-        /// removingPercentEncoding returns `nil` if called on a value
-        /// that hasn't been prior encoded
+    private func encodeQueryParamItemBySigV4Rules(_ value: String) -> String {
+        // removingPercentEncoding returns `nil` if called on a value
+        // that hasn't been prior encoded
         let unencoded = value.removingPercentEncoding ?? value
 
-        /// apply sigv4 encoding
         return unencoded.addingPercentEncoding(
             withAllowedCharacters: Self.sigV4UnreservedCharacters) ?? value
     }
 
-    mutating func queryItemsEncodedPerSigV4Rules(_ queryItems: [String: String]?) {
+    mutating func encodeQueryItemsPerSigV4Rules(_ queryItems: [String: String]?) {
         guard let queryItems = queryItems else {
             return
         }
-        percentEncodedQuery = queryItems.map { (name, value) -> String in
-            let encodedName = encodeQueryParamValueBySigV4Rules(name)
-            let encodedValue = encodeQueryParamValueBySigV4Rules(value)
+        percentEncodedQuery = queryItems.map { name, value in
+            let encodedName = encodeQueryParamItemBySigV4Rules(name)
+            let encodedValue = encodeQueryParamItemBySigV4Rules(value)
 
             return [encodedName, encodedValue].joined(separator: "=")
         }.joined(separator: "&")

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Internal/URLComponents+sigv4Encoding.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Internal/URLComponents+sigv4Encoding.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Amplify
 
 /// Per AWS reference guide https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
 /// URL querystring should be encoded according to the following rules:
@@ -41,14 +42,15 @@ extension URLComponents {
         percentEncodedQuery = try queryItems.map { name, value in
             guard let encodedName = encodeQueryParamItemBySigV4Rules(name),
                   let encodedValue = encodeQueryParamItemBySigV4Rules(value) else {
-                throw SigV4Error.invalidQueryItem(name, value)
+                throw APIError.invalidURL(
+                    "Invalid query parameter.",
+                    """
+                    Review your API plugin configuration and make sure to pass valid query parameters in your request.
+                    The value passed was '\(name)=\(value)'
+                    """)
             }
 
             return [encodedName, encodedValue].joined(separator: "=")
         }.joined(separator: "&")
-    }
-
-    private enum SigV4Error: Error {
-        case invalidQueryItem(String, String)
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequestUtils.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequestUtils.swift
@@ -29,8 +29,15 @@ final class RESTOperationRequestUtils {
             components.path.append(path)
         }
 
-        if let queryParameters = queryParameters {
-            components.encodeQueryItemsPerSigV4Rules(queryParameters)
+        do {
+            try components.encodeQueryItemsPerSigV4Rules(queryParameters)
+        } catch {
+            throw APIError.invalidURL(
+                "Invalid query parameters \(error)",
+                """
+                Review your API plugin configuration and make sure to pass valid query parameters in your request.
+                The value passed was '\(String(describing: queryParameters?.debugDescription))'
+                """, error)
         }
 
         guard let url = components.url else {

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequestUtils.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequestUtils.swift
@@ -30,7 +30,7 @@ final class RESTOperationRequestUtils {
         }
 
         if let queryParameters = queryParameters {
-            components.queryItemsEncodedPerSigV4Rules(queryParameters)
+            components.encodeQueryItemsPerSigV4Rules(queryParameters)
         }
 
         guard let url = components.url else {

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequestUtils.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequestUtils.swift
@@ -30,10 +30,7 @@ final class RESTOperationRequestUtils {
         }
 
         if let queryParameters = queryParameters {
-            components.queryItems = queryParameters.map { (name, value) -> URLQueryItem in
-                URLQueryItem(name: name, value: value)
-            }
-            components.percentEncodeQueryBySigV4Rules()
+            components.queryItemsEncodedPerSigV4Rules(queryParameters)
         }
 
         guard let url = components.url else {

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequestUtils.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequestUtils.swift
@@ -29,10 +29,11 @@ final class RESTOperationRequestUtils {
             components.path.append(path)
         }
 
-        if let queryParameters = queryParameters {
+        if let queryParameters = queryParameters?.sorted(by: { $0.key < $1.key }) {
             components.queryItems = queryParameters.map { (name, value) -> URLQueryItem in
                 URLQueryItem(name: name, value: value)
             }
+            components.percentEncodeQueryBySigV4Rules()
         }
 
         guard let url = components.url else {

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequestUtils.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequestUtils.swift
@@ -29,16 +29,7 @@ final class RESTOperationRequestUtils {
             components.path.append(path)
         }
 
-        do {
-            try components.encodeQueryItemsPerSigV4Rules(queryParameters)
-        } catch {
-            throw APIError.invalidURL(
-                "Invalid query parameters \(error)",
-                """
-                Review your API plugin configuration and make sure to pass valid query parameters in your request.
-                The value passed was '\(String(describing: queryParameters?.debugDescription))'
-                """, error)
-        }
+        try components.encodeQueryItemsPerSigV4Rules(queryParameters)
 
         guard let url = components.url else {
             throw APIError.invalidURL(

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequestUtils.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/RESTOperationRequestUtils.swift
@@ -29,7 +29,7 @@ final class RESTOperationRequestUtils {
             components.path.append(path)
         }
 
-        if let queryParameters = queryParameters?.sorted(by: { $0.key < $1.key }) {
+        if let queryParameters = queryParameters {
             components.queryItems = queryParameters.map { (name, value) -> URLQueryItem in
                 URLQueryItem(name: name, value: value)
             }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithIAMIntegrationTests/RESTWithIAMIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithIAMIntegrationTests/RESTWithIAMIntegrationTests.swift
@@ -81,6 +81,49 @@ class RESTWithIAMIntegrationTests: XCTestCase {
         wait(for: [failedInvoked], timeout: TestCommonConstants.networkTimeout)
     }
 
+    func testGetAPIWithQueryParamsSuccess() {
+        let completeInvoked = expectation(description: "request completed")
+        let request = RESTRequest(path: "/items",
+                                  queryParameters: [
+                                    "user": "hello@email.com",
+                                    "created": "2021-06-18T09:00:00Z"
+                                  ])
+        _ = Amplify.API.get(request: request) { event in
+            switch event {
+            case .success(let data):
+                let result = String(decoding: data, as: UTF8.self)
+                print(result)
+                completeInvoked.fulfill()
+            case .failure(let error):
+                XCTFail("Unexpected .failed event: \(error)")
+            }
+        }
+
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+    }
+
+    func testGetAPIWithEncodedQueryParamsSuccess() {
+        let completeInvoked = expectation(description: "request completed")
+        let request = RESTRequest(path: "/items",
+                                  queryParameters: [
+                                    "user": "hello%40email.com",
+                                    "created": "2021-06-18T09%3A00%3A00Z"
+                                  ])
+        _ = Amplify.API.get(request: request) { event in
+            switch event {
+            case .success(let data):
+                let result = String(decoding: data, as: UTF8.self)
+                print(result)
+                completeInvoked.fulfill()
+            case .failure(let error):
+                XCTFail("Unexpected .failed event: \(error)")
+            }
+        }
+
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+    }
+
+
     func testPutAPISuccess() {
         let completeInvoked = expectation(description: "request completed")
         let request = RESTRequest(path: "/items")

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/RESTWithUserPoolIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/RESTWithUserPoolIntegrationTests.swift
@@ -87,6 +87,28 @@ class RESTWithUserPoolIntegrationTests: XCTestCase {
         wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
     }
 
+    func testGetAPIWithEncodedQueryParamsSuccess() {
+        signIn(username: user1.username, password: user1.password)
+        let completeInvoked = expectation(description: "request completed")
+        let request = RESTRequest(path: "/items",
+                                  queryParameters: [
+                                    "user": "hello%40email.com",
+                                    "created": "2021-06-18T09%3A00%3A00Z"
+                                  ])
+        _ = Amplify.API.get(request: request) { event in
+            switch event {
+            case .success(let data):
+                let result = String(decoding: data, as: UTF8.self)
+                print(result)
+                completeInvoked.fulfill()
+            case .failure(let error):
+                XCTFail("Unexpected .failed event: \(error)")
+            }
+        }
+
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+    }
+
     func testGetAPIFailedWithSignedOutError() {
         let failedInvoked = expectation(description: "request failed")
         let request = RESTRequest(path: "/items")

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/RESTWithUserPoolIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/RESTWithUserPoolIntegrationTests.swift
@@ -65,6 +65,28 @@ class RESTWithUserPoolIntegrationTests: XCTestCase {
         wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
     }
 
+    func testGetAPIWithQueryParamsSuccess() {
+        signIn(username: user1.username, password: user1.password)
+        let completeInvoked = expectation(description: "request completed")
+        let request = RESTRequest(path: "/items",
+                                  queryParameters: [
+                                    "user": "hello@email.com",
+                                    "created": "2021-06-18T09:00:00Z"
+                                  ])
+        _ = Amplify.API.get(request: request) { event in
+            switch event {
+            case .success(let data):
+                let result = String(decoding: data, as: UTF8.self)
+                print(result)
+                completeInvoked.fulfill()
+            case .failure(let error):
+                XCTFail("Unexpected .failed event: \(error)")
+            }
+        }
+
+        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+    }
+
     func testGetAPIFailedWithSignedOutError() {
         let failedInvoked = expectation(description: "request failed")
         let request = RESTRequest(path: "/items")

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Utils/RESTRequestUtilsTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Utils/RESTRequestUtilsTests.swift
@@ -41,7 +41,7 @@ class RESTRequestUtilsTests: XCTestCase {
                           "Test \(testCase): Unexpected query items found \(queryParams)")
             return
         }
-        XCTAssertEqual(expected, queryParams, "Test \(testCase): query params mismatch")
+        XCTAssertEqual(queryParams, expected, "Test \(testCase): query params mismatch")
     }
 
     func testConstructURL() throws {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Utils/RESTRequestUtilsTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Utils/RESTRequestUtilsTests.swift
@@ -6,9 +6,67 @@
 //
 
 import XCTest
+@testable import Amplify
+@testable import AWSAPICategoryPlugin
 
 class RESTRequestUtilsTests: XCTestCase {
-    func testClassMustNotBeEmptyOrSwiftFormatWillCrash() {
-        //TODO implement code
+    private struct ConstructURLTestCase {
+        let baseURL: URL
+        let path: String?
+        let queryParameters: [String: String]?
+        let expectedURL: String
+
+        init(_ url: String, _ path: String?, _ params: [String: String]?, expected: String) {
+            self.baseURL = URL(string: url)!
+            self.path = path
+            self.queryParameters = params
+            self.expectedURL = expected
+        }
+    }
+
+    func testConstructURL() throws {
+        let baseURL = "https://aws.amazon.com"
+        let testCases: [ConstructURLTestCase] = [
+            ConstructURLTestCase(baseURL,
+                              "/projects",
+                              ["author": "john@email.com"],
+                              expected: "https://aws.amazon.com/projects?author=john%40email.com"),
+            ConstructURLTestCase(baseURL,
+                              "/projects",
+                              ["created": "2021-06-18T09:00:00Z"],
+                              expected: baseURL + "/projects?created=2021-06-18T09%3A00%3A00Z"),
+            ConstructURLTestCase(baseURL,
+                                 "/projects",
+                                 [
+                                  "created": "2021-06-18T09:00:00Z",
+                                  "param1": "query!",
+                                  "param2": "!*';:@&=+$,/?%#[]()\\"],
+                                 // swiftlint:disable line_length
+                                 expected: baseURL + "/projects?created=2021-06-18T09%3A00%3A00Z&param1=query%21&param2=%21%2A%27%3B%3A%40%26%3D%2B%24%2C%2F%3F%25%23%5B%5D%28%29%5C"),
+            ConstructURLTestCase(baseURL,
+                                 "/projects",
+                                 nil,
+                                 expected: baseURL + "/projects"),
+            ConstructURLTestCase(baseURL, nil, nil, expected: baseURL)
+        ]
+
+        for (index, test) in testCases.enumerated() {
+            let result = try RESTOperationRequestUtils.constructURL(
+                for: test.baseURL,
+                with: test.path,
+                with: test.queryParameters)
+            XCTAssertEqual(result.absoluteString, test.expectedURL, "Failed test case \(index)")
+        }
+    }
+
+    func testConstructURLRequest() throws {
+        let baseURL = URL(string: "https://aws.amazon.com")!
+        let url = try RESTOperationRequestUtils.constructURL(for: baseURL, with: "/projects", with: nil)
+        let urlRequest = RESTOperationRequestUtils.constructURLRequest(with: url, operationType: .get, headers: nil, requestPayload: nil)
+
+        XCTAssertEqual(urlRequest.httpMethod, RESTOperationType.get.rawValue)
+
+        // a REST operation request should always have at least a "content-type" header
+        XCTAssertFalse(urlRequest.allHTTPHeaderFields!.isEmpty)
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Utils/RESTRequestUtilsTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Utils/RESTRequestUtilsTests.swift
@@ -98,4 +98,15 @@ class RESTRequestUtilsTests: XCTestCase {
         // a REST operation request should always have at least a "content-type" header
         XCTAssertFalse(urlRequest.allHTTPHeaderFields!.isEmpty)
     }
+
+    func testConstructURLRequestFailsWithInvalidQueryParams() throws {
+        let baseURL = URL(string: "https://aws.amazon.com")!
+        let paramValue = String(
+            bytes: [0xd8, 0x00] as [UInt8],
+            encoding: String.Encoding.utf16BigEndian)!
+        let invalidQueryParams: [String: String] = ["param": paramValue]
+        XCTAssertThrowsError(try RESTOperationRequestUtils.constructURL(for: baseURL,
+                                                             with: "/projects",
+                                                             with: invalidQueryParams))
+    }
 }


### PR DESCRIPTION
*Issue #977*

*Description of changes:*
This PR fixes an issue where querystring  parameters aren't correctly encoded according per [AWS reference guide ](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html)
`URLComponents` encodes queryItems values by strictly following [`RFC 3986`](https://tools.ietf.org/html/rfc3986), thus characters in the set ` !*';:+$,/?()` aren't percent-encoded.

This PR adds necessary changes to make the querystring compliant to AWS guidelines without double encoding those characters already encoded by `URLComponents`.

**AWSAPIGatewayClient** adopts a similar strategy by encoding the request URL before generating the signature:
https://github.com/aws-amplify/aws-sdk-ios/blob/main/AWSAPIGateway/AWSAPIGatewayClient.m#L97

**Reference**
- http://www.openradar.me/24076063

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
