### PR TITLE
fix: reconcile multiple models with transaction

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -47,6 +47,8 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
 
     func queryMutationSyncMetadata(for modelId: Model.Identifier) throws -> MutationSyncMetadata?
 
+    func queryMutationSyncMetadata(forModelIds modelIds: [Model.Identifier]) throws -> [MutationSyncMetadata]
+
     func queryModelSyncMetadata(for modelSchema: ModelSchema) throws -> ModelSyncMetadata?
 
     func transaction(_ basicClosure: BasicThrowableClosure) throws

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -168,8 +168,8 @@ final class InitialSyncOperation: AsynchronousOperation {
         let items = syncQueryResult.items
         recordsReceived += UInt(items.count)
 
+        reconciliationQueue.offer(items, modelSchema: modelSchema)
         for item in items {
-            reconciliationQueue.offer(item, modelSchema: modelSchema)
             initialSyncOperationTopic.send(.enqueued(item))
         }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -102,13 +102,13 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
         eventReconciliationQueueTopic.send(.paused)
     }
 
-    func offer(_ remoteModel: MutationSync<AnyModel>, modelSchema: ModelSchema) {
+    func offer(_ remoteModels: [MutationSync<AnyModel>], modelSchema: ModelSchema) {
         guard let queue = reconciliationQueues[modelSchema.name] else {
             // TODO: Error handling
             return
         }
 
-        queue.enqueue(remoteModel)
+        queue.enqueue(remoteModels)
     }
 
     private func onReceiveCompletion(completed: Subscribers.Completion<DataStoreError>) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
@@ -25,6 +25,6 @@ enum IncomingEventReconciliationQueueEvent {
 protocol IncomingEventReconciliationQueue: class, AmplifyCancellable {
     func start()
     func pause()
-    func offer(_ remoteModel: MutationSync<AnyModel>, modelSchema: ModelSchema)
+    func offer(_ remoteModels: [MutationSync<AnyModel>], modelSchema: ModelSchema)
     var publisher: AnyPublisher<IncomingEventReconciliationQueueEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -135,9 +135,13 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
         incomingSubscriptionEventQueue.cancelAllOperations()
     }
 
-    func enqueue(_ remoteModel: MutationSync<AnyModel>) {
+    func enqueue(_ remoteModels: [MutationSync<AnyModel>]) {
+        guard let remoteModel = remoteModels.first else {
+            return
+        }
+
         let reconcileOp = ReconcileAndLocalSaveOperation(modelSchema: modelSchema,
-                                                         remoteModel: remoteModel,
+                                                         remoteModels: remoteModels,
                                                          storageAdapter: storageAdapter)
         var reconcileAndLocalSaveOperationSink: AnyCancellable?
         reconcileAndLocalSaveOperationSink = reconcileOp.publisher.sink(receiveCompletion: { completion in
@@ -166,7 +170,7 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
                 }
             }
             incomingSubscriptionEventQueue.addOperation(CancelAwareBlockOperation {
-                self.enqueue(remoteModel)
+                self.enqueue([remoteModel])
             })
         case .connectionConnected:
             modelReconciliationQueueSubject.send(.connected(modelName: modelSchema.name))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
@@ -28,6 +28,6 @@ protocol ModelReconciliationQueue {
     func start()
     func pause()
     func cancel()
-    func enqueue(_ remoteModel: MutationSync<AnyModel>)
+    func enqueue(_ remoteModels: [MutationSync<AnyModel>])
     var publisher: AnyPublisher<ModelReconciliationQueueEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/RemoteSyncReconciler.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/RemoteSyncReconciler.swift
@@ -13,32 +13,72 @@ struct RemoteSyncReconciler {
     typealias LocalMetadata = ReconcileAndLocalSaveOperation.LocalMetadata
     typealias RemoteModel = ReconcileAndLocalSaveOperation.RemoteModel
 
-    enum Disposition {
-        case applyRemoteModel(RemoteModel, MutationEvent.MutationType)
-        case dropRemoteModel(String)
+    struct Disposition {
+        var createModels = [RemoteModel]()
+        var updateModels = [RemoteModel]()
+        var deleteModels = [RemoteModel]()
+
+        var totalCount: Int {
+            createModels.count + updateModels.count + deleteModels.count
+        }
     }
 
-    static func shouldDropRemoteModel(_ remoteModel: RemoteModel,
-                                      pendingMutations: [MutationEvent]) -> Bool {
-        !pendingMutations.isEmpty
+    static func reconcile(_ remoteModels: [RemoteModel],
+                          pendingMutations: [MutationEvent]) -> [RemoteModel] {
+        guard !pendingMutations.isEmpty else {
+            return remoteModels
+        }
+
+        let pendingMutationModelIdsArr = pendingMutations.map { mutationEvent in
+            mutationEvent.modelId
+        }
+        let pendingMutationModelIds = Set(pendingMutationModelIdsArr)
+
+        return remoteModels.filter { remoteModel in
+            !pendingMutationModelIds.contains(remoteModel.model.id)
+        }
     }
 
-    static func reconcile(remoteModel: RemoteModel,
-                          to localMetadata: LocalMetadata?) -> Disposition {
-        guard let localMetadata = localMetadata else {
-            if remoteModel.syncMetadata.deleted {
-                return .applyRemoteModel(remoteModel, .delete)
-            } else {
-                return .applyRemoteModel(remoteModel, .create)
+    static func reconcile(remoteModels: [RemoteModel],
+                          localMetadatas: [LocalMetadata]) -> Disposition {
+        var disposition = Disposition()
+
+        guard !remoteModels.isEmpty else {
+            return disposition
+        }
+
+        guard !localMetadatas.isEmpty else {
+            remoteModels.forEach { remoteModel in
+                if !remoteModel.syncMetadata.deleted {
+                    disposition.createModels.append(remoteModel)
+                }
+            }
+            return disposition
+        }
+
+        var localMetadataMap = [Model.Identifier: LocalMetadata]()
+        for localMetadata in localMetadatas {
+            localMetadataMap.updateValue(localMetadata, forKey: localMetadata.id)
+        }
+
+        remoteModels.forEach { remoteModel in
+            guard let localMetadata = localMetadataMap[remoteModel.model.id] else {
+                if !remoteModel.syncMetadata.deleted {
+                    disposition.createModels.append(remoteModel)
+                }
+                return
+            }
+
+            if remoteModel.syncMetadata.version >= localMetadata.version {
+                if remoteModel.syncMetadata.deleted {
+                    disposition.deleteModels.append(remoteModel)
+                } else {
+                    disposition.updateModels.append(remoteModel)
+                }
             }
         }
 
-        // Technically, we should never receive a subscription for a version we already have, but we'll be defensive
-        // and make this check include the current version
-        if remoteModel.syncMetadata.version >= localMetadata.version {
-            return .applyRemoteModel(remoteModel, .update)
-        }
+        return disposition
 
-        return .dropRemoteModel(remoteModel.model.modelName)
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Query.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Query.swift
@@ -19,4 +19,48 @@ extension MutationEvent {
                              sort: [sort],
                              paginationInput: nil) { completion($0) }
     }
+
+    static func pendingMutationEvents(forModelIds modelIds: [Model.Identifier],
+                                      storageAdapter: StorageEngineAdapter,
+                                      completion: DataStoreCallback<[MutationEvent]>) {
+        let fields = MutationEvent.keys
+        let predicate = (fields.inProcess == false || fields.inProcess == nil)
+        let maxNumberOfPredicates = 950
+        var queriedMutationEvents: [MutationEvent] = []
+        var queryError: DataStoreError?
+        let chunkedArrays = modelIds.chunked(into: maxNumberOfPredicates)
+        for chunkedArray in chunkedArrays {
+            var queryPredicates: [QueryPredicateOperation] = []
+            for id in chunkedArray {
+                queryPredicates.append(QueryPredicateOperation(field: fields.modelId.stringValue, operator: .equals(id)))
+            }
+            let groupedQueryPredicates =  QueryPredicateGroup(type: .or, predicates: queryPredicates)
+            let final = QueryPredicateGroup(type: .and, predicates: [groupedQueryPredicates, predicate])
+            let sort = QuerySortDescriptor(fieldName: fields.createdAt.stringValue, order: .ascending)
+            let sempahore = DispatchSemaphore(value: 0)
+            storageAdapter.query(MutationEvent.self,
+                                 predicate: final,
+                                 sort: [sort],
+                                 paginationInput: nil) { result in
+                defer {
+                    sempahore.signal()
+                }
+
+                switch result {
+                case .success(let mutationEvents):
+                    queriedMutationEvents.append(contentsOf: mutationEvents)
+                case .failure(let error):
+                    // TODO log?
+                    queryError = error
+                    return
+                }
+            }
+            sempahore.wait()
+        }
+        if let queryError = queryError {
+            completion(.failure(queryError))
+        } else {
+            completion(.success(queriedMutationEvents))
+        }
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This converts ReconcileAndLocalSaveOperation to take in an array of models of the same ModelType, as the remote models are enqeued from a sync query (results up to 1000), and subscription data (single remote model)


**Performance 10k items**:
- 10k items
- 1k page size
- query for pending mutation and query for local mutations: There are 10 metric points each, but because predicate size is max 950 and page size is 1000, we actually end up performing 2 queries each, so 20 reads in total
- queries for pending mutations: 0.43s
- queries for local mutations: 0.235s
- save model: 11.227s
- save metadata: 12.925s
- API calls + deserialize into objects has not changed: 10 calls * <1s each
- Total time: 26.291s for 10k models
- Compared to baseline: ~90-100s, this is approximately 400% faster

**Performance 100k items**:
this was fairly slow, about 20 minutes to save 54k items.

**Performance 100k items, 30 items per ReconcileAndSave**:
total time: 932s (15 minutes) for 100k items

**Performance 100k items, 30 items per ReconcileAndSave, transaction on all operations**:
total time: 460s (7.67 minutes) for 100k items

**Performance 100k items, 30 items per ReconcileAndSave, transaction on all operations, debug logging turned off**:
total time: 222s (3.7 minutes) for 100k items

**Performance 100k items, 1k per ReconcileAndSave, transaction on all operations, debug logging turned off**:
total time: 203s (3.38 minutes) for 100k items

**Performance 100k items, 1k per ReconcileAndSave, transaction on all operations, debug logs removed and turned on**:
total time: 113s (1.88 minutes) for 100k items, each reconcile took about 1s, at 100 reconcilliations (100k items/1k pages). this particular run was 10x faster than the baseline. More runs:
- Iphone 12 Pro SImulator - 184.05s (reconcile took 1.7s each)
- iPhone 11 device - 111s (reconcile took 0.7s)


*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
