### PR TITLE
fix(DataStore): optimize dropping remote model when pending mutations in ReconcileAndLocalSaveOperation

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Action.swift
@@ -15,15 +15,21 @@ extension ReconcileAndLocalSaveOperation {
         /// Operation has been started by the queue
         case started(RemoteModel)
 
-        /// Operation has retrieved RemoteModel's corresponding sync metadata from local database
-        case queried(RemoteModel, LocalMetadata?)
+        /// Operation has retrieved pending mutations
+        case queriedPendingMutations(RemoteModel, [MutationEvent])
 
-        /// Operation has reconciled the incoming remote model with local model and sync metadata
-        case reconciled(RemoteSyncReconciler.Disposition)
+        /// Operation has reconciled remote model with pending mutations
+        case reconciledWithPendingMutations(RemoteModel)
+
+        /// Operation has retrieved local metadata
+        case queriedLocalMetadata(RemoteModel, LocalMetadata?)
+
+        /// Operation has reconciled the local metadata to apply the remote model.
+        case reconciledAsApply(RemoteModel, MutationEvent.MutationType)
 
         /// Operation has applied the incoming RemoteModel to the local database per the reconciled disposition. This
         /// could result in either a save to the local database, or a delete from the local database.
-        case applied(AppliedModel, mutationType: MutationEvent.MutationType)
+        case applied(AppliedModel, MutationEvent.MutationType)
 
         /// Operation dropped the remote model per the reconciled disposition.
         case dropped(modelName: String)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+State.swift
@@ -15,15 +15,22 @@ extension ReconcileAndLocalSaveOperation {
         /// Waiting to be started by the queue
         case waiting
 
-        /// Querying the local database for model data and sync metadata
-        case querying(RemoteModel)
+        /// Querying the pending mutations database
+        case queryingPendingMutations(RemoteModel)
 
-        /// Reconciling incoming remote model with local model and sync metadata
-        case reconciling(RemoteModel, LocalMetadata?)
+        /// Reconciling remote models against pending mutations
+        case reconcilingWithPendingMutations(RemoteModel, [MutationEvent])
 
-        /// Executing the reconciled disposition
-        case executing(RemoteSyncReconciler.Disposition)
+        /// Querying the local metadata database
+        case queryingLocalMetadata(RemoteModel)
 
+        /// Reconcile against local metadata
+        case reconcilingWithLocalMetadata(RemoteModel, LocalMetadata?)
+
+        /// Applying the remote model
+        case applyingRemoteModel(RemoteModel, MutationEvent.MutationType)
+
+        /// Notifying that the model was dropped
         case notifyingDropped(String)
 
         /// Notifying listeners and callbacks of completion

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/RemoteSyncReconciler.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/RemoteSyncReconciler.swift
@@ -12,21 +12,19 @@ import Amplify
 struct RemoteSyncReconciler {
     typealias LocalMetadata = ReconcileAndLocalSaveOperation.LocalMetadata
     typealias RemoteModel = ReconcileAndLocalSaveOperation.RemoteModel
-    typealias SavedModel = ReconcileAndLocalSaveOperation.AppliedModel
 
     enum Disposition {
         case applyRemoteModel(RemoteModel, MutationEvent.MutationType)
         case dropRemoteModel(String)
     }
 
+    static func reoncile(_ remoteModel: RemoteModel,
+                         pendingMutations: [MutationEvent]) -> RemoteModel? {
+        pendingMutations.isEmpty ? remoteModel : nil
+    }
+
     static func reconcile(remoteModel: RemoteModel,
-                          to localMetadata: LocalMetadata?,
-                          pendingMutations: [MutationEvent]) -> Disposition {
-
-        guard pendingMutations.isEmpty else {
-            return .dropRemoteModel(remoteModel.model.modelName)
-        }
-
+                          to localMetadata: LocalMetadata?) -> Disposition {
         guard let localMetadata = localMetadata else {
             if remoteModel.syncMetadata.deleted {
                 return .dropRemoteModel(remoteModel.model.modelName)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/RemoteSyncReconcilerTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/RemoteSyncReconcilerTests.swift
@@ -31,194 +31,107 @@ class RemoteSyncReconcilerTests: XCTestCase {
                                       version: 1,
                                       inProcess: false)
 
-    // MARK: - No local model, no pending mutations
+    // MARK: pending mutations
 
-    func testCreatedOnRemote_noLocal_noPendingMutation() throws {
+    func testReconcile_noPendingMutations() {
         let remoteModel = makeRemoteModel(deleted: false, version: 1)
         let pendingMutations: [MutationEvent] = []
+        let remoteModelToApply = RemoteSyncReconciler.reoncile(remoteModel, pendingMutations: pendingMutations)
+
+        XCTAssertNotNil(remoteModelToApply)
+    }
+
+    func testReconcile_withPendingMutations() {
+        let remoteModel = makeRemoteModel(deleted: false, version: 1)
+        let pendingMutations: [MutationEvent] = [mutationEvent]
+        let remoteModelToApply = RemoteSyncReconciler.reoncile(remoteModel, pendingMutations: pendingMutations)
+
+        XCTAssertNil(remoteModelToApply)
+    }
+
+    // MARK: - No local model
+
+    func testCreatedOnRemote_noLocal() {
+        let remoteModel = makeRemoteModel(deleted: false, version: 1)
 
         let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: nil,
-                                                         pendingMutations: pendingMutations)
+                                                         to: nil)
 
         XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel, .create))
     }
 
-    func testUpdatedOnRemote_noLocal_noPendingMutation() throws {
+    func testUpdatedOnRemote_noLocal() {
         let remoteModel = makeRemoteModel(deleted: false, version: 2)
-        let pendingMutations: [MutationEvent] = []
 
         let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: nil,
-                                                         pendingMutations: pendingMutations)
+                                                         to: nil)
 
         XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel, .create))
     }
 
