### PR TITLE
feat(datastore): support for readonly fields

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -227,6 +227,8 @@
 		6BEE081D2533CCFA00133961 /* OGCScenarioBPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE081B2533CCFA00133961 /* OGCScenarioBPost.swift */; };
 		6BEE08242533D30800133961 /* OGCScenarioBMGroupPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE08222533D30800133961 /* OGCScenarioBMGroupPost.swift */; };
 		6BEE08252533D30800133961 /* OGCScenarioBMGroupPost+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE08232533D30800133961 /* OGCScenarioBMGroupPost+Schema.swift */; };
+		762167CC261542F70033FCD2 /* Record.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762167CB261542F70033FCD2 /* Record.swift */; };
+		762167D52615435C0033FCD2 /* Record+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762167D42615435C0033FCD2 /* Record+Schema.swift */; };
 		7678B38426017D5300B4917F /* AppSyncErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7678B38326017D5300B4917F /* AppSyncErrorTypeTests.swift */; };
 		7678B38526017D5300B4917F /* AppSyncErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7678B38326017D5300B4917F /* AppSyncErrorTypeTests.swift */; };
 		7D5ED6C78E25246DDAF2F2EC /* Pods_Amplify.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84F3A76FB68CEFA45F4BB1BB /* Pods_Amplify.framework */; platformFilter = ios; };
@@ -1089,6 +1091,8 @@
 		71B6F506E5F3F00B0743A9BF /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.debug.xcconfig"; sourceTree = "<group>"; };
 		73C2E5FA55C85539AD9E39EE /* Pods_Amplify_AWSPluginsCore_CoreMLPredictionsPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Amplify_AWSPluginsCore_CoreMLPredictionsPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7503342A8C13588E2B0DDBDE /* Pods-AmplifyFunctionalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyFunctionalTests.debug.xcconfig"; path = "Target Support Files/Pods-AmplifyFunctionalTests/Pods-AmplifyFunctionalTests.debug.xcconfig"; sourceTree = "<group>"; };
+		762167CB261542F70033FCD2 /* Record.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Record.swift; sourceTree = "<group>"; };
+		762167D42615435C0033FCD2 /* Record+Schema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Record+Schema.swift"; sourceTree = "<group>"; };
 		7678B38326017D5300B4917F /* AppSyncErrorTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncErrorTypeTests.swift; sourceTree = "<group>"; };
 		77A2D125114EA0FFA11A7EFD /* Pods-AmplifyTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyTests.debug.xcconfig"; path = "Target Support Files/Pods-AmplifyTests/Pods-AmplifyTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7A238096BAB328655B5E388F /* Pods-Amplify-AWSPluginsCore-CoreMLPredictionsPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AWSPluginsCore-CoreMLPredictionsPlugin.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AWSPluginsCore-CoreMLPredictionsPlugin/Pods-Amplify-AWSPluginsCore-CoreMLPredictionsPlugin.debug.xcconfig"; sourceTree = "<group>"; };
@@ -2886,6 +2890,8 @@
 				6B7743D625906F7E001469F5 /* Restaurant */,
 				6B9F7C542526864800F1F71C /* ScenarioATest6Post.swift */,
 				6B9F7C532526864800F1F71C /* ScenarioATest6Post+Schema.swift */,
+				762167CB261542F70033FCD2 /* Record.swift */,
+				762167D42615435C0033FCD2 /* Record+Schema.swift */,
 				B952182F237E21B900F53237 /* schema.graphql */,
 				6BE9D6E725A6620B00AB5C9A /* TeamProject */,
 				214F49742486D8A200DA616C /* User.swift */,
@@ -5234,6 +5240,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				214F49CD24898E8500DA616C /* Article.swift in Sources */,
+				762167CC261542F70033FCD2 /* Record.swift in Sources */,
+				762167D52615435C0033FCD2 /* Record+Schema.swift in Sources */,
 				B9FAA116238799D3009414B4 /* Author.swift in Sources */,
 				B9521833237E21BA00F53237 /* Comment+Schema.swift in Sources */,
 				FA176ED7238503C200C5C5F9 /* HubListenerTestUtilities.swift in Sources */,

--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -229,6 +229,8 @@
 		6BEE08252533D30800133961 /* OGCScenarioBMGroupPost+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEE08232533D30800133961 /* OGCScenarioBMGroupPost+Schema.swift */; };
 		762167CC261542F70033FCD2 /* Record.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762167CB261542F70033FCD2 /* Record.swift */; };
 		762167D52615435C0033FCD2 /* Record+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762167D42615435C0033FCD2 /* Record+Schema.swift */; };
