### PR TITLE
fix(DataStore): do not send completion event to publisher on DataStore.clear() and DataStore.stop()

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -205,10 +205,6 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
         storageEngineInitSemaphore.signal()
         storageEngine.clear { result in
             self.storageEngine = nil
-            if #available(iOS 13.0, *) {
-                self.dataStorePublisher?.sendFinished()
-            }
-            self.dataStorePublisher = nil
             completion(result)
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -187,10 +187,6 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
         storageEngineInitSemaphore.signal()
         storageEngine.stopSync { result in
             self.storageEngine = nil
-            if #available(iOS 13.0, *) {
-                self.dataStorePublisher?.sendFinished()
-            }
-            self.dataStorePublisher = nil
             completion(result)
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -157,7 +157,7 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
         case .failure(let dataStoreError):
             dataStorePublisher.send(dataStoreError: dataStoreError)
         case .finished:
-            dataStorePublisher.sendFinished()
+            break
         }
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -155,7 +155,7 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
         }
         switch completed {
         case .failure(let dataStoreError):
-            dataStorePublisher.send(dataStoreError: dataStoreError)
+            log.error("Error: \(dataStoreError)")
         case .finished:
             break
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -149,13 +149,9 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
 
     @available(iOS 13.0, *)
     private func onReceiveCompletion(completed: Subscribers.Completion<DataStoreError>) {
-        guard let dataStorePublisher = self.dataStorePublisher else {
-            log.error("Data store publisher not initalized")
-            return
-        }
         switch completed {
         case .failure(let dataStoreError):
-            log.error("Error: \(dataStoreError)")
+            log.error("StorageEngine completed with error: \(dataStoreError)")
         case .finished:
             break
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSAPICategoryPluginTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSAPICategoryPluginTests.swift
@@ -369,8 +369,8 @@ class AWSAPICategoryPluginTests: XCTestCase {
 
             let mockModel = MockSynced(id: "12345")
             try plugin.dataStorePublisher?.send(input: MutationEvent(model: mockModel,
-                                                                 modelSchema: mockModel.schema,
-                                                                 mutationType: .create))
+                                                                     modelSchema: mockModel.schema,
+                                                                     mutationType: .create))
 
             waitForExpectations(timeout: 1.0)
             sink.cancel()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSAPICategoryPluginTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSAPICategoryPluginTests.swift
@@ -386,7 +386,6 @@ class AWSAPICategoryPluginTests: XCTestCase {
     ///     - plugin.stop() is called
     ///     - a mutation event is sent
     /// - Then: The subscriber to plugin's publisher should receive the mutation
-
     func testStorageEngineStartStopSend() {
         let startExpectation = expectation(description: "Start Sync should be called with start")
         let stopExpectation = expectation(description: "Stop should be called")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSAPICategoryPluginTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSAPICategoryPluginTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import AmplifyTestCommon
 
 @testable import Amplify
 @testable import AWSDataStoreCategoryPlugin
@@ -106,21 +107,34 @@ class AWSAPICategoryPluginTests: XCTestCase {
                                         dataStorePublisher: dataStorePublisher,
                                         validAPIPluginKey: "MockAPICategoryPlugin",
                                         validAuthPluginKey: "MockAuthCategoryPlugin")
+
+        let finishReceived = expectation(
+            description: "publisher should receive .finished completion event after stop() is called")
+
         do {
             try plugin.configure(using: nil)
-            XCTAssert(plugin.storageEngine == nil)
+            XCTAssertNil(plugin.storageEngine)
+
+            let sink = plugin.publisher.sink { completion in
+                switch completion {
+                case .finished:
+                    finishReceived.fulfill()
+                case .failure(let error):
+                    XCTFail("Error \(error)")
+                }
+            } receiveValue: { _ in }
 
             let semaphore = DispatchSemaphore(value: 0)
             plugin.start(completion: {_ in
-                XCTAssert(plugin.storageEngine != nil)
-                XCTAssert(plugin.dataStorePublisher != nil)
+                XCTAssertNotNil(plugin.storageEngine)
+                XCTAssertNotNil(plugin.dataStorePublisher)
                 semaphore.signal()
             })
             semaphore.wait()
 
             plugin.stop(completion: { _ in
-                XCTAssert(plugin.storageEngine == nil)
-                XCTAssert(plugin.dataStorePublisher == nil)
+                XCTAssertNil(plugin.storageEngine)
+                XCTAssertNil(plugin.dataStorePublisher)
                 semaphore.signal()
             })
             semaphore.wait()
@@ -130,14 +144,14 @@ class AWSAPICategoryPluginTests: XCTestCase {
             }
 
             plugin.start(completion: { _ in
-                XCTAssert(plugin.storageEngine != nil)
-                XCTAssert(plugin.dataStorePublisher != nil)
+                XCTAssertNotNil(plugin.storageEngine)
+                XCTAssertNotNil(plugin.dataStorePublisher)
             })
-
+            waitForExpectations(timeout: 1.0)
+            sink.cancel()
         } catch {
             XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
         }
-        waitForExpectations(timeout: 1.0)
     }
 
     func testStorageEngineStartClearStart() throws {
@@ -161,21 +175,35 @@ class AWSAPICategoryPluginTests: XCTestCase {
                                         dataStorePublisher: dataStorePublisher,
                                         validAPIPluginKey: "MockAPICategoryPlugin",
                                         validAuthPluginKey: "MockAuthCategoryPlugin")
+
+        let finishNotReceived = expectation(
+            description: "publisher should not receive .finished completion event after clear() is called")
+        finishNotReceived.isInverted = true
+
         do {
             try plugin.configure(using: nil)
-            XCTAssert(plugin.storageEngine == nil)
+            XCTAssertNil(plugin.storageEngine)
+
+            let sink = plugin.publisher.sink { completion in
+                switch completion {
+                case .finished:
+                    finishNotReceived.fulfill()
+                case .failure(let error):
+                    XCTFail("Error \(error)")
+                }
+            } receiveValue: { _ in }
 
             let semaphore = DispatchSemaphore(value: 0)
             plugin.start(completion: {_ in
-                XCTAssert(plugin.storageEngine != nil)
-                XCTAssert(plugin.dataStorePublisher != nil)
+                XCTAssertNotNil(plugin.storageEngine)
+                XCTAssertNotNil(plugin.dataStorePublisher)
                 semaphore.signal()
             })
             semaphore.wait()
 
             plugin.clear(completion: { _ in
-                XCTAssert(plugin.storageEngine == nil)
-                XCTAssert(plugin.dataStorePublisher != nil)
+                XCTAssertNil(plugin.storageEngine)
+                XCTAssertNotNil(plugin.dataStorePublisher)
                 semaphore.signal()
             })
             semaphore.wait()
@@ -184,14 +212,14 @@ class AWSAPICategoryPluginTests: XCTestCase {
             }
 
             plugin.start(completion: { _ in
-                XCTAssert(plugin.storageEngine != nil)
-                XCTAssert(plugin.dataStorePublisher != nil)
+                XCTAssertNotNil(plugin.storageEngine)
+                XCTAssertNotNil(plugin.dataStorePublisher)
             })
-
+            waitForExpectations(timeout: 1.0)
+            sink.cancel()
         } catch {
             XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
         }
-        waitForExpectations(timeout: 1.0)
     }
 
     func testStorageEngineQueryClearQuery() throws {
@@ -216,21 +244,35 @@ class AWSAPICategoryPluginTests: XCTestCase {
                                         dataStorePublisher: dataStorePublisher,
                                         validAPIPluginKey: "MockAPICategoryPlugin",
                                         validAuthPluginKey: "MockAuthCategoryPlugin")
+
+        let finishNotReceived = expectation(
+            description: "publisher should not receive .finished completion event after clear() is called")
+        finishNotReceived.isInverted = true
+
         do {
             try plugin.configure(using: nil)
-            XCTAssert(plugin.storageEngine == nil)
+            XCTAssertNil(plugin.storageEngine)
+
+            let sink = plugin.publisher.sink { completion in
+                switch completion {
+                case .finished:
+                    finishNotReceived.fulfill()
+                case .failure(let error):
+                    XCTFail("Error \(error)")
+                }
+            } receiveValue: { _ in }
 
             let semaphore = DispatchSemaphore(value: 0)
             plugin.query(ExampleWithEveryType.self, completion: {_ in
-                XCTAssert(plugin.storageEngine != nil)
-                XCTAssert(plugin.dataStorePublisher != nil)
+                XCTAssertNotNil(plugin.storageEngine)
+                XCTAssertNotNil(plugin.dataStorePublisher)
                 semaphore.signal()
             })
             semaphore.wait()
 
             plugin.clear(completion: { _ in
-                XCTAssert(plugin.storageEngine == nil)
-                XCTAssert(plugin.dataStorePublisher != nil)
+                XCTAssertNil(plugin.storageEngine)
+                XCTAssertNotNil(plugin.dataStorePublisher)
                 semaphore.signal()
             })
             semaphore.wait()
@@ -239,14 +281,14 @@ class AWSAPICategoryPluginTests: XCTestCase {
             }
 
             plugin.query(ExampleWithEveryType.self, completion: { _ in
-                XCTAssert(plugin.storageEngine != nil)
-                XCTAssert(plugin.dataStorePublisher != nil)
+                XCTAssertNotNil(plugin.storageEngine)
+                XCTAssertNotNil(plugin.dataStorePublisher)
             })
-
+            waitForExpectations(timeout: 1.0)
+            sink.cancel()
         } catch {
             XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
         }
-        waitForExpectations(timeout: 1.0)
     }
 
     func expect(_ expectation: XCTestExpectation, _ currCount: Int, _ expectedCount: Int) -> Int {
@@ -257,11 +299,14 @@ class AWSAPICategoryPluginTests: XCTestCase {
         return count
     }
 
-    /// - Given: Datastore plugin
-    /// - When: Plugin is configured, started and cleared
-    /// - Then: Plugin's publisher should not received .finished and dataStorePublisher should not be nil
+    /// - Given: Datastore plugin is initialized
+    /// - When:
+    ///     - plugin.start() is called
+    ///     - plugin.clear() is called
+    ///     - a mutation event is sent
+    /// - Then: The subscriber to plugin's publisher should receive the mutation
 
-    func testStorageEngineClear() throws {
+    func testStorageEngineStartClearSend() {
         let startExpectation = expectation(description: "Start Sync should be called with start")
         let clearExpectation = expectation(description: "Clear should be called")
 
@@ -273,6 +318,7 @@ class AWSAPICategoryPluginTests: XCTestCase {
         storageEngine.responders[.clear] = ClearResponder { _ in
             count = self.expect(clearExpectation, count, 2)
         }
+
         let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
             return storageEngine
         }
@@ -283,40 +329,53 @@ class AWSAPICategoryPluginTests: XCTestCase {
                                         validAPIPluginKey: "MockAPICategoryPlugin",
                                         validAuthPluginKey: "MockAuthCategoryPlugin")
 
-        let finishNotReceived = expectation(description: "Finish should not be received")
+        let finishNotReceived = expectation(
+            description: "publisher should not receive .finished completion event after clear() is called")
         finishNotReceived.isInverted = true
-        _ = plugin.publisher.sink { completion in
-            switch completion {
-            case .finished:
-                print("Finish received")
-                finishNotReceived.fulfill()
-            case .failure(let error):
-                print("Error \(error)")
-            }
-        } receiveValue: { event in
-            print(event)
-        }
+
+        let publisherReceivedValue = expectation(
+            description: "publisher should receive a value when mutation event is sent")
 
         do {
             try plugin.configure(using: nil)
+            XCTAssertNil(plugin.storageEngine)
+
+            let sink = plugin.publisher.sink { completion in
+                switch completion {
+                case .finished:
+                    finishNotReceived.fulfill()
+                case .failure(let error):
+                    XCTFail("Error \(error)")
+                }
+            } receiveValue: { event in
+                XCTAssertEqual(event.modelId, "12345")
+                publisherReceivedValue.fulfill()
+            }
 
             let semaphore = DispatchSemaphore(value: 0)
             plugin.start(completion: {_ in
-                XCTAssert(plugin.storageEngine != nil)
-                XCTAssert(plugin.dataStorePublisher != nil)
+                XCTAssertNotNil(plugin.storageEngine)
+                XCTAssertNotNil(plugin.dataStorePublisher)
                 semaphore.signal()
             })
             semaphore.wait()
 
             plugin.clear(completion: { _ in
-                XCTAssert(plugin.storageEngine == nil)
-                XCTAssert(plugin.dataStorePublisher != nil)
+                XCTAssertNil(plugin.storageEngine)
+                XCTAssertNotNil(plugin.dataStorePublisher)
                 semaphore.signal()
             })
             semaphore.wait()
+
+            let mockModel = MockSynced(id: "12345")
+            try plugin.dataStorePublisher?.send(input: MutationEvent(model: mockModel,
+                                                                 modelSchema: mockModel.schema,
+                                                                 mutationType: .create))
+
+            waitForExpectations(timeout: 1.0)
+            sink.cancel()
         } catch {
             XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
         }
-        waitForExpectations(timeout: 1.0)
     }
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/395

*Description of changes:* `.finished` events are not sent to datastore plugin subscribers when `Datastore.clear()`  and `Datastore.stop` is called 

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
