### PR TITLE
fix: throw error when plugin added post-configure

### DIFF
--- a/Amplify/Categories/API/AmplifyAPICategory+APICategory.swift
+++ b/Amplify/Categories/API/AmplifyAPICategory+APICategory.swift
@@ -22,8 +22,8 @@ extension AmplifyAPICategory: APICategory {
         guard !isConfigured else {
             let pluginDescription = String(describing: plugin)
             let error = ConfigurationError.amplifyAlreadyConfigured(
-                "\(pluginDescription) has already been configured.",
-                "Remove the duplicate call to `Amplify.configure().`"
+                "\(pluginDescription) cannot be added after `Amplify.configure()`.",
+                "Do not add plugins after calling `Amplify.configure()`."
             )
             throw error
         }

--- a/Amplify/Categories/API/AmplifyAPICategory+APICategory.swift
+++ b/Amplify/Categories/API/AmplifyAPICategory+APICategory.swift
@@ -19,6 +19,15 @@ extension AmplifyAPICategory: APICategory {
             throw error
         }
 
+        guard !isConfigured else {
+            let pluginDescription = String(describing: plugin)
+            let error = ConfigurationError.amplifyAlreadyConfigured(
+                "\(pluginDescription) has already been configured.",
+                "Remove the duplicate call to `Amplify.configure().`"
+            )
+            throw error
+        }
+
         plugins[plugin.key] = plugin
     }
 

--- a/Amplify/Categories/Analytics/AnalyticsCategory.swift
+++ b/Amplify/Categories/Analytics/AnalyticsCategory.swift
@@ -61,8 +61,8 @@ final public class AnalyticsCategory: Category {
         guard !isConfigured else {
             let pluginDescription = String(describing: plugin)
             let error = ConfigurationError.amplifyAlreadyConfigured(
-                "\(pluginDescription) has already been configured.",
-                "Remove the duplicate call to `Amplify.configure().`"
+                "\(pluginDescription) cannot be added after `Amplify.configure()`.",
+                "Do not add plugins after calling `Amplify.configure()`."
             )
             throw error
         }

--- a/Amplify/Categories/Analytics/AnalyticsCategory.swift
+++ b/Amplify/Categories/Analytics/AnalyticsCategory.swift
@@ -58,6 +58,15 @@ final public class AnalyticsCategory: Category {
             throw error
         }
 
+        guard !isConfigured else {
+            let pluginDescription = String(describing: plugin)
+            let error = ConfigurationError.amplifyAlreadyConfigured(
+                "\(pluginDescription) has already been configured.",
+                "Remove the duplicate call to `Amplify.configure().`"
+            )
+            throw error
+        }
+
         plugins[plugin.key] = plugin
     }
 

--- a/Amplify/Categories/Auth/AuthCategory.swift
+++ b/Amplify/Categories/Auth/AuthCategory.swift
@@ -56,6 +56,15 @@ final public class AuthCategory: Category {
             throw error
         }
 
+        guard !isConfigured else {
+            let pluginDescription = String(describing: plugin)
+            let error = ConfigurationError.amplifyAlreadyConfigured(
+                "\(pluginDescription) has already been configured.",
+                "Remove the duplicate call to `Amplify.configure().`"
+            )
+            throw error
+        }
+
         plugins[plugin.key] = plugin
     }
 

--- a/Amplify/Categories/Auth/AuthCategory.swift
+++ b/Amplify/Categories/Auth/AuthCategory.swift
@@ -59,8 +59,8 @@ final public class AuthCategory: Category {
         guard !isConfigured else {
             let pluginDescription = String(describing: plugin)
             let error = ConfigurationError.amplifyAlreadyConfigured(
-                "\(pluginDescription) has already been configured.",
-                "Remove the duplicate call to `Amplify.configure().`"
+                "\(pluginDescription) cannot be added after `Amplify.configure()`.",
+                "Do not add plugins after calling `Amplify.configure()`."
             )
             throw error
         }

--- a/Amplify/Categories/DataStore/DataStoreCategory.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory.swift
@@ -59,6 +59,15 @@ final public class DataStoreCategory: Category {
             throw error
         }
 
+        guard !isConfigured else {
+            let pluginDescription = String(describing: plugin)
+            let error = ConfigurationError.amplifyAlreadyConfigured(
+                "\(pluginDescription) has already been configured.",
+                "Remove the duplicate call to `Amplify.configure().`"
+            )
+            throw error
+        }
+
         plugins[plugin.key] = plugin
     }
 