+		762C978526210F6400798FA3 /* RecordCover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762C978426210F6400798FA3 /* RecordCover.swift */; };
+		762C978E26210FF100798FA3 /* RecordCover+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762C978D26210FF100798FA3 /* RecordCover+Schema.swift */; };
 		7678B38426017D5300B4917F /* AppSyncErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7678B38326017D5300B4917F /* AppSyncErrorTypeTests.swift */; };
 		7678B38526017D5300B4917F /* AppSyncErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7678B38326017D5300B4917F /* AppSyncErrorTypeTests.swift */; };
 		7D5ED6C78E25246DDAF2F2EC /* Pods_Amplify.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84F3A76FB68CEFA45F4BB1BB /* Pods_Amplify.framework */; platformFilter = ios; };
@@ -1093,6 +1095,8 @@
 		7503342A8C13588E2B0DDBDE /* Pods-AmplifyFunctionalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyFunctionalTests.debug.xcconfig"; path = "Target Support Files/Pods-AmplifyFunctionalTests/Pods-AmplifyFunctionalTests.debug.xcconfig"; sourceTree = "<group>"; };
 		762167CB261542F70033FCD2 /* Record.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Record.swift; sourceTree = "<group>"; };
 		762167D42615435C0033FCD2 /* Record+Schema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Record+Schema.swift"; sourceTree = "<group>"; };
+		762C978426210F6400798FA3 /* RecordCover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordCover.swift; sourceTree = "<group>"; };
+		762C978D26210FF100798FA3 /* RecordCover+Schema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecordCover+Schema.swift"; sourceTree = "<group>"; };
 		7678B38326017D5300B4917F /* AppSyncErrorTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncErrorTypeTests.swift; sourceTree = "<group>"; };
 		77A2D125114EA0FFA11A7EFD /* Pods-AmplifyTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyTests.debug.xcconfig"; path = "Target Support Files/Pods-AmplifyTests/Pods-AmplifyTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7A238096BAB328655B5E388F /* Pods-Amplify-AWSPluginsCore-CoreMLPredictionsPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AWSPluginsCore-CoreMLPredictionsPlugin.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AWSPluginsCore-CoreMLPredictionsPlugin/Pods-Amplify-AWSPluginsCore-CoreMLPredictionsPlugin.debug.xcconfig"; sourceTree = "<group>"; };
@@ -2892,6 +2896,8 @@
 				6B9F7C532526864800F1F71C /* ScenarioATest6Post+Schema.swift */,
 				762167CB261542F70033FCD2 /* Record.swift */,
 				762167D42615435C0033FCD2 /* Record+Schema.swift */,
+				762C978426210F6400798FA3 /* RecordCover.swift */,
+				762C978D26210FF100798FA3 /* RecordCover+Schema.swift */,
 				B952182F237E21B900F53237 /* schema.graphql */,
 				6BE9D6E725A6620B00AB5C9A /* TeamProject */,
 				214F49742486D8A200DA616C /* User.swift */,
@@ -5298,6 +5304,7 @@
 				214F49772486D8A200DA616C /* UserFollowers+Schema.swift in Sources */,
 				B9FAA11423878CEA009414B4 /* UserProfile+Schema.swift in Sources */,
 				6BE9D6EF25A6622000AB5C9A /* Team+Schema.swift in Sources */,
+				762C978E26210FF100798FA3 /* RecordCover+Schema.swift in Sources */,
 				217D5EBC2577F9DF009F0639 /* User5.swift in Sources */,
 				6B7743DF25906FD3001469F5 /* Dish.swift in Sources */,
 				217D5EB82577F9DF009F0639 /* Project2+Schema.swift in Sources */,
@@ -5344,6 +5351,7 @@
 				FA1846EE23998E44009B9D01 /* MockAPIResponders.swift in Sources */,
 				6B7743E225906FD3001469F5 /* Dish+Schema.swift in Sources */,
 				217D5EC32577F9DF009F0639 /* PostEditor5.swift in Sources */,
