### PR TITLE
feat: increase sync concurrecny count based on associations

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
@@ -182,4 +182,8 @@ extension Array where Element == ModelSchema {
         return sortedKeys.map { sortMap[$0]! }
     }
 
+    func containsAssociations() -> Bool {
+        // TODO: actually check for associations
+        return false
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -47,6 +47,8 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
 
     func queryMutationSyncMetadata(for modelId: Model.Identifier) throws -> MutationSyncMetadata?
 
+    func queryMutationSyncMetadata(forModelIds modelIds: [Model.Identifier]) throws -> [MutationSyncMetadata]
+
     func queryModelSyncMetadata(for modelSchema: ModelSchema) throws -> ModelSyncMetadata?
 
     func transaction(_ basicClosure: BasicThrowableClosure) throws

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -168,8 +168,8 @@ final class InitialSyncOperation: AsynchronousOperation {
         let items = syncQueryResult.items
         recordsReceived += UInt(items.count)
 
+        reconciliationQueue.offer(items, modelSchema: modelSchema)
         for item in items {
-            reconciliationQueue.offer(item, modelSchema: modelSchema)
             initialSyncOperationTopic.send(.enqueued(item))
         }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
@@ -85,6 +85,9 @@ final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
 
             let modelNames = syncableModelSchemas.map { $0.name }
             self.dispatchSyncQueriesStarted(for: modelNames)
+            if !syncableModelSchemas.containsAssociations() {
+                self.syncOperationQueue.maxConcurrentOperationCount = syncableModelSchemas.count
+            }
             self.syncOperationQueue.isSuspended = false
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -102,13 +102,13 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
         eventReconciliationQueueTopic.send(.paused)
     }
 
-    func offer(_ remoteModel: MutationSync<AnyModel>, modelSchema: ModelSchema) {
+    func offer(_ remoteModels: [MutationSync<AnyModel>], modelSchema: ModelSchema) {
         guard let queue = reconciliationQueues[modelSchema.name] else {
             // TODO: Error handling
             return
         }
 
-        queue.enqueue(remoteModel)
+        queue.enqueue(remoteModels)
     }
 
     private func onReceiveCompletion(completed: Subscribers.Completion<DataStoreError>) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
@@ -25,6 +25,6 @@ enum IncomingEventReconciliationQueueEvent {
 protocol IncomingEventReconciliationQueue: class, AmplifyCancellable {
     func start()
     func pause()
-    func offer(_ remoteModel: MutationSync<AnyModel>, modelSchema: ModelSchema)
+    func offer(_ remoteModels: [MutationSync<AnyModel>], modelSchema: ModelSchema)
     var publisher: AnyPublisher<IncomingEventReconciliationQueueEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -135,9 +135,14 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
         incomingSubscriptionEventQueue.cancelAllOperations()
     }
 
-    func enqueue(_ remoteModel: MutationSync<AnyModel>) {
+    func enqueue(_ remoteModels: [MutationSync<AnyModel>]) {
+        guard let remoteModel = remoteModels.first else {
+            log.info("\(#function) skipping reconcilliation, no models to enqueue.")
+            return
+        }
+
         let reconcileOp = ReconcileAndLocalSaveOperation(modelSchema: modelSchema,
-                                                         remoteModel: remoteModel,
+                                                         remoteModels: remoteModels,
                                                          storageAdapter: storageAdapter)
         var reconcileAndLocalSaveOperationSink: AnyCancellable?
         reconcileAndLocalSaveOperationSink = reconcileOp.publisher.sink(receiveCompletion: { completion in
@@ -166,7 +171,7 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
                 }
             }
             incomingSubscriptionEventQueue.addOperation(CancelAwareBlockOperation {
-                self.enqueue(remoteModel)
+                self.enqueue([remoteModel])
             })
         case .connectionConnected:
             modelReconciliationQueueSubject.send(.connected(modelName: modelSchema.name))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
@@ -28,6 +28,6 @@ protocol ModelReconciliationQueue {
     func start()
     func pause()
     func cancel()
-    func enqueue(_ remoteModel: MutationSync<AnyModel>)
+    func enqueue(_ remoteModels: [MutationSync<AnyModel>])
     var publisher: AnyPublisher<ModelReconciliationQueueEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Action.swift
@@ -13,23 +13,10 @@ extension ReconcileAndLocalSaveOperation {
     /// Actions are declarative, they say what I just did
     enum Action {
         /// Operation has been started by the queue
-        case started(RemoteModel)
+        case started([RemoteModel])
 
-        /// Operation has retrieved RemoteModel's corresponding sync metadata from local database
-        case queried(RemoteModel, LocalMetadata?)
-
-        /// Operation has reconciled the incoming remote model with local model and sync metadata
-        case reconciled(RemoteSyncReconciler.Disposition)
-
-        /// Operation has applied the incoming RemoteModel to the local database per the reconciled disposition. This
-        /// could result in either a save to the local database, or a delete from the local database.
-        case applied(AppliedModel, mutationType: MutationEvent.MutationType)
-
-        /// Operation dropped the remote model per the reconciled disposition.
-        case dropped(modelName: String)
-
-        /// Operation notified listeners and callbacks of completion
-        case notified
+        /// Operation completed reconcilliation
+        case reconciled
 
         /// Operation has been cancelled by the queue
         case cancelled

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Resolver.swift
@@ -19,25 +19,10 @@ extension ReconcileAndLocalSaveOperation {
         static func resolve(currentState: State, action: Action) -> State {
             switch (currentState, action) {
 
-            case (.waiting, .started(let remoteModel)):
-                return .querying(remoteModel)
+            case (.waiting, .started(let remoteModels)):
+                return .reconciling(remoteModels)
 
-            case (.querying, .queried(let remoteModel, let localModel)):
-                return .reconciling(remoteModel, localModel)
-
-            case (.reconciling, .reconciled(let disposition)):
-                return .executing(disposition)
-
-            case (.executing, .dropped(let modelName)):
-                return .notifyingDropped(modelName)
-
-            case (.notifyingDropped, .notified):
-                return .finished
-
-            case (.executing, .applied(let savedModel, let mutationType)):
-                return .notifying(savedModel, mutationType)
-
-            case (.notifying, .notified):
+            case (.reconciling, .reconciled):
                 return .finished
 
             case (_, .errored(let amplifyError)):

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+State.swift
@@ -15,19 +15,8 @@ extension ReconcileAndLocalSaveOperation {
         /// Waiting to be started by the queue
         case waiting
 
-        /// Querying the local database for model data and sync metadata
-        case querying(RemoteModel)
-
-        /// Reconciling incoming remote model with local model and sync metadata
-        case reconciling(RemoteModel, LocalMetadata?)
-
-        /// Executing the reconciled disposition
-        case executing(RemoteSyncReconciler.Disposition)
-
-        case notifyingDropped(String)
-
-        /// Notifying listeners and callbacks of completion
-        case notifying(AppliedModel, MutationEvent.MutationType)
+        /// Reconiling remote models with local data
+        case reconciling([RemoteModel])
 
         /// Operation has successfully completed
         case finished

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -32,28 +32,29 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
 
     private weak var storageAdapter: StorageEngineAdapter?
     private let stateMachine: StateMachine<State, Action>
-    private let remoteModel: RemoteModel
+    private let remoteModels: [RemoteModel]
     private let modelSchema: ModelSchema
     private let stopwatch: Stopwatch
     private var stateMachineSink: AnyCancellable?
-
+    private var cancellables: Set<AnyCancellable>
     private let mutationEventPublisher: PassthroughSubject<ReconcileAndLocalSaveOperationEvent, DataStoreError>
     public var publisher: AnyPublisher<ReconcileAndLocalSaveOperationEvent, DataStoreError> {
         return mutationEventPublisher.eraseToAnyPublisher()
     }
 
     init(modelSchema: ModelSchema,
-         remoteModel: RemoteModel,
+         remoteModels: [RemoteModel],
          storageAdapter: StorageEngineAdapter?,
          stateMachine: StateMachine<State, Action>? = nil) {
         self.modelSchema = modelSchema
-        self.remoteModel = remoteModel
+        self.remoteModels = remoteModels
         self.storageAdapter = storageAdapter
         self.stopwatch = Stopwatch()
         self.stateMachine = stateMachine ?? StateMachine(initialState: .waiting,
                                                          resolver: Resolver.resolve(currentState:action:))
         self.mutationEventPublisher = PassthroughSubject<ReconcileAndLocalSaveOperationEvent, DataStoreError>()
 
+        self.cancellables = Set<AnyCancellable>()
         super.init()
 
         self.stateMachineSink = self.stateMachine
@@ -77,7 +78,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
         }
 
         stopwatch.start()
-        stateMachine.notify(action: .started(remoteModel))
+        stateMachine.notify(action: .started(remoteModels))
     }
 
     /// Listens to incoming state changes and invokes the appropriate asynchronous methods in response.
@@ -88,45 +89,23 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
         case .waiting:
             break
 
-        case .querying(let remoteModel):
-            query(remoteModel: remoteModel)
-
-        case .reconciling(let remoteModel, let localMetadata):
-            reconcile(remoteModel: remoteModel, to: localMetadata)
-
-        case .executing(let disposition):
-            execute(disposition: disposition)
-
-        case .notifyingDropped(let modelName):
-            notifyDropped(modelName: modelName)
-
-        case .notifying(let savedModel, let mutationType):
-            notify(savedModel: savedModel, mutationType: mutationType)
+        case .reconciling(let remoteModels):
+            reconcile(remoteModels: remoteModels)
 
         case .inError(let error):
             // Maybe we have to notify the Hub?
             log.error(error: error)
             notifyFinished()
-            finish()
 
         case .finished:
             // Maybe we have to notify the Hub?
             notifyFinished()
-            if log.logLevel == .debug {
-                log.debug("total time: \(stopwatch.stop())s")
-            }
-            finish()
         }
-
     }
 
     // MARK: - Responder methods
 
-    /// Responder method for `querying`. Notify actions:
-    /// - queried
-    /// - errored
-    func query(remoteModel: RemoteModel) {
-        log.verbose("query: \(remoteModel)")
+    func reconcile(remoteModels: [RemoteModel]) {
         guard !isCancelled else {
             log.info("\(#function) - cancelled, aborting")
             return
@@ -137,186 +116,269 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
             return
         }
 
-        let localMetadata: MutationSyncMetadata?
+        guard !remoteModels.isEmpty else {
+            stateMachine.notify(action: .reconciled)
+            return
+        }
+
+        let remoteModelIds = remoteModels.map { remoteModel in
+            remoteModel.model.id
+        }
+
         do {
-            localMetadata = try storageAdapter.queryMutationSyncMetadata(for: remoteModel.model.id)
+            try storageAdapter.transaction {
+                queryPendingMutations(forModelIds: remoteModelIds)
+                    .flatMap { mutationEvents -> Future<([RemoteModel], [LocalMetadata]), DataStoreError> in
+                        let remoteModelsToApply = self.reconcile(remoteModels, pendingMutations: mutationEvents)
+                        return self.queryLocalMetadata(remoteModelsToApply)
+                    }
+                    .flatMap { (remoteModelsToApply, localMetadatas) -> Future<Void, DataStoreError> in
+                        let dispositions = self.reconcile(remoteModelsToApply, localMetadatas: localMetadatas)
+                        return self.applyRemoteModels(dispositions: dispositions)
+                    }
+                    .sink(
+                        receiveCompletion: {
+                            if case .failure(let error) = $0 {
+                                self.stateMachine.notify(action: .errored(error))
+                            }
+                        },
+                        receiveValue: {
+                            self.stateMachine.notify(action: .reconciled)
+                        }
+                    )
+                    .store(in: &cancellables)
+            }
         } catch {
-            stateMachine.notify(action: .errored(DataStoreError(error: error)))
-            return
-        }
-
-        let queriedAction = Action.queried(remoteModel, localMetadata)
-
-        if log.logLevel == .debug {
-            log.debug("query local metadata: \(stopwatch.lap())s")
-        }
-
-        stateMachine.notify(action: queriedAction)
-    }
-
-    /// Responder method for `reconciling`. Notify actions:
-    /// - reconciled
-    /// - conflict
-    /// - errored
-    func reconcile(remoteModel: RemoteModel, to localMetadata: LocalMetadata?) {
-        log.verbose(#function)
-        guard !isCancelled else {
-            log.verbose("\(#function) - cancelled, aborting")
-            return
-        }
-
-        let pendingMutations: [MutationEvent]
-        switch getPendingMutations(forModelId: remoteModel.model.id) {
-        case .failure(let dataStoreError):
+            let dataStoreError = error as? DataStoreError ?? .invalidOperation(causedBy: error)
             stateMachine.notify(action: .errored(dataStoreError))
-            return
-        case .success(let mutationEvents):
-            pendingMutations = mutationEvents
         }
-        if log.logLevel == .debug {
-            log.debug("query pending mutations: \(stopwatch.lap())s")
-        }
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localMetadata,
-                                                         pendingMutations: pendingMutations)
 
-        stateMachine.notify(action: .reconciled(disposition))
     }
 
-    /// Responder method for `executing`. Applies the appropriate disposition. Either invokes `apply`, or directly
-    /// notifies the state machine for:
-    /// - errored
-    /// - dropped
-    func execute(disposition: RemoteSyncReconciler.Disposition) {
-        switch disposition {
-        case .applyRemoteModel(let remoteModel, let mutationType):
-            apply(remoteModel: remoteModel, mutationType: mutationType)
-        case .dropRemoteModel(let modelName):
-            stateMachine.notify(action: .dropped(modelName: modelName))
-        }
-    }
-
-    /// Execution method for the `applyRemoteModel` disposition. Does not notify directly, but delegates to save or
-    /// delete methods, which eventually notify with:
-    /// - applied
-    /// - errored
-    private func apply(remoteModel: RemoteModel, mutationType: MutationEvent.MutationType) {
-        if log.logLevel == .verbose {
-            log.verbose("\(#function): remoteModel")
-        }
-
-        guard !isCancelled else {
-            log.verbose("\(#function) - cancelled, aborting")
-            return
-        }
-
-        guard let storageAdapter = storageAdapter else {
-            Amplify.Logging.log.warn("No storageAdapter, aborting")
-            return
-        }
-
-        // TODO: Wrap this in a transaction
-        if mutationType == .delete {
-            saveDeleteMutation(storageAdapter: storageAdapter, remoteModel: remoteModel)
-        } else {
-            saveCreateOrUpdateMutation(storageAdapter: storageAdapter,
-                                       remoteModel: remoteModel,
-                                       mutationType: mutationType)
-        }
-    }
-
-    private func saveDeleteMutation(storageAdapter: StorageEngineAdapter,
-                                    remoteModel: RemoteModel) {
-        log.verbose(#function)
-
-        guard let modelType = ModelRegistry.modelType(from: modelSchema.name) else {
-            let error = DataStoreError.invalidModelName(modelSchema.name)
-            stateMachine.notify(action: .errored(error))
-            return
-        }
-
-        storageAdapter.delete(untypedModelType: modelType,
-                              modelSchema: modelSchema,
-                              withId: remoteModel.model.id,
-                              predicate: nil) { response in
-            if log.logLevel == .debug {
-                log.debug("delete model: \(stopwatch.lap())s")
+    func queryPendingMutations(forModelIds modelIds: [Model.Identifier]) -> Future<[MutationEvent], DataStoreError> {
+        Future<[MutationEvent], DataStoreError> { promise in
+            guard !self.isCancelled else {
+                self.log.info("\(#function) - cancelled, aborting")
+                return
             }
-            switch response {
-            case .failure(let dataStoreError):
-                let errorAction = Action.errored(dataStoreError)
-                self.stateMachine.notify(action: errorAction)
-            case .success:
-                self.saveMetadata(storageAdapter: storageAdapter,
-                                  inProcessModel: remoteModel,
-                                  mutationType: .delete)
+            guard let storageAdapter = self.storageAdapter else {
+                promise(.failure(DataStoreError.nilStorageAdapter()))
+                return
             }
-        }
-    }
 
-    private func saveCreateOrUpdateMutation(storageAdapter: StorageEngineAdapter,
-                                            remoteModel: RemoteModel,
-                                            mutationType: MutationEvent.MutationType) {
-        log.verbose(#function)
-        storageAdapter.save(untypedModel: remoteModel.model.instance) { response in
-            if self.log.logLevel == .debug {
-                self.log.debug("save model: \(self.stopwatch.lap())s")
+            guard !modelIds.isEmpty else {
+                promise(.success([]))
+                return
             }
-            switch response {
-            case .failure(let dataStoreError):
-                let errorAction = Action.errored(dataStoreError)
-                self.stateMachine.notify(action: errorAction)
-            case .success(let savedModel):
-                let anyModel: AnyModel
-                do {
-                    anyModel = try savedModel.eraseToAnyModel()
-                } catch {
-                    self.stateMachine.notify(action: .errored(DataStoreError(error: error)))
-                    return
+
+            MutationEvent.pendingMutationEvents(forModelIds: modelIds,
+                                                storageAdapter: storageAdapter) { result in
+                switch result {
+                case .failure(let dataStoreError):
+                    let newError = DataStoreError.unknown("Unable to query pending mutation events",
+                                                          AmplifyErrorMessages.shouldNotHappenReportBugToAWS(),
+                                                          dataStoreError)
+                    promise(.failure(newError))
+                case .success(let mutationEvents):
+                    promise(.success(mutationEvents))
                 }
-                let inProcessModel = MutationSync(model: anyModel, syncMetadata: remoteModel.syncMetadata)
-                self.saveMetadata(storageAdapter: storageAdapter,
-                                  inProcessModel: inProcessModel,
-                                  mutationType: mutationType)
+            }
+        }
+    }
+
+    func reconcile(_ remoteModels: [RemoteModel], pendingMutations: [MutationEvent]) -> [RemoteModel] {
+        guard let remoteModel = remoteModels.first else {
+            return []
+        }
+
+        let remoteModelsToApply = RemoteSyncReconciler.reconcile(remoteModels,
+                                                                 pendingMutations: pendingMutations)
+
+        for _ in 0 ..< (remoteModels.count - remoteModelsToApply.count) {
+            notifyDropped(modelName: remoteModel.model.modelName)
+        }
+
+        return remoteModelsToApply
+    }
+
+    func queryLocalMetadata(_ remoteModels: [RemoteModel]) -> Future<([RemoteModel], [LocalMetadata]), DataStoreError> {
+        Future<([RemoteModel], [LocalMetadata]), DataStoreError> { promise in
+            guard !self.isCancelled else {
+                self.log.info("\(#function) - cancelled, aborting")
+                return
+            }
+            guard let storageAdapter = self.storageAdapter else {
+                promise(.failure(DataStoreError.nilStorageAdapter()))
+                return
+            }
+
+            guard !remoteModels.isEmpty else {
+                promise(.success(([], [])))
+                return
+            }
+
+            do {
+                let localMetadatas = try storageAdapter.queryMutationSyncMetadata(
+                    forModelIds: remoteModels.map { $0.model.id })
+                promise(.success((remoteModels, localMetadatas)))
+            } catch {
+                promise(.failure(DataStoreError(error: error)))
+                return
+            }
+        }
+    }
+
+    func reconcile(_ remoteModels: [RemoteModel],
+                   localMetadatas: [LocalMetadata]) -> [RemoteSyncReconciler.Disposition] {
+        guard let remoteModel = remoteModels.first else {
+            return []
+        }
+
+        let dispositions = RemoteSyncReconciler.reconcile(remoteModels,
+                                                          localMetadatas: localMetadatas)
+        for _ in 0 ..< (remoteModels.count - dispositions.count) {
+            notifyDropped(modelName: remoteModel.model.modelName)
+        }
+
+        return dispositions
+    }
+
+    func applyRemoteModels(dispositions: [RemoteSyncReconciler.Disposition]) -> Future<Void, DataStoreError> {
+        Future<Void, DataStoreError> { promise in
+            guard !self.isCancelled else {
+                self.log.info("\(#function) - cancelled, aborting")
+                return
+            }
+            guard let storageAdapter = self.storageAdapter else {
+                promise(.failure(DataStoreError.nilStorageAdapter()))
+                return
+            }
+
+            guard !dispositions.isEmpty else {
+                promise(.successfulVoid)
+                return
+            }
+
+            let publishers = dispositions.map { disposition ->
+                Publishers.FlatMap<Future<Void, DataStoreError>,
+                                   Future<ReconcileAndLocalSaveOperation.RemoteModel, DataStoreError>> in
+
+                switch disposition {
+                case .create(let remoteModel):
+                    let publisher = self.save(storageAdapter: storageAdapter,
+                                              remoteModel: remoteModel)
+                        .flatMap { inProcessModel in
+                            self.saveMetadata(storageAdapter: storageAdapter,
+                                                    inProcessModel: inProcessModel,
+                                                    mutationType: .create)
+                        }
+                    return publisher
+                case .update(let remoteModel):
+                    let publisher = self.save(storageAdapter: storageAdapter,
+                                              remoteModel: remoteModel)
+                        .flatMap { inProcessModel in
+                            self.saveMetadata(storageAdapter: storageAdapter,
+                                                    inProcessModel: inProcessModel,
+                                                    mutationType: .update)
+                        }
+                    return publisher
+                case .delete(let remoteModel):
+                    let publisher = self.delete(storageAdapter: storageAdapter,
+                                                remoteModel: remoteModel)
+                        .flatMap { inProcessModel in
+                            self.saveMetadata(storageAdapter: storageAdapter,
+                                                    inProcessModel: inProcessModel,
+                                                    mutationType: .delete)
+                        }
+                    return publisher
+                }
+            }
+
+            Publishers.MergeMany(publishers)
+                .collect()
+                .sink(
+                    receiveCompletion: {
+                        if case .failure(let error) = $0 {
+                            promise(.failure(error))
+                        }
+                    },
+                    receiveValue: { _ in
+                        promise(.successfulVoid)
+                    }
+                )
+                .store(in: &self.cancellables)
+        }
+    }
+
+    private func delete(storageAdapter: StorageEngineAdapter,
+                        remoteModel: RemoteModel) -> Future<RemoteModel, DataStoreError> {
+        Future<RemoteModel, DataStoreError> { promise in
+            guard let modelType = ModelRegistry.modelType(from: self.modelSchema.name) else {
+                let error = DataStoreError.invalidModelName(self.modelSchema.name)
+                promise(.failure(error))
+                return
+            }
+
+            storageAdapter.delete(untypedModelType: modelType,
+                                  modelSchema: self.modelSchema,
+                                  withId: remoteModel.model.id,
+                                  predicate: nil) { response in
+                switch response {
+                case .failure(let dataStoreError):
+                    promise(.failure(dataStoreError))
+                case .success:
+                    promise(.success(remoteModel))
+                }
+            }
+        }
+    }
+
+    private func save(storageAdapter: StorageEngineAdapter,
+                      remoteModel: RemoteModel) -> Future<RemoteModel, DataStoreError> {
+        Future<RemoteModel, DataStoreError> { promise in
+            storageAdapter.save(untypedModel: remoteModel.model.instance) { response in
+                switch response {
+                case .failure(let dataStoreError):
+                    promise(.failure(dataStoreError))
+                case .success(let savedModel):
+                    let anyModel: AnyModel
+                    do {
+                        anyModel = try savedModel.eraseToAnyModel()
+                    } catch {
+                        let dataStoreError = DataStoreError(error: error)
+                        promise(.failure(dataStoreError))
+                        return
+                    }
+                    let inProcessModel = MutationSync(model: anyModel, syncMetadata: remoteModel.syncMetadata)
+                    promise(.success(inProcessModel))
+                }
             }
         }
     }
 
     private func saveMetadata(storageAdapter: StorageEngineAdapter,
                               inProcessModel: AppliedModel,
-                              mutationType: MutationEvent.MutationType) {
-        log.verbose(#function)
-
-        storageAdapter.save(remoteModel.syncMetadata, condition: nil) { result in
-            if self.log.logLevel == .debug {
-                self.log.debug("save metadata: \(self.stopwatch.lap())s")
-            }
-            switch result {
-            case .failure(let dataStoreError):
-                let errorAction = Action.errored(dataStoreError)
-                self.stateMachine.notify(action: errorAction)
-            case .success(let syncMetadata):
-                let appliedModel = MutationSync(model: inProcessModel.model, syncMetadata: syncMetadata)
-                self.stateMachine.notify(action: .applied(appliedModel, mutationType: mutationType))
+                              mutationType: MutationEvent.MutationType) -> Future<Void, DataStoreError> {
+        Future<Void, DataStoreError> { promise in
+            storageAdapter.save(inProcessModel.syncMetadata, condition: nil) { result in
+                switch result {
+                case .failure(let dataStoreError):
+                    promise(.failure(dataStoreError))
+                case .success(let syncMetadata):
+                    let appliedModel = MutationSync(model: inProcessModel.model, syncMetadata: syncMetadata)
+                    self.notify(savedModel: appliedModel, mutationType: mutationType)
+                    promise(.successfulVoid)
+                }
             }
         }
     }
 
-    func notifyDropped(modelName: String) {
+    private func notifyDropped(modelName: String) {
         mutationEventPublisher.send(.mutationEventDropped(modelName: modelName))
-        stateMachine.notify(action: .notified)
     }
 
-    /// Responder method for `notifying`. Notify actions:
-    /// - notified
-    func notify(savedModel: AppliedModel,
-                mutationType: MutationEvent.MutationType) {
-        log.verbose(#function)
-
-        guard !isCancelled else {
-            log.verbose("\(#function) - cancelled, aborting")
-            return
-        }
+    private func notify(savedModel: AppliedModel,
+                        mutationType: MutationEvent.MutationType) {
         let version = savedModel.syncMetadata.version
 
         // TODO: Dispatch/notify error if we can't erase to any model? Would imply an error in JSON decoding,
@@ -336,35 +398,14 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
         Amplify.Hub.dispatch(to: .dataStore, payload: payload)
 
         mutationEventPublisher.send(.mutationEvent(mutationEvent))
-
-        stateMachine.notify(action: .notified)
     }
 
     private func notifyFinished() {
+        if log.logLevel == .debug {
+            log.debug("total time: \(stopwatch.stop())s")
+        }
         mutationEventPublisher.send(completion: .finished)
-    }
-
-    private func getPendingMutations(forModelId modelId: Model.Identifier) -> DataStoreResult<[MutationEvent]> {
-        guard let storageAdapter = storageAdapter else {
-            return .failure(DataStoreError.nilStorageAdapter())
-        }
-
-        let semaphore = DispatchSemaphore(value: 0)
-        var pendingMutationResultFromQuery: DataStoreResult<[MutationEvent]>?
-        MutationEvent.pendingMutationEvents(forModelId: modelId,
-                                            storageAdapter: storageAdapter) {
-            pendingMutationResultFromQuery = $0
-            semaphore.signal()
-        }
-        semaphore.wait()
-
-        guard let pendingMutationResult = pendingMutationResultFromQuery else {
-            let dataStoreError = DataStoreError.unknown("Unable to query pending mutation events",
-                                                        AmplifyErrorMessages.shouldNotHappenReportBugToAWS())
-            return .failure(dataStoreError)
-        }
-
-        return pendingMutationResult
+        finish()
     }
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Query.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Query.swift
@@ -6,17 +6,57 @@
 //
 
 import Amplify
+import Dispatch
 
 extension MutationEvent {
     static func pendingMutationEvents(forModelId modelId: Model.Identifier,
                                       storageAdapter: StorageEngineAdapter,
                                       completion: DataStoreCallback<[MutationEvent]>) {
+
+        pendingMutationEvents(forModelIds: [modelId], storageAdapter: storageAdapter, completion: completion)
+    }
+
+    static func pendingMutationEvents(forModelIds modelIds: [Model.Identifier],
+                                      storageAdapter: StorageEngineAdapter,
+                                      completion: DataStoreCallback<[MutationEvent]>) {
         let fields = MutationEvent.keys
-        let predicate = fields.modelId == modelId && (fields.inProcess == false || fields.inProcess == nil)
-        let sort = QuerySortDescriptor(fieldName: fields.createdAt.stringValue, order: .ascending)
-        storageAdapter.query(MutationEvent.self,
-                             predicate: predicate,
-                             sort: [sort],
-                             paginationInput: nil) { completion($0) }
+        let predicate = (fields.inProcess == false || fields.inProcess == nil)
+        let maxNumberOfPredicates = 950
+        var queriedMutationEvents: [MutationEvent] = []
+        var queryError: DataStoreError?
+        let chunkedArrays = modelIds.chunked(into: maxNumberOfPredicates)
+        for chunkedArray in chunkedArrays {
+            var queryPredicates: [QueryPredicateOperation] = []
+            for id in chunkedArray {
+                queryPredicates.append(QueryPredicateOperation(field: fields.modelId.stringValue,
+                                                               operator: .equals(id)))
+            }
+            let groupedQueryPredicates =  QueryPredicateGroup(type: .or, predicates: queryPredicates)
+            let final = QueryPredicateGroup(type: .and, predicates: [groupedQueryPredicates, predicate])
+            let sort = QuerySortDescriptor(fieldName: fields.createdAt.stringValue, order: .ascending)
+            let sempahore = DispatchSemaphore(value: 0)
+            storageAdapter.query(MutationEvent.self,
+                                 predicate: final,
+                                 sort: [sort],
+                                 paginationInput: nil) { result in
+                defer {
+                    sempahore.signal()
+                }
+
+                switch result {
+                case .success(let mutationEvents):
+                    queriedMutationEvents.append(contentsOf: mutationEvents)
+                case .failure(let error):
+                    queryError = error
+                    return
+                }
+            }
+            sempahore.wait()
+        }
+        if let queryError = queryError {
+            completion(.failure(queryError))
+        } else {
+            completion(.success(queriedMutationEvents))
+        }
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -564,4 +564,8 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
 
         _ = UserDefaults.removeObject(userDefaults)
     }
+
+    func testQueryMutationSyncMetadata() {
+        // TODO
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -270,7 +270,7 @@ class InitialSyncOperationTests: XCTestCase {
         let reconciliationQueue = MockReconciliationQueue()
         reconciliationQueue.listeners.append { message in
             if message.hasPrefix("offer(_:)")
-                && message.contains("MutationSync<AnyModel>")
+                && message.contains("MutationSync<AWSPluginsCore.AnyModel>")
                 && message.contains(#"id: "1"#) {
                 itemSubmitted.fulfill()
             }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -7,21 +7,24 @@
 
 import Foundation
 import XCTest
+import Combine
 
 @testable import Amplify
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 @testable import AWSDataStoreCategoryPlugin
 
+// swiftlint:disable type_body_length
+// swiftlint:disable file_length
 class ReconcileAndLocalSaveOperationTests: XCTestCase {
     var storageAdapter: MockSQLiteStorageEngineAdapter!
     var anyPostMetadata: MutationSyncMetadata!
     var anyPostMutationSync: MutationSync<AnyModel>!
     var anyPostDeletedMutationSync: MutationSync<AnyModel>!
-
+    var anyPostMutationEvent: MutationEvent!
     var operation: ReconcileAndLocalSaveOperation!
     var stateMachine: MockStateMachine<ReconcileAndLocalSaveOperation.State, ReconcileAndLocalSaveOperation.Action>!
-
+    var cancellables: Set<AnyCancellable>!
     override func setUp() {
         tryOrFail {
             try setUpWithAPI()
@@ -43,7 +46,11 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
                                                          lastChangedAt: Int(Date().timeIntervalSince1970),
                                                          version: 2)
         anyPostDeletedMutationSync = MutationSync<AnyModel>(model: anyPostDelete, syncMetadata: anyPostDeleteMetadata)
-
+        anyPostMutationEvent = MutationEvent(id: "1",
+                                             modelId: "3",
+                                             modelName: testPost.modelName,
+                                             json: "",
+                                             mutationType: .create)
         storageAdapter = MockSQLiteStorageEngineAdapter()
         storageAdapter.returnOnQuery(dataStoreResult: .none)
         storageAdapter.returnOnSave(dataStoreResult: .none)
@@ -51,230 +58,748 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
                                         resolver: ReconcileAndLocalSaveOperation.Resolver.resolve(currentState:action:))
 
         operation = ReconcileAndLocalSaveOperation(modelSchema: anyPostMutationSync.model.schema,
-                                                   remoteModel: anyPostMutationSync,
+                                                   remoteModels: [anyPostMutationSync],
                                                    storageAdapter: storageAdapter,
                                                    stateMachine: stateMachine)
+        cancellables = Set<AnyCancellable>()
     }
 
     func testCreateOperation() throws {
         XCTAssertEqual(stateMachine.state, ReconcileAndLocalSaveOperation.State.waiting)
     }
 
-    func testQuerying() throws {
-        let expect = expectation(description: "action .queried notified")
-        storageAdapter.returnOnQueryMutationSyncMetadata(anyPostMetadata)
+    // MARK: - Reconcile
+
+    func testReconcile() {
+        let expect = expectation(description: "action .reconciled")
+
+        storageAdapter.returnOnSave(dataStoreResult: .success(anyPostMutationSync.model))
         stateMachine.pushExpectActionCriteria { action in
-            XCTAssertEqual(action,
-                           ReconcileAndLocalSaveOperation.Action.queried(self.anyPostMutationSync,
-                                                                         self.anyPostMetadata))
+            XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.reconciled)
             expect.fulfill()
         }
 
-        stateMachine.state = .querying(anyPostMutationSync)
+        stateMachine.state = .reconciling([anyPostMutationSync])
 
         waitForExpectations(timeout: 1)
     }
-    /*
-     //    TODO: Need to check the model registry
-     func testQueryingUnregisteredModel_error() throws {
-     let comment = Comment(content: "testContent", post: testPost)
-     let anyComment = AnyModel(comment)
-     let anyCommentMetadata = MutationSyncMetadata(id: "3",
-     deleted: false,
-     lastChangedAt: Int(Date().timeIntervalSince1970),
-     version: 2)
-     let anyCommentMutationSync = MutationSync<AnyModel>(model: anyComment, syncMetadata: anyCommentMetadata)
 
-     stateMachine.state = .querying(anyCommentMutationSync)
+    func testReconcile_nilStorageAdapter() {
+        let expect = expectation(description: "action .errored")
 
-     }
-     */
-    func testQueryingWithInvalidStorageAdapter_error() throws {
-        let expect = expectation(description: "action .errored nil storage adapter")
+        storageAdapter = nil
         stateMachine.pushExpectActionCriteria { action in
             XCTAssertEqual(action,
                            ReconcileAndLocalSaveOperation.Action.errored(DataStoreError.nilStorageAdapter()))
             expect.fulfill()
         }
 
+        stateMachine.state = .reconciling([anyPostMutationSync])
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testReconcile_emptyRemoteModels() {
+        let expect = expectation(description: "action .reconciled")
+
+        stateMachine.pushExpectActionCriteria { action in
+            XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.reconciled)
+            expect.fulfill()
+        }
+
+        stateMachine.state = .reconciling([])
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testReconcile_transactionError() {
+        let expect = expectation(description: "action .errored")
+
+        let error = DataStoreError.internalOperation("Transaction failed", "")
+        storageAdapter.errorToThrowOnTransaction = error
+        stateMachine.pushExpectActionCriteria { action in
+            XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.errored(error))
+            expect.fulfill()
+        }
+
+        stateMachine.state = .reconciling([anyPostMutationSync])
+
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - queryPendingMutations
+
+    func testQueryPendingMutations_nilStorageAdapter() {
+        let expect = expectation(description: "storage adapter error")
+
         storageAdapter = nil
-        stateMachine.state = .querying(anyPostMutationSync)
+        operation.queryPendingMutations(forModelIds: [anyPostMutationSync.model.id])
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    XCTAssertEqual(error.errorDescription, DataStoreError.nilStorageAdapter().errorDescription)
+                    expect.fulfill()
+                case .finished:
+                    XCTFail("Should have failed")
+                }
+            }, receiveValue: { mutationEvents in
+                XCTFail("Unexpected \(mutationEvents)")
+            }).store(in: &cancellables)
 
         waitForExpectations(timeout: 1)
     }
 
-    func testQueryingWithErrorOnQuery() throws {
-        let expect = expectation(description: "action .errored notified")
-        let error = DataStoreError.invalidModelName("invalidModelName")
-        storageAdapter.throwOnQueryMutationSyncMetadata(error: error)
-        stateMachine.pushExpectActionCriteria { action in
-            XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.errored(error))
-            expect.fulfill()
+    func testQueryPendingMutations_emptyModels() {
+        let expect = expectation(description: "should complete successfully for empty input")
+        expect.expectedFulfillmentCount = 2
+
+        operation.queryPendingMutations(forModelIds: [])
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    XCTFail("Unexpected failure \(error)")
+                case .finished:
+                    expect.fulfill()
+                }
+            }, receiveValue: { mutationEvents in
+                XCTAssertTrue(mutationEvents.isEmpty)
+                expect.fulfill()
+            }).store(in: &cancellables)
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testQueryPendingMutations_querySuccess() {
+        let expect = expectation(description: "queried pending mutations success")
+        expect.expectedFulfillmentCount = 2
+
+        let queryResponder = QueryModelTypePredicateResponder<MutationEvent> { _, _ in
+            return .success([self.anyPostMutationEvent])
         }
-
-        stateMachine.state = .querying(anyPostMutationSync)
+        storageAdapter.responders[.queryModelTypePredicate] = queryResponder
+        operation.queryPendingMutations(forModelIds: [anyPostMutationSync.model.id])
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    XCTFail("Unexpected failure \(error)")
+                case .finished:
+                    expect.fulfill()
+                }
+            }, receiveValue: { mutationEvents in
+                XCTAssertEqual(mutationEvents, [self.anyPostMutationEvent])
+                expect.fulfill()
+            }).store(in: &cancellables)
 
         waitForExpectations(timeout: 1)
     }
 
-    func testQueryingWithEmptyLocalStore() throws {
-        let expect = expectation(description: "action .queried notified with local data == nil")
-        storageAdapter.returnOnQueryMutationSyncMetadata(nil)
-        stateMachine.pushExpectActionCriteria { action in
-            XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.queried(self.anyPostMutationSync, nil))
-            expect.fulfill()
+    func testQueryPendingMutations_queryFailure() {
+        let expect = expectation(description: "queried pending mutations failed")
+
+        let queryResponder = QueryModelTypePredicateResponder<MutationEvent> { _, _ in
+            return .failure(DataStoreError.internalOperation("Query failed", ""))
         }
-
-        stateMachine.state = .querying(anyPostMutationSync)
+        storageAdapter.responders[.queryModelTypePredicate] = queryResponder
+        operation.queryPendingMutations(forModelIds: [anyPostMutationSync.model.id])
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure:
+                    expect.fulfill()
+                case .finished:
+                    XCTFail("Expected to complete with failure")
+                }
+            }, receiveValue: { _ in
+                XCTFail("Should not return a value")
+            }).store(in: &cancellables)
 
         waitForExpectations(timeout: 1)
     }
 
-    func testReconcilingWithoutLocalModel() throws {
-        let expect = expectation(description: "action .reconciled notified")
-        let expectedDisposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostMutationSync, .create)
-        stateMachine.pushExpectActionCriteria { action in
-            XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.reconciled(expectedDisposition))
-            expect.fulfill()
+    // MARK: - reconcile(remoteModels:pendingMutations)
+
+    func testReconcilePendingMutations_emptyModels() {
+        let result = operation.reconcile([], pendingMutations: [anyPostMutationEvent])
+
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testReconcilePendingMutations_emptyPendingMutations() {
+        let result = operation.reconcile([anyPostMutationSync], pendingMutations: [])
+
+        guard let remoteModelToApply = result.first else {
+            XCTFail("Missing models to apply")
+            return
         }
-        stateMachine.state = .reconciling(anyPostMutationSync, nil)
+        XCTAssertEqual(remoteModelToApply.model.id, anyPostMutationSync.model.id)
+    }
+
+    func testReconcilePendingMutations_notifyDropped() {
+        let expect = expectation(description: "notify dropped twice")
+        expect.expectedFulfillmentCount = 2
+        let model1 = AnyModel(Post(title: "post1", content: "content", createdAt: .now()))
+        let model2 = AnyModel(Post(title: "post2", content: "content", createdAt: .now()))
+        let metadata1 = MutationSyncMetadata(id: model1.id,
+                                             deleted: false,
+                                             lastChangedAt: Int(Date().timeIntervalSince1970),
+                                             version: 1)
+        let metadata2 = MutationSyncMetadata(id: model2.id,
+                                             deleted: false,
+                                             lastChangedAt: Int(Date().timeIntervalSince1970),
+                                             version: 1)
+        let remoteModel1 = MutationSync<AnyModel>(model: model1, syncMetadata: metadata1)
+        let remoteModel2 = MutationSync<AnyModel>(model: model2, syncMetadata: metadata2)
+
+        let mutationEvent1 = MutationEvent(id: "1",
+                                           modelId: remoteModel1.model.id,
+                                           modelName: remoteModel1.model.modelName,
+                                           json: "",
+                                           mutationType: .create)
+        let mutationEvent2 = MutationEvent(id: "2",
+                                           modelId: remoteModel2.model.id,
+                                           modelName: remoteModel2.model.modelName,
+                                           json: "",
+                                           mutationType: .create)
+        operation.publisher
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    XCTFail("Unexpected completion")
+                case .failure(let error):
+                    XCTFail("Unexpected error \(error)")
+                }
+            } receiveValue: { event in
+                switch event {
+                case .mutationEventDropped(let name):
+                    XCTAssertEqual(name, Post.modelName)
+                    expect.fulfill()
+                default:
+                    break
+                }
+            }.store(in: &cancellables)
+
+        let result = operation.reconcile([remoteModel1, remoteModel2],
+                                         pendingMutations: [mutationEvent1, mutationEvent2])
+
+        XCTAssertTrue(result.isEmpty)
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - queryLocalMetadata
+
+    func testQueryLocalMetadata_nilStorageAdapter() {
+        let expect = expectation(description: "storage adapter error")
+
+        storageAdapter = nil
+        operation.queryLocalMetadata([anyPostMutationSync])
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    XCTAssertEqual(error.errorDescription, DataStoreError.nilStorageAdapter().errorDescription)
+                    expect.fulfill()
+                case .finished:
+                    XCTFail("Should have failed")
+                }
+            }, receiveValue: { result in
+                XCTFail("Unexpected \(result)")
+            }).store(in: &cancellables)
 
         waitForExpectations(timeout: 1)
     }
 
-    func testExecuteApplyRemoteModelCreate() throws {
-        let expect = expectation(description: "action .execute applyRemoteModel")
-        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostMutationSync, .create)
-        storageAdapter.returnOnSave(dataStoreResult: .success(anyPostMutationSync.model))
-        stateMachine.pushExpectActionCriteria { action in
-            XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.applied(self.anyPostMutationSync,
-                                                                                 mutationType: .create))
-            expect.fulfill()
+    func testQueryLocalMetadata_emptyModels() {
+        let expect = expectation(description: "should complete successfully for empty input")
+        expect.expectedFulfillmentCount = 2
+
+        operation.queryLocalMetadata([])
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    XCTFail("Unexpected failure \(error)")
+                case .finished:
+                    expect.fulfill()
+                }
+            }, receiveValue: { remoteModels, localMetadatas in
+                XCTAssertTrue(remoteModels.isEmpty)
+                XCTAssertTrue(localMetadatas.isEmpty)
+                expect.fulfill()
+            }).store(in: &cancellables)
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testQueryLocalMetadata_querySuccess() {
+        let expect = expectation(description: "queried local metadata success")
+        expect.expectedFulfillmentCount = 2
+
+        storageAdapter.returnOnQueryMutationSyncMetadatas([anyPostMetadata])
+        operation.queryLocalMetadata([anyPostMutationSync])
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    XCTFail("Unexpected failure \(error)")
+                case .finished:
+                    expect.fulfill()
+                }
+            }, receiveValue: { remoteModels, localMetadatas in
+                guard let remoteModel = remoteModels.first else {
+                    XCTFail("Empty remote models")
+                    return
+                }
+                XCTAssertEqual(remoteModel.model.id, self.anyPostMutationSync.model.id)
+                guard let localMetadata = localMetadatas.first else {
+                    XCTFail("Empty local metadata")
+                    return
+                }
+                XCTAssertEqual(localMetadata, self.anyPostMetadata)
+                expect.fulfill()
+            }).store(in: &cancellables)
+
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - reconcile(remoteModels:localMetadata)
+
+    func testReconcileLocalMetadata_emptyModels() {
+        let result = operation.reconcile([], localMetadatas: [anyPostMetadata])
+
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testReconcileLocalMetadata_emptyLocalMetadatas() {
+        let result = operation.reconcile([anyPostMutationSync], localMetadatas: [])
+
+        guard let remoteModelDisposition = result.first else {
+            XCTFail("Missing models to apply")
+            return
         }
+        XCTAssertEqual(remoteModelDisposition, .create(anyPostMutationSync))
+    }
 
-        stateMachine.state = .executing(disposition)
+    func testReconcileLocalMetadata_success() {
+        let expect = expectation(description: "notify dropped twice")
+        expect.expectedFulfillmentCount = 2
+        let model1 = AnyModel(Post(title: "post1", content: "content", createdAt: .now()))
+        let model2 = AnyModel(Post(title: "post2", content: "content", createdAt: .now()))
+        let metadata1 = MutationSyncMetadata(id: model1.id,
+                                             deleted: false,
+                                             lastChangedAt: Int(Date().timeIntervalSince1970),
+                                             version: 1)
+        let metadata2 = MutationSyncMetadata(id: model2.id,
+                                             deleted: false,
+                                             lastChangedAt: Int(Date().timeIntervalSince1970),
+                                             version: 1)
+        let remoteModel1 = MutationSync<AnyModel>(model: model1, syncMetadata: metadata1)
+        let remoteModel2 = MutationSync<AnyModel>(model: model2, syncMetadata: metadata2)
+
+        let localMetadata1 = MutationSyncMetadata(id: model1.id,
+                                                  deleted: false,
+                                                  lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                  version: 3)
+        let localMetadata2 = MutationSyncMetadata(id: model2.id,
+                                                  deleted: false,
+                                                  lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                  version: 4)
+        operation.publisher
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    XCTFail("Unexpected completion")
+                case .failure(let error):
+                    XCTFail("Unexpected error \(error)")
+                }
+            } receiveValue: { event in
+                switch event {
+                case .mutationEventDropped(let name):
+                    XCTAssertEqual(name, Post.modelName)
+                    expect.fulfill()
+                default:
+                    break
+                }
+            }.store(in: &cancellables)
+
+        let result = operation.reconcile([remoteModel1, remoteModel2],
+                                         localMetadatas: [localMetadata1, localMetadata2])
+
+        XCTAssertTrue(result.isEmpty)
         waitForExpectations(timeout: 1)
     }
 
-    func testExecuteApplyRemoteModelUpdate() throws {
-        let expect = expectation(description: "action .execute applyRemoteModel")
-        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostMutationSync, .update)
+    // MARK: - applyRemoteModels
 
-        storageAdapter.returnOnSave(dataStoreResult: .success(anyPostMutationSync.model))
-        stateMachine.pushExpectActionCriteria { action in
-            XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.applied(self.anyPostMutationSync,
-                                                                                 mutationType: .update))
-            expect.fulfill()
-        }
-        stateMachine.state = .executing(disposition)
+    func testApplyRemoteModels_nilStorageAdapter() {
+        let expect = expectation(description: "storage adapter error")
 
-        waitForExpectations(timeout: 1)
-    }
-
-    func testExecuteApplyRemoteModel_saveMutationFailed() throws {
-        let expect = expectation(description: "action .execute error on save model")
-        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostMutationSync, .create)
-        let error = DataStoreError.invalidModelName("invModelName")
-        storageAdapter.returnOnSave(dataStoreResult: .failure(error))
-        stateMachine.pushExpectActionCriteria { action in
-            XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.errored(error))
-            expect.fulfill()
-        }
-
-        stateMachine.state = .executing(disposition)
-
-        waitForExpectations(timeout: 1)
-    }
-
-    func testExecuteApplyRemoteModel_saveMutationOK_MetadataFailed() throws {
-        let expect = expectation(description: "action .execute error on save mutation")
-        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostMutationSync, .create)
-        let error = DataStoreError.invalidModelName("forceError")
-        storageAdapter.returnOnSave(dataStoreResult: .success(anyPostMutationSync.model))
-        storageAdapter.shouldReturnErrorOnSaveMetadata = true
-        stateMachine.pushExpectActionCriteria { action in
-            XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.errored(error))
-            expect.fulfill()
-        }
-
-        stateMachine.state = .executing(disposition)
-        waitForExpectations(timeout: 1)
-    }
-
-    func testExecuteApplyRemoteModel_Delete() throws {
-        let expect = expectation(description: "action .execute applyRemoteModel delete success case")
-        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostDeletedMutationSync, .delete)
-        storageAdapter.returnOnSave(dataStoreResult: .success(anyPostDeletedMutationSync.model))
-        stateMachine.pushExpectActionCriteria { action in
-            XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.applied(self.anyPostDeletedMutationSync,
-                                                                                 mutationType: .delete))
-            expect.fulfill()
-        }
-
-        stateMachine.state = .executing(disposition)
-        waitForExpectations(timeout: 1)
-    }
-
-    func testExecuteApplyRemoteModel_Delete_saveMutationFailed() throws {
-        let expect = expectation(description: "action .execute applyRemoteModel delete mutation error")
-        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostDeletedMutationSync, .delete)
-        let error = DataStoreError.invalidModelName("DelMutate")
-        storageAdapter.shouldReturnErrorOnDeleteMutation = true
-        stateMachine.pushExpectActionCriteria { action in
-            XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.errored(error))
-            expect.fulfill()
-        }
-
-        stateMachine.state = .executing(disposition)
+        storageAdapter = nil
+        operation.applyRemoteModels(dispositions: [])
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    XCTAssertEqual(error.errorDescription, DataStoreError.nilStorageAdapter().errorDescription)
+                    expect.fulfill()
+                case .finished:
+                    XCTFail("Should have failed")
+                }
+            }, receiveValue: { result in
+                XCTFail("Unexpected \(result)")
+            }).store(in: &cancellables)
 
         waitForExpectations(timeout: 1)
     }
 
-    func testExecuteApplyRemoteModel_Delete_saveMutationOK_saveMetadataFailed() throws {
-        let expect = expectation(description: "action .execute applyRemoteModel delete metadata error")
-        let disposition = RemoteSyncReconciler.Disposition.applyRemoteModel(anyPostDeletedMutationSync, .delete)
-        let error = DataStoreError.invalidModelName("forceError")
-        storageAdapter.shouldReturnErrorOnSaveMetadata = true
-        storageAdapter.returnOnSave(dataStoreResult: .failure(error))
-        stateMachine.pushExpectActionCriteria { action in
-            XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.errored(error))
-            expect.fulfill()
-        }
+    func testApplyRemoteModels_emptyDisposition() {
+        let expect = expectation(description: "should complete successfully")
+        expect.expectedFulfillmentCount = 2
 
-        stateMachine.state = .executing(disposition)
+        operation.applyRemoteModels(dispositions: [])
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    XCTFail("Unexpected failure \(error)")
+                case .finished:
+                    expect.fulfill()
+                }
+            }, receiveValue: { _ in
+                expect.fulfill()
+            }).store(in: &cancellables)
         waitForExpectations(timeout: 1)
     }
 
