### PR TITLE
fix(DataStore): redundant local metadata query in ReconcileAndLocalSaveOperation

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Action.swift
@@ -23,7 +23,7 @@ extension ReconcileAndLocalSaveOperation {
 
         /// Operation has applied the incoming RemoteModel to the local database per the reconciled disposition. This
         /// could result in either a save to the local database, or a delete from the local database.
-        case applied(AppliedModel, existsLocally: Bool)
+        case applied(AppliedModel, mutationType: MutationEvent.MutationType)
 
         /// Operation dropped the remote model per the reconciled disposition.
         case dropped(modelName: String)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Resolver.swift
@@ -34,8 +34,8 @@ extension ReconcileAndLocalSaveOperation {
             case (.notifyingDropped, .notified):
                 return .finished
 
-            case (.executing, .applied(let savedModel, let existsLocally)):
-                return .notifying(savedModel, existsLocally)
+            case (.executing, .applied(let savedModel, let mutationType)):
+                return .notifying(savedModel, mutationType)
 
             case (.notifying, .notified):
                 return .finished

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+State.swift
@@ -27,7 +27,7 @@ extension ReconcileAndLocalSaveOperation {
         case notifyingDropped(String)
 
         /// Notifying listeners and callbacks of completion
-        case notifying(AppliedModel, Bool)
+        case notifying(AppliedModel, MutationEvent.MutationType)
 
         /// Operation has successfully completed
         case finished

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -217,7 +217,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
 
         // TODO: Wrap this in a transaction
         if mutationType == .delete {
-            saveDeleteMutation(storageAdapter: storageAdapter, remoteModel: remoteModel, mutationType: mutationType)
+            saveDeleteMutation(storageAdapter: storageAdapter, remoteModel: remoteModel)
         } else {
             saveCreateOrUpdateMutation(storageAdapter: storageAdapter,
                                        remoteModel: remoteModel,
@@ -226,8 +226,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
     }
 
     private func saveDeleteMutation(storageAdapter: StorageEngineAdapter,
-                                    remoteModel: RemoteModel,
-                                    mutationType: MutationEvent.MutationType) {
+                                    remoteModel: RemoteModel) {
         log.verbose(#function)
 
         guard let modelType = ModelRegistry.modelType(from: modelSchema.name) else {
@@ -250,7 +249,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
             case .success:
                 self.saveMetadata(storageAdapter: storageAdapter,
                                   inProcessModel: remoteModel,
-                                  mutationType: mutationType)
+                                  mutationType: .delete)
             }
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -100,8 +100,8 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
         case .notifyingDropped(let modelName):
             notifyDropped(modelName: modelName)
 
-        case .notifying(let savedModel, let existsLocally):
-            notify(savedModel: savedModel, existsLocally: existsLocally)
+        case .notifying(let savedModel, let mutationType):
+            notify(savedModel: savedModel, mutationType: mutationType)
 
         case .inError(let error):
             // Maybe we have to notify the Hub?
@@ -189,12 +189,10 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
     /// - dropped
     func execute(disposition: RemoteSyncReconciler.Disposition) {
         switch disposition {
-        case .applyRemoteModel(let remoteModel):
-            apply(remoteModel: remoteModel)
+        case .applyRemoteModel(let remoteModel, let mutationType):
+            apply(remoteModel: remoteModel, mutationType: mutationType)
         case .dropRemoteModel(let modelName):
             stateMachine.notify(action: .dropped(modelName: modelName))
-        case .error(let dataStoreError):
-            stateMachine.notify(action: .errored(dataStoreError))
         }
     }
 
@@ -202,7 +200,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
     /// delete methods, which eventually notify with:
     /// - applied
     /// - errored
-    private func apply(remoteModel: RemoteModel) {
+    private func apply(remoteModel: RemoteModel, mutationType: MutationEvent.MutationType) {
         if log.logLevel == .verbose {
             log.verbose("\(#function): remoteModel")
         }
@@ -218,15 +216,18 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
         }
 
         // TODO: Wrap this in a transaction
-        if remoteModel.syncMetadata.deleted {
-            saveDeleteMutation(storageAdapter: storageAdapter, remoteModel: remoteModel)
+        if mutationType == .delete {
+            saveDeleteMutation(storageAdapter: storageAdapter, remoteModel: remoteModel, mutationType: mutationType)
         } else {
-            saveCreateOrUpdateMutation(storageAdapter: storageAdapter, remoteModel: remoteModel)
+            saveCreateOrUpdateMutation(storageAdapter: storageAdapter,
+                                       remoteModel: remoteModel,
+                                       mutationType: mutationType)
         }
-
     }
 
-    private func saveDeleteMutation(storageAdapter: StorageEngineAdapter, remoteModel: RemoteModel) {
+    private func saveDeleteMutation(storageAdapter: StorageEngineAdapter,
+                                    remoteModel: RemoteModel,
+                                    mutationType: MutationEvent.MutationType) {
         log.verbose(#function)
 
         guard let modelType = ModelRegistry.modelType(from: modelSchema.name) else {
@@ -247,12 +248,16 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
                 let errorAction = Action.errored(dataStoreError)
                 self.stateMachine.notify(action: errorAction)
             case .success:
-                self.saveMetadata(storageAdapter: storageAdapter, inProcessModel: remoteModel)
+                self.saveMetadata(storageAdapter: storageAdapter,
+                                  inProcessModel: remoteModel,
+                                  mutationType: mutationType)
             }
         }
     }
 
-    private func saveCreateOrUpdateMutation(storageAdapter: StorageEngineAdapter, remoteModel: RemoteModel) {
+    private func saveCreateOrUpdateMutation(storageAdapter: StorageEngineAdapter,
+                                            remoteModel: RemoteModel,
+                                            mutationType: MutationEvent.MutationType) {
         log.verbose(#function)
         storageAdapter.save(untypedModel: remoteModel.model.instance) { response in
             if self.log.logLevel == .debug {
@@ -271,25 +276,18 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
                     return
                 }
                 let inProcessModel = MutationSync(model: anyModel, syncMetadata: remoteModel.syncMetadata)
-                self.saveMetadata(storageAdapter: storageAdapter, inProcessModel: inProcessModel)
+                self.saveMetadata(storageAdapter: storageAdapter,
+                                  inProcessModel: inProcessModel,
+                                  mutationType: mutationType)
             }
         }
     }
 
     private func saveMetadata(storageAdapter: StorageEngineAdapter,
-                              inProcessModel: AppliedModel) {
+                              inProcessModel: AppliedModel,
+                              mutationType: MutationEvent.MutationType) {
         log.verbose(#function)
 
-        /// Do a local metadata query before saving to check if the `AppliedModel` is of `create` or
-        /// `update` MutationType from the perspective of the local store
-        let existsLocally: Bool
-        do {
-            let localMetadata = try storageAdapter.queryMutationSyncMetadata(for: remoteModel.model.id)
-            existsLocally = localMetadata != nil
-        } catch {
-            log.error("Failed to query for sync metadata")
-            return
-        }
         storageAdapter.save(remoteModel.syncMetadata, condition: nil) { result in
             if self.log.logLevel == .debug {
                 self.log.debug("save metadata: \(self.stopwatch.lap())s")
@@ -300,7 +298,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
                 self.stateMachine.notify(action: errorAction)
             case .success(let syncMetadata):
                 let appliedModel = MutationSync(model: inProcessModel.model, syncMetadata: syncMetadata)
-                self.stateMachine.notify(action: .applied(appliedModel, existsLocally: existsLocally))
+                self.stateMachine.notify(action: .applied(appliedModel, mutationType: mutationType))
             }
         }
     }
@@ -313,23 +311,14 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
     /// Responder method for `notifying`. Notify actions:
     /// - notified
     func notify(savedModel: AppliedModel,
-                existsLocally: Bool) {
+                mutationType: MutationEvent.MutationType) {
         log.verbose(#function)
 
         guard !isCancelled else {
             log.verbose("\(#function) - cancelled, aborting")
             return
         }
-
-        let mutationType: MutationEvent.MutationType
         let version = savedModel.syncMetadata.version
-        if savedModel.syncMetadata.deleted {
-            mutationType = .delete
-        } else if !existsLocally {
-            mutationType = .create
-        } else {
-            mutationType = .update
-        }
 
         // TODO: Dispatch/notify error if we can't erase to any model? Would imply an error in JSON decoding,
         // which shouldn't be possible this late in the process. Possibly notify global conflict/error handler?

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/RemoteSyncReconciler.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/RemoteSyncReconciler.swift
@@ -15,9 +15,8 @@ struct RemoteSyncReconciler {
     typealias SavedModel = ReconcileAndLocalSaveOperation.AppliedModel
 
     enum Disposition {
-        case applyRemoteModel(RemoteModel)
+        case applyRemoteModel(RemoteModel, MutationEvent.MutationType)
         case dropRemoteModel(String)
-        case error(DataStoreError)
     }
 
     static func reconcile(remoteModel: RemoteModel,
@@ -29,13 +28,21 @@ struct RemoteSyncReconciler {
         }
 
         guard let localMetadata = localMetadata else {
-            return .applyRemoteModel(remoteModel)
+            if remoteModel.syncMetadata.deleted {
+                return .dropRemoteModel(remoteModel.model.modelName)
+            } else {
+                return .applyRemoteModel(remoteModel, .create)
+            }
         }
 
         // Technically, we should never receive a subscription for a version we already have, but we'll be defensive
         // and make this check include the current version
         if remoteModel.syncMetadata.version >= localMetadata.version {
-            return .applyRemoteModel(remoteModel)
+            if remoteModel.syncMetadata.deleted {
+                return .applyRemoteModel(remoteModel, .delete)
+            } else {
+                return .applyRemoteModel(remoteModel, .update)
+            }
         }
 
         return .dropRemoteModel(remoteModel.model.modelName)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -132,7 +132,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
 
     func testReconcilingWithoutLocalModel() throws {
         let expect = expectation(description: "action .reconciled notified")
-        let expectedDisposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostMutationSync)
+        let expectedDisposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostMutationSync, .create)
         stateMachine.pushExpectActionCriteria { action in
             XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.reconciled(expectedDisposition))
             expect.fulfill()
@@ -142,13 +142,13 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    func testExecuteApplyRemoteModelThatDoesNotExistLocally() throws {
+    func testExecuteApplyRemoteModelCreate() throws {
         let expect = expectation(description: "action .execute applyRemoteModel")
-        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostMutationSync)
+        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostMutationSync, .create)
         storageAdapter.returnOnSave(dataStoreResult: .success(anyPostMutationSync.model))
         stateMachine.pushExpectActionCriteria { action in
             XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.applied(self.anyPostMutationSync,
-                                                                                 existsLocally: false))
+                                                                                 mutationType: .create))
             expect.fulfill()
         }
 
@@ -156,15 +156,14 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    func testExecuteApplyRemoteModelThatExistsLocally() throws {
+    func testExecuteApplyRemoteModelUpdate() throws {
         let expect = expectation(description: "action .execute applyRemoteModel")
-        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostMutationSync)
+        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostMutationSync, .update)
 
         storageAdapter.returnOnSave(dataStoreResult: .success(anyPostMutationSync.model))
-        storageAdapter.returnOnQueryMutationSyncMetadata(.some(anyPostMetadata))
         stateMachine.pushExpectActionCriteria { action in
             XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.applied(self.anyPostMutationSync,
-                                                                                 existsLocally: true))
+                                                                                 mutationType: .update))
             expect.fulfill()
         }
         stateMachine.state = .executing(disposition)
@@ -174,7 +173,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
 
     func testExecuteApplyRemoteModel_saveMutationFailed() throws {
         let expect = expectation(description: "action .execute error on save model")
-        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostMutationSync)
+        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostMutationSync, .create)
         let error = DataStoreError.invalidModelName("invModelName")
         storageAdapter.returnOnSave(dataStoreResult: .failure(error))
         stateMachine.pushExpectActionCriteria { action in
@@ -189,7 +188,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
 
     func testExecuteApplyRemoteModel_saveMutationOK_MetadataFailed() throws {
         let expect = expectation(description: "action .execute error on save mutation")
-        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostMutationSync)
+        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostMutationSync, .create)
         let error = DataStoreError.invalidModelName("forceError")
         storageAdapter.returnOnSave(dataStoreResult: .success(anyPostMutationSync.model))
         storageAdapter.shouldReturnErrorOnSaveMetadata = true
@@ -204,11 +203,11 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
 
     func testExecuteApplyRemoteModel_Delete() throws {
         let expect = expectation(description: "action .execute applyRemoteModel delete success case")
-        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostDeletedMutationSync)
+        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostDeletedMutationSync, .delete)
         storageAdapter.returnOnSave(dataStoreResult: .success(anyPostDeletedMutationSync.model))
         stateMachine.pushExpectActionCriteria { action in
             XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.applied(self.anyPostDeletedMutationSync,
-                                                                                 existsLocally: false))
+                                                                                 mutationType: .delete))
             expect.fulfill()
         }
 
@@ -218,7 +217,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
 
     func testExecuteApplyRemoteModel_Delete_saveMutationFailed() throws {
         let expect = expectation(description: "action .execute applyRemoteModel delete mutation error")
-        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostDeletedMutationSync)
+        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostDeletedMutationSync, .delete)
         let error = DataStoreError.invalidModelName("DelMutate")
         storageAdapter.shouldReturnErrorOnDeleteMutation = true
         stateMachine.pushExpectActionCriteria { action in
@@ -233,7 +232,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
 
     func testExecuteApplyRemoteModel_Delete_saveMutationOK_saveMetadataFailed() throws {
         let expect = expectation(description: "action .execute applyRemoteModel delete metadata error")
-        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostDeletedMutationSync)
+        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostDeletedMutationSync, .delete)
         let error = DataStoreError.invalidModelName("forceError")
         storageAdapter.shouldReturnErrorOnSaveMetadata = true
         storageAdapter.returnOnSave(dataStoreResult: .failure(error))