+				762C978526210F6400798FA3 /* RecordCover.swift in Sources */,
 				216E45ED248E914F0035E3CE /* Category.swift in Sources */,
 				6BE9D6ED25A6622000AB5C9A /* Project+Schema.swift in Sources */,
 				6BE9D6EC25A6622000AB5C9A /* Project.swift in Sources */,

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -126,12 +126,7 @@ public enum ModelFieldWritability {
     case readWrite
 
     var isReadOnly: Bool {
-        switch self {
-        case .readOnly:
-            return true
-        case .readWrite:
-            return false
-        }
+        self == .readOnly
     }
 }
 

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -121,17 +121,6 @@ public enum ModelFieldNullability {
 
 /// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
 ///   directly by host applications. The behavior of this may change without warning.
-public enum ModelFieldWritability {
-    case readOnly
-    case readWrite
-
-    var isReadOnly: Bool {
-        self == .readOnly
-    }
-}
-
-/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
-///   directly by host applications. The behavior of this may change without warning.
 public struct ModelSchemaDefinition {
 
     internal let name: String
@@ -178,14 +167,14 @@ public enum ModelFieldDefinition {
     case field(name: String,
                type: ModelFieldType,
                nullability: ModelFieldNullability,
-               writability: ModelFieldWritability,
+               isReadOnly: Bool,
                association: ModelAssociation?,
                attributes: [ModelFieldAttribute],
                authRules: AuthRules)
 
     public static func field(_ key: CodingKey,
                              is nullability: ModelFieldNullability = .required,
-                             access writability: ModelFieldWritability = .readWrite,
+                             isReadOnly: Bool = false,
                              ofType type: ModelFieldType = .string,
                              attributes: [ModelFieldAttribute] = [],
                              association: ModelAssociation? = nil,
@@ -193,7 +182,7 @@ public enum ModelFieldDefinition {
         return .field(name: key.stringValue,
                       type: type,
                       nullability: nullability,
-                      writability: writability,
+                      isReadOnly: isReadOnly,
                       association: association,
                       attributes: attributes,
                       authRules: authRules)
@@ -207,7 +196,7 @@ public enum ModelFieldDefinition {
         return .field(name: name,
                       type: .string,
                       nullability: .required,
-                      writability: .readWrite,
+                      isReadOnly: false,
                       association: nil,
                       attributes: [.primaryKey],
                       authRules: [])
@@ -215,38 +204,38 @@ public enum ModelFieldDefinition {
 
     public static func hasMany(_ key: CodingKey,
                                is nullability: ModelFieldNullability = .required,
-                               access writability: ModelFieldWritability = .readWrite,
+                               isReadOnly: Bool = false,
                                ofType type: Model.Type,
                                associatedWith associatedKey: CodingKey) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
-                      access: writability,
+                      isReadOnly: isReadOnly,
                       ofType: .collection(of: type),
                       association: .hasMany(associatedWith: associatedKey))
     }
 
     public static func hasOne(_ key: CodingKey,
                               is nullability: ModelFieldNullability = .required,
-                              access writability: ModelFieldWritability = .readWrite,
+                              isReadOnly: Bool = false,
                               ofType type: Model.Type,
                               associatedWith associatedKey: CodingKey,
                               targetName: String? = nil) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
-                      access: writability,
+                      isReadOnly: isReadOnly,
                       ofType: .model(type: type),
                       association: .hasOne(associatedWith: associatedKey, targetName: targetName))
     }
 
     public static func belongsTo(_ key: CodingKey,
                                  is nullability: ModelFieldNullability = .required,
-                                 access writability: ModelFieldWritability = .readWrite,
+                                 isReadOnly: Bool = false,
                                  ofType type: Model.Type,
                                  associatedWith associatedKey: CodingKey? = nil,
                                  targetName: String? = nil) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
-                      access: writability,
+                      isReadOnly: isReadOnly,
                       ofType: .model(type: type),
                       association: .belongsTo(associatedWith: associatedKey, targetName: targetName))
     }
@@ -255,7 +244,7 @@ public enum ModelFieldDefinition {
         guard case let .field(name,
                               type,
                               nullability,
-                              writability,
+                              isReadOnly,
                               association,
                               attributes,
                               authRules) = self else {
@@ -264,7 +253,7 @@ public enum ModelFieldDefinition {
         return ModelField(name: name,
                           type: type,
                           isRequired: nullability.isRequired,
-                          isReadOnly: writability.isReadOnly,
+                          isReadOnly: isReadOnly,
                           isArray: type.isArray,
                           attributes: attributes,
                           association: association,

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
+/// - Warning: Although this has `public` access, it is in tended for internal & codegen use and should not be used
 ///   directly by host applications. The behavior of this may change without warning.
 public enum ModelAttribute {
 
@@ -29,6 +29,7 @@ public struct ModelField {
     public let name: String
     public let type: ModelFieldType
     public let isRequired: Bool
+    public let isReadOnly: Bool
     public let isArray: Bool
     public let attributes: [ModelFieldAttribute]
     public let association: ModelAssociation?
@@ -41,6 +42,7 @@ public struct ModelField {
     public init(name: String,
                 type: ModelFieldType,
                 isRequired: Bool = false,
+                isReadOnly: Bool = false,
                 isArray: Bool = false,
                 attributes: [ModelFieldAttribute] = [],
                 association: ModelAssociation? = nil,
@@ -48,6 +50,7 @@ public struct ModelField {
         self.name = name
         self.type = type
         self.isRequired = isRequired
+        self.isReadOnly = isReadOnly
         self.isArray = isArray
         self.attributes = attributes
         self.association = association

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-/// - Warning: Although this has `public` access, it is in tended for internal & codegen use and should not be used
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
 ///   directly by host applications. The behavior of this may change without warning.
 public enum ModelAttribute {
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelDecorator.swift
@@ -27,7 +27,7 @@ public struct ModelDecorator: ModelBasedGraphQLDocumentDecorator {
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
         var inputs = document.inputs
-        var graphQLInput = model.graphQLInput(modelSchema)
+        var graphQLInput = model.graphQLInputForMutation(modelSchema)
 
         if !modelSchema.authRules.isEmpty {
             modelSchema.authRules.forEach { authRule in

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLMutation.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLMutation.swift
@@ -29,8 +29,7 @@ public struct GraphQLMutation: SingleDirectiveGraphQLDocument {
     }
 
     public init(modelSchema: ModelSchema) {
-        let fields = modelSchema.graphQLFields.filter { !$0.isReadOnly }
-        self.selectionSet = SelectionSet(fields: fields)
+        self.selectionSet = SelectionSet(fields: modelSchema.graphQLFields)
     }
 
     public var name: String = ""

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLMutation.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLMutation.swift
@@ -29,7 +29,8 @@ public struct GraphQLMutation: SingleDirectiveGraphQLDocument {
     }
 
     public init(modelSchema: ModelSchema) {
-        self.selectionSet = SelectionSet(fields: modelSchema.graphQLFields)
+        let fields = modelSchema.graphQLFields.filter { !$0.isReadOnly }
+        self.selectionSet = SelectionSet(fields: fields)
     }
 
     public var name: String = ""

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -17,7 +17,7 @@ extension Model {
     /// used as the `input` of GraphQL related operations.
     func graphQLInput(_ modelSchema: ModelSchema) -> GraphQLInput {
         var input: GraphQLInput = [:]
-        modelSchema.fields.forEach {
+        modelSchema.fields.filter { !$0.value.isReadOnly }.forEach {
             let modelField = $0.value
 
             // TODO how to handle associations of type "many" (i.e. cascade save)?

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -15,10 +15,15 @@ extension Model {
 
     /// Get the `Model` values as a `Dictionary` of `String` to `Any?` that can be
     /// used as the `input` of GraphQL related operations.
-    func graphQLInput(_ modelSchema: ModelSchema) -> GraphQLInput {
+    func graphQLInputForMutation(_ modelSchema: ModelSchema) -> GraphQLInput {
         var input: GraphQLInput = [:]
-        modelSchema.fields.filter { !$0.value.isReadOnly }.forEach {
+        modelSchema.fields.forEach {
             let modelField = $0.value
+
+            // When the field is read-only don't add it to the GraphQL input object
+            if modelField.isReadOnly {
+                return
+            }
 
             // TODO how to handle associations of type "many" (i.e. cascade save)?
             // This is not supported right now and might be added as a future feature

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
@@ -248,8 +248,10 @@ class GraphQLCreateMutationTests: XCTestCase {
         mutation CreateRecord($input: CreateRecordInput!) {
           createRecord(input: $input) {
             id
+            createdAt
             description
             name
+            updatedAt
             __typename
             _version
             _deleted
@@ -270,7 +272,7 @@ class GraphQLCreateMutationTests: XCTestCase {
         XCTAssertEqual(input["id"] as? String, record.id)
         XCTAssertEqual(input["name"] as? String, record.name)
         XCTAssertEqual(input["description"] as? String, record.description)
-        XCTAssertNil(input["createdAt"]!)
-        XCTAssertNil(input["updatedAt"]!)
+        XCTAssertNil(input["createdAt"] as? Temporal.DateTime)
+        XCTAssertNil(input["updatedAt"] as? Temporal.DateTime)
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
@@ -237,7 +237,8 @@ class GraphQLCreateMutationTests: XCTestCase {
     }
 
     func testCreateGraphQLMutationFromModelWithReadonlyFields() {
-        let record = Record(name: "name", description: "description")
+        let recordCover = RecordCover(artist: "artist")
+        let record = Record(name: "name", description: "description", cover: recordCover)
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Record.schema,
                                                                operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
@@ -248,6 +248,7 @@ class GraphQLCreateMutationTests: XCTestCase {
         mutation CreateRecord($input: CreateRecordInput!) {
           createRecord(input: $input) {
             id
+            coverId
             createdAt
             description
             name
@@ -274,5 +275,6 @@ class GraphQLCreateMutationTests: XCTestCase {
         XCTAssertEqual(input["description"] as? String, record.description)
         XCTAssertNil(input["createdAt"] as? Temporal.DateTime)
         XCTAssertNil(input["updatedAt"] as? Temporal.DateTime)
+        XCTAssertNil(input["cover"] as? RecordCover)
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDeleteMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDeleteMutationTests.swift
@@ -120,7 +120,8 @@ class GraphQLDeleteMutationTests: XCTestCase {
     }
 
     func testDeleteGraphQLMutationModelWithReadOnlyFields() {
-        let record = Record(name: "name", description: "description")
+        let recordCover = RecordCover(artist: "artist")
+        let record = Record(name: "name", description: "description", cover: recordCover)
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Record.schema,
                                                                operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .delete))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDeleteMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDeleteMutationTests.swift
@@ -118,4 +118,46 @@ class GraphQLDeleteMutationTests: XCTestCase {
         XCTAssert(input["id"] as? String == post.id)
         XCTAssert(input["_version"] as? Int == 5)
     }
+
+    func testDeleteGraphQLMutationModelWithReadOnlyFields() {
+        let record = Record(name: "name", description: "description")
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Record.schema,
+                                                               operationType: .mutation)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .delete))
+        documentBuilder.add(decorator: ModelDecorator(model: record))
+        documentBuilder.add(decorator: ConflictResolutionDecorator())
+        let document = documentBuilder.build()
+        let expectedQueryDocument = """
+        mutation DeleteRecord($input: DeleteRecordInput!) {
+          deleteRecord(input: $input) {
+            id
+            coverId
+            createdAt
+            description
+            name
+            updatedAt
+            __typename
+            _version
+            _deleted
+            _lastChangedAt
+          }
+        }
+        """
+        XCTAssertEqual(document.name, "deleteRecord")
+        XCTAssertEqual(document.stringValue, expectedQueryDocument)
+        guard let variables = document.variables else {
+            XCTFail("The document doesn't contain variables")
+            return
+        }
+        guard let input = variables["input"] as? GraphQLInput else {
+            XCTFail("Variables should contain a valid input")
+            return
+        }
+        XCTAssertEqual(input["id"] as? String, record.id)
+        XCTAssertEqual(input["name"] as? String, record.name)
+        XCTAssertEqual(input["description"] as? String, record.description)
+        XCTAssertNil(input["createdAt"] as? Temporal.DateTime)
+        XCTAssertNil(input["updatedAt"] as? Temporal.DateTime)
+        XCTAssertNil(input["cover"] as? RecordCover)
+    }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/ModelGraphQLTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/ModelGraphQLTests.swift
@@ -73,6 +73,15 @@ class ModelGraphQLTests: XCTestCase {
         XCTAssertEqual(expectedColor["blue"] as? Int, color.blue)
     }
 
+    func testRecordModelWithReadOnlyFields() {
+        let record = Record(id: "id", name: "name", description: "description")
+        let graphQLInput = record.graphQLInput(Record.schema)
+        XCTAssertEqual(graphQLInput["id"] as? String, record.id)
+        XCTAssertEqual(graphQLInput["name"] as? String, record.name)
+        XCTAssertEqual(graphQLInput["description"] as? String, record.description)
+        XCTAssertNil(graphQLInput["createdAt"] as? Temporal.DateTime)
+        XCTAssertNil(graphQLInput["updatedAt"] as? Temporal.DateTime)
+    }
 
     // MARK: - `Project1` and `Team1`
 

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/ModelGraphQLTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/ModelGraphQLTests.swift
@@ -31,7 +31,7 @@ class ModelGraphQLTests: XCTestCase {
                         rating: 5.0,
                         status: status)
 
-        let graphQLInput = post.graphQLInput(Post.schema)
+        let graphQLInput = post.graphQLInputForMutation(Post.schema)
 
         XCTAssertEqual(graphQLInput["title"] as? String, post.title)
         XCTAssertEqual(graphQLInput["content"] as? String, post.content)
@@ -52,7 +52,7 @@ class ModelGraphQLTests: XCTestCase {
                         categories: [category],
                         stickies: ["stickie1"])
 
-        let graphQLInput = todo.graphQLInput(Todo.schema)
+        let graphQLInput = todo.graphQLInputForMutation(Todo.schema)
 
         XCTAssertEqual(graphQLInput["id"] as? String, todo.id)
         XCTAssertEqual(graphQLInput["name"] as? String, todo.name)
@@ -75,7 +75,7 @@ class ModelGraphQLTests: XCTestCase {
 
     func testRecordModelWithReadOnlyFields() {
         let record = Record(id: "id", name: "name", description: "description")
-        let graphQLInput = record.graphQLInput(Record.schema)
+        let graphQLInput = record.graphQLInputForMutation(Record.schema)
         XCTAssertEqual(graphQLInput["id"] as? String, record.id)
         XCTAssertEqual(graphQLInput["name"] as? String, record.name)
         XCTAssertEqual(graphQLInput["description"] as? String, record.description)
@@ -89,7 +89,7 @@ class ModelGraphQLTests: XCTestCase {
         let team1 = Team1(name: "team")
         let project1 = Project1(team: team1)
 
-        let graphQLInput = project1.graphQLInput(Project1.schema)
+        let graphQLInput = project1.graphQLInputForMutation(Project1.schema)
 
         XCTAssertEqual(graphQLInput["id"] as? String, project1.id)
         XCTAssertTrue(graphQLInput.keys.contains("name"))
@@ -103,7 +103,7 @@ class ModelGraphQLTests: XCTestCase {
     func testProjectHasOneTeamSuccess() {
         let team2 = Team2(name: "team")
         let project2 = Project2(teamID: team2.id, team: team2)
-        let graphQLInput = project2.graphQLInput(Project2.schema)
+        let graphQLInput = project2.graphQLInputForMutation(Project2.schema)
         XCTAssertEqual(graphQLInput["id"] as? String, project2.id)
         XCTAssertTrue(graphQLInput.keys.contains("name"))
         XCTAssertNil(graphQLInput["name"]!)
@@ -115,7 +115,7 @@ class ModelGraphQLTests: XCTestCase {
     func testProjectHasOneTeamRandomTeamIDSuccess() {
         let team2 = Team2(name: "team")
         let project2 = Project2(teamID: "randomTeamId", team: team2)
-        let graphQLInput = project2.graphQLInput(Project2.schema)
+        let graphQLInput = project2.graphQLInputForMutation(Project2.schema)
         XCTAssertEqual(graphQLInput["id"] as? String, project2.id)
         XCTAssertTrue(graphQLInput.keys.contains("name"))
         XCTAssertNil(graphQLInput["name"]!)
@@ -127,7 +127,7 @@ class ModelGraphQLTests: XCTestCase {
     func testProjectHasOneTeamMisingTeamObjectSuccess() {
         let team2 = Team2(name: "team")
         let project2 = Project2(teamID: team2.id)
-        let graphQLInput = project2.graphQLInput(Project2.schema)
+        let graphQLInput = project2.graphQLInputForMutation(Project2.schema)
         XCTAssertEqual(graphQLInput["id"] as? String, project2.id)
         XCTAssertTrue(graphQLInput.keys.contains("name"))
         XCTAssertNil(graphQLInput["name"]!)

--- a/AmplifyTestCommon/Models/Record+Schema.swift
+++ b/AmplifyTestCommon/Models/Record+Schema.swift
@@ -1,0 +1,39 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Foundation
+import Amplify
+
+extension Record {
+  // MARK: - CodingKeys
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case name
+    case description
+    case createdAt
+    case updatedAt
+  }
+
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema
+
+  public static let schema = defineSchema { model in
+    let record = Record.keys
+
+    model.pluralName = "Records"
+
+    model.fields(
+        .id(),
+        .field(record.name, is: .required, ofType: .string),
+        .field(record.description, is: .optional, ofType: .string),
+        .field(record.createdAt, is: .optional, access: .readOnly, ofType: .date),
+        .field(record.updatedAt, is: .optional, access: .readOnly, ofType: .date)
+        )
+    }
+}
+

--- a/AmplifyTestCommon/Models/Record+Schema.swift
+++ b/AmplifyTestCommon/Models/Record+Schema.swift
@@ -31,8 +31,8 @@ extension Record {
         .id(),
         .field(record.name, is: .required, ofType: .string),
         .field(record.description, is: .optional, ofType: .string),
-        .field(record.createdAt, is: .optional, access: .readOnly, ofType: .date),
-        .field(record.updatedAt, is: .optional, access: .readOnly, ofType: .date)
+        .field(record.createdAt, is: .optional, access: .readOnly, ofType: .dateTime),
+        .field(record.updatedAt, is: .optional, access: .readOnly, ofType: .dateTime)
         )
     }
 }

--- a/AmplifyTestCommon/Models/Record+Schema.swift
+++ b/AmplifyTestCommon/Models/Record+Schema.swift
@@ -15,6 +15,8 @@ extension Record {
     case id
     case name
     case description
+    case coverId
+    case cover
     case createdAt
     case updatedAt
   }
@@ -31,6 +33,14 @@ extension Record {
         .id(),
         .field(record.name, is: .required, ofType: .string),
         .field(record.description, is: .optional, ofType: .string),
+        .field(record.coverId, is: .optional, access: .readOnly, ofType: .string),
+        .hasOne(
+            record.cover,
+            is: .optional,
+            access: .readOnly,
+            ofType: RecordCover.self,
+            associatedWith: RecordCover.keys.id,
+            targetName: "coverId"),
         .field(record.createdAt, is: .optional, access: .readOnly, ofType: .dateTime),
         .field(record.updatedAt, is: .optional, access: .readOnly, ofType: .dateTime)
         )

--- a/AmplifyTestCommon/Models/Record+Schema.swift
+++ b/AmplifyTestCommon/Models/Record+Schema.swift
@@ -33,16 +33,16 @@ extension Record {
         .id(),
         .field(record.name, is: .required, ofType: .string),
         .field(record.description, is: .optional, ofType: .string),
-        .field(record.coverId, is: .optional, access: .readOnly, ofType: .string),
+        .field(record.coverId, is: .optional, isReadOnly: true, ofType: .string),
         .hasOne(
             record.cover,
             is: .optional,
-            access: .readOnly,
+            isReadOnly: true,
             ofType: RecordCover.self,
             associatedWith: RecordCover.keys.id,
             targetName: "coverId"),
-        .field(record.createdAt, is: .optional, access: .readOnly, ofType: .dateTime),
-        .field(record.updatedAt, is: .optional, access: .readOnly, ofType: .dateTime)
+        .field(record.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+        .field(record.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
         )
     }
 }

--- a/AmplifyTestCommon/Models/Record.swift
+++ b/AmplifyTestCommon/Models/Record.swift
@@ -1,0 +1,27 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Foundation
+import Amplify
+
+public struct Record: Model {
+  public let id: String
+  public var name: String
+  public var description: String?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+
+  public init(id: String = UUID().uuidString,
+      name: String,
+      description: String? = nil) {
+      self.id = id
+      self.name = name
+      self.description = description
+  }
+}
+

--- a/AmplifyTestCommon/Models/Record.swift
+++ b/AmplifyTestCommon/Models/Record.swift
@@ -13,6 +13,8 @@ public struct Record: Model {
     public let id: String
     public var name: String
     public var description: String?
+    public var coverId: String?
+    public let cover: RecordCover?
     public let createdAt: Temporal.DateTime?
     public let updatedAt: Temporal.DateTime?
 
@@ -20,18 +22,23 @@ public struct Record: Model {
                 description: String? = nil) {
     self.init(name: name,
               description: description,
+              coverId: nil,
+              cover: nil,
               createdAt: nil,
               updatedAt: nil)
     }
-  
+
     internal init(id: String = UUID().uuidString,
                   name: String,
                   description: String? = nil,
+                  coverId: String? = nil,
+                  cover: RecordCover? = nil,
                   createdAt: Temporal.DateTime? = nil,
                   updatedAt: Temporal.DateTime? = nil) {
         self.id = id
         self.name = name
         self.description = description
+        self.cover = cover
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }

--- a/AmplifyTestCommon/Models/Record.swift
+++ b/AmplifyTestCommon/Models/Record.swift
@@ -10,18 +10,30 @@ import Foundation
 import Amplify
 
 public struct Record: Model {
-  public let id: String
-  public var name: String
-  public var description: String?
-  public var createdAt: Temporal.DateTime?
-  public var updatedAt: Temporal.DateTime?
+    public let id: String
+    public var name: String
+    public var description: String?
+    public let createdAt: Temporal.DateTime?
+    public let updatedAt: Temporal.DateTime?
 
-  public init(id: String = UUID().uuidString,
-      name: String,
-      description: String? = nil) {
-      self.id = id
-      self.name = name
-      self.description = description
-  }
+    public init(name: String,
+                description: String? = nil) {
+    self.init(name: name,
+              description: description,
+              createdAt: nil,
+              updatedAt: nil)
+    }
+  
+    internal init(id: String = UUID().uuidString,
+                  name: String,
+                  description: String? = nil,
+                  createdAt: Temporal.DateTime? = nil,
+                  updatedAt: Temporal.DateTime? = nil) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
 }
 

--- a/AmplifyTestCommon/Models/RecordCover+Schema.swift
+++ b/AmplifyTestCommon/Models/RecordCover+Schema.swift
@@ -1,0 +1,36 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Foundation
+import Amplify
+
+extension RecordCover {
+  // MARK: - CodingKeys
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case artist
+    case createdAt
+    case updatedAt
+  }
+
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema
+
+  public static let schema = defineSchema { model in
+    let recordCover = RecordCover.keys
+
+    model.pluralName = "RecordCovers"
+
+    model.fields(
+        .id(),
+        .field(recordCover.artist, is: .required, ofType: .string),
+        .field(recordCover.createdAt, is: .optional, access: .readOnly, ofType: .dateTime),
+        .field(recordCover.updatedAt, is: .optional, access: .readOnly, ofType: .dateTime)
+        )
+    }
+}

--- a/AmplifyTestCommon/Models/RecordCover+Schema.swift
+++ b/AmplifyTestCommon/Models/RecordCover+Schema.swift
@@ -29,8 +29,8 @@ extension RecordCover {
     model.fields(
         .id(),
         .field(recordCover.artist, is: .required, ofType: .string),
-        .field(recordCover.createdAt, is: .optional, access: .readOnly, ofType: .dateTime),
-        .field(recordCover.updatedAt, is: .optional, access: .readOnly, ofType: .dateTime)
+        .field(recordCover.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+        .field(recordCover.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
         )
     }
 }

--- a/AmplifyTestCommon/Models/RecordCover.swift
+++ b/AmplifyTestCommon/Models/RecordCover.swift
@@ -1,0 +1,34 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Amplify
+
+// swiftlint:disable all
+
+public struct RecordCover: Model {
+    public let id: String
+    public var artist: String
+    public let createdAt: Temporal.DateTime?
+    public let updatedAt: Temporal.DateTime?
+
+    public init(artist: String) {
+        self.init(artist: artist,
+              createdAt: nil,
+              updatedAt: nil)
+    }
+
+    internal init(id: String = UUID().uuidString,
+                  artist: String,
+                  createdAt: Temporal.DateTime? = nil,
+                  updatedAt: Temporal.DateTime? = nil) {
+        self.id = id
+        self.artist = artist
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}


### PR DESCRIPTION
### Issue
Amplify CLI generates `createdAt` and `updatedAt` fields on every `@model`, and customer can also specify custom field name by defining models as follows
```
type Todo @model(timestamps:{ createdAt: "createdOn", updatedAt: "updatedOn" }) {
  id: ID!
  name: String!
  description: String
}
```
These fields are not currently included in autogenerated models thus are not accessible to customers.
Codegen is being updated to generate these fields (https://github.com/aws-amplify/amplify-codegen/pull/114) but, as they're fully managed by AppSync, they need a special treatment. To avoid AppSync throwing an error, they must NOT be included in the mutation _input_.

### Solution
Since we can't rely on their name to omit `createdAt` and `updatedAt` from the mutation input, codegen will mark them as "read-only". This PR introduces necessary changes to support read-only fields.

Below an example of an updated model and schema
```swift
public struct Todo: Model {
    public let id: String
    public var name: String
    public var done: Bool
    public var priority: Priority?
    public var description: String?
    public let createdAt: Temporal.DateTime?
    public let updatedAt: Temporal.DateTime?
    public init(name: String,
                done: Bool,
                priority: Priority? = nil,
                description: String? = nil)
    {
        self.init(name: name,
                  done: done,
                  priority: priority,
                  description: description,
                  createdAt: nil,
                  updatedAt: nil)
    }
    internal init(id: String = UUID().uuidString,
                  name: String,
                  done: Bool,
                  priority: Priority? = nil,
                  description: String? = nil,
                  createdAt: Temporal.DateTime? = nil,
                  updatedAt: Temporal.DateTime? = nil)
    {
        self.id = id
        self.name = name
        self.done = done
        self.priority = priority
        self.description = description
        self.createdAt = createdAt
        self.updatedAt = updatedAt
    }
}
```
```swift
extension Todo {
...
  public static let schema = defineSchema { model in
      let todo = Todo.keys
  
      model.pluralName = "Tods"
  
      model.fields(
          .id(),
          .field(todo.name, is: .required, ofType: .string),
          .field(todo.description, is: .optional, ofType: .string),
          .field(todo.createdAt, is: .optional, isReadOnly: true, ofType: .date),
          .field(todo.updatedAt, is: .optional, isReadOnly: true, ofType: .date)
          )
  }
}
```


### References
Android: https://github.com/aws-amplify/amplify-android/pull/1249
CodeGen changes: https://github.com/aws-amplify/amplify-codegen/pull/114

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
