### PR TITLE
feat(datastore): support for @auth provider

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 		762167D52615435C0033FCD2 /* Record+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762167D42615435C0033FCD2 /* Record+Schema.swift */; };
 		762C978526210F6400798FA3 /* RecordCover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762C978426210F6400798FA3 /* RecordCover.swift */; };
 		762C978E26210FF100798FA3 /* RecordCover+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762C978D26210FF100798FA3 /* RecordCover+Schema.swift */; };
+		762F70A426683EE2001F8252 /* AuthRuleExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762F70A326683EE2001F8252 /* AuthRuleExtensionTests.swift */; };
 		7678B38426017D5300B4917F /* AppSyncErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7678B38326017D5300B4917F /* AppSyncErrorTypeTests.swift */; };
 		7678B38526017D5300B4917F /* AppSyncErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7678B38326017D5300B4917F /* AppSyncErrorTypeTests.swift */; };
 		7D5ED6C78E25246DDAF2F2EC /* Pods_Amplify.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84F3A76FB68CEFA45F4BB1BB /* Pods_Amplify.framework */; platformFilter = ios; };
@@ -1129,6 +1130,7 @@
 		762167D42615435C0033FCD2 /* Record+Schema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Record+Schema.swift"; sourceTree = "<group>"; };
 		762C978426210F6400798FA3 /* RecordCover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordCover.swift; sourceTree = "<group>"; };
 		762C978D26210FF100798FA3 /* RecordCover+Schema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecordCover+Schema.swift"; sourceTree = "<group>"; };
+		762F70A326683EE2001F8252 /* AuthRuleExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRuleExtensionTests.swift; sourceTree = "<group>"; };
 		7678B38326017D5300B4917F /* AppSyncErrorTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncErrorTypeTests.swift; sourceTree = "<group>"; };
 		77A2D125114EA0FFA11A7EFD /* Pods-AmplifyTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyTests.debug.xcconfig"; path = "Target Support Files/Pods-AmplifyTests/Pods-AmplifyTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7A238096BAB328655B5E388F /* Pods-Amplify-AWSPluginsCore-CoreMLPredictionsPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AWSPluginsCore-CoreMLPredictionsPlugin.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AWSPluginsCore-CoreMLPredictionsPlugin/Pods-Amplify-AWSPluginsCore-CoreMLPredictionsPlugin.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1884,6 +1886,7 @@
 			children = (
 				2129BE2F2394828A006363A1 /* QueryPredicateGraphQLTests.swift */,
 				D83C515F248964780091548E /* ModelGraphQLTests.swift */,
+				762F70A326683EE2001F8252 /* AuthRuleExtensionTests.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -5260,6 +5263,7 @@
 				FAC23564227A056600424678 /* StorageCategoryClientAPITests.swift in Sources */,
 				FAAFAF3123904B75002CF932 /* AtomicValue+BoolTests.swift in Sources */,
 				B9AF547E23F37DF20059E6C4 /* TemporalOperationTests.swift in Sources */,
