### PR TITLE
fix(auth): handle tooManyRequests and limitExceeded separately in AuthErrorHelper

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Error/AWSCognitoAuthError.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Error/AWSCognitoAuthError.swift
@@ -34,7 +34,7 @@ public enum AWSCognitoAuthError: Error {
     /// Password given is invalid.
     case invalidPassword
 
-    /// Number of allowed operation have exceeded.
+    /// The user has exceeded the limit for a requested AWS resource.
     case limitExceeded
 
     /// Amazon Cognito cannot find a multi-factor authentication (MFA) method.

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Error/AWSCognitoAuthError.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Error/AWSCognitoAuthError.swift
@@ -34,7 +34,7 @@ public enum AWSCognitoAuthError: Error {
     /// Password given is invalid.
     case invalidPassword
 
-    /// The user has exceeded the limit for a requested AWS resource.
+    /// Limit exceeded for the requested AWS resource
     case limitExceeded
 
     /// Amazon Cognito cannot find a multi-factor authentication (MFA) method.

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Constants/AuthPluginErrorConstants.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Constants/AuthPluginErrorConstants.swift
@@ -233,7 +233,7 @@ extension AuthPluginErrorConstants {
     """
 
     static let limitExceededError: RecoverySuggestion = """
-    User might have exceeded the resource limit of the requested AWS resource
+    Make sure that the request made to the particular AWS resources are under the resource quota limits
     """
 
     static let configurationError: RecoverySuggestion = """

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Constants/AuthPluginErrorConstants.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Constants/AuthPluginErrorConstants.swift
@@ -229,7 +229,11 @@ extension AuthPluginErrorConstants {
     static let tooManyFailedError: RecoverySuggestion = "User might have tried too many times with failed input"
 
     static let tooManyRequestError: RecoverySuggestion = """
-    Make sure the requests send are controlled and the errors are properlly handled
+    Make sure the requests send are controlled and the errors are properly handled
+    """
+
+    static let limitExceededError: RecoverySuggestion = """
+    User might have exceeded the resource limit of the requested AWS resource
     """
 
     static let configurationError: RecoverySuggestion = """

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AuthErrorHelper.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AuthErrorHelper.swift
@@ -99,11 +99,15 @@ struct AuthErrorHelper {
                                             AuthPluginErrorConstants.tooManyFailedError,
                                             AWSCognitoAuthError.failedAttemptsLimitExceeded)
 
-        case .tooManyRequests(let message),
-             .limitExceeded(let message):
+        case .tooManyRequests(let message):
             return AuthError.service(message,
                                             AuthPluginErrorConstants.tooManyRequestError,
                                             AWSCognitoAuthError.requestLimitExceeded)
+
+        case .limitExceeded(let message):
+            return AuthError.service(message,
+                                     AuthPluginErrorConstants.limitExceededError,
+                                     AWSCognitoAuthError.limitExceeded)
 
         case .errorLoadingPage(let message):
             return AuthError.service(message,

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorChangePasswordTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorChangePasswordTests.swift
@@ -149,7 +149,7 @@ class UserBehaviorChangePasswordTests: BaseUserBehaviorTest {
     /// - When:
     ///    - I invoke changePassword with old password and new password
     /// - Then:
-    ///    - I should get a .requestLimitExceeded error
+    ///    - I should get a .limitExceeded error
     ///
     func testChangePasswordWithLimitExceededException() {
 
@@ -168,7 +168,7 @@ class UserBehaviorChangePasswordTests: BaseUserBehaviorTest {
                     XCTFail("Should produce service error instead of \(error)")
                     return
                 }
-                guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
                     XCTFail("Underlying error should be requestLimitExceeded \(error)")
                     return
                 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorChangePasswordTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorChangePasswordTests.swift
@@ -169,7 +169,7 @@ class UserBehaviorChangePasswordTests: BaseUserBehaviorTest {
                     return
                 }
                 guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
-                    XCTFail("Underlying error should be requestLimitExceeded \(error)")
+                    XCTFail("Underlying error should be limitExceeded \(error)")
                     return
                 }
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorConfirmAttributeTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorConfirmAttributeTests.swift
@@ -211,7 +211,7 @@ class UserBehaviorConfirmAttributeTests: BaseUserBehaviorTest {
                     return
                 }
                 guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
-                    XCTFail("Underlying error should be requestLimitExceeded \(error)")
+                    XCTFail("Underlying error should be limitExceeded \(error)")
                     return
                 }
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorConfirmAttributeTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorConfirmAttributeTests.swift
@@ -190,7 +190,7 @@ class UserBehaviorConfirmAttributeTests: BaseUserBehaviorTest {
     /// - When:
     ///    - I invoke confirmUpdateUserAttributes with confirmation code
     /// - Then:
-    ///    - I should get a .requestLimitExceeded error
+    ///    - I should get a .limitExceeded error
     ///
     func testConfirmUpdateUserAttributesWithLimitExceededException() {
 
@@ -210,7 +210,7 @@ class UserBehaviorConfirmAttributeTests: BaseUserBehaviorTest {
                     XCTFail("Should produce service error instead of \(error)")
                     return
                 }
-                guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
                     XCTFail("Underlying error should be requestLimitExceeded \(error)")
                     return
                 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorResendCodeTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorResendCodeTests.swift
@@ -250,7 +250,7 @@ class UserBehaviorResendCodeTests: BaseUserBehaviorTest {
                     return
                 }
                 guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
-                    XCTFail("Underlying error should be requestLimitExceeded \(error)")
+                    XCTFail("Underlying error should be limitExceeded \(error)")
                     return
                 }
 

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorResendCodeTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthUserBehaviorTests/UserBehaviorResendCodeTests.swift
@@ -229,7 +229,7 @@ class UserBehaviorResendCodeTests: BaseUserBehaviorTest {
     /// - When:
     ///    - I invoke resendConfirmationCode
     /// - Then:
-    ///    - I should get a .service error with  .requestLimitExceeded as underlyingError
+    ///    - I should get a .service error with .limitExceeded as underlyingError
     ///
     func testResendConfirmationCodeWithLimitExceededException() {
 
@@ -249,7 +249,7 @@ class UserBehaviorResendCodeTests: BaseUserBehaviorTest {
                     XCTFail("Should produce service error instead of \(error)")
                     return
                 }
-                guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
                     XCTFail("Underlying error should be requestLimitExceeded \(error)")
                     return
                 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderConfirmResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderConfirmResetPasswordTests.swift
@@ -352,7 +352,7 @@ class AuthenticationProviderConfirmResetPasswordTests: BaseAuthenticationProvide
     /// - When:
     ///    - I invoke confirmResetPassword with a valid username, a new password and a confirmation code
     /// - Then:
-    ///    - I should get a .requestLimitExceeded error
+    ///    - I should get a .limitExceeded error
     ///
     func testConfirmResetPasswordWithLimitExceededException() {
 
@@ -374,7 +374,7 @@ class AuthenticationProviderConfirmResetPasswordTests: BaseAuthenticationProvide
                     XCTFail("Should produce service error instead of \(error)")
                     return
                 }
-                guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
                     XCTFail("Underlying error should be resourceNotFound \(error)")
                     return
                 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderConfirmResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderConfirmResetPasswordTests.swift
@@ -375,7 +375,7 @@ class AuthenticationProviderConfirmResetPasswordTests: BaseAuthenticationProvide
                     return
                 }
                 guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
-                    XCTFail("Underlying error should be resourceNotFound \(error)")
+                    XCTFail("Underlying error should be limitExceeded \(error)")
                     return
                 }
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderConfirmSignupTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderConfirmSignupTests.swift
@@ -375,7 +375,7 @@ class AuthenticationProviderConfirmSignupTests: BaseAuthenticationProviderTest {
                     return
                 }
                 guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
-                    XCTFail("Underlying error should be resourceNotFound \(error)")
+                    XCTFail("Underlying error should be limitExceeded \(error)")
                     return
                 }
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderConfirmSignupTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderConfirmSignupTests.swift
@@ -353,7 +353,7 @@ class AuthenticationProviderConfirmSignupTests: BaseAuthenticationProviderTest {
     /// - When:
     ///    - I invoke confirmSignup with a valid username and confirmationCode
     /// - Then:
-    ///    - I should get a .requestLimitExceeded error
+    ///    - I should get a .limitExceeded error
     ///
     func testConfirmSignUpWithLimitExceededException() {
 
@@ -374,7 +374,7 @@ class AuthenticationProviderConfirmSignupTests: BaseAuthenticationProviderTest {
                     XCTFail("Should produce service error instead of \(error)")
                     return
                 }
-                guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
                     XCTFail("Underlying error should be resourceNotFound \(error)")
                     return
                 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderResendSignupCodeTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderResendSignupCodeTests.swift
@@ -330,7 +330,7 @@ class AuthenticationProviderResendSignupCodeTests: BaseAuthenticationProviderTes
                     return
                 }
                 guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
-                    XCTFail("Underlying error should be resourceNotFound \(error)")
+                    XCTFail("Underlying error should be limitExceeded \(error)")
                     return
                 }
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderResendSignupCodeTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderResendSignupCodeTests.swift
@@ -309,7 +309,7 @@ class AuthenticationProviderResendSignupCodeTests: BaseAuthenticationProviderTes
     /// - When:
     ///    - I invoke resendSignUpCode with a valid username
     /// - Then:
-    ///    - I should get a .requestLimitExceeded error
+    ///    - I should get a .limitExceeded error
     ///
     func testResendSignupCodeWithLimitExceededException() {
 
@@ -329,7 +329,7 @@ class AuthenticationProviderResendSignupCodeTests: BaseAuthenticationProviderTes
                     XCTFail("Should produce service error instead of \(error)")
                     return
                 }
-                guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
                     XCTFail("Underlying error should be resourceNotFound \(error)")
                     return
                 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderResetPasswordTests.swift
@@ -324,7 +324,7 @@ class AuthenticationProviderResetPasswordTests: BaseAuthenticationProviderTest {
                     return
                 }
                 guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
-                    XCTFail("Underlying error should be requestLimitExceeded \(error)")
+                    XCTFail("Underlying error should be limitExceeded \(error)")
                     return
                 }
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderResetPasswordTests.swift
@@ -303,7 +303,7 @@ class AuthenticationProviderResetPasswordTests: BaseAuthenticationProviderTest {
     /// - When:
     ///    - I invoke resetPassword with username
     /// - Then:
-    ///    - I should get a .requestLimitExceeded error
+    ///    - I should get a .limitExceeded error
     ///
     func testResetPasswordWithLimitExceededException() {
 
@@ -323,7 +323,7 @@ class AuthenticationProviderResetPasswordTests: BaseAuthenticationProviderTest {
                     XCTFail("Should produce service error instead of \(error)")
                     return
                 }
-                guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
                     XCTFail("Underlying error should be requestLimitExceeded \(error)")
                     return
                 }


### PR DESCRIPTION
*Issue #, if available:* 1041

*Description of changes:* Removed the coupling tooManyRequests and limitExceeded in the switch block inside AuthErrorHelper 

*Check points:*

~~Added new tests to cover change, if needed~~
- [x] All unit tests pass
- [x] All integration tests pass
~~Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
