### PR TITLE
fix: increase sync concurrency count based on associations

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Attributes.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Attributes.swift
@@ -19,4 +19,10 @@ public extension ModelSchema {
     var hasAuthenticationRules: Bool {
         return !authRules.isEmpty
     }
+
+    var hasAssociations: Bool {
+        fields.values.contains { modelField in
+            modelField.hasAssociation
+        }
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
@@ -182,4 +182,9 @@ extension Array where Element == ModelSchema {
         return sortedKeys.map { sortMap[$0]! }
     }
 
+    func hasAssociations() -> Bool {
+        contains { modelSchema in
+            modelSchema.hasAssociations
+        }
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
@@ -42,7 +42,7 @@ final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
 
     // Future optimization: can perform sync on each root in parallel, since we know they won't have any
     // interdependencies
-    private let syncOperationQueue: OperationQueue
+    let syncOperationQueue: OperationQueue
     private let concurrencyQueue = DispatchQueue(label: "com.amazonaws.InitialSyncOrchestrator.concurrencyQueue",
                                                  target: DispatchQueue.global())
 
@@ -85,6 +85,9 @@ final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
 
             let modelNames = syncableModelSchemas.map { $0.name }
             self.dispatchSyncQueriesStarted(for: modelNames)
+            if !syncableModelSchemas.hasAssociations() {
+                self.syncOperationQueue.maxConcurrentOperationCount = syncableModelSchemas.count
+            }
             self.syncOperationQueue.isSuspended = false
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Increase the concurrency count for performing SyncOperation when it can be determined that the models have no associations. When models have no associations, we can perform SyncOperations for each model in parallel since there are no models that depend on another model's data to be present before it can be reconciled.

<img width="1497" alt="Screen Shot 2021-06-08 at 9 04 53 AM" src="https://user-images.githubusercontent.com/1365977/121219581-b37d7700-c838-11eb-92ef-416faa36453d.png">

In the current system (left side of diagram), if a pre-determined order of model results in having a model with a large dataset in front of a model with a small dataset, the smaller dataset model will be blocked by the larger dataset's completion of the reconcilliation path. 

If models do not have any associations among them, perform the SyncOperation in parallel, which will enqueue reconcile operations to the queue in an unordered sequence, thus interweaving the reconcile operations for both the model with a larger dataset and smaller dataset. When the reconcillation queue catches up, the models with smaller dataset will be reconciled earlier than before this PR change.

*Testing done*:

Setup
TodoB item count: 0
TodoC item count: 0
Todo item count: 100k
TodoD item count: 10k
TodoE item count: 1k

Baseline result:
[ModelSynced] TodoB elapsed time: 15.19s
[ModelSynced] TodoC elapsed time: 18.80s
[ModelSynced] Todo elapsed time: 20.40s
[ModelSynced] TodoD elapsed time: 20.58s
[ModelSynced] TodoE elapsed time: 20.74s

Proposed change result:
[ModelSynced] TodoB elapsed time: 1.18s
[ModelSynced] TodoC elapsed time: 1.17s
[ModelSynced] Todo elapsed time: 18.56s
[ModelSynced] TodoD elapsed time: 1.21s
[ModelSynced] TodoE elapsed time: 1.20s

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