-    func testDeletedOnRemote_noLocal_noPendingMutation() throws {
+    func testDeletedOnRemote_noLocal() {
         let remoteModel = makeRemoteModel(deleted: true, version: 2)
-        let pendingMutations: [MutationEvent] = []
 
         let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: nil,
-                                                         pendingMutations: pendingMutations)
+                                                         to: nil)
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
+        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel(remoteModel.model.modelName))
     }
 
-    // MARK: - No local model, with pending mutations
-
-    func testCreatedOnRemote_noLocal_withPendingMutations() throws {
-        let remoteModel = makeRemoteModel(deleted: false, version: 1)
-        let pendingMutations: [MutationEvent] = [mutationEvent]
-
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: nil,
-                                                         pendingMutations: pendingMutations)
-
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
-    }
-
-    func testUpdatedOnRemote_noLocal_withPendingMutations() throws {
-        let remoteModel = makeRemoteModel(deleted: false, version: 2)
-        let pendingMutations: [MutationEvent] = [mutationEvent]
-
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: nil,
-                                                         pendingMutations: pendingMutations)
-
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
-    }
-
-    func testDeletedOnRemote_noLocal_withPendingMutations() throws {
-        let remoteModel = makeRemoteModel(deleted: true, version: 2)
-        let pendingMutations: [MutationEvent] = [mutationEvent]
-
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: nil,
-                                                         pendingMutations: pendingMutations)
-
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
-    }
-
-    // MARK: - With local model having lower version, no pending mutations
+    // MARK: - With local model having lower version
 
     // "Create" doesn't really have a "lower" version case, so we'll test equal versions
-    func testCreatedOnRemote_withLocalEqualVersion_noPendingMutations() throws {
+    func testCreatedOnRemote_withLocalEqualVersion() {
         let remoteModel = makeRemoteModel(deleted: false, version: 1)
         let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 1)
-        let pendingMutations: [MutationEvent] = []
 
         let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
+                                                         to: localSyncMetadata)
 
         XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel, .update))
     }
 
-    func testUpdatedOnRemote_withLocalLowerVersion_noPendingMutations() throws {
+    func testUpdatedOnRemote_withLocalLowerVersion() {
         let remoteModel = makeRemoteModel(deleted: false, version: 2)
         let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 1)
-        let pendingMutations: [MutationEvent] = []
 
         let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
+                                                         to: localSyncMetadata)
 
         XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel, .update))
     }
 
-    func testDeletedOnRemote_withLocalLowerVersion_noPendingMutations() throws {
+    func testDeletedOnRemote_withLocalLowerVersion() {
         let remoteModel = makeRemoteModel(deleted: true, version: 2)
         let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 1)
-        let pendingMutations: [MutationEvent] = []
 
         let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
+                                                         to: localSyncMetadata)
 
         XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel, .delete))
     }
 