@@ -259,20 +258,6 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    func testExecuteErrorOnDisposition() throws {
-        let expect = expectation(description: "action .execute error")
-        let error = DataStoreError.invalidModelName("invModelName")
-        let disposition = RemoteSyncReconciler.Disposition.error(error)
-        stateMachine.pushExpectActionCriteria { action in
-            XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.errored(error))
-            expect.fulfill()
-        }
-
-        stateMachine.state = .executing(disposition)
-
-        waitForExpectations(timeout: 1)
-    }
-
     func testNotifying() throws {
         let hubExpect = expectation(description: "Hub is notified")
         let notifyExpect = expectation(description: "action .notified notified")
@@ -286,7 +271,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
             notifyExpect.fulfill()
         }
 
-        stateMachine.state = .notifying(anyPostMutationSync, false)
+        stateMachine.state = .notifying(anyPostMutationSync, .create)
 
         waitForExpectations(timeout: 1)
         Amplify.Hub.removeListener(hubListener)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/RemoteSyncReconcilerTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/RemoteSyncReconcilerTests.swift
@@ -41,7 +41,7 @@ class RemoteSyncReconcilerTests: XCTestCase {
                                                          to: nil,
                                                          pendingMutations: pendingMutations)
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel))
+        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel, .create))
     }
 
     func testUpdatedOnRemote_noLocal_noPendingMutation() throws {
@@ -52,7 +52,7 @@ class RemoteSyncReconcilerTests: XCTestCase {
                                                          to: nil,
                                                          pendingMutations: pendingMutations)
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel))
+        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel, .create))
     }
 
     func testDeletedOnRemote_noLocal_noPendingMutation() throws {
@@ -63,7 +63,7 @@ class RemoteSyncReconcilerTests: XCTestCase {
                                                          to: nil,
                                                          pendingMutations: pendingMutations)
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel))
+        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
     }
 
     // MARK: - No local model, with pending mutations
