### PR TITLE
Resolves aws-amplify/amplify-flutter#544

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/SignInResult+Extension.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/SignInResult+Extension.swift
@@ -22,7 +22,7 @@ extension SignInResult {
             let deliveryDetails = AuthCodeDeliveryDetails(destination: .sms(codeDetails?.destination))
             return .confirmSignInWithSMSMFACode(deliveryDetails, nil)
         case .customChallenge:
-            return .confirmSignInWithCustomChallenge(nil)
+            return .confirmSignInWithCustomChallenge(parameters)
         case .newPasswordRequired:
             return .confirmSignInWithNewPassword(nil)
         default:


### PR DESCRIPTION
Pass public challenge parameters (AdditionalInfo) when authenticating with custom challenge

*Issue #: aws-amplify/amplify-flutter#544*

*Description of changes:*
Pass the expected `AdditionalInfo` parameter when calling `confirmSignInWithCustomChallenge()` instead of `nil`

**Note:** I am not familiar with this code base (or Swift for that matter), but I needed to patch this for my project. I'm currently using a fork of `amplify-ios` with this fix in place. I'm submitting this here for feedback. Let me know if there are additional changes required to get this merged into a future release.

*Check points:*
- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