-    func testExecuteDropRemoteModel() throws {
-        let expect = expectation(description: "action .execute dropRemoteModel")
-        let disposition = RemoteSyncReconciler.Disposition.dropRemoteModel
-        stateMachine.pushExpectActionCriteria { action in
-            XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.dropped(modelName: "Post"))
-            expect.fulfill()
-        }
-
-        stateMachine.state = .executing(disposition("Post"))
-
-        waitForExpectations(timeout: 1)
-    }
-
-    func testNotifying() throws {
+    func testApplyRemoteModels_createDisposition() {
+        let expect = expectation(description: "operation should send value and complete successfully")
+        expect.expectedFulfillmentCount = 2
+        let stoargeExpect = expectation(description: "storage save should be called")
+        let storageMetadataExpect = expectation(description: "storage save metadata should be called")
+        let notifyExpect = expectation(description: "mutation event should be emitted")
         let hubExpect = expectation(description: "Hub is notified")
-        let notifyExpect = expectation(description: "action .notified notified")
+        let saveResponder = SaveUntypedModelResponder { model, completion in
+            stoargeExpect.fulfill()
+            completion(.success(model))
+        }
+
+        storageAdapter.responders[.saveUntypedModel] = saveResponder
+
+        let saveMetadataResponder = SaveModelCompletionResponder<MutationSyncMetadata> { model, completion in
+            storageMetadataExpect.fulfill()
+            completion(.success(model))
+        }
+        storageAdapter.responders[.saveModelCompletion] = saveMetadataResponder
+
         let hubListener = Amplify.Hub.listen(to: .dataStore) { payload in
             if payload.eventName == "DataStore.syncReceived" {
                 hubExpect.fulfill()
             }
         }
-        stateMachine.pushExpectActionCriteria { action in
-            XCTAssertEqual(action, ReconcileAndLocalSaveOperation.Action.notified)
-            notifyExpect.fulfill()
-        }
+        operation.publisher
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    XCTFail("Unexpected completion")
+                case .failure(let error):
+                    XCTFail("Unexpected error \(error)")
+                }
+            } receiveValue: { event in
+                switch event {
+                case .mutationEvent(let mutationEvent):
+                    XCTAssertEqual(mutationEvent.modelId, self.anyPostMutationSync.model.id)
+                    notifyExpect.fulfill()
+                default:
+                    break
+                }
+            }.store(in: &cancellables)
 