@@ -113,7 +113,7 @@ class RemoteSyncReconcilerTests: XCTestCase {
                                                          to: localSyncMetadata,
                                                          pendingMutations: pendingMutations)
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel))
+        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel, .update))
     }
 
     func testUpdatedOnRemote_withLocalLowerVersion_noPendingMutations() throws {
@@ -125,7 +125,7 @@ class RemoteSyncReconcilerTests: XCTestCase {
                                                          to: localSyncMetadata,
                                                          pendingMutations: pendingMutations)
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel))
+        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel, .update))
     }
 
     func testDeletedOnRemote_withLocalLowerVersion_noPendingMutations() throws {
@@ -137,7 +137,7 @@ class RemoteSyncReconcilerTests: XCTestCase {
                                                          to: localSyncMetadata,
                                                          pendingMutations: pendingMutations)
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel))
+        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel, .delete))
     }
 
     // MARK: - With local model having higher version, no pending mutations
@@ -234,7 +234,7 @@ class RemoteSyncReconcilerTests: XCTestCase {
     }
 
     private func makeRemoteModel(deleted: Bool, version: Int) -> ReconcileAndLocalSaveOperation.RemoteModel {
-        let remoteSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 1)
+        let remoteSyncMetadata = makeMutationSyncMetadata(deleted: deleted, version: version)
         let remoteModel = ReconcileAndLocalSaveOperation.RemoteModel(model: remoteMockSynced,
                                                                      syncMetadata: remoteSyncMetadata)
         return remoteModel

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/EquatableExtensions.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/EquatableExtensions.swift
@@ -13,13 +13,12 @@ extension RemoteSyncReconciler.Disposition: Equatable {
     public static func == (lhs: RemoteSyncReconciler.Disposition,
                            rhs: RemoteSyncReconciler.Disposition) -> Bool {
         switch (lhs, rhs) {
-        case (.applyRemoteModel(let rm1), .applyRemoteModel(let rm2)):
+        case (.applyRemoteModel(let rm1, let mutationType1), .applyRemoteModel(let rm2, let mutationType2)):
             return rm1.model.id == rm2.model.id &&
-                rm1.model.modelName == rm2.model.modelName
+                rm1.model.modelName == rm2.model.modelName &&
+                mutationType1 == mutationType2
         case (.dropRemoteModel, .dropRemoteModel):
             return true
-        case (.error(let error1), .error(let error2)):
-            return error1.errorDescription == error2.errorDescription
         default:
             return false
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This removes a redundant query performed in ReconcileAndLocalSaveOperation by extending the logic in  `RemoteSyncReconciler` to produce a disposition `.applyRemoteModel` containing the mutationType. A new behavior has also been introduced: When there is no local metadata, drop the remote model if it has been deleted (`remoteModel.syncMetadata.deleted == true`). Originally, the deleted remote model would result in an apply- calling storageAdapter.delete and saving the metadata containing the deleted version. In this change, the remote model will not result in the two SQL write attempts (DELETE model and INSERT metadata), but instead will be dropped. If a model is deleted and does not exist locally, it is unnecessary to store that metadata locally, since a deleted model cannot be undeleted.

*Current system - ReconcileAndLocalSaveOperation*:

1. *Query* for the local metadata by model.id
2. *Query* for the pending mutation events by model.id
3. When do we apply the remote model to the local store?
    1. If there are pending mutations, drop the remote model
    2. If there are no pending mutations, and..
        1. If there is no local metadata, _apply the remote model_
        2. If the remote model is greater in version than local metadata, _apply the remote model_
        3. there is a local model that has a higher version, drop the remote model
4. Applying remote model
    1. if remote model is deleted, *delete* the model from local store, and save metadata(5)
    2. or if remote model is not deleted, *save* the remote model (first *query* then *insert or update* the model), and save metadata(5)
5. Saving Metadata
    1. *query* for local metadata, and if there is local metadata, notify that applied model was a "create"
    2. save the metadata, which does a *query* and then an *insert/update*

*Proposed change*:

Remove step 5.1

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