-    // MARK: - With local model having higher version, no pending mutations
+    // MARK: - With local model having higher version
 
     // Create and update are both treated the same
-    func testMutatedOnRemote_withLocalHigherVersion_noPendingMutations() throws {
+    func testMutatedOnRemote_withLocalHigherVersion_noPendingMutations() {
         let remoteModel = makeRemoteModel(deleted: false, version: 1)
         let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 2)
-        let pendingMutations: [MutationEvent] = []
 
         let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
+                                                         to: localSyncMetadata)
 
         XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
     }
 
     // This shouldn't be possible except in case of an error (either the service side did not properly resolve a
     // conflict updating a deleted record, or the client is incorrectly manipulating the version
-    func testDeletedOnRemote_withLocalHigherVersion_noPendingMutations() throws {
+    func testDeletedOnRemote_withLocalHigherVersion() {
         let remoteModel = makeRemoteModel(deleted: true, version: 1)
         let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 2)
-        let pendingMutations: [MutationEvent] = []
 
         let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
-
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
-    }
-
-    // MARK: - With local model having lower version, with pending mutations
-
-    // Create and update are both treated the same
-    func testMutatedOnRemote_withLocalLowerVersion_withPendingMutations() throws {
-        let remoteModel = makeRemoteModel(deleted: false, version: 2)
-        let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 1)
-        let pendingMutations: [MutationEvent] = [mutationEvent]
-
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
-
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
-    }
-
-    func testDeletedOnRemote_withLocalLowerVersion_withPendingMutations() throws {
-        let remoteModel = makeRemoteModel(deleted: true, version: 2)
-        let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 1)
-        let pendingMutations: [MutationEvent] = [mutationEvent]
-
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
-
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
-    }
-
-    // MARK: - With local model having higher version, with pending mutations
-
-    // Create and update are both treated the same
-    func testMutatedOnRemote_withLocalHigherVersion_withPendingMutations() throws {
-        let remoteModel = makeRemoteModel(deleted: false, version: 2)
-        let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 3)
-        let pendingMutations: [MutationEvent] = [mutationEvent]
-
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
-
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
-    }
-
-    func testDeletedOnRemote_withLocalHigherVersion_withPendingMutations() throws {
-        let remoteModel = makeRemoteModel(deleted: true, version: 2)
-        let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 3)
-        let pendingMutations: [MutationEvent] = [mutationEvent]
-
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
+                                                         to: localSyncMetadata)
 
         XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/EquatableExtensions.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/EquatableExtensions.swift