-        stateMachine.state = .notifying(anyPostMutationSync, .create)
-
+        operation.applyRemoteModels(dispositions: [.create(anyPostMutationSync)])
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    XCTFail("Unexpected failure \(error)")
+                case .finished:
+                    expect.fulfill()
+                }
+            }, receiveValue: { _ in
+                expect.fulfill()
+            }).store(in: &cancellables)
         waitForExpectations(timeout: 1)
         Amplify.Hub.removeListener(hubListener)
+    }
+
+    func testApplyRemoteModels_updateDisposition() {
+        let expect = expectation(description: "operation should send value and complete successfully")
+        expect.expectedFulfillmentCount = 2
+        let stoargeExpect = expectation(description: "storage save should be called")
+        let storageMetadataExpect = expectation(description: "storage save metadata should be called")
+        let notifyExpect = expectation(description: "mutation event should be emitted")
+        let hubExpect = expectation(description: "Hub is notified")
+        let saveResponder = SaveUntypedModelResponder { _, completion in
+            stoargeExpect.fulfill()
+            completion(.success(self.anyPostMutationSync.model))
+        }
+        storageAdapter.responders[.saveUntypedModel] = saveResponder
+
+        let saveMetadataResponder = SaveModelCompletionResponder<MutationSyncMetadata> { model, completion in
+            storageMetadataExpect.fulfill()
+            completion(.success(model))
+        }
+        storageAdapter.responders[.saveModelCompletion] = saveMetadataResponder
+        let hubListener = Amplify.Hub.listen(to: .dataStore) { payload in
+            if payload.eventName == "DataStore.syncReceived" {
+                hubExpect.fulfill()
+            }
+        }
+        operation.publisher
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    XCTFail("Unexpected completion")
+                case .failure(let error):
+                    XCTFail("Unexpected error \(error)")
+                }
+            } receiveValue: { event in
+                switch event {
+                case .mutationEvent(let mutationEvent):
+                    XCTAssertEqual(mutationEvent.modelId, self.anyPostMutationSync.model.id)
+                    notifyExpect.fulfill()
+                default:
+                    break
+                }
+            }.store(in: &cancellables)
+
+        operation.applyRemoteModels(dispositions: [.update(anyPostMutationSync)])
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    XCTFail("Unexpected failure \(error)")
+                case .finished:
+                    expect.fulfill()
+                }
+            }, receiveValue: { _ in
+                expect.fulfill()
+            }).store(in: &cancellables)
+        waitForExpectations(timeout: 1)
+    }
+
+    func testApplyRemoteModels_deleteDisposition() {
+        let expect = expectation(description: "operation should send value and complete successfully")
+        expect.expectedFulfillmentCount = 2
+        let stoargeExpect = expectation(description: "storage delete should be called")
+        let storageMetadataExpect = expectation(description: "storage save metadata should be called")
+        let notifyExpect = expectation(description: "mutation event should be emitted")
+        let hubExpect = expectation(description: "Hub is notified")
+        let deleteResponder = DeleteUntypedModelCompletionResponder { _, id in
+            XCTAssertEqual(id, self.anyPostMutationSync.model.id)
+            stoargeExpect.fulfill()
+        }
+        storageAdapter.responders[.deleteUntypedModel] = deleteResponder
+
+        let saveMetadataResponder = SaveModelCompletionResponder<MutationSyncMetadata> { model, completion in
+            storageMetadataExpect.fulfill()
+            completion(.success(model))
+        }
+        storageAdapter.responders[.saveModelCompletion] = saveMetadataResponder
+        let hubListener = Amplify.Hub.listen(to: .dataStore) { payload in
+            if payload.eventName == "DataStore.syncReceived" {
+                hubExpect.fulfill()
+            }
+        }
+        operation.publisher
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    XCTFail("Unexpected completion")
+                case .failure(let error):
+                    XCTFail("Unexpected error \(error)")
+                }
+            } receiveValue: { event in
+                switch event {
+                case .mutationEvent(let mutationEvent):
+                    XCTAssertEqual(mutationEvent.modelId, self.anyPostMutationSync.model.id)
+                    notifyExpect.fulfill()
+                default:
+                    break
+                }
+            }.store(in: &cancellables)
+
+        operation.applyRemoteModels(dispositions: [.delete(anyPostMutationSync)])
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    XCTFail("Unexpected failure \(error)")
+                case .finished:
+                    expect.fulfill()
+                }
+            }, receiveValue: { _ in
+                expect.fulfill()
+            }).store(in: &cancellables)
+        waitForExpectations(timeout: 1)
+    }
+
+    func testApplyRemoteModels_multipleDispositions() {
+        let dispositions: [RemoteSyncReconciler.Disposition] = [.create(anyPostMutationSync),
+                                                                .create(anyPostMutationSync),
+                                                                .update(anyPostMutationSync),
+                                                                .update(anyPostMutationSync),
+                                                                .delete(anyPostMutationSync),
+                                                                .delete(anyPostMutationSync),
+                                                                .create(anyPostMutationSync),
+                                                                .update(anyPostMutationSync),
+                                                                .delete(anyPostMutationSync)]
+        let expect = expectation(description: "should complete successfully")
+        expect.expectedFulfillmentCount = 2
+        let stoargeExpect = expectation(description: "storage save/delete should be called")
+        stoargeExpect.expectedFulfillmentCount = dispositions.count
+        let storageMetadataExpect = expectation(description: "storage save metadata should be called")
+        storageMetadataExpect.expectedFulfillmentCount = dispositions.count
+        let notifyExpect = expectation(description: "mutation event should be emitted")
+        notifyExpect.expectedFulfillmentCount = dispositions.count
+        let hubExpect = expectation(description: "Hub is notified")
+        hubExpect.expectedFulfillmentCount = dispositions.count
+
+        let saveResponder = SaveUntypedModelResponder { _, completion in
+            stoargeExpect.fulfill()
+            completion(.success(self.anyPostMutationSync.model))
+        }
+        storageAdapter.responders[.saveUntypedModel] = saveResponder
+
+        let deleteResponder = DeleteUntypedModelCompletionResponder { _, id in
+            XCTAssertEqual(id, self.anyPostMutationSync.model.id)
+            stoargeExpect.fulfill()
+        }
+        storageAdapter.responders[.deleteUntypedModel] = deleteResponder
+
+        let saveMetadataResponder = SaveModelCompletionResponder<MutationSyncMetadata> { model, completion in
+            storageMetadataExpect.fulfill()
+            completion(.success(model))
+        }
+        storageAdapter.responders[.saveModelCompletion] = saveMetadataResponder
+        let hubListener = Amplify.Hub.listen(to: .dataStore) { payload in
+            if payload.eventName == "DataStore.syncReceived" {
+                hubExpect.fulfill()
+            }
+        }
+        operation.publisher
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    XCTFail("Unexpected completion")
+                case .failure(let error):
+                    XCTFail("Unexpected error \(error)")
+                }
+            } receiveValue: { event in
+                switch event {
+                case .mutationEvent(let mutationEvent):
+                    XCTAssertEqual(mutationEvent.modelId, self.anyPostMutationSync.model.id)
+                    notifyExpect.fulfill()
+                default:
+                    break
+                }
+            }.store(in: &cancellables)
+
+        operation.applyRemoteModels(dispositions: dispositions)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    XCTFail("Unexpected failure \(error)")
+                case .finished:
+                    expect.fulfill()
+                }
+            }, receiveValue: { _ in
+                expect.fulfill()
+            }).store(in: &cancellables)
+        waitForExpectations(timeout: 1)
+    }
+
+    func testApplyRemoteModels_saveFail() {
+        let dispositions: [RemoteSyncReconciler.Disposition] = [.create(anyPostMutationSync),
+                                                                .create(anyPostMutationSync),
+                                                                .update(anyPostMutationSync),
+                                                                .update(anyPostMutationSync),
+                                                                .delete(anyPostMutationSync),
+                                                                .delete(anyPostMutationSync),
+                                                                .create(anyPostMutationSync),
+                                                                .update(anyPostMutationSync),
+                                                                .delete(anyPostMutationSync)]
+        let expect = expectation(description: "should fail")
+        let saveResponder = SaveUntypedModelResponder { _, completion in
+            completion(.failure(DataStoreError.internalOperation("Failed to save", "")))
+        }
+        storageAdapter.responders[.saveUntypedModel] = saveResponder
+
+        operation.applyRemoteModels(dispositions: dispositions)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure:
+                    expect.fulfill()
+                case .finished:
+                    XCTFail("Unexpected successfully completion")
+                }
+            }, receiveValue: { _ in
+                XCTFail("Unexpected value received")
+            }).store(in: &cancellables)
+        waitForExpectations(timeout: 1)
+    }
+
+    func testApplyRemoteModels_deleteFail() {
+        let dispositions: [RemoteSyncReconciler.Disposition] = [.create(anyPostMutationSync),
+                                                                .create(anyPostMutationSync),
+                                                                .update(anyPostMutationSync),
+                                                                .update(anyPostMutationSync),
+                                                                .delete(anyPostMutationSync),
+                                                                .delete(anyPostMutationSync),
+                                                                .create(anyPostMutationSync),
+                                                                .update(anyPostMutationSync),
+                                                                .delete(anyPostMutationSync)]
+        let expect = expectation(description: "should fail")
+        let saveResponder = SaveUntypedModelResponder { _, completion in
+            completion(.success(self.anyPostMutationSync.model))
+        }
+        storageAdapter.responders[.saveUntypedModel] = saveResponder
+        storageAdapter.shouldReturnErrorOnDeleteMutation = true
+
+        operation.applyRemoteModels(dispositions: dispositions)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure:
+                    expect.fulfill()
+                case .finished:
+                    XCTFail("Unexpected successfully completion")
+                }
+            }, receiveValue: { _ in
+                XCTFail("Unexpected value received")
+            }).store(in: &cancellables)
+        waitForExpectations(timeout: 1)
+    }
+
+    func testApplyRemoteModels_saveMetadataFail() {
+        let dispositions: [RemoteSyncReconciler.Disposition] = [.create(anyPostMutationSync),
+                                                                .create(anyPostMutationSync),
+                                                                .update(anyPostMutationSync),
+                                                                .update(anyPostMutationSync),
+                                                                .delete(anyPostMutationSync),
+                                                                .delete(anyPostMutationSync),
+                                                                .create(anyPostMutationSync),
+                                                                .update(anyPostMutationSync),
+                                                                .delete(anyPostMutationSync)]
+        let expect = expectation(description: "should fail")
+        let saveResponder = SaveUntypedModelResponder { _, completion in
+            completion(.success(self.anyPostMutationSync.model))
+        }
+        storageAdapter.responders[.saveUntypedModel] = saveResponder
+        let saveMetadataResponder = SaveModelCompletionResponder<MutationSyncMetadata> { _, completion in
+            completion(.failure(.internalOperation("Failed to save metadata", "")))
+        }
+        storageAdapter.responders[.saveModelCompletion] = saveMetadataResponder
+
+        operation.applyRemoteModels(dispositions: dispositions)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure:
+                    expect.fulfill()
+                case .finished:
+                    XCTFail("Unexpected successfully completion")
+                }
+            }, receiveValue: { _ in
+                XCTFail("Unexpected value received")
+            }).store(in: &cancellables)
+        waitForExpectations(timeout: 1)
     }
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndSaveQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndSaveQueueTests.swift
@@ -50,7 +50,7 @@ class ReconcileAndSaveQueueTests: XCTestCase {
             }
         }
         let operation = ReconcileAndLocalSaveOperation(modelSchema: anyPostMutationSync.model.schema,
-                                                       remoteModel: anyPostMutationSync,
+                                                       remoteModels: [anyPostMutationSync],
                                                        storageAdapter: storageAdapter,
                                                        stateMachine: stateMachine)
         queue.addOperation(operation, modelName: Post.modelName)
