### PR TITLE
feat(datastore): process OperationDisabled error

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -140,10 +140,10 @@
 		21A4ED5E259CD7F400E1047D /* CoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A4ED5D259CD7F400E1047D /* CoreError.swift */; };
 		21A4ED6E259CDA4600E1047D /* List+LazyLoad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A4ED6D259CDA4600E1047D /* List+LazyLoad.swift */; };
 		21A4ED77259CDF6800E1047D /* List+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A4ED76259CDF6800E1047D /* List+Combine.swift */; };
-		21A7C8AA25ACB6C8004355D6 /* ArrayLiteralListProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C8A925ACB6C8004355D6 /* ArrayLiteralListProviderTests.swift */; };
-		21A7C90225ACC4D1004355D6 /* MockDataStoreResponders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C90125ACC4D1004355D6 /* MockDataStoreResponders.swift */; };
 		21A4F26325A3CD3D00E1047D /* List+Pagination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A4F26225A3CD3D00E1047D /* List+Pagination.swift */; };
 		21A4F8F325A77D9100E1047D /* ListPaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A4F8F225A77D9100E1047D /* ListPaginationTests.swift */; };
+		21A7C8AA25ACB6C8004355D6 /* ArrayLiteralListProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C8A925ACB6C8004355D6 /* ArrayLiteralListProviderTests.swift */; };
+		21A7C90225ACC4D1004355D6 /* MockDataStoreResponders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7C90125ACC4D1004355D6 /* MockDataStoreResponders.swift */; };
 		21AD424B249BF0DA0016FE95 /* AnyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACBAD522386160100E29E56 /* AnyModel.swift */; };
 		21AD424C249BF0DE0016FE95 /* AnyModel+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8EE776238626D60097E4F1 /* AnyModel+Codable.swift */; };
 		21AD424D249BF0E50016FE95 /* AnyModel+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8EE78223862DDB0097E4F1 /* AnyModel+Schema.swift */; };
@@ -227,6 +227,8 @@
 		6BEE081D2533CCFA00133961 /* OGCScenarioBPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE081B2533CCFA00133961 /* OGCScenarioBPost.swift */; };
 		6BEE08242533D30800133961 /* OGCScenarioBMGroupPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE08222533D30800133961 /* OGCScenarioBMGroupPost.swift */; };
 		6BEE08252533D30800133961 /* OGCScenarioBMGroupPost+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE08232533D30800133961 /* OGCScenarioBMGroupPost+Schema.swift */; };
+		7678B38426017D5300B4917F /* AppSyncErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7678B38326017D5300B4917F /* AppSyncErrorTypeTests.swift */; };
+		7678B38526017D5300B4917F /* AppSyncErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7678B38326017D5300B4917F /* AppSyncErrorTypeTests.swift */; };
 		7D5ED6C78E25246DDAF2F2EC /* Pods_Amplify.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84F3A76FB68CEFA45F4BB1BB /* Pods_Amplify.framework */; platformFilter = ios; };
 		7F27B1DCE59C1E674172CCD6 /* Pods_Amplify_AmplifyTestConfigs_AmplifyTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 976D972EC2BBCAAD023694EB /* Pods_Amplify_AmplifyTestConfigs_AmplifyTests.framework */; };
 		881246F5DCC59436DC932469 /* Pods_Amplify_AWSPluginsCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35D92182B8445C8F9B0FAE94 /* Pods_Amplify_AWSPluginsCore.framework */; };
