### PR TITLE
fix: API unit test to use only the plugin and not Amplify

### DIFF
--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSRESTOperationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSRESTOperationTests.swift
@@ -38,7 +38,7 @@ class AWSRESTOperationTests: OperationTestBase {
         // Use this as a semaphore to ensure the task is cleaned up before proceeding to the next test
         let listenerWasInvoked = expectation(description: "Listener was invoked")
         let request = RESTRequest(apiName: "Valid", path: "/path")
-        let operation = Amplify.API.get(request: request) { _ in listenerWasInvoked.fulfill() }
+        let operation = apiPlugin.get(request: request) { _ in listenerWasInvoked.fulfill() }
 
         XCTAssertNotNil(operation)
 
@@ -61,7 +61,7 @@ class AWSRESTOperationTests: OperationTestBase {
         let receivedFailure = expectation(description: "Received failed")
 
         let request = RESTRequest(apiName: "INVALID_API_NAME", path: "/path")
-        _ = Amplify.API.get(request: request) { event in
+        _ = apiPlugin.get(request: request) { event in
             switch event {
             case .success:
                 receivedSuccess.fulfill()
@@ -82,7 +82,7 @@ class AWSRESTOperationTests: OperationTestBase {
 
         let callbackInvoked = expectation(description: "Callback was invoked")
         let request = RESTRequest(apiName: "Valid", path: "/path")
-        _ = Amplify.API.get(request: request) { event in
+        _ = apiPlugin.get(request: request) { event in
             switch event {
             case .success(let data):
                 XCTAssertEqual(data, sentData)

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLMutateCombineTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLMutateCombineTests.swift
@@ -29,7 +29,7 @@ class GraphQLMutateCombineTests: OperationTestBase {
         let receivedFailure = expectation(description: "Received failed")
         receivedFailure.isInverted = true
 
-        let sink = Amplify.API.mutate(request: request)
+        let sink = apiPlugin.mutate(request: request)
             .resultPublisher
             .sink(receiveCompletion: { completion in
                 switch completion {
@@ -65,7 +65,7 @@ class GraphQLMutateCombineTests: OperationTestBase {
         let receivedFailure = expectation(description: "Received failed")
         receivedFailure.isInverted = true
 
-        let sink = Amplify.API.mutate(request: request)
+        let sink = apiPlugin.mutate(request: request)
             .resultPublisher
             .sink(receiveCompletion: { completion in
                 switch completion {
@@ -101,7 +101,7 @@ class GraphQLMutateCombineTests: OperationTestBase {
         receivedFinish.isInverted = true
         let receivedFailure = expectation(description: "Received failed")
 
-        let sink = Amplify.API.mutate(request: request)
+        let sink = apiPlugin.mutate(request: request)
             .resultPublisher
             .sink(receiveCompletion: { completion in
                 switch completion {
@@ -133,7 +133,7 @@ class GraphQLMutateCombineTests: OperationTestBase {
         let receivedFailure = expectation(description: "Received failed")
         receivedFailure.isInverted = true
 
-        let operation = Amplify.API.mutate(request: request)
+        let operation = apiPlugin.mutate(request: request)
         let sink = operation
             .resultPublisher
             .sink(receiveCompletion: { completion in

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLQueryCombineTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLQueryCombineTests.swift
@@ -29,7 +29,7 @@ class GraphQLQueryCombineTests: OperationTestBase {
         let receivedFailure = expectation(description: "Received failed")
         receivedFailure.isInverted = true
 
-        let sink = Amplify.API.query(request: request)
+        let sink = apiPlugin.query(request: request)
             .resultPublisher
             .sink(receiveCompletion: { completion in
                 switch completion {
@@ -65,7 +65,7 @@ class GraphQLQueryCombineTests: OperationTestBase {
         let receivedFailure = expectation(description: "Received failed")
         receivedFailure.isInverted = true
 
-        let sink = Amplify.API.query(request: request)
+        let sink = apiPlugin.query(request: request)
             .resultPublisher
             .sink(receiveCompletion: { completion in
                 switch completion {
@@ -101,7 +101,7 @@ class GraphQLQueryCombineTests: OperationTestBase {
         receivedFinish.isInverted = true
         let receivedFailure = expectation(description: "Received failed")
 
-        let sink = Amplify.API.query(request: request)
+        let sink = apiPlugin.query(request: request)
             .resultPublisher
             .sink(receiveCompletion: { completion in
                 switch completion {
@@ -133,7 +133,7 @@ class GraphQLQueryCombineTests: OperationTestBase {
         let receivedFailure = expectation(description: "Received failed")
         receivedFailure.isInverted = true
 
-        let operation = Amplify.API.query(request: request)
+        let operation = apiPlugin.query(request: request)
         let sink = operation
             .resultPublisher
             .sink(receiveCompletion: { completion in

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLSubscribeTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLSubscribeTests.swift
@@ -260,7 +260,7 @@ class GraphQLSubscribeTests: OperationTestBase {
             responseType: JSONValue.self
         )
 
-        let operation = Amplify.API.subscribe(
+        let operation = apiPlugin.subscribe(
             request: request,
             valueListener: { value in
                 switch value {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/OperationTestBase.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/OperationTestBase.swift
@@ -12,13 +12,15 @@ import XCTest
 
 class OperationTestBase: XCTestCase {
 
+    var apiPlugin: AWSAPIPlugin!
+
     /// There are no throwing methods in this, but in order to let subclasses have a predictable way
     /// of setting up plugins, this base class uses `setUpWithError` instead of `setUp`. (XCTest
     /// lifecycle normally invokes `setUp` after `setUpWithError`, which means that any state config
     /// done inside of a subclass' `setUpWithError` could be erased by this class' call to
     /// `Amplify.reset` from inside `setUp`.
     override func setUpWithError() throws {
-        Amplify.reset()
+        apiPlugin = nil
     }
 
     func setUpPlugin(
@@ -26,7 +28,7 @@ class OperationTestBase: XCTestCase {
         subscriptionConnectionFactory: SubscriptionConnectionFactory? = nil,
         endpointType: AWSAPICategoryPluginEndpointType
     ) throws {
-        let apiPlugin = AWSAPIPlugin(sessionFactory: sessionFactory)
+        apiPlugin = AWSAPIPlugin(sessionFactory: sessionFactory)
 
         let configurationValues: JSONValue = [
             "Valid": [
@@ -45,20 +47,6 @@ class OperationTestBase: XCTestCase {
         )
 
         apiPlugin.configure(using: dependencies)
-
-        do {
-            // TODO: Refactor plugin configuration to allow dependencies to be passed in at
-            // plugin init
-
-            // Note that we're configuring Amplify first, then adding the pre-configured plugin.
-            // This is a hack to let us assign the mock dependencies to the plugin without having
-            // it overwritten by a subsequent call to `Amplify.configure()`.
-            try Amplify.configure(AmplifyConfiguration())
-            try Amplify.add(plugin: apiPlugin)
-        } catch {
-            continueAfterFailure = false
-            XCTFail("Error during setup: \(error)")
-        }
     }
 
     func setUpPluginForSingleResponse(

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/OperationTestBase.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/OperationTestBase.swift
@@ -18,8 +18,15 @@ class OperationTestBase: XCTestCase {
     /// of setting up plugins, this base class uses `setUpWithError` instead of `setUp`. (XCTest
     /// lifecycle normally invokes `setUp` after `setUpWithError`, which means that any state config
     /// done inside of a subclass' `setUpWithError` could be erased by this class' call to
-    /// `Amplify.reset` from inside `setUp`.
+    /// `AWSAPIPlugin.reset` from inside `setUp`.
     override func setUpWithError() throws {
+        if apiPlugin != nil {
+            let waitForReset = DispatchSemaphore(value: 0)
+            apiPlugin.reset {
+                waitForReset.signal()
+            }
+            waitForReset.wait()
+        }
         apiPlugin = nil
     }
 

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/RESTCombineTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/RESTCombineTests.swift
@@ -25,7 +25,7 @@ class RESTCombineTests: OperationTestBase {
         let receivedFailure = expectation(description: "Received failed")
         receivedFailure.isInverted = true
 
-        let sink = Amplify.API.get(request: request)
+        let sink = apiPlugin.get(request: request)
             .resultPublisher
             .sink(receiveCompletion: { completion in
                 switch completion {
@@ -55,7 +55,7 @@ class RESTCombineTests: OperationTestBase {
         receivedFinish.isInverted = true
         let receivedFailure = expectation(description: "Received failed")
 
-        let sink = Amplify.API.get(request: request)
+        let sink = apiPlugin.get(request: request)
             .resultPublisher
             .sink(receiveCompletion: { completion in
                 switch completion {
@@ -83,7 +83,7 @@ class RESTCombineTests: OperationTestBase {
         let receivedFailure = expectation(description: "Received failed")
         receivedFailure.isInverted = true
 
-        let operation = Amplify.API.get(request: request)
+        let operation = apiPlugin.get(request: request)
 
         let sink = operation
             .resultPublisher


### PR DESCRIPTION
*Description of changes:*

Unit test of API plugin is currently required to configure Amplify. This PR removes that dependency and makes the unit test light as possible and test the unit of code.

*Check points:*

- [ ] ~Added new tests to cover change, if needed~
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