@@ -78,7 +78,7 @@ class ReconcileAndSaveQueueTests: XCTestCase {
             }
         }
         let operation = ReconcileAndLocalSaveOperation(modelSchema: anyPostMutationSync.model.schema,
-                                                       remoteModel: anyPostMutationSync,
+                                                       remoteModels: [anyPostMutationSync],
                                                        storageAdapter: storageAdapter,
                                                        stateMachine: stateMachine)
         queue.addOperation(operation, modelName: Post.modelName)
@@ -107,7 +107,7 @@ class ReconcileAndSaveQueueTests: XCTestCase {
             }
         }
         let operation = ReconcileAndLocalSaveOperation(modelSchema: anyPostMutationSync.model.schema,
-                                                       remoteModel: anyPostMutationSync,
+                                                       remoteModels: [anyPostMutationSync],
                                                        storageAdapter: storageAdapter,
                                                        stateMachine: stateMachine)
         queue.addOperation(operation, modelName: Post.modelName)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/RemoteSyncReconcilerTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/RemoteSyncReconcilerTests.swift
@@ -19,225 +19,227 @@ class RemoteSyncReconcilerTests: XCTestCase {
         continueAfterFailure = false
     }
 
-    // swiftlint:disable:next force_try
-    let remoteMockSynced = try! MockSynced().eraseToAnyModel()
+    // MARK: reconcile(pendingMutations)
 