--- a/Amplify/Categories/DataStore/DataStoreCategory.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory.swift
@@ -62,8 +62,8 @@ final public class DataStoreCategory: Category {
         guard !isConfigured else {
             let pluginDescription = String(describing: plugin)
             let error = ConfigurationError.amplifyAlreadyConfigured(
-                "\(pluginDescription) has already been configured.",
-                "Remove the duplicate call to `Amplify.configure().`"
+                "\(pluginDescription) cannot be added after `Amplify.configure()`.",
+                "Do not add plugins after calling `Amplify.configure()`."
             )
             throw error
         }

--- a/Amplify/Categories/Predictions/PredictionsCategory.swift
+++ b/Amplify/Categories/Predictions/PredictionsCategory.swift
@@ -59,8 +59,8 @@ final public class PredictionsCategory: Category {
         guard !isConfigured else {
             let pluginDescription = String(describing: plugin)
             let error = ConfigurationError.amplifyAlreadyConfigured(
-                "\(pluginDescription) has already been configured.",
-                "Remove the duplicate call to `Amplify.configure().`"
+                "\(pluginDescription) cannot be added after `Amplify.configure()`.",
+                "Do not add plugins after calling `Amplify.configure()`."
             )
             throw error
         }

--- a/Amplify/Categories/Predictions/PredictionsCategory.swift
+++ b/Amplify/Categories/Predictions/PredictionsCategory.swift
@@ -56,6 +56,15 @@ final public class PredictionsCategory: Category {
             throw error
         }
 
+        guard !isConfigured else {
+            let pluginDescription = String(describing: plugin)
+            let error = ConfigurationError.amplifyAlreadyConfigured(
+                "\(pluginDescription) has already been configured.",
+                "Remove the duplicate call to `Amplify.configure().`"
+            )
+            throw error
+        }
+
         plugins[plugin.key] = plugin
     }
 

--- a/Amplify/Categories/Storage/StorageCategory.swift
+++ b/Amplify/Categories/Storage/StorageCategory.swift
@@ -60,8 +60,8 @@ final public class StorageCategory: Category {
         guard !isConfigured else {
             let pluginDescription = String(describing: plugin)
             let error = ConfigurationError.amplifyAlreadyConfigured(
-                "\(pluginDescription) has already been configured.",
-                "Remove the duplicate call to `Amplify.configure().`"
+                "\(pluginDescription) cannot be added after `Amplify.configure()`.",
+                "Do not add plugins after calling `Amplify.configure()`."
             )
             throw error
         }

--- a/Amplify/Categories/Storage/StorageCategory.swift
+++ b/Amplify/Categories/Storage/StorageCategory.swift
@@ -57,6 +57,15 @@ final public class StorageCategory: Category {
             throw error
         }
 
+        guard !isConfigured else {
+            let pluginDescription = String(describing: plugin)
+            let error = ConfigurationError.amplifyAlreadyConfigured(
+                "\(pluginDescription) has already been configured.",
+                "Remove the duplicate call to `Amplify.configure().`"
+            )
+            throw error
+        }
+
         plugins[plugin.key] = plugin
     }
 

--- a/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
@@ -349,4 +349,34 @@ class APICategoryConfigurationTests: XCTestCase {
 
         waitForExpectations(timeout: 0.1)
     }
+
+    /// Test if adding a plugin after configuration throws an error
+    ///
+    /// - Given: Amplify is configured
+    /// - When:
+    ///    - Add  is called for API category
+    /// - Then:
+    ///    - Should throw an exception
+    ///
+    func testAddAfterConfigureThrowsError() throws {
+        let plugin = MockAPICategoryPlugin()
+        try Amplify.add(plugin: plugin)
+
+        let config = APICategoryConfiguration(
+            plugins: ["MockAPICategoryPlugin": true]
+        )
+
+        let amplifyConfig = AmplifyConfiguration(api: config)
+
+        try Amplify.configure(amplifyConfig)
+
+        XCTAssertThrowsError(try Amplify.add(plugin: plugin),
+                             "configure() an already configured plugin should throw") { error in
+                                guard case ConfigurationError.amplifyAlreadyConfigured = error else {
+                                    XCTFail("Expected ConfigurationError.amplifyAlreadyConfigured")
+                                    return
+                                }
+        }
+
+    }
 }

--- a/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryConfigurationTests.swift
@@ -293,4 +293,33 @@ class AnalyticsCategoryConfigurationTests: XCTestCase {
         waitForExpectations(timeout: 0.1)
     }
 
+    /// Test if adding a plugin after configuration throws an error
+    ///
+    /// - Given: Amplify is configured
+    /// - When:
+    ///    - Add  is called for Analytics category
+    /// - Then:
+    ///    - Should throw an exception
+    ///
+    func testAddAfterConfigureThrowsError() throws {
+        let plugin = MockAnalyticsCategoryPlugin()
+        try Amplify.add(plugin: plugin)
+
+        let config = AnalyticsCategoryConfiguration(
+            plugins: ["MockAnalyticsCategoryPlugin": true]
+        )
+
+        let amplifyConfig = AmplifyConfiguration(analytics: config)
+
+        try Amplify.configure(amplifyConfig)
+
+        XCTAssertThrowsError(try Amplify.add(plugin: plugin),
+                             "configure() an already configured plugin should throw") { error in
+                                guard case ConfigurationError.amplifyAlreadyConfigured = error else {
+                                    XCTFail("Expected ConfigurationError.amplifyAlreadyConfigured")
+                                    return
+                                }
+        }
+
+    }
 }