@@ -32,16 +32,26 @@ extension ReconcileAndLocalSaveOperation.Action: Equatable {
         case (.started(let model1), .started(let model2)):
             return model1.model.id == model2.model.id
                 && model1.model.modelName == model2.model.modelName
-        case (.queried(let model1, let lmetadata1), .queried(let model2, let lmetadata2)):
-            return model1.model.id == model2.model.id
-                && lmetadata1?.id == lmetadata2?.id
-                && model1.model.modelName == model2.model.modelName
-        case (.reconciled(let disposition1), .reconciled(let disposition2)):
-            return disposition1 == disposition2
-        case (.applied(let model1, let existsLocally1), .applied(let model2, let existsLocally2)):
+        case (.queriedPendingMutations(let model1, let pendingMutations1),
+              .queriedPendingMutations(let model2, let pendingMutations2)):
             return model1.model.id == model2.model.id
                 && model1.model.modelName == model2.model.modelName
-                && existsLocally1 == existsLocally2
+                && pendingMutations1 == pendingMutations2
+        case (.reconciledWithPendingMutations(let model1), .reconciledWithPendingMutations(let model2)):
+            return model1.model.id == model2.model.id
+                && model1.model.modelName == model2.model.modelName
+        case (.queriedLocalMetadata(let model1, let localmetadata1), .queriedLocalMetadata(let model2, let localmetadata2)):
+            return model1.model.id == model2.model.id
+                && model1.model.modelName == model2.model.modelName
+                && localmetadata1 == localmetadata2
+        case (.reconciledAsApply(let model1, let mutationEvent1), .reconciledAsApply(let model2, let mutationEvent2)):
+            return model1.model.id == model2.model.id
+                && model1.model.modelName == model2.model.modelName
+                && mutationEvent1 == mutationEvent2
+        case (.applied(let model1, let mutationEvent1), applied(let model2, let mutationEvent2)):
+            return model1.model.id == model2.model.id
+                && model1.model.modelName == model2.model.modelName
+                && mutationEvent1 == mutationEvent2
         case (.dropped, dropped):
             return true
         case (.notified, .notified):
@@ -62,15 +72,16 @@ extension ReconcileAndLocalSaveOperation.State: Equatable {
         switch (lhs, rhs) {
         case (.waiting, .waiting):
             return true
-        case (.querying(let model1), .querying(let model2)):
+        case (.queryingPendingMutations(let model1), .queryingPendingMutations(let model2)):
             return model1.model.id == model2.model.id
                 && model1.model.modelName == model2.model.modelName
-        case (.reconciling(let model1, let lmetadata1), .reconciling(let model2, let lmetadata2)):
+        case (.queryingLocalMetadata(let model1), .queryingLocalMetadata(let model2)):
             return model1.model.id == model2.model.id
-                && lmetadata1?.id == lmetadata2?.id
                 && model1.model.modelName == model2.model.modelName
-        case (.executing(let disposition1), .executing(let disposition2)):
-            return disposition1 == disposition2
+        case (.applyingRemoteModel(let model1, let mutationEvent1), .applyingRemoteModel(let model2, let mutationEvent2)):
+            return model1.model.id == model2.model.id
+                && model1.model.modelName == model2.model.modelName
+                && mutationEvent1 == mutationEvent2
         case (.notifying(let model1, let existsLocally1), .notifying(let model2, let existsLocally2)):
             return model1.model.id == model2.model.id
                 && model1.model.modelName == model2.model.modelName
@@ -102,5 +113,19 @@ extension MutationSyncMetadata: Equatable {
             && lhs.deleted == rhs.deleted
             && lhs.lastChangedAt == rhs.lastChangedAt
             && lhs.version == rhs.version
+    }
+}
+
+extension MutationEvent: Equatable {
+    public static func == (lhs: MutationEvent, rhs: MutationEvent) -> Bool {
+        return lhs.id == rhs.id
+            && lhs.modelId == rhs.modelId
+            && lhs.modelName == rhs.modelName
+            && lhs.json == rhs.json
+            && lhs.mutationType == rhs.mutationType
+            && lhs.createdAt == rhs.createdAt
+            && lhs.version == rhs.version
+            && lhs.inProcess == rhs.inProcess
+            && lhs.graphQLFilterJSON == rhs.graphQLFilterJSON
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This refactors the state machine in ReconcileAndLocalSaveOperation to optimize in dropping the remote model when there are pending mutations, so to avoid an extra query for local metadata

*Current system - ReconcileAndLocalSaveOperation*:

1. *Query* for the local metadata by model.id
2. *Query* for the pending mutation events by model.id
3. When do we apply the remote model to the local store?
    1. If there are pending mutations, drop the remote model
    2. If there are no pending mutations, and..
        1. If there is no local metadata, _apply the remote model_
        2. If the remote model is greater in version than local metadata, _apply the remote model_
        3. there is a local model that has a higher version, drop the remote model
4. Applying remote model
    1. if remote model is deleted, *delete* the model from local store, and save metadata(5)
    2. or if remote model is not deleted, *save* the remote model (first *query* then *insert or update* the model), and save metadata(5)
5. Saving Metadata, which does a *query* and then an *insert/update*

*Proposed change*:

Perform step 2 and check 3.1, before performing step 1, to look like the following:

1. *Query* for the pending mutation events by model.id
2. If there are pending mutations, drop the remote model
3. *Query* for the local metadata by model.id
     1. If there is no local metadata, _apply the remote model_
     2. If the remote model is greater in version than local metadata, _apply the remote model_
     3. there is a local model that has a higher version, drop the remote model
4. Applying remote model
    1. if remote model is deleted, *delete* the model from local store, and save metadata(5)
    2. or if remote model is not deleted, *save* the remote model (first *query* then *insert or update* the model), and save metadata(5)
5. Saving Metadata, which does a *query* and then an *insert/update*

**NOTE**

This PR is draft because the unit tests have not been written against the new state machine, and some of the older unit tests were commented out

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
