### PR TITLE
fix(API): Reachability resolve to GraphQL API

### DIFF
--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		21D7A118237B54D90057D00D /* APIKeyURLRequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0D5237B54D90057D00D /* APIKeyURLRequestInterceptor.swift */; };
 		21D7A119237B54D90057D00D /* IAMURLRequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0D6237B54D90057D00D /* IAMURLRequestInterceptor.swift */; };
 		21D7A11A237B54D90057D00D /* AWSAPICategoryPluginError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7A0D7237B54D90057D00D /* AWSAPICategoryPluginError.swift */; };
+		21DFD3EB2627514C0078833B /* AWSAPICategoryPlugin+ReachabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFD3EA2627514C0078833B /* AWSAPICategoryPlugin+ReachabilityTests.swift */; };
 		21F40A2B23A0423C0074678E /* GraphQLSyncBasedTests-amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21F40A2923A0423C0074678E /* GraphQLSyncBasedTests-amplifyconfiguration.json */; };
 		21F40A2E23A0707E0074678E /* GraphQLModelBasedTests-amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21F40A2D23A0707E0074678E /* GraphQLModelBasedTests-amplifyconfiguration.json */; };
 		21FDBB762587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FDBB752587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift */; };
@@ -417,6 +418,7 @@
 		21D7A0D6237B54D90057D00D /* IAMURLRequestInterceptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IAMURLRequestInterceptor.swift; sourceTree = "<group>"; };
 		21D7A0D7237B54D90057D00D /* AWSAPICategoryPluginError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSAPICategoryPluginError.swift; sourceTree = "<group>"; };
 		21D7A0DE237B54D90057D00D /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		21DFD3EA2627514C0078833B /* AWSAPICategoryPlugin+ReachabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSAPICategoryPlugin+ReachabilityTests.swift"; sourceTree = "<group>"; };
 		21F40A2923A0423C0074678E /* GraphQLSyncBasedTests-amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GraphQLSyncBasedTests-amplifyconfiguration.json"; sourceTree = "<group>"; };
 		21F40A2D23A0707E0074678E /* GraphQLModelBasedTests-amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GraphQLModelBasedTests-amplifyconfiguration.json"; sourceTree = "<group>"; };
 		21FDBB752587D9E40086FCDC /* GraphQLConnectionScenario6Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQLConnectionScenario6Tests.swift; sourceTree = "<group>"; };
@@ -1092,6 +1094,7 @@
 				B4DFA5DE237A611D0013E17B /* AWSAPICategoryPlugin+ConfigureTests.swift */,
 				B4DFA5CC237A611D0013E17B /* AWSAPICategoryPlugin+GraphQLBehaviorTests.swift */,
 				B4DFA5C9237A611D0013E17B /* AWSAPICategoryPlugin+InterceptorBehaviorTests.swift */,
+				21DFD3EA2627514C0078833B /* AWSAPICategoryPlugin+ReachabilityTests.swift */,
 				B4DFA5CD237A611D0013E17B /* AWSAPICategoryPlugin+ResetTests.swift */,
 				B4DFA5CA237A611D0013E17B /* AWSAPICategoryPlugin+RESTClientBehaviorTests.swift */,
 				B4DFA5D5237A611D0013E17B /* AWSAPICategoryPlugin+URLSessionBehaviorDelegateTests.swift */,
@@ -2420,6 +2423,7 @@
 				FAF2199A24C0F25E00171A3D /* OperationTestBase.swift in Sources */,
 				B4DFA5F3237A611D0013E17B /* GraphQLOperationRequestValidateTests.swift in Sources */,
 				216449982587F9BC00C548A5 /* GraphQLResponseDecoder+DecodeDataTests.swift in Sources */,