-    let mutationEvent = MutationEvent(id: "mutation-1",
-                                      modelId: "local-model-1",
-                                      modelName: MockSynced.modelName,
-                                      json: "{}",
-                                      mutationType: .create,
-                                      createdAt: .now(),
-                                      version: 1,
-                                      inProcess: false)
+    func testReconcilePendingMutations_EmptyRemoteModels() {
+        let pendingMutations: [MutationEvent] = [makeMutationEvent()]
+        let results = RemoteSyncReconciler.reconcile([], pendingMutations: pendingMutations)
 
-    // MARK: - No local model, no pending mutations
+        XCTAssertTrue(results.isEmpty)
+    }
 
-    func testCreatedOnRemote_noLocal_noPendingMutation() throws {
+    func testReconcilePendingMutations_EmptyPendingMutations() {
+        let remoteModel = makeRemoteModel()
+        let results = RemoteSyncReconciler.reconcile([remoteModel], pendingMutations: [])
+
+        XCTAssertEqual(results.first?.model.id, remoteModel.model.id)
+    }
+
+    func testReconcilePendingMutations_pendingMutationMatchRemoteModel() {
+        let remoteModel = makeRemoteModel()
+        let pendingMutation = makeMutationEvent(modelId: remoteModel.model.id)
+        let results = RemoteSyncReconciler.reconcile([remoteModel], pendingMutations: [pendingMutation])
+
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testReconcilePendingMutations_pendingMutationDoesNotMatchRemoteModel() {
+        let remoteModel = makeRemoteModel(modelId: "1")
+        let pendingMutation = makeMutationEvent(modelId: "2")
+        let results = RemoteSyncReconciler.reconcile([remoteModel], pendingMutations: [pendingMutation])
+
+        XCTAssertEqual(results.first?.model.id, remoteModel.model.id)
+    }
+
+    // MARK: - reconcile(remoteModel:localMetadata)
+
+    func testReconcileLocalMetadata_nilLocalMetadata() {
         let remoteModel = makeRemoteModel(deleted: false, version: 1)
-        let pendingMutations: [MutationEvent] = []
 
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: nil,
-                                                         pendingMutations: pendingMutations)
+        let disposition = RemoteSyncReconciler.reconcile(remoteModel,
+                                                          localMetadata: nil)
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel, .create))
+        XCTAssertEqual(disposition, .create(remoteModel))
     }
 
