### PR TITLE
chore(DataStore): fix non-compiling list nullability test

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreScalarTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreScalarTests.swift
@@ -152,14 +152,16 @@ class DataStoreScalarTests: SyncEngineIntegrationTestBase {
         XCTAssertNil(emptyModel)
     }
 
+    // TODO: Not sure how this was compiling and tested before, should be fixed with
+    // https://github.com/aws-amplify/amplify-ios/pull/1145
     func testListContainerWithNil() throws {
         try startAmplifyAndWaitForSync()
         let container = ListStringContainer(
             test: "test",
             nullableString: nil,
             stringList: ["value1"],
-            stringNullableList: nil,
-            nullableStringList: [nil],
+            stringNullableList: [], // TODO: test with `nil` with new codegen feature
+            nullableStringList: ["value1"], // TODO: test with `[nil]`
             nullableStringNullableList: nil)
 
         let updatedContainer = ListStringContainer(id: container.id,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The sets the properties `stringNullableList` and `nullableStringList` to the lowest possible values, before the antipicated codegen changes that will generate new models allowing us to set nil values

I'm not 100% how this test was able to pass before and discovered this when i started working off of a fresh copy of the repo.

related PR that turn this test into a more accurate "test with nil" values test: https://github.com/aws-amplify/amplify-ios/pull/1145


*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