--- a/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
@@ -406,4 +406,34 @@ class AuthCategoryConfigurationTests: XCTestCase {
             XCTAssertNotNil(error as? AuthError)
         }
     }
+
+    /// Test if adding a plugin after configuration throws an error
+    ///
+    /// - Given: Amplify is configured
+    /// - When:
+    ///    - Add  is called for Auth category
+    /// - Then:
+    ///    - Should throw an exception
+    ///
+    func testAddAfterConfigureThrowsError() throws {
+        let plugin = MockAuthCategoryPlugin()
+        try Amplify.add(plugin: plugin)
+
+        let config = AuthCategoryConfiguration(
+            plugins: ["MockAuthCategoryPlugin": true]
+        )
+
+        let amplifyConfig = AmplifyConfiguration(auth: config)
+
+        try Amplify.configure(amplifyConfig)
+
+        XCTAssertThrowsError(try Amplify.add(plugin: plugin),
+                             "configure() an already configured plugin should throw") { error in
+                                guard case ConfigurationError.amplifyAlreadyConfigured = error else {
+                                    XCTFail("Expected ConfigurationError.amplifyAlreadyConfigured")
+                                    return
+                                }
+        }
+
+    }
 }

--- a/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
@@ -312,4 +312,33 @@ class DataStoreCategoryConfigurationTests: XCTestCase {
         waitForExpectations(timeout: 0.1)
     }
 
+    /// Test if adding a plugin after configuration throws an error
+    ///
+    /// - Given: Amplify is configured
+    /// - When:
+    ///    - Add  is called for Datastore category
+    /// - Then:
+    ///    - Should throw an exception
+    ///
+    func testAddAfterConfigureThrowsError() throws {
+        let plugin = MockDataStoreCategoryPlugin()
+        try Amplify.add(plugin: plugin)
+
+        let config = DataStoreCategoryConfiguration(
+            plugins: ["MockDataStoreCategoryPlugin": true]
+        )
+
+        let amplifyConfig = AmplifyConfiguration(dataStore: config)
+
+        try Amplify.configure(amplifyConfig)
+
+        XCTAssertThrowsError(try Amplify.add(plugin: plugin),
+                             "configure() an already configured plugin should throw") { error in
+                                guard case ConfigurationError.amplifyAlreadyConfigured = error else {
+                                    XCTFail("Expected ConfigurationError.amplifyAlreadyConfigured")
+                                    return
+                                }
+        }
+
+    }
 }

--- a/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryConfigurationTests.swift
@@ -405,4 +405,33 @@ class PredictionsCategoryConfigurationTests: XCTestCase {
         waitForExpectations(timeout: 0.1)
     }
 
+    /// Test if adding a plugin after configuration throws an error
+    ///
+    /// - Given: Amplify is configured
+    /// - When:
+    ///    - Add  is called for Predictions category
+    /// - Then:
+    ///    - Should throw an exception
+    ///
+    func testAddAfterConfigureThrowsError() throws {
+        let plugin = MockPredictionsCategoryPlugin()
+        try Amplify.add(plugin: plugin)
+
+        let config = PredictionsCategoryConfiguration(
+            plugins: ["MockPredictionsCategoryPlugin": true]
+        )
+
+        let amplifyConfig = AmplifyConfiguration(predictions: config)
+
+        try Amplify.configure(amplifyConfig)
+
+        XCTAssertThrowsError(try Amplify.add(plugin: plugin),
+                             "configure() an already configured plugin should throw") { error in
+                                guard case ConfigurationError.amplifyAlreadyConfigured = error else {
+                                    XCTFail("Expected ConfigurationError.amplifyAlreadyConfigured")
+                                    return
+                                }
+        }
+
+    }
 }

--- a/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
@@ -294,4 +294,33 @@ class StorageCategoryConfigurationTests: XCTestCase {
         waitForExpectations(timeout: 0.1)
     }
 
+    /// Test if adding a plugin after configuration throws an error
+    ///
+    /// - Given: Amplify is configured
+    /// - When:
+    ///    - Add  is called for Storage category
+    /// - Then:
+    ///    - Should throw an exception
+    ///
+    func testAddAfterConfigureThrowsError() throws {
+        let plugin = MockStorageCategoryPlugin()
+        try Amplify.add(plugin: plugin)
+
+        let config = StorageCategoryConfiguration(
+            plugins: ["MockStorageCategoryPlugin": true]
+        )
+
+        let amplifyConfig = AmplifyConfiguration(storage: config)
+
+        try Amplify.configure(amplifyConfig)
+
+        XCTAssertThrowsError(try Amplify.add(plugin: plugin),
+                             "configure() an already configured plugin should throw") { error in
+                                guard case ConfigurationError.amplifyAlreadyConfigured = error else {
+                                    XCTFail("Expected ConfigurationError.amplifyAlreadyConfigured")
+                                    return
+                                }
+        }
+
+    }
 }


### PR DESCRIPTION
*Description of changes:*
Ensures that `add` method for Auth, Analytics, Storage, Datastore, API and Predictions categories throw an error when attempt is made to add a plugin after configuration.

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