-    func testUpdatedOnRemote_noLocal_noPendingMutation() throws {
-        let remoteModel = makeRemoteModel(deleted: false, version: 2)
-        let pendingMutations: [MutationEvent] = []
-
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: nil,
-                                                         pendingMutations: pendingMutations)
-
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel, .create))
-    }
-
-    func testDeletedOnRemote_noLocal_noPendingMutation() throws {
+    func testReconcileLocalMetadata_nilLocalMetadata_deletedModel() {
         let remoteModel = makeRemoteModel(deleted: true, version: 2)
-        let pendingMutations: [MutationEvent] = []
 
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: nil,
-                                                         pendingMutations: pendingMutations)
+        let disposition = RemoteSyncReconciler.reconcile(remoteModel,
+                                                          localMetadata: nil)
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
+        XCTAssertNil(disposition)
     }
 
-    // MARK: - No local model, with pending mutations
-
-    func testCreatedOnRemote_noLocal_withPendingMutations() throws {
+    func testReconcileLocalMetadata_withLocalEqualVersion() {
         let remoteModel = makeRemoteModel(deleted: false, version: 1)
-        let pendingMutations: [MutationEvent] = [mutationEvent]
+        let localSyncMetadata = makeMutationSyncMetadata(modelId: remoteModel.model.id,
+                                                         deleted: false,
+                                                         version: 1)
 
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: nil,
-                                                         pendingMutations: pendingMutations)
+        let disposition = RemoteSyncReconciler.reconcile(remoteModel,
+                                                         localMetadata: localSyncMetadata)
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
+        XCTAssertEqual(disposition, .update(remoteModel))
     }
 