@@ -946,10 +948,10 @@
 		21A4ED5D259CD7F400E1047D /* CoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreError.swift; sourceTree = "<group>"; };
 		21A4ED6D259CDA4600E1047D /* List+LazyLoad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "List+LazyLoad.swift"; sourceTree = "<group>"; };
 		21A4ED76259CDF6800E1047D /* List+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "List+Combine.swift"; sourceTree = "<group>"; };
-		21A7C8A925ACB6C8004355D6 /* ArrayLiteralListProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayLiteralListProviderTests.swift; sourceTree = "<group>"; };
-		21A7C90125ACC4D1004355D6 /* MockDataStoreResponders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDataStoreResponders.swift; sourceTree = "<group>"; };
 		21A4F26225A3CD3D00E1047D /* List+Pagination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "List+Pagination.swift"; sourceTree = "<group>"; };
 		21A4F8F225A77D9100E1047D /* ListPaginationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListPaginationTests.swift; sourceTree = "<group>"; };
+		21A7C8A925ACB6C8004355D6 /* ArrayLiteralListProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayLiteralListProviderTests.swift; sourceTree = "<group>"; };
+		21A7C90125ACC4D1004355D6 /* MockDataStoreResponders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDataStoreResponders.swift; sourceTree = "<group>"; };
 		21AD4255249BFFDF0016FE95 /* DeprecatedTodo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DeprecatedTodo.swift; path = Deprecated/DeprecatedTodo.swift; sourceTree = "<group>"; };
 		21C395B2245729EC00597EA2 /* AppSyncErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncErrorType.swift; sourceTree = "<group>"; };
 		21D79FD9237617C60057D00D /* SubscriptionEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionEvent.swift; sourceTree = "<group>"; };
@@ -1087,6 +1089,7 @@
 		71B6F506E5F3F00B0743A9BF /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.debug.xcconfig"; sourceTree = "<group>"; };
 		73C2E5FA55C85539AD9E39EE /* Pods_Amplify_AWSPluginsCore_CoreMLPredictionsPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Amplify_AWSPluginsCore_CoreMLPredictionsPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7503342A8C13588E2B0DDBDE /* Pods-AmplifyFunctionalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyFunctionalTests.debug.xcconfig"; path = "Target Support Files/Pods-AmplifyFunctionalTests/Pods-AmplifyFunctionalTests.debug.xcconfig"; sourceTree = "<group>"; };
+		7678B38326017D5300B4917F /* AppSyncErrorTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncErrorTypeTests.swift; sourceTree = "<group>"; };
 		77A2D125114EA0FFA11A7EFD /* Pods-AmplifyTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyTests.debug.xcconfig"; path = "Target Support Files/Pods-AmplifyTests/Pods-AmplifyTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7A238096BAB328655B5E388F /* Pods-Amplify-AWSPluginsCore-CoreMLPredictionsPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AWSPluginsCore-CoreMLPredictionsPlugin.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AWSPluginsCore-CoreMLPredictionsPlugin/Pods-Amplify-AWSPluginsCore-CoreMLPredictionsPlugin.debug.xcconfig"; sourceTree = "<group>"; };
 		7A7FD9B3CFF63FD16788A990 /* Pods-Amplify-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.release.xcconfig"; path = "Target Support Files/Pods-Amplify-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests/Pods-Amplify-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin-AWSPinpointAnalyticsPluginTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -2421,6 +2424,14 @@
 			path = Auth;
 			sourceTree = "<group>";
 		};
+		7678B38226017D2900B4917F /* API */ = {
+			isa = PBXGroup;
+			children = (
+				7678B38326017D5300B4917F /* AppSyncErrorTypeTests.swift */,
+			);
+			path = API;
+			sourceTree = "<group>";
+		};
 		95DAAB00237E63370028544F /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -3096,6 +3107,7 @@
 		FA131AB82360FE070008381C /* AWSPluginsCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				7678B38226017D2900B4917F /* API */,
 				6BEE0815253114E600133961 /* Auth */,
 				FA131ABB2360FE070008381C /* Info.plist */,
 				2129BE2223948085006363A1 /* Model */,
@@ -4710,6 +4722,7 @@
 				6B9F7C5225267E1500F1F71C /* MockAWSAuthUser.swift in Sources */,
 				6B5087CD25673AC8000AB673 /* QueryPredicateEvaluateGeneratedTimeTests.swift in Sources */,
 				21AD425A249C0D910016FE95 /* AnyModelTester.swift in Sources */,
+				7678B38526017D5300B4917F /* AppSyncErrorTypeTests.swift in Sources */,
 				6BDF15B62541262000B5BE69 /* ModelWithOwnerAuthAndGroupWithGroupClaim.swift in Sources */,
 				2129BE3C2394828B006363A1 /* GraphQLRequestModelTests.swift in Sources */,
 				2183A56523EA4A8400232880 /* GraphQLListQueryTests.swift in Sources */,
