### PR TITLE
Fix provider not sending validationData in signin

### DIFF
--- a/Amplify/Categories/Auth/Request/AuthSignInRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthSignInRequest.swift
@@ -31,11 +31,8 @@ public extension AuthSignInRequest {
         /// key/values
         public let pluginOptions: Any?
 
-        public let validationData: Dictionary<String, String>?
-
-        public init(pluginOptions: Any? = nil, validationData: Dictionary<String, String>? = nil) {
+        public init(pluginOptions: Any? = nil) {
             self.pluginOptions = pluginOptions
-            self.validationData = validationData
         }
     }
 }

--- a/Amplify/Categories/Auth/Request/AuthSignInRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthSignInRequest.swift
@@ -31,8 +31,11 @@ public extension AuthSignInRequest {
         /// key/values
         public let pluginOptions: Any?
 
-        public init(pluginOptions: Any? = nil) {
+        public let validationData: Dictionary<String, String>?
+
+        public init(pluginOptions: Any? = nil, validationData: Dictionary<String, String>? = nil) {
             self.pluginOptions = pluginOptions
+            self.validationData = validationData
         }
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -30,7 +30,7 @@ extension AuthenticationProviderAdapter {
 
         awsMobileClient.signIn(username: username,
                                password: password,
-                               validationData: nil,
+                               validationData: request.options.validationData as! [String:String],
                                clientMetaData: clientMetaData) { [weak self] result, error in
             guard let self = self else { return }
 

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -26,11 +26,13 @@ extension AuthenticationProviderAdapter {
         // Password can be nil, but awsmobileclient need it to have a dummy value.
         let password = request.password ?? ""
 
+        let validationData = (request.options.pluginOptions as? AWSAuthSignInOptions)?.validationData ?? [:]
+
         let clientMetaData = (request.options.pluginOptions as? AWSAuthSignInOptions)?.metadata ?? [:]
 
         awsMobileClient.signIn(username: username,
                                password: password,
-                               validationData: request.options.validationData as! [String:String],
+                               validationData: validationData,
                                clientMetaData: clientMetaData) { [weak self] result, error in
             guard let self = self else { return }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/506

*Description of changes:*
The iOS auth provider do not send the validationData to the awsclient.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