-    func testUpdatedOnRemote_noLocal_withPendingMutations() throws {
+    func testReconcileLocalMetadata_withLocalLowerVersion() {
         let remoteModel = makeRemoteModel(deleted: false, version: 2)
-        let pendingMutations: [MutationEvent] = [mutationEvent]
+        let localSyncMetadata = makeMutationSyncMetadata(modelId: remoteModel.model.id,
+                                                         deleted: false,
+                                                         version: 1)
 
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: nil,
-                                                         pendingMutations: pendingMutations)
+        let disposition = RemoteSyncReconciler.reconcile(remoteModel,
+                                                         localMetadata: localSyncMetadata)
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
+        XCTAssertEqual(disposition, .update(remoteModel))
     }
 
-    func testDeletedOnRemote_noLocal_withPendingMutations() throws {
+    func testReconcileLocalMetadata_withLocalLowerVersion_deletedModel() {
         let remoteModel = makeRemoteModel(deleted: true, version: 2)
-        let pendingMutations: [MutationEvent] = [mutationEvent]
+        let localSyncMetadata = makeMutationSyncMetadata(modelId: remoteModel.model.id,
+                                                         deleted: false,
+                                                         version: 1)
 
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: nil,
-                                                         pendingMutations: pendingMutations)
+        let disposition = RemoteSyncReconciler.reconcile(remoteModel,
+                                                         localMetadata: localSyncMetadata)
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
+        XCTAssertEqual(disposition, .delete(remoteModel))
     }
 
-    // MARK: - With local model having lower version, no pending mutations
-
-    // "Create" doesn't really have a "lower" version case, so we'll test equal versions
-    func testCreatedOnRemote_withLocalEqualVersion_noPendingMutations() throws {
+    func testReconcileLocalMetadata_withLocalHigherVersion() {
         let remoteModel = makeRemoteModel(deleted: false, version: 1)
-        let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 1)
-        let pendingMutations: [MutationEvent] = []
+        let localSyncMetadata = makeMutationSyncMetadata(modelId: remoteModel.model.id,
+                                                         deleted: false,
+                                                         version: 2)
 
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
+        let disposition = RemoteSyncReconciler.reconcile(remoteModel,
+                                                         localMetadata: localSyncMetadata)
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel, .update))
-    }
-
-    func testUpdatedOnRemote_withLocalLowerVersion_noPendingMutations() throws {
-        let remoteModel = makeRemoteModel(deleted: false, version: 2)
-        let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 1)
-        let pendingMutations: [MutationEvent] = []
-
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
-
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel, .update))
-    }
-
-    func testDeletedOnRemote_withLocalLowerVersion_noPendingMutations() throws {
-        let remoteModel = makeRemoteModel(deleted: true, version: 2)
-        let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 1)
-        let pendingMutations: [MutationEvent] = []
-
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
-
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.applyRemoteModel(remoteModel, .delete))
-    }
-
-    // MARK: - With local model having higher version, no pending mutations
-
-    // Create and update are both treated the same
-    func testMutatedOnRemote_withLocalHigherVersion_noPendingMutations() throws {
-        let remoteModel = makeRemoteModel(deleted: false, version: 1)
-        let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 2)
-        let pendingMutations: [MutationEvent] = []
-
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
-
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
+        XCTAssertNil(disposition)
     }
 
     // This shouldn't be possible except in case of an error (either the service side did not properly resolve a
     // conflict updating a deleted record, or the client is incorrectly manipulating the version
-    func testDeletedOnRemote_withLocalHigherVersion_noPendingMutations() throws {
+    func testReconcileLocalMetadata_withLocalHigherVersion_deletedModel() {
         let remoteModel = makeRemoteModel(deleted: true, version: 1)
-        let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 2)
-        let pendingMutations: [MutationEvent] = []
+        let localSyncMetadata = makeMutationSyncMetadata(modelId: remoteModel.model.id,
+                                                         deleted: false,
+                                                         version: 2)
 
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
+        let disposition = RemoteSyncReconciler.reconcile(remoteModel,
+                                                         localMetadata: localSyncMetadata)
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
+        XCTAssertNil(disposition)
     }
 
-    // MARK: - With local model having lower version, with pending mutations
+    // MARK: - reconcile(remoteModels:localMetadatas)
 
-    // Create and update are both treated the same
-    func testMutatedOnRemote_withLocalLowerVersion_withPendingMutations() throws {
-        let remoteModel = makeRemoteModel(deleted: false, version: 2)
-        let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 1)
-        let pendingMutations: [MutationEvent] = [mutationEvent]
+    func testReconcileLocalMetadatas_emptyRemoteModel() {
+        let localSyncMetadata = makeMutationSyncMetadata(modelId: "1", deleted: false, version: 1)
 
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
+        let dispositions = RemoteSyncReconciler.reconcile([], localMetadatas: [localSyncMetadata])
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
+        XCTAssertTrue(dispositions.isEmpty)
     }
 
-    func testDeletedOnRemote_withLocalLowerVersion_withPendingMutations() throws {
+    func testReconcileLocalMetadatas_emptyLocal() {
+        let remoteModel = makeRemoteModel(deleted: false, version: 1)
+
+        let dispositions = RemoteSyncReconciler.reconcile([remoteModel], localMetadatas: [])
+
+        XCTAssertEqual(dispositions.first, .create(remoteModel))
+    }
+
+    func testReconcileLocalMetadatas_emptyLocal_deletedModel() {
         let remoteModel = makeRemoteModel(deleted: true, version: 2)
-        let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 1)
-        let pendingMutations: [MutationEvent] = [mutationEvent]
 
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
+        let dispositions = RemoteSyncReconciler.reconcile([remoteModel], localMetadatas: [])
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
+        XCTAssertTrue(dispositions.isEmpty)
     }
 
-    // MARK: - With local model having higher version, with pending mutations
+    func testReconcileLocalMetadatas_multiple() {
+        // no corresponding local metadata, not deleted remote, should be create
+        let createModel = makeRemoteModel(deleted: false, version: 1)
 
-    // Create and update are both treated the same
-    func testMutatedOnRemote_withLocalHigherVersion_withPendingMutations() throws {
-        let remoteModel = makeRemoteModel(deleted: false, version: 2)
-        let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 3)
-        let pendingMutations: [MutationEvent] = [mutationEvent]
+        // no corresponding local metadata, deleted remote, should be dropped
+        let droppedModel = makeRemoteModel(deleted: true, version: 2)
 
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
+        // with local metadata, not deleted remote, should be update
+        let updateModel = makeRemoteModel(deleted: false, version: 2)
+        let localUpdateMetadata = makeMutationSyncMetadata(modelId: updateModel.model.id,
+                                                         deleted: false,
+                                                         version: 1)
 
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
-    }
+        // with local metadata, deleted remote, should be delete
+        let deleteModel = makeRemoteModel(deleted: true, version: 2)
+        let localDeleteMetadata = makeMutationSyncMetadata(modelId: deleteModel.model.id,
+                                                         deleted: false,
+                                                         version: 1)
 
