### PR TITLE
fix: Pass additional info in signIn next step

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/SignInResult+Extension.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/SignInResult+Extension.swift
@@ -20,11 +20,11 @@ extension SignInResult {
             return .done
         case .smsMFA:
             let deliveryDetails = AuthCodeDeliveryDetails(destination: .sms(codeDetails?.destination))
-            return .confirmSignInWithSMSMFACode(deliveryDetails, nil)
+            return .confirmSignInWithSMSMFACode(deliveryDetails, parameters)
         case .customChallenge:
             return .confirmSignInWithCustomChallenge(parameters)
         case .newPasswordRequired:
-            return .confirmSignInWithNewPassword(nil)
+            return .confirmSignInWithNewPassword(parameters)
         default:
             throw (AuthError.unknown("AWSMobileClient auth state is not handled"))
         }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
@@ -186,6 +186,123 @@ class AuthenticationProviderSigninTests: BaseAuthenticationProviderTest {
         wait(for: [resultExpectation], timeout: apiTimeout)
     }
 
+    /// Test a signIn with additional info in next step
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mock additional info in custom auth
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a the info in next step
+    ///
+    func testCustomAuthWithAdditionalInfo() {
+
+        let mockSigninResult = SignInResult(signInState: .customChallenge, parameters: ["paramKey": "value"])
+        mockAWSMobileClient?.signInMockResult = .success(mockSigninResult)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                guard case .confirmSignInWithCustomChallenge(let additionalInfo) = signinResult.nextStep else {
+                    XCTFail("Result should be .confirmSignInWithCustomChallenge for next step")
+                    return
+                }
+                guard let addditionalValue = additionalInfo?["paramKey"] else {
+                    XCTFail("Additional info should be passed to the result")
+                    return
+                }
+                XCTAssertEqual(addditionalValue, "value", "Additional info should be same")
+                XCTAssertFalse(signinResult.isSignedIn, "Signin result should not be complete")
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with additional info in next step
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mock additional info in sms mfa
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a the info in next step
+    ///
+    func testSMSMFAWithAdditionalInfo() {
+
+        let mockSigninResult = SignInResult(signInState: .smsMFA, parameters: ["paramKey": "value"])
+        mockAWSMobileClient?.signInMockResult = .success(mockSigninResult)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                guard case .confirmSignInWithSMSMFACode(_, let additionalInfo) = signinResult.nextStep else {
+                    XCTFail("Result should be .confirmSignInWithSMSMFACode for next step")
+                    return
+                }
+                guard let addditionalValue = additionalInfo?["paramKey"] else {
+                    XCTFail("Additional info should be passed to the result")
+                    return
+                }
+                XCTAssertEqual(addditionalValue, "value", "Additional info should be same")
+                XCTAssertFalse(signinResult.isSignedIn, "Signin result should not be complete")
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
+    /// Test a signIn with additional info in next step
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mock additional info in new password
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a the info in next step
+    ///
+    func testNewPasswordWithAdditionalInfo() {
+
+        let mockSigninResult = SignInResult(signInState: .newPasswordRequired, parameters: ["paramKey": "value"])
+        mockAWSMobileClient?.signInMockResult = .success(mockSigninResult)
+
+        let options = AuthSignInRequest.Options()
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                guard case .confirmSignInWithNewPassword(let additionalInfo) = signinResult.nextStep else {
+                    XCTFail("Result should be .confirmSignInWithNewPassword for next step")
+                    return
+                }
+                guard let addditionalValue = additionalInfo?["paramKey"] else {
+                    XCTFail("Additional info should be passed to the result")
+                    return
+                }
+                XCTAssertEqual(addditionalValue, "value", "Additional info should be same")
+                XCTAssertFalse(signinResult.isSignedIn, "Signin result should not be complete")
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
     /// Test a signIn with customChallenge as signIn result response
     ///
     /// - Given: Given an auth plugin with mocked service. Mock customChallenge response for signIn result


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/544

*Description of changes:*

Passes the additional info in the next step.
Similar logic in android [here](https://github.com/aws-amplify/amplify-android/blob/50b63dc25923ef54f2bbaf79590e673bd2542b88/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/AWSCognitoAuthPlugin.java#L1172)

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