+				762F70A426683EE2001F8252 /* AuthRuleExtensionTests.swift in Sources */,
 				FAD3937D23820D0200463F5E /* DataStoreCategoryConfigurationTests.swift in Sources */,
 				FA607FE2233D131B00DFEA24 /* AmplifyOperationHubTests.swift in Sources */,
 				B4944D52251C141200BF0BFE /* JSONValueHolderTest.swift in Sources */,

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/AuthRule.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/AuthRule.swift
@@ -25,6 +25,14 @@ public enum ModelOperation {
 
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
+public enum AuthRuleProvider {
+    case apiKey
+    case oidc
+    case custom(name: String)
+}
+
+/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+///   by host applications. The behavior of this may change without warning.
 public typealias AuthRules = [AuthRule]
 
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
@@ -37,6 +45,7 @@ public struct AuthRule {
     public let groups: [String]
     public let groupsField: String?
     public let operations: [ModelOperation]
+    public let provider: AuthRuleProvider?
 
     public init(allow: AuthStrategy,
                 ownerField: String? = nil,
@@ -44,6 +53,7 @@ public struct AuthRule {
                 groupClaim: String? = nil,
                 groups: [String] = [],
                 groupsField: String? = nil,
+                provider: AuthRuleProvider? = nil,
                 operations: [ModelOperation] = []) {
         self.allow = allow
         self.ownerField = ownerField
@@ -51,6 +61,7 @@ public struct AuthRule {
         self.groupClaim = groupClaim
         self.groups = groups
         self.groupsField = groupsField
+        self.provider = provider
         self.operations = operations
     }
 }

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/AuthRule.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/AuthRule.swift
@@ -28,7 +28,8 @@ public enum ModelOperation {
 public enum AuthRuleProvider {
     case apiKey
     case oidc
-    case custom(name: String)
+    case iam
+    case userPools
 }
 
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/Model+Schema.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/Model+Schema.swift
@@ -63,6 +63,7 @@ extension Model {
                             groupClaim: String? = nil,
                             groups: [String] = [],
                             groupsField: String? = nil,
+                            provider: AuthRuleProvider? = nil,
                             operations: [ModelOperation] = []) -> AuthRule {
         return AuthRule(allow: allow,
                         ownerField: ownerField,
@@ -70,6 +71,7 @@ extension Model {
                         groupClaim: groupClaim,
                         groups: groups,
                         groupsField: groupsField,
+                        provider: provider,
                         operations: operations)
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/AuthRule+Extension.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/AuthRule+Extension.swift
@@ -7,23 +7,7 @@
 
 import Amplify
 
-protocol AWSAuthRuleProvider {
-    static var iam: AuthRuleProvider { get }
-    static var userPools: AuthRuleProvider { get }
-}
-
-extension AuthRuleProvider: AWSAuthRuleProvider {
-    private static func valueForIAM() -> String { "iam" }
-    private static func valueForCognitoUserPool() -> String { "userPools" }
-
-    public static var iam: AuthRuleProvider {
-        .custom(name: valueForIAM())
-    }
-
-    public static var userPools: AuthRuleProvider {
-        .custom(name: valueForCognitoUserPool())
-    }
-
+extension AuthRuleProvider {
     public func toAWSAuthorizationType() throws -> AWSAuthorizationType {
         var authType: AWSAuthorizationType
         switch self {
@@ -31,14 +15,10 @@ extension AuthRuleProvider: AWSAuthRuleProvider {
             authType = .apiKey
         case .oidc:
             authType = .openIDConnect
-        case .custom(name: let name) where name == AuthRuleProvider.valueForIAM():
+        case .iam:
             authType = .awsIAM
-        case .custom(name: let name) where name == AuthRuleProvider.valueForCognitoUserPool():
+        case .userPools:
             authType = .amazonCognitoUserPools
-        case .custom(name: let name):
-            throw DataStoreError.unknown(
-                "Invalid AWS authorization provider in schema @auth rule: \(name)",
-                "Verify your schema.")
         }
         return authType
     }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/AuthRule+Extension.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/AuthRule+Extension.swift
@@ -33,7 +33,6 @@ extension AuthRuleProvider: AWSAuthRuleProvider {
             authType = .openIDConnect
         case .custom(name: let name) where name == AuthRuleProvider.valueForIAM():
             authType = .awsIAM
-
         case .custom(name: let name) where name == AuthRuleProvider.valueForCognitoUserPool():
             authType = .amazonCognitoUserPools
         case .custom(name: let name):

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/AuthRule+Extension.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/AuthRule+Extension.swift
@@ -7,6 +7,44 @@
 
 import Amplify
 
+protocol AWSAuthRuleProvider {
+    static var iam: AuthRuleProvider { get }
+    static var userPools: AuthRuleProvider { get }
+}
+
+extension AuthRuleProvider: AWSAuthRuleProvider {
+    private static func valueForIAM() -> String { "iam" }
+    private static func valueForCognitoUserPool() -> String { "userPools" }
+
+    public static var iam: AuthRuleProvider {
+        .custom(name: valueForIAM())
+    }
+
+    public static var userPools: AuthRuleProvider {
+        .custom(name: valueForCognitoUserPool())
+    }
+
+    public func toAWSAuthorizationType() throws -> AWSAuthorizationType {
+        var authType: AWSAuthorizationType
+        switch self {
+        case .apiKey:
+            authType = .apiKey
+        case .oidc:
+            authType = .openIDConnect
+        case .custom(name: let name) where name == AuthRuleProvider.valueForIAM():
+            authType = .awsIAM
+
+        case .custom(name: let name) where name == AuthRuleProvider.valueForCognitoUserPool():
+            authType = .amazonCognitoUserPools
+        case .custom(name: let name):
+            throw DataStoreError.unknown(
+                "Invalid AWS authorization provider in schema @auth rule: \(name)",
+                "Verify your schema.")
+        }
+        return authType
+    }
+}
+
 extension AuthRule {
     func getOwnerFieldOrDefault() -> String {
         guard let ownerField = ownerField else {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/AuthRuleExtensionTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/AuthRuleExtensionTests.swift
@@ -23,9 +23,4 @@ class AuthRuleExtensionTests: XCTestCase {
             XCTAssertEqual(try provider.toAWSAuthorizationType(), expectedAuthTypes[index])
         }
     }
-
-    func testShouldThrowIfInvalidAuthAWSProvider() throws {
-        let authRuleProvider: AuthRuleProvider = .custom(name: "invalid")
-        XCTAssertThrowsError(try authRuleProvider.toAWSAuthorizationType())
-    }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/AuthRuleExtensionTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/AuthRuleExtensionTests.swift
@@ -1,0 +1,31 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import Amplify
+import AWSPluginsCore
+
+class AuthRuleExtensionTests: XCTestCase {
+    func testAuthRuleProviderToAWSAuth() throws {
+        let authRuleProviders: [AuthRuleProvider] = [.apiKey, .oidc, .iam, .userPools]
+        let expectedAuthTypes: [AWSAuthorizationType] = [
+            .apiKey,
+            .openIDConnect,
+            .awsIAM,
+            .amazonCognitoUserPools
+        ]
+
+        for (index, provider) in authRuleProviders.enumerated() {
+            XCTAssertEqual(try provider.toAWSAuthorizationType(), expectedAuthTypes[index])
+        }
+    }
+
+    func testShouldThrowIfInvalidAuthAWSProvider() throws {
+        let authRuleProvider: AuthRuleProvider = .custom(name: "invalid")
+        XCTAssertThrowsError(try authRuleProvider.toAWSAuthorizationType())
+    }
+}


### PR DESCRIPTION
*Description of changes:*
This PR introduces changes to capture the value of `provider` in @auth directives as an `AuthRule` metadata.

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