-    func testDeletedOnRemote_withLocalHigherVersion_withPendingMutations() throws {
-        let remoteModel = makeRemoteModel(deleted: true, version: 2)
-        let localSyncMetadata = makeMutationSyncMetadata(deleted: false, version: 3)
-        let pendingMutations: [MutationEvent] = [mutationEvent]
+        let remoteModels = [createModel, droppedModel, updateModel, deleteModel]
+        let localMetadatas = [localUpdateMetadata, localDeleteMetadata]
+        let dispositions = RemoteSyncReconciler.reconcile(remoteModels,
+                                                         localMetadatas: localMetadatas)
 
-        let disposition = RemoteSyncReconciler.reconcile(remoteModel: remoteModel,
-                                                         to: localSyncMetadata,
-                                                         pendingMutations: pendingMutations)
-
-        XCTAssertEqual(disposition, RemoteSyncReconciler.Disposition.dropRemoteModel("MockSynced"))
+        XCTAssertEqual(dispositions.count, 3)
+        let create = expectation(description: "exactly one create")
+        let update = expectation(description: "exactly one update")
+        let delete = expectation(description: "exactly one delete")
+        for disposition in dispositions {
+            switch disposition {
+            case .create(let remoteModel):
+                XCTAssertEqual(remoteModel.model.id, createModel.model.id)
+                create.fulfill()
+            case .update(let remoteModel):
+                XCTAssertEqual(remoteModel.model.id, updateModel.model.id)
+                update.fulfill()
+            case .delete(let remoteModel):
+                XCTAssertEqual(remoteModel.model.id, deleteModel.model.id)
+                delete.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 1)
     }
 
     // MARK: - Utilities
 
-    private func makeMutationSyncMetadata(deleted: Bool, version: Int) -> MutationSyncMetadata {
-        let remoteSyncMetadata = MutationSyncMetadata(id: remoteMockSynced.id,
+    private func makeMutationSyncMetadata(modelId: String,
+                                          deleted: Bool = false,
+                                          version: Int = 1) -> MutationSyncMetadata {
+
+        let remoteSyncMetadata = MutationSyncMetadata(id: modelId,
                                                       deleted: deleted,
                                                       lastChangedAt: Date().unixSeconds,
                                                       version: version)
         return remoteSyncMetadata
     }
 
-    private func makeRemoteModel(deleted: Bool, version: Int) -> ReconcileAndLocalSaveOperation.RemoteModel {
-        let remoteSyncMetadata = makeMutationSyncMetadata(deleted: deleted, version: version)
-        let remoteModel = ReconcileAndLocalSaveOperation.RemoteModel(model: remoteMockSynced,
-                                                                     syncMetadata: remoteSyncMetadata)
-        return remoteModel
+    private func makeRemoteModel(modelId: String = UUID().uuidString,
+                                 deleted: Bool = false,
+                                 version: Int = 1) -> ReconcileAndLocalSaveOperation.RemoteModel {
+        do {
+            let remoteMockSynced = try MockSynced(id: modelId).eraseToAnyModel()
+            let remoteSyncMetadata = makeMutationSyncMetadata(modelId: remoteMockSynced.id,
+                                                              deleted: deleted,
+                                                              version: version)
+            return ReconcileAndLocalSaveOperation.RemoteModel(model: remoteMockSynced,
+                                                              syncMetadata: remoteSyncMetadata)
+        } catch {
+            fatalError("Failed to create remote model")
+        }
+    }
+
+    private func makeMutationEvent(modelId: String = UUID().uuidString) -> MutationEvent {
+        return MutationEvent(id: "mutation-1",
+                             modelId: modelId,
+                             modelName: MockSynced.modelName,
+                             json: "{}",
+                             mutationType: .create,
+                             createdAt: .now(),
+                             version: 1,
+                             inProcess: false)
     }
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/EquatableExtensions.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/EquatableExtensions.swift
@@ -13,12 +13,15 @@ extension RemoteSyncReconciler.Disposition: Equatable {
     public static func == (lhs: RemoteSyncReconciler.Disposition,
                            rhs: RemoteSyncReconciler.Disposition) -> Bool {
         switch (lhs, rhs) {
-        case (.applyRemoteModel(let rm1, let mutationType1), .applyRemoteModel(let rm2, let mutationType2)):
-            return rm1.model.id == rm2.model.id &&
-                rm1.model.modelName == rm2.model.modelName &&
-                mutationType1 == mutationType2
-        case (.dropRemoteModel, .dropRemoteModel):
-            return true
+        case (.create(let model1), .create(let model2)):
+            return model1.model.id == model2.model.id &&
+                model1.model.modelName == model2.model.modelName
+        case (.update(let model1), .update(let model2)):
+            return model1.model.id == model2.model.id &&
+                model1.model.modelName == model2.model.modelName
+        case (.delete(let model1), .delete(let model2)):
+            return model1.model.id == model2.model.id &&
+                model1.model.modelName == model2.model.modelName
         default:
             return false
         }
@@ -29,22 +32,9 @@ extension ReconcileAndLocalSaveOperation.Action: Equatable {
     public static func == (lhs: ReconcileAndLocalSaveOperation.Action,
                            rhs: ReconcileAndLocalSaveOperation.Action) -> Bool {
         switch (lhs, rhs) {
-        case (.started(let model1), .started(let model2)):
-            return model1.model.id == model2.model.id
-                && model1.model.modelName == model2.model.modelName
-        case (.queried(let model1, let lmetadata1), .queried(let model2, let lmetadata2)):
-            return model1.model.id == model2.model.id
-                && lmetadata1?.id == lmetadata2?.id
-                && model1.model.modelName == model2.model.modelName
-        case (.reconciled(let disposition1), .reconciled(let disposition2)):
-            return disposition1 == disposition2
-        case (.applied(let model1, let existsLocally1), .applied(let model2, let existsLocally2)):
-            return model1.model.id == model2.model.id
-                && model1.model.modelName == model2.model.modelName
-                && existsLocally1 == existsLocally2
-        case (.dropped, dropped):
-            return true
-        case (.notified, .notified):
+        case (.started(let models1), .started(let models2)):
+            return models1.count == models2.count
+        case (.reconciled, .reconciled):
             return true
         case (.cancelled, .cancelled):
             return true
@@ -62,19 +52,8 @@ extension ReconcileAndLocalSaveOperation.State: Equatable {
         switch (lhs, rhs) {
         case (.waiting, .waiting):
             return true
-        case (.querying(let model1), .querying(let model2)):
-            return model1.model.id == model2.model.id
-                && model1.model.modelName == model2.model.modelName
-        case (.reconciling(let model1, let lmetadata1), .reconciling(let model2, let lmetadata2)):
-            return model1.model.id == model2.model.id
-                && lmetadata1?.id == lmetadata2?.id
-                && model1.model.modelName == model2.model.modelName
-        case (.executing(let disposition1), .executing(let disposition2)):
-            return disposition1 == disposition2
-        case (.notifying(let model1, let existsLocally1), .notifying(let model2, let existsLocally2)):
-            return model1.model.id == model2.model.id
-                && model1.model.modelName == model2.model.modelName
-                && existsLocally1 == existsLocally2
+        case (.reconciling(let models1), .reconciling(let models2)):
+            return models1.count == models2.count
         case (.finished, .finished):
             return true
         case (.inError(let error1), .inError(let error2)):
@@ -102,5 +81,19 @@ extension MutationSyncMetadata: Equatable {
             && lhs.deleted == rhs.deleted
             && lhs.lastChangedAt == rhs.lastChangedAt
             && lhs.version == rhs.version
+    }
+}
+
+extension MutationEvent: Equatable {
+    public static func == (lhs: MutationEvent, rhs: MutationEvent) -> Bool {
+        return lhs.id == rhs.id
+            && lhs.modelId == rhs.modelId
+            && lhs.modelName == rhs.modelName
+            && lhs.json == rhs.json
+            && lhs.mutationType == rhs.mutationType
+            && lhs.createdAt == rhs.createdAt
+            && lhs.version == rhs.version
+            && lhs.inProcess == rhs.inProcess
+            && lhs.graphQLFilterJSON == rhs.graphQLFilterJSON
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockModelReconciliationQueue.swift
@@ -45,7 +45,7 @@ class MockModelReconciliationQueue: ModelReconciliationQueue {
         //no-op
     }
 
-    func enqueue(_ remoteModel: MutationSync<AnyModel>) {
+    func enqueue(_ remoteModels: [MutationSync<AnyModel>]) {
         //no-op
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -20,7 +20,9 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
     var resultForSave: DataStoreResult<Model>?
 
     var resultForQueryMutationSyncMetadata: MutationSyncMetadata?
+    var resultForQueryMutationSyncMetadatas: [MutationSyncMetadata]
     var errorToThrowOnMutationSyncMetadata: DataStoreError?
+    var errorToThrowOnTransaction: DataStoreError?
 
     var shouldReturnErrorOnSaveMetadata: Bool
     var shouldReturnErrorOnDeleteMutation: Bool
@@ -31,6 +33,7 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
     init() {
         self.shouldReturnErrorOnSaveMetadata = false
         self.shouldReturnErrorOnDeleteMutation = false
+        self.resultForQueryMutationSyncMetadatas = [MutationSyncMetadata]()
     }
 
     func setUp(modelSchemas: [ModelSchema]) throws {
@@ -47,6 +50,10 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
         resultForQueryMutationSyncMetadata = mutationSyncMetadata
     }
 
+    func returnOnQueryMutationSyncMetadatas(_ mutationSyncMetadatas: [MutationSyncMetadata]) {
+        resultForQueryMutationSyncMetadatas = mutationSyncMetadatas
+    }
+
     func returnOnSave(dataStoreResult: DataStoreResult<Model>?) {
         resultForSave = dataStoreResult
     }
@@ -58,6 +65,10 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
 
     func throwOnQueryMutationSyncMetadata(error: DataStoreError) {
         errorToThrowOnMutationSyncMetadata = error
+    }
+
+    func throwOnTransaction(error: DataStoreError) {
+        errorToThrowOnTransaction = error
     }
 
     // MARK: - StorageEngineAdapter
@@ -194,13 +205,29 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
         return resultForQueryMutationSyncMetadata
     }
 
+    func queryMutationSyncMetadata(forModelIds modelIds: [String]) throws -> [MutationSyncMetadata] {
+        if let responder = responders[.queryMutationSyncMetadatas] as? QueryMutationSyncMetadatasResponder {
+            return try responder.callback(modelIds)
+        }
+
+        if let err = errorToThrowOnMutationSyncMetadata {
+            errorToThrowOnMutationSyncMetadata = nil
+            throw err
+        }
+        return resultForQueryMutationSyncMetadatas
+    }
+
     func queryModelSyncMetadata(for modelSchema: ModelSchema) throws -> ModelSyncMetadata? {
         listenerForModelSyncMetadata?()
         return resultForQueryModelSyncMetadata
     }
 
     func transaction(_ basicClosure: () throws -> Void) throws {
-        XCTFail("Not expected to execute")
+        if let err = errorToThrowOnTransaction {
+            errorToThrowOnTransaction = nil
+            throw err
+        }
+        try basicClosure()
     }
     func clear(completion: @escaping DataStoreCallback<Void>) {
         XCTFail("Not expected to execute")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapterResponders.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapterResponders.swift
@@ -15,6 +15,7 @@ extension MockSQLiteStorageEngineAdapter {
         // swiftlint:disable:next identifier_name
         case queryModelTypePredicate
         case queryMutationSyncMetadata
+        case queryMutationSyncMetadatas
         case saveModelCompletion
         case saveUntypedModel
         case deleteUntypedModel
@@ -29,6 +30,8 @@ typealias QueryModelTypePredicateResponder<M: Model> =
     MockResponder<(M.Type, QueryPredicate?), DataStoreResult<[M]>>
 
 typealias QueryMutationSyncMetadataResponder = ThrowingMockResponder<String, MutationSyncMetadata?>
+
+typealias QueryMutationSyncMetadatasResponder = ThrowingMockResponder<[String], [MutationSyncMetadata]>
 
 typealias SaveModelCompletionResponder<M: Model> = MockResponder<(M, DataStoreCallback<M>), Void>
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
@@ -47,7 +47,7 @@ class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue 
         incomingEventSubject.send(.paused)
     }
 
-    func offer(_ remoteModel: MutationSync<AnyModel>, modelSchema: ModelSchema) {
+    func offer(_ remoteModels: [MutationSync<AnyModel>], modelSchema: ModelSchema) {
         //no-op for mock
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
@@ -21,8 +21,8 @@ final class MockReconciliationQueue: MessageReporter, IncomingEventReconciliatio
         notify()
     }
 
-    func offer(_ remoteModel: MutationSync<AnyModel>, modelSchema: ModelSchema) {
-        notify("offer(_:) remoteModel: \(remoteModel)")
+    func offer(_ remoteModels: [MutationSync<AnyModel>], modelSchema: ModelSchema) {
+        notify("offer(_:) remoteModels: \(remoteModels)")
     }
 
     var publisher: AnyPublisher<IncomingEventReconciliationQueueEvent, DataStoreError> {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There is a single thread allocated for two different queues, the Sync queue and the Reconcilliation queue. When the sync operations produce a reconcillliation operation containing 1000 items in memory, the resource spent on saving to disk causes the sync thread to get deprioitized. The result of this is most of the time spent writing to disk while network traffic trickles in.

This PR increases the thread count when we can determine that it can be optimized, for example when the models have no associations among them, then they can be retrieved and reconciled in any order. If it cannot be optimized (models with associations) then it falls back to the 1 thread per sync and recon queue. With the optimization, setting the thread to the number of models will immedately kick off one API call per sync operation, getting the results in memory (a reconcilliation operation) in the FIFO reconcilliation queue. Because they are reconcilled in order of the insertion into the queue, models with little data will not be blocked by models with a lot of data.


Baseline testing (TBD):
- AModel, 200k items
- BModel, 100k
- CModel, 10k
- DModel, 1k
- EModel, 100

total ModelSync time for each

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