@@ -5184,6 +5197,7 @@
 				FA47B8362350C2D60031A0E3 /* AutoUnsubscribeOperationTests.swift in Sources */,
 				976D4D5124DC8A370083F5AC /* GestureRecognizerTests.swift in Sources */,
 				B4F3E9F824314E2B00F23296 /* AuthCategoryConfigurationTests.swift in Sources */,
+				7678B38426017D5300B4917F /* AppSyncErrorTypeTests.swift in Sources */,
 				FA1C80D6258688BD006160E9 /* DefaultLoggingPluginAmplifyVersionableTests.swift in Sources */,
 				FAC2356E227A056600424678 /* AnalyticsCategoryClientAPITests.swift in Sources */,
 				B4BD6B3323708C0000A1F0A7 /* PredictionsCategoryClientAPITests.swift in Sources */,

--- a/AmplifyPlugins/Core/AWSPluginsCore/API/AppSyncErrorType.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/API/AppSyncErrorType.swift
@@ -13,6 +13,7 @@ public enum AppSyncErrorType: Equatable {
     private static let conditionalCheckFailedErrorString = "ConditionalCheckFailedException"
     private static let conflictUnhandledErrorString = "ConflictUnhandled"
     private static let unauthorizedErrorString = "Unauthorized"
+    private static let operationDisabledErrorString = "OperationDisabled"
 
     /// Conflict detection finds a version mismatch and the conflict handler rejects the mutation.
     /// See https://docs.aws.amazon.com/appsync/latest/devguide/conflict-detection-and-sync.html for more information
@@ -21,6 +22,8 @@ public enum AppSyncErrorType: Equatable {
     case conditionalCheck
 
     case unauthorized
+    
+    case operationDisabled
 
     case unknown(String)
 
@@ -32,6 +35,8 @@ public enum AppSyncErrorType: Equatable {
             self = .conflictUnhandled
         case AppSyncErrorType.unauthorizedErrorString:
             self = .unauthorized
+        case AppSyncErrorType.operationDisabledErrorString:
+            self = .operationDisabled
         default:
             self = .unknown(value)
         }
@@ -45,6 +50,8 @@ public enum AppSyncErrorType: Equatable {
             return AppSyncErrorType.conflictUnhandledErrorString
         case .unauthorized:
             return AppSyncErrorType.unauthorizedErrorString
+        case .operationDisabled:
+            return AppSyncErrorType.operationDisabledErrorString
         case .unknown(let value):
             return value
         }

--- a/AmplifyPlugins/Core/AWSPluginsCore/API/AppSyncErrorType.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/API/AppSyncErrorType.swift
@@ -22,7 +22,7 @@ public enum AppSyncErrorType: Equatable {
     case conditionalCheck
 
     case unauthorized
-    
+
     case operationDisabled
 
     case unknown(String)

--- a/AmplifyPlugins/Core/AWSPluginsCore/API/AppSyncErrorType.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/API/AppSyncErrorType.swift
@@ -23,6 +23,9 @@ public enum AppSyncErrorType: Equatable {
 
     case unauthorized
 
+    /// This error is not for general use unless you have consulted directly with AWS.
+    /// When DataStore encounters this error, it will ignore it and continue running.
+    /// This error is subject to be **deprecated/removed** in the future.
     case operationDisabled
 
     case unknown(String)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/API/AppSyncErrorTypeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/API/AppSyncErrorTypeTests.swift
@@ -1,0 +1,25 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+@testable import AWSPluginsCore
+
+class AppSyncErrorTypeTests: XCTestCase {
+    func testAppSyncErrorTypeFromErrorString() {
+        let errorTypes: [String: AppSyncErrorType] = [
+            AppSyncErrorType.conflictUnhandled.rawValue: .conflictUnhandled,
+            AppSyncErrorType.conditionalCheck.rawValue: .conditionalCheck,
+            AppSyncErrorType.unauthorized.rawValue: .unauthorized,
+            AppSyncErrorType.operationDisabled.rawValue: .operationDisabled,
+            "unknownError": .unknown("unknownError")
+        ]
+        for error in errorTypes {
+            XCTAssertEqual(error.value, AppSyncErrorType(error.key))
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
@@ -92,6 +92,9 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
                 // TODO: dispatch Hub event
                 log.debug("Unauthorized mutation \(errorType)")
                 finish(result: .success(nil))
+            case .operationDisabled:
+                log.debug("Operation disabled \(errorType)")
+                finish(result: .success(nil))
             case .unknown(let errorType):
                 log.debug("Unhandled error with errorType \(errorType)")
                 finish(result: .success(nil))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -132,7 +132,8 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
                     self.eventReconciliationQueueTopic.send(.initialized)
                 }
             }
-        case .disconnected(modelName: let modelName, reason: .unauthorized):
+        case .disconnected(modelName: let modelName, reason: .operationDisabled),
+             .disconnected(modelName: let modelName, reason: .unauthorized):
             connectionStatusSerialQueue.async {
                 self.reconciliationQueues[modelName]?.cancel()
                 self.modelReconciliationQueueSinks[modelName]?.cancel()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -10,7 +10,7 @@ import AWSPluginsCore
 import Combine
 import Foundation
 
-//Used for testing:
+// Used for testing:
 @available(iOS 13.0, *)
 typealias IncomingEventReconciliationQueueFactory =
     ([ModelSchema],
@@ -60,7 +60,7 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
         self.reconciliationQueueConnectionStatus = [:]
         self.modelReconciliationQueueFactory = modelReconciliationQueueFactory ??
             AWSModelReconciliationQueue.init(modelSchema:storageAdapter:api:modelPredicate:auth:incomingSubscriptionEvents:)
-        //TODO: Add target for SyncEngine system to help prevent thread explosion and increase performance
+        // TODO: Add target for SyncEngine system to help prevent thread explosion and increase performance
         // https://github.com/aws-amplify/amplify-ios/issues/399
         self.connectionStatusSerialQueue
             = DispatchQueue(label: "com.amazonaws.DataStore.AWSIncomingEventReconciliationQueue")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -245,7 +245,7 @@ extension AWSModelReconciliationQueue {
         }
         return nil
     }
-    
+
     private func errorTypeValueFrom(graphQLError: GraphQLError) -> String? {
         guard case let .string(errorTypeValue) = graphQLError.extensions?["errorType"] else {
             return nil
@@ -262,7 +262,7 @@ extension AWSModelReconciliationQueue {
         }
         return false
     }
-    
+
     private func isOperationDisabledError(_ error: Error?) -> Bool {
         if let responseError = error as? GraphQLResponseError<ResponseType>,
            let graphQLError = graphqlErrors(from: responseError)?.first,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -184,6 +184,11 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
                 modelReconciliationQueueSubject.send(.disconnected(modelName: modelSchema.name, reason: .unauthorized))
                 return
             }
+            if case let .api(error, _) = dataStoreError,
+               case let APIError.operationError(_, _, underlyingError) = error, isOperationDisabledError(underlyingError) {
+                modelReconciliationQueueSubject.send(.disconnected(modelName: modelSchema.name, reason: .operationDisabled))
+                return
+            }
             log.error("receiveCompletion: error: \(dataStoreError)")
             modelReconciliationQueueSubject.send(completion: .failure(dataStoreError))
         }
@@ -230,7 +235,7 @@ extension AWSModelReconciliationQueue: Resettable {
 
 }
 
-// MARK: Auth errors handling
+// MARK: Errors handling
 @available(iOS 13.0, *)
 extension AWSModelReconciliationQueue {
     private typealias ResponseType = MutationSync<AnyModel>
@@ -240,13 +245,29 @@ extension AWSModelReconciliationQueue {
         }
         return nil
     }
+    
+    private func errorTypeValueFrom(graphQLError: GraphQLError) -> String? {
+        guard case let .string(errorTypeValue) = graphQLError.extensions?["errorType"] else {
+            return nil
+        }
+        return errorTypeValue
+    }
 
     private func isUnauthorizedError(_ error: Error?) -> Bool {
         if let responseError = error as? GraphQLResponseError<ResponseType>,
            let graphQLError = graphqlErrors(from: responseError)?.first,
-           let extensions = graphQLError.extensions,
-           case let .string(errorTypeValue) = extensions["errorType"],
+           let errorTypeValue = errorTypeValueFrom(graphQLError: graphQLError),
            case .unauthorized = AppSyncErrorType(errorTypeValue) {
+            return true
+        }
+        return false
+    }
+    
+    private func isOperationDisabledError(_ error: Error?) -> Bool {
+        if let responseError = error as? GraphQLResponseError<ResponseType>,
+           let graphQLError = graphqlErrors(from: responseError)?.first,
+           let errorTypeValue = errorTypeValueFrom(graphQLError: graphQLError),
+           case .operationDisabled = AppSyncErrorType(errorTypeValue) {
             return true
         }
         return false

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
@@ -11,6 +11,7 @@ import Combine
 
 enum ModelConnectionDisconnectedReason {
     case unauthorized
+    case operationDisabled
 }
 
 enum ModelReconciliationQueueEvent {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -16,6 +16,7 @@ import Combine
 
 // swiftlint:disable type_body_length
 // swiftlint:disable type_name
+// swiftlint:disable file_length
 @available(iOS 13.0, *)
 class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     // swiftlint:enable type_name

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -34,19 +34,22 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     }
     var operationQueue: OperationQueue!
 
-    //This test case attempts to hit a race condition, and may be required to execute multiple times
-    // in order to demonstrate the bug
-    func testTwoConnectionStatusUpdatesAtSameTime() {
-        let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
-
-        let modelReconciliationQueueFactory
-            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:api:modelPredicate:auth:incomingSubscriptionEvents:)
-        let eventQueue = AWSIncomingEventReconciliationQueue(
-            modelSchemas: [Post.schema, Comment.schema],
+    func initEventQueue(modelSchemas: [ModelSchema]) -> AWSIncomingEventReconciliationQueue {
+        let modelReconciliationQueueFactory = MockModelReconciliationQueue.init
+        return AWSIncomingEventReconciliationQueue(
+            modelSchemas: modelSchemas,
             api: apiPlugin,
             storageAdapter: storageAdapter,
             syncExpressions: [],
             modelReconciliationQueueFactory: modelReconciliationQueueFactory)
+    }
+
+    // This test case attempts to hit a race condition, and may be required to execute multiple times
+    // in order to demonstrate the bug
+    func testTwoConnectionStatusUpdatesAtSameTime() {
+        let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
+
+        let eventQueue = initEventQueue(modelSchemas: [Post.schema, Comment.schema])
         eventQueue.start()
 
         // We need to keep this in scope for the duration of the test or else Combine will release the listeners.
@@ -77,14 +80,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
 
     func testSubscriptionFailedWithSingleModelUnauthorizedError() {
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
-        let modelReconciliationQueueFactory
-            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:api:modelPredicate:auth:incomingSubscriptionEvents:)
-        let eventQueue = AWSIncomingEventReconciliationQueue(
-            modelSchemas: [Post.schema],
-            api: apiPlugin,
-            storageAdapter: storageAdapter,
-            syncExpressions: [],
-            modelReconciliationQueueFactory: modelReconciliationQueueFactory)
+        let eventQueue = initEventQueue(modelSchemas: [Post.schema])
         eventQueue.start()
 
         let sink = eventQueue.publisher.sink(receiveCompletion: { _ in
@@ -115,14 +111,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     // model subscriptions out of two failed - Post subscription will fail but Comment will succeed
     func testSubscriptionFailedWithMultipleModels() {
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
-        let modelReconciliationQueueFactory
-            = MockModelReconciliationQueue.init(modelSchema:storageAdapter:api:modelPredicate:auth:incomingSubscriptionEvents:)
-        let eventQueue = AWSIncomingEventReconciliationQueue(
-            modelSchemas: [Post.schema, Comment.schema],
-            api: apiPlugin,
-            storageAdapter: storageAdapter,
-            syncExpressions: [],
-            modelReconciliationQueueFactory: modelReconciliationQueueFactory)
+        let eventQueue = initEventQueue(modelSchemas: [Post.schema, Comment.schema])
         eventQueue.start()
 
         let sink = eventQueue.publisher.sink(receiveCompletion: { _ in
@@ -143,6 +132,36 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
                     .disconnected(modelName: queueName, reason: .unauthorized) :
                     .connected(modelName: queueName)
                 queue.modelReconciliationQueueSubject.send(event)
+            }
+            operationQueue.addOperation(cancellableOperation)
+        }
+        operationQueue.isSuspended = false
+        waitForExpectations(timeout: 2)
+
+        sink.cancel()
+    }
+
+    func testSubscriptionFailedWithSingleModelOperationDisabled() {
+        let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
+        let eventQueue = initEventQueue(modelSchemas: [Post.schema])
+        eventQueue.start()
+
+        let sink = eventQueue.publisher.sink(receiveCompletion: { _ in
+            XCTFail("Not expecting this to call")
+        }, receiveValue: { event  in
+            switch event {
+            case .initialized:
+                expectInitialized.fulfill()
+            default:
+                XCTFail("Should not expect any other state, received: \(event)")
+            }
+        })
+
+        let reconciliationQueues = MockModelReconciliationQueue.mockModelReconciliationQueues
+        for (queueName, queue) in reconciliationQueues {
+            let cancellableOperation = CancelAwareBlockOperation {
+                queue.modelReconciliationQueueSubject.send(
+                    .disconnected(modelName: queueName, reason: .operationDisabled))
             }
             operationQueue.addOperation(cancellableOperation)
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import Combine
 
 @testable import Amplify
 @testable import AmplifyTestCommon
@@ -393,6 +394,61 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                    eventsSentViaPublisher3], timeout: 1.0)
     }
 
+}
+
+extension ModelReconciliationQueueBehaviorTests {
+    private func completionSignalWithAppSyncError(_ error: AppSyncErrorType) -> Subscribers.Completion<DataStoreError> {
+        let appSyncJSONValue: JSONValue = .string(error.rawValue)
+        let graphqlError = GraphQLError.init(message: "",
+                                             locations: nil,
+                                             path: nil,
+                                             extensions: [
+                                                "errorType": appSyncJSONValue])
+        let graphqlResponseError = GraphQLResponseError<MutationSync<AnyModel>>.error([graphqlError])
+        let apiError = APIError.operationError("error message", "recovery message", graphqlResponseError)
+        let dataStoreError = DataStoreError.api(apiError, nil)
+        return .failure(dataStoreError)
+    }
+
+    func testProcessingUnauthorizedError() {
+        let eventSentViaPublisher = expectation(description: "Sent via publisher")
+        let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
+                                                storageAdapter: storageAdapter,
+                                                api: apiPlugin,
+                                                modelPredicate: modelPredicate,
+                                                auth: authPlugin,
+                                                incomingSubscriptionEvents: subscriptionEventsPublisher)
+        let completion = completionSignalWithAppSyncError(AppSyncErrorType.unauthorized)
+
+        let queueSink = queue.publisher.sink(receiveCompletion: { value in
+            XCTFail("Not expecting a call to completion, received \(value)")
+        }, receiveValue: { _ in
+            eventSentViaPublisher.fulfill()
+        })
+
+        subscriptionEventsSubject.send(completion: completion)
+        wait(for: [eventSentViaPublisher], timeout: 1.0)
+    }
+
+    func testProcessingOperationDisabledError() {
+        let eventSentViaPublisher = expectation(description: "Sent via publisher")
+        let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
+                                                storageAdapter: storageAdapter,
+                                                api: apiPlugin,
+                                                modelPredicate: modelPredicate,
+                                                auth: authPlugin,
+                                                incomingSubscriptionEvents: subscriptionEventsPublisher)
+        let completion = completionSignalWithAppSyncError(AppSyncErrorType.operationDisabled)
+
+        let queueSink = queue.publisher.sink(receiveCompletion: { value in
+            XCTFail("Not expecting a call to completion, received \(value)")
+        }, receiveValue: { _ in
+            eventSentViaPublisher.fulfill()
+        })
+
+        subscriptionEventsSubject.send(completion: completion)
+        wait(for: [eventSentViaPublisher], timeout: 1.0)
+    }
 }
 
 enum EventState {


### PR DESCRIPTION
*Description of changes:*
This PR introduces a set of changes to let DataStore process a new type of error _OperationDisabled_ without halting the sync engine.
Developers will be able to mark an operation as "disabled" by throwing an error directly from an AppSync resolver
```JavaScript
$util.error("Subscription are disabled.", "OperationDisabled")
```

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
