### PR TITLE
Increase `maxConcurrentOperationCount` to 20

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
@@ -63,7 +63,7 @@ final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
 
         let syncOperationQueue = OperationQueue()
         syncOperationQueue.name = "com.amazon.InitialSyncOrchestrator.syncOperationQueue"
-        syncOperationQueue.maxConcurrentOperationCount = 1
+        syncOperationQueue.maxConcurrentOperationCount = 20
         syncOperationQueue.isSuspended = true
         self.syncOperationQueue = syncOperationQueue
 


### PR DESCRIPTION
*Description of changes:*

Increase the `maxConcurrentOperationCount` for initial DataStore sync from `1` to `20`.

This fixes an issues where an application I am developing for work is slow to start due to the current DataStore behaviour of serially loading model data.