+				21DFD3EB2627514C0078833B /* AWSAPICategoryPlugin+ReachabilityTests.swift in Sources */,
 				FA45D78D24C1032E006CBEE9 /* RESTCombineTests.swift in Sources */,
 				21A4F42425A62E3600E1047D /* AppSyncListPayloadTests.swift in Sources */,
 			);

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Reachability.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Reachability.swift
@@ -17,7 +17,16 @@ extension AWSAPIPlugin {
 
     @available(iOS 13.0, *)
     public func reachabilityPublisher(for apiName: String?) throws -> AnyPublisher<ReachabilityUpdate, Never>? {
-        let hostName = try determineHostName(apiName: apiName)
+        let endpoint = try pluginConfig.endpoints.getConfig(for: apiName)
+        guard let hostName = endpoint.baseURL.host else {
+            let error = APIError.invalidConfiguration("Invalid endpoint configuration",
+                """
+                baseURL does not contain a valid hostname
+                """
+            )
+            throw error
+        }
+
         if let networkReachability = reachabilityMap[hostName] {
             return networkReachability.publisher
         }
@@ -32,51 +41,4 @@ extension AWSAPIPlugin {
             return nil
         }
     }
-
-    private func determineHostName(apiName: String?) throws -> String {
-        if let apiName = apiName {
-            guard let baseUrl = pluginConfig.endpoints[apiName]?.baseURL,
-                let host = baseUrl.host else {
-                    let error = APIError.invalidConfiguration("Invalid endpoint configuration for \(apiName)",
-                                                              """
-                                                              baseURL does not contain a valid hostname
-                                                              for apiName: \(apiName)
-                                                              """
-                    )
-                    throw error
-            }
-            return host
-        }
-
-        if pluginConfig.endpoints.count > 1 {
-            let error = APIError.invalidConfiguration("Unable to determine which endpoint configuration",
-                                                      """
-                                                      Pass in the apiName to disambiguate between which endpoint
-                                                      you are requesting reachability for
-                                                      """
-            )
-            throw error
-        }
-
-        guard let configEntry = pluginConfig.endpoints.first else {
-            let error = APIError.invalidConfiguration("No API configurations found",
-                                                      """
-                                                      Review how the API category is being instantiated and
-                                                      configured.
-                                                      """
-            )
-            throw error
-        }
-
-        guard let host = configEntry.value.baseURL.host else {
-            let error = APIError.invalidConfiguration("Invalid endpoint configuration",
-                """
-                baseURL does not contain a valid hostname
-                """
-            )
-            throw error
-        }
-        return host
-    }
-
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Reachability.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Reachability.swift
@@ -27,6 +27,10 @@ extension AWSAPIPlugin {
             throw error
         }
 
+        reachabilityMapLock.lock()
+        defer {
+            reachabilityMapLock.unlock()
+        }
         if let networkReachability = reachabilityMap[hostName] {
             return networkReachability.publisher
         }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Resettable.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Resettable.swift
@@ -26,7 +26,9 @@ extension AWSAPIPlugin: Resettable {
         authService = nil
 
         if #available(iOS 13.0, *) {
+            reachabilityMapLock.lock()
             reachabilityMap.removeAll()
+            reachabilityMapLock.unlock()
         }
 
         subscriptionConnectionFactory = nil

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin.swift
@@ -58,7 +58,7 @@ final public class AWSAPIPlugin: NSObject, APICategoryPlugin {
     }
 
     /// Lock used for performing operations atomically when getting and setting `reachabilityMap`.
-    let reachabilityMapLock = NSLock()
+    let reachabilityMapLock: NSLock
 
     public init(
         modelRegistration: AmplifyModelRegistration? = nil,
@@ -67,7 +67,8 @@ final public class AWSAPIPlugin: NSObject, APICategoryPlugin {
     ) {
         self.mapper = OperationTaskMapper()
         self.queue = OperationQueue()
-        self.authProviderFactory =  apiAuthProviderFactory ?? APIAuthProviderFactory()
+        self.authProviderFactory = apiAuthProviderFactory ?? APIAuthProviderFactory()
+        self.reachabilityMapLock = NSLock()
         super.init()
 
         modelRegistration?.registerModels(registry: ModelRegistry.self)

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin.swift
@@ -57,6 +57,9 @@ final public class AWSAPIPlugin: NSObject, APICategoryPlugin {
         }
     }
 
+    /// Lock used for performing operations atomically when getting and setting `reachabilityMap`.
+    let reachabilityMapLock = NSLock()
+
     public init(
         modelRegistration: AmplifyModelRegistration? = nil,
         sessionFactory: URLSessionBehaviorFactory? = nil,

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginConfiguration+EndpointConfig.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginConfiguration+EndpointConfig.swift
@@ -281,31 +281,26 @@ public extension AWSAPICategoryPluginConfiguration {
 }
 
 extension Dictionary where Key == String, Value == AWSAPICategoryPluginConfiguration.EndpointConfig {
-    func getConfig(for apiName: String?,
-                   endpointType: AWSAPICategoryPluginEndpointType) throws ->
+
+    /// Getting the `EndpointConfig` resolves to the following rules:
+    /// 1. If `apiName` is specified, retrieve the endpoint configuration for this api
+    /// 2. If `apiName` is not specified, and `endpointType` is, retrieve the endpoint if there is only one.
+    /// 3. If nothing is specified, return the endpoint only if there is a single one, with GraphQL taking precedent
+    /// over REST.
+    func getConfig(for apiName: String? = nil,
+                   endpointType: AWSAPICategoryPluginEndpointType? = nil) throws ->
         AWSAPICategoryPluginConfiguration.EndpointConfig {
         if let apiName = apiName {
             return try getConfig(for: apiName)
         }
-
-        let apiForEndpointType = filter { (_, endpointConfig) -> Bool in
-            return endpointConfig.endpointType == endpointType
+        if let endpointType = endpointType {
+            return try getConfig(for: endpointType)
         }
 
-        guard let endpointConfig = apiForEndpointType.first else {
-            throw APIError.invalidConfiguration("Missing API for \(endpointType) endpointType",
-                                                "Add the \(endpointType) API to configuration.")
-        }
-
-        if apiForEndpointType.count > 1 {
-            throw APIError.invalidConfiguration(
-                "More than one \(endpointType) API configured. Could not infer which API to call",
-                "Use the apiName to specify which API to call")
-        }
-
-        return endpointConfig.value
+        return try getConfig()
     }
 
+    // Retrieve the endpoint configuration for the specified `apiName`
     private func getConfig(for apiName: String) throws -> AWSAPICategoryPluginConfiguration.EndpointConfig {
         guard let endpointConfig = self[apiName] else {
 
@@ -321,5 +316,50 @@ extension Dictionary where Key == String, Value == AWSAPICategoryPluginConfigura
         }
 
         return endpointConfig
+    }
+
+    // Retrieve the endpoint configuration when there is only one endpoint of the specified `endpointType`
+    private func getConfig(for endpointType: AWSAPICategoryPluginEndpointType) throws ->
+    AWSAPICategoryPluginConfiguration.EndpointConfig {
+        let apiForEndpointType = filter { (_, endpointConfig) -> Bool in
+            return endpointConfig.endpointType == endpointType
+        }
+
+        guard let endpointConfig = apiForEndpointType.first else {
+            throw APIError.invalidConfiguration("Missing API for \(endpointType) endpointType",
+                                                "Add the \(endpointType) API to configuration.")
+        }
+
+        if apiForEndpointType.count > 1 {
+            throw APIError.invalidConfiguration(
+                "More than one \(endpointType) API configured. Could not infer which API to call",
+                "Use the apiName to specify which API to call")
+        }
+        return endpointConfig.value
+    }
+
+    // Retrieve the endpoint only if there is a single one, with GraphQL taking precedent over REST.
+    private func getConfig() throws -> AWSAPICategoryPluginConfiguration.EndpointConfig {
+        let graphQLEndpoints = filter { (_, endpointConfig) -> Bool in
+            return endpointConfig.endpointType == .graphQL
+        }
+
+        if graphQLEndpoints.count == 1, let endpoint = graphQLEndpoints.first {
+            return endpoint.value
+        }
+
+        let restEndpoints = filter { (_, endpointConfig) -> Bool in
+            return endpointConfig.endpointType == .rest
+        }
+
+        if restEndpoints.count == 1, let endpoint = restEndpoints.first {
+            return endpoint.value
+        }
+
+        throw APIError.invalidConfiguration("Unable to determine which endpoint configuration",
+                                            """
+                                            Pass in the apiName to disambiguate between which endpoint
+                                            you are requesting for
+                                            """)
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginConfiguration+EndpointConfig.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginConfiguration+EndpointConfig.swift
@@ -320,22 +320,22 @@ extension Dictionary where Key == String, Value == AWSAPICategoryPluginConfigura
 
     // Retrieve the endpoint configuration when there is only one endpoint of the specified `endpointType`
     private func getConfig(for endpointType: AWSAPICategoryPluginEndpointType) throws ->
-    AWSAPICategoryPluginConfiguration.EndpointConfig {
-        let apiForEndpointType = filter { (_, endpointConfig) -> Bool in
-            return endpointConfig.endpointType == endpointType
-        }
+        AWSAPICategoryPluginConfiguration.EndpointConfig {
+            let apiForEndpointType = filter { (_, endpointConfig) -> Bool in
+                return endpointConfig.endpointType == endpointType
+            }
 
-        guard let endpointConfig = apiForEndpointType.first else {
-            throw APIError.invalidConfiguration("Missing API for \(endpointType) endpointType",
-                                                "Add the \(endpointType) API to configuration.")
-        }
+            guard let endpointConfig = apiForEndpointType.first else {
+                throw APIError.invalidConfiguration("Missing API for \(endpointType) endpointType",
+                                                    "Add the \(endpointType) API to configuration.")
+            }
 
-        if apiForEndpointType.count > 1 {
-            throw APIError.invalidConfiguration(
-                "More than one \(endpointType) API configured. Could not infer which API to call",
-                "Use the apiName to specify which API to call")
-        }
-        return endpointConfig.value
+            if apiForEndpointType.count > 1 {
+                throw APIError.invalidConfiguration(
+                    "More than one \(endpointType) API configured. Could not infer which API to call",
+                    "Use the apiName to specify which API to call")
+            }
+            return endpointConfig.value
     }
 
     // Retrieve the endpoint only if there is a single one, with GraphQL taking precedent over REST.
@@ -356,10 +356,10 @@ extension Dictionary where Key == String, Value == AWSAPICategoryPluginConfigura
             return endpoint.value
         }
 
-        throw APIError.invalidConfiguration("Unable to determine which endpoint configuration",
+        throw APIError.invalidConfiguration("Unable to resolve endpoint configuration",
                                             """
-                                            Pass in the apiName to disambiguate between which endpoint
-                                            you are requesting for
+                                            Pass in the apiName to specify the endpoint you are
+                                            retrieving the config for
                                             """)
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginConfiguration+EndpointConfig.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Configuration/AWSAPICategoryPluginConfiguration+EndpointConfig.swift
@@ -300,7 +300,6 @@ extension Dictionary where Key == String, Value == AWSAPICategoryPluginConfigura
         return try getConfig()
     }
 
-    // Retrieve the endpoint configuration for the specified `apiName`
     private func getConfig(for apiName: String) throws -> AWSAPICategoryPluginConfiguration.EndpointConfig {
         guard let endpointConfig = self[apiName] else {
 
@@ -318,7 +317,7 @@ extension Dictionary where Key == String, Value == AWSAPICategoryPluginConfigura
         return endpointConfig
     }
 
-    // Retrieve the endpoint configuration when there is only one endpoint of the specified `endpointType`
+    /// Retrieve the endpoint configuration when there is only one endpoint of the specified `endpointType`
     private func getConfig(for endpointType: AWSAPICategoryPluginEndpointType) throws ->
         AWSAPICategoryPluginConfiguration.EndpointConfig {
             let apiForEndpointType = filter { (_, endpointConfig) -> Bool in
@@ -338,7 +337,7 @@ extension Dictionary where Key == String, Value == AWSAPICategoryPluginConfigura
             return endpointConfig.value
     }
 
-    // Retrieve the endpoint only if there is a single one, with GraphQL taking precedent over REST.
+    /// Retrieve the endpoint only if there is a single one, with GraphQL taking precedent over REST.
     private func getConfig() throws -> AWSAPICategoryPluginConfiguration.EndpointConfig {
         let graphQLEndpoints = filter { (_, endpointConfig) -> Bool in
             return endpointConfig.endpointType == .graphQL

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ReachabilityTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ReachabilityTests.swift
@@ -1,0 +1,95 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import Foundation
+import AWSPluginsCore
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSAPICategoryPlugin
+
+@available(iOS 13.0, *)
+class AWSAPICategoryPluginReachabilityTests: XCTestCase {
+
+    var apiPlugin: AWSAPIPlugin!
+
+    override func setUp() {
+        apiPlugin = AWSAPIPlugin()
+    }
+
+    override func tearDown() {
+        if let api = apiPlugin {
+            api.reset {
+            }
+        }
+    }
+
+    func testReachabilityReturnsGraphQLAPI() throws {
+        let graphQLAPI = "graphQLAPI"
+        do {
+            let endpointConfig = [graphQLAPI: try getEndpointConfig(apiName: graphQLAPI, endpointType: .graphQL)]
+            let pluginConfig = AWSAPICategoryPluginConfiguration(endpoints: endpointConfig)
+            let dependencies = AWSAPIPlugin.ConfigurationDependencies(
+                pluginConfig: pluginConfig,
+                authService: MockAWSAuthService(),
+                subscriptionConnectionFactory: AWSSubscriptionConnectionFactory()
+            )
+            apiPlugin.configure(using: dependencies)
+        } catch {
+            XCTFail("Failed to create endpoint config")
+        }
+
+        let publisher = try apiPlugin.reachabilityPublisher()
+        XCTAssertNotNil(publisher)
+        XCTAssertEqual(apiPlugin.reachabilityMap.count, 1)
+        guard let reachability = apiPlugin.reachabilityMap.first else {
+            return
+        }
+        XCTAssertEqual(reachability.key, graphQLAPI)
+    }
+
+    func testReachabilityReturnsGraphQLAPIForMultipleEndpoints() throws {
+        let graphQLAPI = "graphQLAPI"
+        let restAPI = "restAPI"
+        do {
+            let endpointConfig = [graphQLAPI: try getEndpointConfig(apiName: graphQLAPI, endpointType: .graphQL),
+                                  restAPI: try getEndpointConfig(apiName: restAPI, endpointType: .rest)]
+            let pluginConfig = AWSAPICategoryPluginConfiguration(endpoints: endpointConfig)
+            let dependencies = AWSAPIPlugin.ConfigurationDependencies(
+                pluginConfig: pluginConfig,
+                authService: MockAWSAuthService(),
+                subscriptionConnectionFactory: AWSSubscriptionConnectionFactory()
+            )
+            apiPlugin.configure(using: dependencies)
+        } catch {
+            XCTFail("Failed to create endpoint config")
+        }
+
+        let publisher = try apiPlugin.reachabilityPublisher()
+        XCTAssertNotNil(publisher)
+        XCTAssertEqual(apiPlugin.reachabilityMap.count, 1)
+        guard let reachability = apiPlugin.reachabilityMap.first else {
+            return
+        }
+        XCTAssertEqual(reachability.key, graphQLAPI)
+    }
+
+    // MARK: - Helpers
+
+    func getEndpointConfig(apiName: String, endpointType: AWSAPICategoryPluginEndpointType) throws ->
+    AWSAPICategoryPluginConfiguration.EndpointConfig {
+        try AWSAPICategoryPluginConfiguration.EndpointConfig(
+            name: apiName,
+            baseURL: URL(string: "http://\(apiName)")!,
+            region: nil,
+            authorizationType: AWSAuthorizationType.none,
+            authorizationConfiguration: AWSAuthorizationConfiguration.none,
+            endpointType: endpointType,
+            apiAuthProviderFactory: APIAuthProviderFactory())
+    }
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ReachabilityTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ReachabilityTests.swift
@@ -48,6 +48,7 @@ class AWSAPICategoryPluginReachabilityTests: XCTestCase {
         XCTAssertNotNil(publisher)
         XCTAssertEqual(apiPlugin.reachabilityMap.count, 1)
         guard let reachability = apiPlugin.reachabilityMap.first else {
+            XCTFail("Missing expeected `reachability`")
             return
         }
         XCTAssertEqual(reachability.key, graphQLAPI)
@@ -74,6 +75,7 @@ class AWSAPICategoryPluginReachabilityTests: XCTestCase {
         XCTAssertNotNil(publisher)
         XCTAssertEqual(apiPlugin.reachabilityMap.count, 1)
         guard let reachability = apiPlugin.reachabilityMap.first else {
+            XCTFail("Missing expeected `reachability`")
             return
         }
         XCTAssertEqual(reachability.key, graphQLAPI)

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationEndpointConfigTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationEndpointConfigTests.swift
@@ -6,10 +6,154 @@
 //
 
 import XCTest
+import AWSPluginsCore
+@testable import Amplify
+@testable import AWSAPICategoryPlugin
+@testable import AmplifyTestCommon
 
 // swiftlint:disable:next type_name
 class AWSAPICategoryPluginConfigurationEndpointConfigTests: XCTestCase {
-    func testClassMustNotBeEmptyOrSwiftFormatWillCrash() {
-        //TODO implement code
+
+    let graphQLAPI = "graphQLAPI"
+    let graphQLAPI2 = "graphQLAPI2"
+    let restAPI = "restAPI"
+    let restAPI2 = "restAPI2"
+
+    func testGetConfigAPIName() throws {
+        let endpointConfig = [graphQLAPI: try getEndpointConfig(apiName: graphQLAPI, endpointType: .graphQL)]
+
+        let endpoint = try endpointConfig.getConfig(for: graphQLAPI)
+
+        XCTAssertEqual(endpoint.name, graphQLAPI)
+        XCTAssertEqual(endpoint.endpointType, .graphQL)
+    }
+
+    func testGetConfigAPINameFailsWhenInvalidAPIName() throws {
+        let endpointConfig = [graphQLAPI: try getEndpointConfig(apiName: graphQLAPI, endpointType: .graphQL)]
+
+        do {
+             _ = try endpointConfig.getConfig(for: "incorrectAPIName")
+        } catch let error as APIError {
+            guard case .invalidConfiguration = error else {
+                XCTFail("Unexpected error \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Should have been APIError")
+        }
+    }
+
+    func testGetConfigEndpointTypeForGraphQL() throws {
+        let endpointConfig = [graphQLAPI: try getEndpointConfig(apiName: graphQLAPI, endpointType: .graphQL),
+                              restAPI: try getEndpointConfig(apiName: restAPI, endpointType: .rest)]
+
+        let endpoint = try endpointConfig.getConfig(endpointType: .graphQL)
+
+        XCTAssertEqual(endpoint.name, graphQLAPI)
+        XCTAssertEqual(endpoint.endpointType, .graphQL)
+    }
+
+    func testGetConfigEndpointTypeFailsWhenMoreThanOneEndpointOfTheTypeExists() throws {
+        let endpointConfig = [graphQLAPI: try getEndpointConfig(apiName: graphQLAPI, endpointType: .graphQL),
+                              graphQLAPI2: try getEndpointConfig(apiName: graphQLAPI2, endpointType: .graphQL)]
+
+        do {
+             _ = try endpointConfig.getConfig(endpointType: .graphQL)
+        } catch let error as APIError {
+            guard case .invalidConfiguration = error else {
+                XCTFail("Unexpected error \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Should have been APIError")
+        }
+    }
+
+    func testGetConfigEndpointTypeFailsWhenMissingEndpointForType() throws {
+        let endpointConfig = [restAPI: try getEndpointConfig(apiName: restAPI, endpointType: .rest)]
+
+        do {
+             _ = try endpointConfig.getConfig(endpointType: .graphQL)
+        } catch let error as APIError {
+            guard case .invalidConfiguration = error else {
+                XCTFail("Unexpected error \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Should have been APIError")
+        }
+    }
+
+    func testGetConfigEndpointTypeForREST() throws {
+        let endpointConfig = [restAPI: try getEndpointConfig(apiName: restAPI, endpointType: .rest)]
+
+        let endpoint = try endpointConfig.getConfig(endpointType: .rest)
+
+        XCTAssertEqual(endpoint.name, restAPI)
+        XCTAssertEqual(endpoint.endpointType, .rest)
+    }
+
+    func testGetConfigForOneGraphQLAndOneRESTEndpoint() throws {
+        let endpointConfig = [graphQLAPI: try getEndpointConfig(apiName: graphQLAPI, endpointType: .graphQL),
+                              restAPI: try getEndpointConfig(apiName: restAPI, endpointType: .rest)]
+
+        let endpoint = try endpointConfig.getConfig()
+
+        XCTAssertEqual(endpoint.name, graphQLAPI)
+        XCTAssertEqual(endpoint.endpointType, .graphQL)
+    }
+
+    func testGetConfigForMoreThanOneGraphQLAndOneRESTEndpoint() throws {
+        let endpointConfig = [graphQLAPI: try getEndpointConfig(apiName: graphQLAPI, endpointType: .graphQL),
+                              graphQLAPI2: try getEndpointConfig(apiName: graphQLAPI2, endpointType: .graphQL),
+                              restAPI: try getEndpointConfig(apiName: restAPI, endpointType: .rest)]
+
+        let endpoint = try endpointConfig.getConfig()
+
+        XCTAssertEqual(endpoint.name, restAPI)
+        XCTAssertEqual(endpoint.endpointType, .rest)
+    }
+
+    func testGetConfigForOneGraphQLAndMoreThanOneRESTEndpoint() throws {
+        let endpointConfig = [graphQLAPI: try getEndpointConfig(apiName: graphQLAPI, endpointType: .graphQL),
+                              restAPI: try getEndpointConfig(apiName: restAPI, endpointType: .rest),
+                              restAPI2: try getEndpointConfig(apiName: restAPI2, endpointType: .rest)]
+
+        let endpoint = try endpointConfig.getConfig()
+
+        XCTAssertEqual(endpoint.name, graphQLAPI)
+        XCTAssertEqual(endpoint.endpointType, .graphQL)
+    }
+
+    func testGetConfigShouldFailForMoreThanOneGraphQLAndRESTEndpoints() throws {
+        let endpointConfig = [graphQLAPI: try getEndpointConfig(apiName: graphQLAPI, endpointType: .graphQL),
+                              graphQLAPI2: try getEndpointConfig(apiName: graphQLAPI2, endpointType: .graphQL),
+                              restAPI: try getEndpointConfig(apiName: restAPI, endpointType: .rest),
+                              restAPI2: try getEndpointConfig(apiName: restAPI2, endpointType: .rest)]
+
+        do {
+             _ = try endpointConfig.getConfig()
+        } catch let error as APIError {
+            guard case .invalidConfiguration = error else {
+                XCTFail("Unexpected error \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Should have been APIError")
+        }
+    }
+
+    // MARK: - Helpers
+
+    func getEndpointConfig(apiName: String, endpointType: AWSAPICategoryPluginEndpointType) throws ->
+    AWSAPICategoryPluginConfiguration.EndpointConfig {
+        try AWSAPICategoryPluginConfiguration.EndpointConfig(
+            name: apiName,
+            baseURL: URL(string: "http://myhost")!,
+            region: nil,
+            authorizationType: AWSAuthorizationType.none,
+            authorizationConfiguration: AWSAuthorizationConfiguration.none,
+            endpointType: endpointType,
+            apiAuthProviderFactory: APIAuthProviderFactory())
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/1159
Part of https://github.com/aws-amplify/amplify-ios/issues/1103

*Description of changes:*
This improves the endpoint resolution logic to return the GraphQL endpoint whenever it is possible to. This makes is so that when using DataStore, the APIPlugin's reachability by default will return the first GraphQL endpoint configured, even when there is more than one API. For example
1. one REST and one graphQL API will return the graphQL API
2. one REST and two graphQL APIs will return the REST API
3. two REST APIs and one GraphQL API wil return the GraphQL API
4. two REST APIs and two GraphQL APIs will not be able to resolve

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
