### PR TITLE
chore: 1.9.1 release - swift package update AppSyncRTClient 1.5.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
         "state": {
           "branch": null,
-          "revision": "16c2c3aaf0b0a812dbc2023cecb0dbd433f99810",
-          "version": "1.4.4"
+          "revision": "55d670f329b9cf9f4830d5f1b37e50b100934d09",
+          "version": "1.5.0"
         }
       },
       {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Now that AppSyncRTClient 1.5.0 has been released, customer using Amplify via SPM will automatically pull in 1.5.0. We should keep the `Package.resolved` up to date with what the customer would potentially be pulling in on their app.

We do this in the [fastlane script](https://github.com/aws-amplify/amplify-ios/blob/main/fastlane/Fastfile#L126-L151) for pods that generates this [commit](https://github.com/aws-amplify/amplify-ios/commit/6e6fbd4e3e9e6cdbb11cac85dba83f0341420040) so I think we should be doing similarly for SPM `swift package update` as part of the finalize release as well.

This PR is to manually update the `Package.resolved`

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
