### PR TITLE
feat(Storage): AWSS3PluginPrefixResolver

### DIFF
--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin+ClientBehavior.swift
@@ -31,6 +31,7 @@ extension AWSS3StoragePlugin {
         let options = options ?? StorageGetURLRequest.Options()
         let request = StorageGetURLRequest(key: key, options: options)
         let getURLOperation = AWSS3StorageGetURLOperation(request,
+                                                          storageConfiguration: storageConfiguration,
                                                           storageService: storageService,
                                                           authService: authService,
                                                           resultListener: resultListener)
@@ -59,6 +60,7 @@ extension AWSS3StoragePlugin {
         let options = options ?? StorageDownloadDataRequest.Options()
         let request = StorageDownloadDataRequest(key: key, options: options)
         let downloadDataOperation = AWSS3StorageDownloadDataOperation(request,
+                                                                      storageConfiguration: storageConfiguration,
                                                                       storageService: storageService,
                                                                       authService: authService,
                                                                       progressListener: progressListener,
@@ -90,6 +92,7 @@ extension AWSS3StoragePlugin {
         let options = options ?? StorageDownloadFileRequest.Options()
         let request = StorageDownloadFileRequest(key: key, local: local, options: options)
         let downloadFileOperation = AWSS3StorageDownloadFileOperation(request,
+                                                                      storageConfiguration: storageConfiguration,
                                                                       storageService: storageService,
                                                                       authService: authService,
                                                                       progressListener: progressListener,
@@ -122,10 +125,11 @@ extension AWSS3StoragePlugin {
         let request = StorageUploadDataRequest(key: key, data: data, options: options)
 
         let uploadDataOperation = AWSS3StorageUploadDataOperation(request,
-                                                            storageService: storageService,
-                                                            authService: authService,
-                                                            progressListener: progressListener,
-                                                            resultListener: resultListener)
+                                                                  storageConfiguration: storageConfiguration,
+                                                                  storageService: storageService,
+                                                                  authService: authService,
+                                                                  progressListener: progressListener,
+                                                                  resultListener: resultListener)
 
         queue.addOperation(uploadDataOperation)
 
@@ -154,6 +158,7 @@ extension AWSS3StoragePlugin {
         let request = StorageUploadFileRequest(key: key, local: local, options: options)
 
         let uploadFileOperation = AWSS3StorageUploadFileOperation(request,
+                                                                  storageConfiguration: storageConfiguration,
                                                                   storageService: storageService,
                                                                   authService: authService,
                                                                   progressListener: progressListener,
@@ -182,6 +187,7 @@ extension AWSS3StoragePlugin {
         let options = options ?? StorageRemoveRequest.Options()
         let request = StorageRemoveRequest(key: key, options: options)
         let removeOperation = AWSS3StorageRemoveOperation(request,
+                                                          storageConfiguration: storageConfiguration,
                                                           storageService: storageService,
                                                           authService: authService,
                                                           resultListener: resultListener)
@@ -205,6 +211,7 @@ extension AWSS3StoragePlugin {
         let options = options ?? StorageListRequest.Options()
         let request = StorageListRequest(options: options)
         let listOperation = AWSS3StorageListOperation(request,
+                                                      storageConfiguration: storageConfiguration,
                                                       storageService: storageService,
                                                       authService: authService,
                                                       resultListener: resultListener)

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
@@ -29,8 +29,13 @@ final public class AWSS3StoragePlugin: StorageCategoryPlugin {
         return PluginConstants.awsS3StoragePluginKey
     }
 
+    /// The storage plugin configuration
+    let storageConfiguration: AWSS3StoragePluginConfiguration
+
     /// Instantiates an instance of the AWSS3StoragePlugin.
-    public init() {
+    public init(configuration
+                    storageConfiguration: AWSS3StoragePluginConfiguration = AWSS3StoragePluginConfiguration()) {
+        self.storageConfiguration = storageConfiguration
     }
 }
 

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Configuration/AWSS3PluginPrefixResolver.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Configuration/AWSS3PluginPrefixResolver.swift
@@ -1,0 +1,46 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Amplify
+import AWSPluginsCore
+
+/// Resolves the final prefix prepended to the S3 key for a given request.
+public protocol AWSS3PluginPrefixResolver {
+    func resolvePrefix(for accessLevel: StorageAccessLevel, targetIdentityId: String?) -> Result<String, StorageError>
+}
+
+/// Convenience resolver. Resolves the provided key as-is, with no manipulation
+public struct PassThroughPrefixResolver: AWSS3PluginPrefixResolver {
+    public func resolvePrefix(for accessLevel: StorageAccessLevel,
+                              targetIdentityId: String?) -> Result<String, StorageError> {
+        return .success("")
+    }
+}
+
+/// AWSS3StoragePlugin default logic
+struct StorageAccessLevelAwarePrefixResolver: AWSS3PluginPrefixResolver {
+    let authService: AWSAuthServiceBehavior
+
+    public init(authService: AWSAuthServiceBehavior) {
+        self.authService = authService
+    }
+
+    public func resolvePrefix(for accessLevel: StorageAccessLevel,
+                              targetIdentityId: String?) -> Result<String, StorageError> {
+        let identityIdResult = authService.getIdentityId()
+        switch identityIdResult {
+        case .success(let identityId):
+            let prefix = StorageRequestUtils.getAccessLevelPrefix(accessLevel: accessLevel,
+                                                                  identityId: identityId,
+                                                                  targetIdentityId: targetIdentityId)
+            return .success(prefix)
+        case .failure(let error):
+            return .failure(StorageError.authError(error.errorDescription, error.recoverySuggestion))
+        }
+    }
+}

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Configuration/AWSS3StoragePluginConfiguration.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Configuration/AWSS3StoragePluginConfiguration.swift
@@ -1,0 +1,23 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// Plugin specific configuration
+public struct AWSS3StoragePluginConfiguration {
+
+    public let prefixResolver: AWSS3PluginPrefixResolver?
+
+    public init(prefixResolver: AWSS3PluginPrefixResolver? = nil) {
+        self.prefixResolver = prefixResolver
+    }
+
+    public static func prefixResolver(
+        _ prefixResolver: AWSS3PluginPrefixResolver) -> AWSS3StoragePluginConfiguration {
+        .init(prefixResolver: prefixResolver)
+    }
+}

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadDataOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadDataOperation.swift
@@ -22,6 +22,7 @@ public class AWSS3StorageDownloadDataOperation: AmplifyInProcessReportingOperati
     StorageError
 >, StorageDownloadDataOperation {
 
+    let storageConfiguration: AWSS3StoragePluginConfiguration
     let storageService: AWSS3StorageServiceBehaviour
     let authService: AWSAuthServiceBehavior
 
@@ -31,11 +32,13 @@ public class AWSS3StorageDownloadDataOperation: AmplifyInProcessReportingOperati
     private let storageTaskActionQueue = DispatchQueue(label: "com.amazonaws.amplify.StorageTaskActionQueue")
 
     init(_ request: StorageDownloadDataRequest,
+         storageConfiguration: AWSS3StoragePluginConfiguration,
          storageService: AWSS3StorageServiceBehaviour,
          authService: AWSAuthServiceBehavior,
          progressListener: InProcessListener?,
          resultListener: ResultListener?) {
 
+        self.storageConfiguration = storageConfiguration
         self.storageService = storageService
         self.authService = authService
         super.init(categoryType: .storage,
@@ -82,29 +85,19 @@ public class AWSS3StorageDownloadDataOperation: AmplifyInProcessReportingOperati
             return
         }
 
-        let identityIdResult = authService.getIdentityId()
-
-        guard case let .success(identityId) = identityIdResult else {
-            if case let .failure(error) = identityIdResult {
-                dispatch(StorageError.authError(error.errorDescription, error.recoverySuggestion))
+        let prefixResolver = (storageConfiguration.prefixResolver != nil) ? storageConfiguration.prefixResolver! :
+            StorageAccessLevelAwarePrefixResolver(authService: authService)
+        let prefix = prefixResolver.resolvePrefix(for: request.options.accessLevel,
+                                                  targetIdentityId: request.options.targetIdentityId)
+        switch prefix {
+        case .success(let prefix):
+            let serviceKey = prefix + request.key
+            storageService.download(serviceKey: serviceKey, fileURL: nil) { [weak self] event in
+                self?.onServiceEvent(event: event)
             }
-
+        case .failure(let error):
+            dispatch(error)
             finish()
-            return
-        }
-
-        let serviceKey = StorageRequestUtils.getServiceKey(accessLevel: request.options.accessLevel,
-                                                           identityId: identityId,
-                                                           key: request.key,
-                                                           targetIdentityId: request.options.targetIdentityId)
-
-        if isCancelled {
-            finish()
-            return
-        }
-
-        storageService.download(serviceKey: serviceKey, fileURL: nil) { [weak self] event in
-            self?.onServiceEvent(event: event)
         }
     }
 

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadDataOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadDataOperation.swift
@@ -85,11 +85,11 @@ public class AWSS3StorageDownloadDataOperation: AmplifyInProcessReportingOperati
             return
         }
 
-        let prefixResolver = (storageConfiguration.prefixResolver != nil) ? storageConfiguration.prefixResolver! :
+        let prefixResolver = storageConfiguration.prefixResolver ??
             StorageAccessLevelAwarePrefixResolver(authService: authService)
-        let prefix = prefixResolver.resolvePrefix(for: request.options.accessLevel,
-                                                  targetIdentityId: request.options.targetIdentityId)
-        switch prefix {
+        let prefixResolution = prefixResolver.resolvePrefix(for: request.options.accessLevel,
+                                                            targetIdentityId: request.options.targetIdentityId)
+        switch prefixResolution {
         case .success(let prefix):
             let serviceKey = prefix + request.key
             storageService.download(serviceKey: serviceKey, fileURL: nil) { [weak self] event in

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadFileOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadFileOperation.swift
@@ -88,11 +88,11 @@ public class AWSS3StorageDownloadFileOperation: AmplifyInProcessReportingOperati
             return
         }
 
-        let prefixResolver = (storageConfiguration.prefixResolver != nil) ? storageConfiguration.prefixResolver! :
+        let prefixResolver = storageConfiguration.prefixResolver ??
             StorageAccessLevelAwarePrefixResolver(authService: authService)
-        let prefix = prefixResolver.resolvePrefix(for: request.options.accessLevel,
-                                                  targetIdentityId: request.options.targetIdentityId)
-        switch prefix {
+        let prefixResolution = prefixResolver.resolvePrefix(for: request.options.accessLevel,
+                                                            targetIdentityId: request.options.targetIdentityId)
+        switch prefixResolution {
         case .success(let prefix):
             let serviceKey = prefix + request.key
             storageService.download(serviceKey: serviceKey, fileURL: request.local) { [weak self] event in

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadFileOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadFileOperation.swift
@@ -25,6 +25,7 @@ public class AWSS3StorageDownloadFileOperation: AmplifyInProcessReportingOperati
     StorageError
 >, StorageDownloadFileOperation {
 
+    let storageConfiguration: AWSS3StoragePluginConfiguration
     let storageService: AWSS3StorageServiceBehaviour
     let authService: AWSAuthServiceBehavior
 
@@ -34,11 +35,13 @@ public class AWSS3StorageDownloadFileOperation: AmplifyInProcessReportingOperati
     private let storageTaskActionQueue = DispatchQueue(label: "com.amazonaws.amplify.StorageTaskActionQueue")
 
     init(_ request: StorageDownloadFileRequest,
+         storageConfiguration: AWSS3StoragePluginConfiguration,
          storageService: AWSS3StorageServiceBehaviour,
          authService: AWSAuthServiceBehavior,
          progressListener: InProcessListener?,
          resultListener: ResultListener?) {
 
+        self.storageConfiguration = storageConfiguration
         self.storageService = storageService
         self.authService = authService
         super.init(categoryType: .storage,
@@ -85,28 +88,19 @@ public class AWSS3StorageDownloadFileOperation: AmplifyInProcessReportingOperati
             return
         }
 
-        let identityIdResult = authService.getIdentityId()
-        guard case let .success(identityId) = identityIdResult else {
-            if case let .failure(error) = identityIdResult {
-                dispatch(StorageError.authError(error.errorDescription, error.recoverySuggestion))
+        let prefixResolver = (storageConfiguration.prefixResolver != nil) ? storageConfiguration.prefixResolver! :
+            StorageAccessLevelAwarePrefixResolver(authService: authService)
+        let prefix = prefixResolver.resolvePrefix(for: request.options.accessLevel,
+                                                  targetIdentityId: request.options.targetIdentityId)
+        switch prefix {
+        case .success(let prefix):
+            let serviceKey = prefix + request.key
+            storageService.download(serviceKey: serviceKey, fileURL: request.local) { [weak self] event in
+                self?.onServiceEvent(event: event)
             }
-
+        case .failure(let error):
+            dispatch(error)
             finish()
-            return
-        }
-
-        let serviceKey = StorageRequestUtils.getServiceKey(accessLevel: request.options.accessLevel,
-                                                           identityId: identityId,
-                                                           key: request.key,
-                                                           targetIdentityId: request.options.targetIdentityId)
-
-        if isCancelled {
-            finish()
-            return
-        }
-
-        storageService.download(serviceKey: serviceKey, fileURL: request.local) { [weak self] event in
-            self?.onServiceEvent(event: event)
         }
     }
 

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageGetURLOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageGetURLOperation.swift
@@ -58,11 +58,11 @@ public class AWSS3StorageGetURLOperation: AmplifyOperation<
             return
         }
 
-        let prefixResolver = (storageConfiguration.prefixResolver != nil) ? storageConfiguration.prefixResolver! :
+        let prefixResolver = storageConfiguration.prefixResolver ??
             StorageAccessLevelAwarePrefixResolver(authService: authService)
-        let prefix = prefixResolver.resolvePrefix(for: request.options.accessLevel,
-                                                  targetIdentityId: request.options.targetIdentityId)
-        switch prefix {
+        let prefixResolution = prefixResolver.resolvePrefix(for: request.options.accessLevel,
+                                                            targetIdentityId: request.options.targetIdentityId)
+        switch prefixResolution {
         case .success(let prefix):
             let serviceKey = prefix + request.key
             storageService.getPreSignedURL(serviceKey: serviceKey,

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageGetURLOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageGetURLOperation.swift
@@ -21,14 +21,17 @@ public class AWSS3StorageGetURLOperation: AmplifyOperation<
     StorageError
 >, StorageGetURLOperation {
 
+    let storageConfiguration: AWSS3StoragePluginConfiguration
     let storageService: AWSS3StorageServiceBehaviour
     let authService: AWSAuthServiceBehavior
 
     init(_ request: StorageGetURLRequest,
+         storageConfiguration: AWSS3StoragePluginConfiguration,
          storageService: AWSS3StorageServiceBehaviour,
          authService: AWSAuthServiceBehavior,
          resultListener: ResultListener?) {
 
+        self.storageConfiguration = storageConfiguration
         self.storageService = storageService
         self.authService = authService
         super.init(categoryType: .storage,
@@ -55,28 +58,20 @@ public class AWSS3StorageGetURLOperation: AmplifyOperation<
             return
         }
 
-        let identityIdResult = authService.getIdentityId()
-        guard case let .success(identityId) = identityIdResult else {
-            if case let .failure(error) = identityIdResult {
-                dispatch(StorageError.authError(error.errorDescription, error.recoverySuggestion))
+        let prefixResolver = (storageConfiguration.prefixResolver != nil) ? storageConfiguration.prefixResolver! :
+            StorageAccessLevelAwarePrefixResolver(authService: authService)
+        let prefix = prefixResolver.resolvePrefix(for: request.options.accessLevel,
+                                                  targetIdentityId: request.options.targetIdentityId)
+        switch prefix {
+        case .success(let prefix):
+            let serviceKey = prefix + request.key
+            storageService.getPreSignedURL(serviceKey: serviceKey,
+                                           expires: request.options.expires) { [weak self] event in
+                self?.onServiceEvent(event: event)
             }
-
+        case .failure(let error):
+            dispatch(error)
             finish()
-            return
-        }
-
-        let serviceKey = StorageRequestUtils.getServiceKey(accessLevel: request.options.accessLevel,
-                                                           identityId: identityId,
-                                                           key: request.key,
-                                                           targetIdentityId: request.options.targetIdentityId)
-
-        if isCancelled {
-            finish()
-            return
-        }
-
-        storageService.getPreSignedURL(serviceKey: serviceKey, expires: request.options.expires) { [weak self] event in
-            self?.onServiceEvent(event: event)
         }
     }
 

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageListOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageListOperation.swift
@@ -21,14 +21,17 @@ public class AWSS3StorageListOperation: AmplifyOperation<
     StorageError
 >, StorageListOperation {
 
+    let storageConfiguration: AWSS3StoragePluginConfiguration
     let storageService: AWSS3StorageServiceBehaviour
     let authService: AWSAuthServiceBehavior
 
     init(_ request: StorageListRequest,
+         storageConfiguration: AWSS3StoragePluginConfiguration,
          storageService: AWSS3StorageServiceBehaviour,
          authService: AWSAuthServiceBehavior,
          resultListener: ResultListener?) {
 
+        self.storageConfiguration = storageConfiguration
         self.storageService = storageService
         self.authService = authService
         super.init(categoryType: .storage,
@@ -55,29 +58,18 @@ public class AWSS3StorageListOperation: AmplifyOperation<
             return
         }
 
-        let identityIdResult = authService.getIdentityId()
-
-        guard case let .success(identityId) = identityIdResult else {
-            if case let .failure(error) = identityIdResult {
-                dispatch(StorageError.authError(error.errorDescription, error.recoverySuggestion))
+        let prefixResolver = (storageConfiguration.prefixResolver != nil) ? storageConfiguration.prefixResolver! :
+            StorageAccessLevelAwarePrefixResolver(authService: authService)
+        let prefix = prefixResolver.resolvePrefix(for: request.options.accessLevel,
+                                                  targetIdentityId: request.options.targetIdentityId)
+        switch prefix {
+        case .success(let prefix):
+            storageService.list(prefix: prefix, path: request.options.path) { [weak self] event in
+                self?.onServiceEvent(event: event)
             }
-
+        case .failure(let error):
+            dispatch(error)
             finish()
-            return
-        }
-
-        let accessLevelPrefix = StorageRequestUtils
-            .getAccessLevelPrefix(accessLevel: request.options.accessLevel,
-                                  identityId: identityId,
-                                  targetIdentityId: request.options.targetIdentityId)
-
-        if isCancelled {
-            finish()
-            return
-        }
-
-        storageService.list(prefix: accessLevelPrefix, path: request.options.path) { [weak self] event in
-            self?.onServiceEvent(event: event)
         }
     }
 

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageListOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageListOperation.swift
@@ -58,11 +58,11 @@ public class AWSS3StorageListOperation: AmplifyOperation<
             return
         }
 
-        let prefixResolver = (storageConfiguration.prefixResolver != nil) ? storageConfiguration.prefixResolver! :
+        let prefixResolver = storageConfiguration.prefixResolver ??
             StorageAccessLevelAwarePrefixResolver(authService: authService)
-        let prefix = prefixResolver.resolvePrefix(for: request.options.accessLevel,
-                                                  targetIdentityId: request.options.targetIdentityId)
-        switch prefix {
+        let prefixResolution = prefixResolver.resolvePrefix(for: request.options.accessLevel,
+                                                            targetIdentityId: request.options.targetIdentityId)
+        switch prefixResolution {
         case .success(let prefix):
             storageService.list(prefix: prefix, path: request.options.path) { [weak self] event in
                 self?.onServiceEvent(event: event)

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageRemoveOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageRemoveOperation.swift
@@ -58,11 +58,11 @@ public class AWSS3StorageRemoveOperation: AmplifyOperation<
             return
         }
 
-        let prefixResolver = (storageConfiguration.prefixResolver != nil) ? storageConfiguration.prefixResolver! :
+        let prefixResolver = storageConfiguration.prefixResolver ??
             StorageAccessLevelAwarePrefixResolver(authService: authService)
-        let prefix = prefixResolver.resolvePrefix(for: request.options.accessLevel,
-                                                  targetIdentityId: nil)
-        switch prefix {
+        let prefixResolution = prefixResolver.resolvePrefix(for: request.options.accessLevel,
+                                                            targetIdentityId: nil)
+        switch prefixResolution {
         case .success(let prefix):
             let serviceKey = prefix + request.key
             storageService.delete(serviceKey: serviceKey) { [weak self] event in

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageRemoveOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageRemoveOperation.swift
@@ -21,14 +21,17 @@ public class AWSS3StorageRemoveOperation: AmplifyOperation<
     StorageError
 >, StorageRemoveOperation {
 
+    let storageConfiguration: AWSS3StoragePluginConfiguration
     let storageService: AWSS3StorageServiceBehaviour
     let authService: AWSAuthServiceBehavior
 
     init(_ request: StorageRemoveRequest,
+         storageConfiguration: AWSS3StoragePluginConfiguration,
          storageService: AWSS3StorageServiceBehaviour,
          authService: AWSAuthServiceBehavior,
          resultListener: ResultListener?) {
 
+        self.storageConfiguration = storageConfiguration
         self.storageService = storageService
         self.authService = authService
         super.init(categoryType: .storage,
@@ -55,27 +58,19 @@ public class AWSS3StorageRemoveOperation: AmplifyOperation<
             return
         }
 
-        let identityIdResult = authService.getIdentityId()
-        guard case let .success(identityId) = identityIdResult else {
-            if case let .failure(error) = identityIdResult {
-                dispatch(StorageError.authError(error.errorDescription, error.recoverySuggestion))
+        let prefixResolver = (storageConfiguration.prefixResolver != nil) ? storageConfiguration.prefixResolver! :
+            StorageAccessLevelAwarePrefixResolver(authService: authService)
+        let prefix = prefixResolver.resolvePrefix(for: request.options.accessLevel,
+                                                  targetIdentityId: nil)
+        switch prefix {
+        case .success(let prefix):
+            let serviceKey = prefix + request.key
+            storageService.delete(serviceKey: serviceKey) { [weak self] event in
+                self?.onServiceEvent(event: event)
             }
-
+        case .failure(let error):
+            dispatch(error)
             finish()
-            return
-        }
-
-        let serviceKey = StorageRequestUtils.getServiceKey(accessLevel: request.options.accessLevel,
-                                                           identityId: identityId,
-                                                           key: request.key)
-
-        if isCancelled {
-            finish()
-            return
-        }
-
-        storageService.delete(serviceKey: serviceKey) { [weak self] event in
-            self?.onServiceEvent(event: event)
         }
     }
 

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageUploadDataOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageUploadDataOperation.swift
@@ -85,11 +85,11 @@ public class AWSS3StorageUploadDataOperation: AmplifyInProcessReportingOperation
             return
         }
 
-        let prefixResolver = (storageConfiguration.prefixResolver != nil) ? storageConfiguration.prefixResolver! :
+        let prefixResolver = storageConfiguration.prefixResolver ??
             StorageAccessLevelAwarePrefixResolver(authService: authService)
-        let prefix = prefixResolver.resolvePrefix(for: request.options.accessLevel,
-                                                  targetIdentityId: request.options.targetIdentityId)
-        switch prefix {
+        let prefixResolution = prefixResolver.resolvePrefix(for: request.options.accessLevel,
+                                                            targetIdentityId: request.options.targetIdentityId)
+        switch prefixResolution {
         case .success(let prefix):
             let serviceKey = prefix + request.key
             let serviceMetadata = StorageRequestUtils.getServiceMetadata(request.options.metadata)

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageUploadDataOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageUploadDataOperation.swift
@@ -22,6 +22,7 @@ public class AWSS3StorageUploadDataOperation: AmplifyInProcessReportingOperation
     StorageError
 >, StorageUploadDataOperation {
 
+    let storageConfiguration: AWSS3StoragePluginConfiguration
     let storageService: AWSS3StorageServiceBehaviour
     let authService: AWSAuthServiceBehavior
 
@@ -31,11 +32,13 @@ public class AWSS3StorageUploadDataOperation: AmplifyInProcessReportingOperation
     private let storageTaskActionQueue = DispatchQueue(label: "com.amazonaws.amplify.StorageTaskActionQueue")
 
     init(_ request: StorageUploadDataRequest,
+         storageConfiguration: AWSS3StoragePluginConfiguration,
          storageService: AWSS3StorageServiceBehaviour,
          authService: AWSAuthServiceBehavior,
          progressListener: InProcessListener?,
          resultListener: ResultListener?) {
 
+        self.storageConfiguration = storageConfiguration
         self.storageService = storageService
         self.authService = authService
         super.init(categoryType: .storage,
@@ -82,40 +85,32 @@ public class AWSS3StorageUploadDataOperation: AmplifyInProcessReportingOperation
             return
         }
 
-        let identityIdResult = authService.getIdentityId()
-        guard case let .success(identityId) = identityIdResult else {
-            if case let .failure(error) = identityIdResult {
-                dispatch(StorageError.authError(error.errorDescription, error.recoverySuggestion))
+        let prefixResolver = (storageConfiguration.prefixResolver != nil) ? storageConfiguration.prefixResolver! :
+            StorageAccessLevelAwarePrefixResolver(authService: authService)
+        let prefix = prefixResolver.resolvePrefix(for: request.options.accessLevel,
+                                                  targetIdentityId: request.options.targetIdentityId)
+        switch prefix {
+        case .success(let prefix):
+            let serviceKey = prefix + request.key
+            let serviceMetadata = StorageRequestUtils.getServiceMetadata(request.options.metadata)
+            if request.data.count > StorageUploadDataRequest.Options.multiPartUploadSizeThreshold {
+                storageService.multiPartUpload(serviceKey: serviceKey,
+                                               uploadSource: .data(request.data),
+                                               contentType: request.options.contentType,
+                                               metadata: serviceMetadata) { [weak self] event in
+                                                   self?.onServiceEvent(event: event)
+                                               }
+            } else {
+                storageService.upload(serviceKey: serviceKey,
+                                      uploadSource: .data(request.data),
+                                      contentType: request.options.contentType,
+                                      metadata: serviceMetadata) { [weak self] event in
+                                          self?.onServiceEvent(event: event)
+                                      }
             }
-
+        case .failure(let error):
+            dispatch(error)
             finish()
-            return
-        }
-
-        let serviceKey = StorageRequestUtils.getServiceKey(accessLevel: request.options.accessLevel,
-                                                           identityId: identityId,
-                                                           key: request.key)
-        let serviceMetadata = StorageRequestUtils.getServiceMetadata(request.options.metadata)
-
-        if isCancelled {
-            finish()
-            return
-        }
-
-        if request.data.count > StorageUploadDataRequest.Options.multiPartUploadSizeThreshold {
-            storageService.multiPartUpload(serviceKey: serviceKey,
-                                           uploadSource: .data(request.data),
-                                           contentType: request.options.contentType,
-                                           metadata: serviceMetadata) { [weak self] event in
-                                               self?.onServiceEvent(event: event)
-                                           }
-        } else {
-            storageService.upload(serviceKey: serviceKey,
-                                  uploadSource: .data(request.data),
-                                  contentType: request.options.contentType,
-                                  metadata: serviceMetadata) { [weak self] event in
-                                      self?.onServiceEvent(event: event)
-                                  }
         }
     }
 

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageUploadFileOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageUploadFileOperation.swift
@@ -22,6 +22,7 @@ public class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation
     StorageError
 >, StorageUploadFileOperation {
 
+    let storageConfiguration: AWSS3StoragePluginConfiguration
     let storageService: AWSS3StorageServiceBehaviour
     let authService: AWSAuthServiceBehavior
 
@@ -31,11 +32,13 @@ public class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation
     private let storageTaskActionQueue = DispatchQueue(label: "com.amazonaws.amplify.StorageTaskActionQueue")
 
     init(_ request: StorageUploadFileRequest,
+         storageConfiguration: AWSS3StoragePluginConfiguration,
          storageService: AWSS3StorageServiceBehaviour,
          authService: AWSAuthServiceBehavior,
          progressListener: InProcessListener?,
          resultListener: ResultListener?) {
 
+        self.storageConfiguration = storageConfiguration
         self.storageService = storageService
         self.authService = authService
         super.init(categoryType: .storage,
@@ -82,16 +85,6 @@ public class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation
             return
         }
 
-        let identityIdResult = authService.getIdentityId()
-        guard case let .success(identityId) = identityIdResult else {
-            if case let .failure(error) = identityIdResult {
-                dispatch(StorageError.authError(error.errorDescription, error.recoverySuggestion, error))
-            }
-
-            finish()
-            return
-        }
-
         let uploadSize: UInt64
         do {
             uploadSize = try StorageRequestUtils.getSize(request.local)
@@ -105,30 +98,32 @@ public class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation
             return
         }
 
-        let serviceKey = StorageRequestUtils.getServiceKey(accessLevel: request.options.accessLevel,
-                                                           identityId: identityId,
-                                                           key: request.key)
-        let serviceMetadata = StorageRequestUtils.getServiceMetadata(request.options.metadata)
-
-        if isCancelled {
+        let prefixResolver = (storageConfiguration.prefixResolver != nil) ? storageConfiguration.prefixResolver! :
+            StorageAccessLevelAwarePrefixResolver(authService: authService)
+        let prefix = prefixResolver.resolvePrefix(for: request.options.accessLevel,
+                                                  targetIdentityId: request.options.targetIdentityId)
+        switch prefix {
+        case .success(let prefix):
+            let serviceKey = prefix + request.key
+            let serviceMetadata = StorageRequestUtils.getServiceMetadata(request.options.metadata)
+            if uploadSize > StorageUploadFileRequest.Options.multiPartUploadSizeThreshold {
+                storageService.multiPartUpload(serviceKey: serviceKey,
+                                               uploadSource: .local(request.local),
+                                               contentType: request.options.contentType,
+                                               metadata: serviceMetadata) { [weak self] event in
+                                                   self?.onServiceEvent(event: event)
+                                               }
+            } else {
+                storageService.upload(serviceKey: serviceKey,
+                                      uploadSource: .local(request.local),
+                                      contentType: request.options.contentType,
+                                      metadata: serviceMetadata) { [weak self] event in
+                                          self?.onServiceEvent(event: event)
+                                      }
+            }
+        case .failure(let error):
+            dispatch(error)
             finish()
-            return
-        }
-
-        if uploadSize > StorageUploadFileRequest.Options.multiPartUploadSizeThreshold {
-            storageService.multiPartUpload(serviceKey: serviceKey,
-                                           uploadSource: .local(request.local),
-                                           contentType: request.options.contentType,
-                                           metadata: serviceMetadata) { [weak self] event in
-                                               self?.onServiceEvent(event: event)
-                                           }
-        } else {
-            storageService.upload(serviceKey: serviceKey,
-                                  uploadSource: .local(request.local),
-                                  contentType: request.options.contentType,
-                                  metadata: serviceMetadata) { [weak self] event in
-                                      self?.onServiceEvent(event: event)
-                                  }
         }
     }
 

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageUploadFileOperation.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Operation/AWSS3StorageUploadFileOperation.swift
@@ -98,11 +98,11 @@ public class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation
             return
         }
 
-        let prefixResolver = (storageConfiguration.prefixResolver != nil) ? storageConfiguration.prefixResolver! :
+        let prefixResolver = storageConfiguration.prefixResolver ??
             StorageAccessLevelAwarePrefixResolver(authService: authService)
-        let prefix = prefixResolver.resolvePrefix(for: request.options.accessLevel,
-                                                  targetIdentityId: request.options.targetIdentityId)
-        switch prefix {
+        let prefixResolution = prefixResolver.resolvePrefix(for: request.options.accessLevel,
+                                                            targetIdentityId: request.options.targetIdentityId)
+        switch prefixResolution {
         case .success(let prefix):
             let serviceKey = prefix + request.key
             let serviceMetadata = StorageRequestUtils.getServiceMetadata(request.options.metadata)

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Utils/StorageErrorHelper.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Utils/StorageErrorHelper.swift
@@ -22,8 +22,7 @@ class StorageErrorHelper {
                                             "Make sure the key exists before trying to download it.")
         }
 
-        // TODO status error mapper
-        return StorageError.httpStatusError(statusCode, "TODO some status code to recovery message mapper")
+        return StorageError.httpStatusError(statusCode, "")
     }
 
     static func mapServiceError(_ error: NSError) -> StorageError {

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Utils/StorageRequestUtils+Getter.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Utils/StorageRequestUtils+Getter.swift
@@ -11,16 +11,6 @@ import Amplify
 extension StorageRequestUtils {
     // MARK: Getter methods
 
-    static func getServiceKey(accessLevel: StorageAccessLevel,
-                              identityId: String,
-                              key: String,
-                              targetIdentityId: String? = nil) -> String {
-
-        return getAccessLevelPrefix(accessLevel: accessLevel,
-                                    identityId: identityId,
-                                    targetIdentityId: targetIdentityId) + key
-    }
-
     static func getAccessLevelPrefix(accessLevel: StorageAccessLevel,
                                      identityId: String,
                                      targetIdentityId: String?) -> String {

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginAccessLevelTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginAccessLevelTests.swift
@@ -7,11 +7,11 @@
 
 import XCTest
 import Amplify
-@testable import AWSS3StoragePlugin
 import AWSS3
-import AWSCognitoIdentityProvider
-@testable import AmplifyTestCommon
 import AWSPluginsCore
+
+@testable import AWSS3StoragePlugin
+@testable import AmplifyTestCommon
 
 class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase {
 

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginPrefixKeyResolverTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginPrefixKeyResolverTests.swift
@@ -1,0 +1,163 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AmplifyPlugins
+import AWSS3StoragePlugin
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+
+class AWSS3StoragePluginKeyResolverTests: XCTestCase {
+
+    static let amplifyConfiguration = "AWSS3StoragePluginTests-amplifyconfiguration"
+
+    override func setUp() {
+        do {
+            Amplify.reset()
+            try Amplify.add(plugin: AWSCognitoAuthPlugin())
+            try Amplify.add(plugin: AWSS3StoragePlugin(
+                                configuration: .prefixResolver(MockGuestOverridePrefixResolver())))
+            let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(
+                forResource: AWSS3StoragePluginTestBase.amplifyConfiguration)
+            try Amplify.configure(amplifyConfig)
+        } catch {
+            XCTFail("Failed to initialize and configure Amplify \(error)")
+        }
+    }
+
+    override func tearDown() {
+        Amplify.reset()
+    }
+
+    // This mock resolver shows how to perform an upload to the `.guest` access level with a custom prefix value.
+    struct MockGuestOverridePrefixResolver: AWSS3PluginPrefixResolver {
+        func resolvePrefix(for accessLevel: StorageAccessLevel,
+                           targetIdentityId: String?) -> Result<String, StorageError> {
+            switch accessLevel {
+            case .guest:
+                return .success("public/customPublic/")
+            case .protected:
+                return .failure(.configuration("`.protected` StorageAccessLevel is not used", "", nil))
+            case .private:
+                return .failure(.configuration("`.protected` StorageAccessLevel is not used", "", nil))
+            }
+        }
+    }
+
+    /// Storage operations (upload, list, download) performed using a developer defined prefixKey resolver.
+    ///
+    /// - Given: Operations for default access level (.guest) and a mock key resolver in plugin configuration.
+    /// - When:
+    ///    - Upload, then List with path equal to the uniquely generated`key` to the single item
+    ///    - Download using the key from the List API
+    /// - Then:
+    ///    - Download is successful
+    ///
+    func testUploadListDownload() {
+        let key = UUID().uuidString
+        let data = key.data(using: .utf8)!
+        let uploadCompleted = expectation(description: "upload completed")
+
+        _ = Amplify.Storage.uploadData(key: key, data: data) { event in
+            switch event {
+            case .success:
+                uploadCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("Failed with \(error)")
+            }
+        }
+        wait(for: [uploadCompleted], timeout: TestCommonConstants.networkTimeout)
+
+        let listCompleted = expectation(description: "list completed")
+        let listOptions = StorageListRequest.Options(path: key)
+        var resultItem: StorageListResult.Item?
+        _ = Amplify.Storage.list(options: listOptions) { event in
+            switch event {
+            case .success(let result):
+                XCTAssertNotNil(result)
+                XCTAssertNotNil(result.items)
+                XCTAssertEqual(result.items.count, 1)
+                resultItem = result.items.first
+                listCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("Failed with \(error)")
+            }
+        }
+        wait(for: [listCompleted], timeout: TestCommonConstants.networkTimeout)
+
+        guard let item = resultItem else {
+            XCTFail("Failed to retrieve key from List API")
+            return
+        }
+        XCTAssertEqual(item.key, key)
+        let downloadCompleted = expectation(description: "download completed")
+        _ = Amplify.Storage.downloadData(key: item.key) { event in
+            switch event {
+            case .success(let data):
+                XCTAssertNotNil(data)
+                downloadCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("Failed with \(error)")
+            }
+        }
+
+        wait(for: [downloadCompleted], timeout: TestCommonConstants.networkTimeout)
+    }
+
+    /// Storage operations (upload, remove, download) performed using a developer defined prefixkey resolver.
+    ///
+    /// - Given: Operations for default access level (.guest) and a mock key resolver in plugin configuration.
+    /// - When:
+    ///    - Upload, Remove, Download
+    /// - Then:
+    ///    - The removed file should not exist with accurate error
+    ///
+    func testUploadRemoveDownload() {
+        let key = UUID().uuidString
+        let data = key.data(using: .utf8)!
+        let uploadCompleted = expectation(description: "upload completed")
+
+        _ = Amplify.Storage.uploadData(key: key, data: data) { event in
+            switch event {
+            case .success:
+                uploadCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("Failed with \(error)")
+            }
+        }
+        wait(for: [uploadCompleted], timeout: TestCommonConstants.networkTimeout)
+
+        let removeCompleted = expectation(description: "remove completed")
+        Amplify.Storage.remove(key: key) { event in
+            switch event {
+            case .success(let result):
+                XCTAssertNotNil(result)
+                removeCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("Failed with \(error)")
+            }
+        }
+        wait(for: [removeCompleted], timeout: TestCommonConstants.networkTimeout)
+
+        let downloadCompleted = expectation(description: "download completed")
+        _ = Amplify.Storage.downloadData(key: key) { event in
+            switch event {
+            case .success:
+                XCTFail("Should have failed")
+            case .failure(let error):
+                guard case .keyNotFound = error else {
+                    XCTFail("Should have failed with .keyNotFound")
+                    return
+                }
+                downloadCompleted.fulfill()
+            }
+        }
+
+        wait(for: [downloadCompleted], timeout: TestCommonConstants.networkTimeout)
+    }
+}

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginTestBase.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginTestBase.swift
@@ -10,8 +10,6 @@ import XCTest
 @testable import Amplify
 import AWSS3StoragePlugin
 import AmplifyPlugins
-import AWSS3
-import AWSCognitoIdentityProvider
 @testable import AmplifyTestCommon
 
 class AWSS3StoragePluginTestBase: XCTestCase {

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/README.md
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/README.md
@@ -13,7 +13,7 @@ The following steps demonstrate how to set up Storage with unauthenticated and a
 ? Please select from one of the below mentioned services: `Content (Images, audio, video, etc.)`
 ? You need to add auth (Amazon Cognito) to your project in order to add storage for user files. Do you want to add auth now? `Yes`
  Do you want to use the default authentication and security configuration? `Default configuration`
- How do you want users to be able to sign in? `Email`
+ How do you want users to be able to sign in? `Username`
  Do you want to configure advanced settings? `No, I am done.`
 Successfully added auth resource
 ? Please provide a friendly name for your resource that will be used to label this category in the project: `s3f34a5918`
@@ -28,29 +28,38 @@ Successfully added auth resource
 
 [temporary step]: Until Amplify CLI supports adding the auth section into amplifyconfiguation.json, copy `awsconfiguration.json`'s auth section over
 
-4. Copy `amplifyconfiguration.json` as `AWSS3StoragePluginTests-amplifyconfiguration.json`
+4.  Create the empty configuration files
+```
+touch AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginTests-credentials.json
+touch AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginTests-amplifyconfiguration.json
+```
 
-5. Create `AWSS3StoragePluginTests-credentials.json` with a json object containing `user1`, `user2`, and `password`, used to create the cognito user in the userpool. In step 2, the cognito userpool is configured to allow users to sign up with their email as the username.
+5. Copy `amplifyconfiguration.json` as `AWSS3StoragePluginTests-amplifyconfiguration.json`
+
+7. Create two new users in the userpool. First, retrieve the Cognito User Pool's Pool Id, you can find this in `amplifyconfiguration.json` under
+```
+"CognitoUserPool": {
+    "Default": {
+        "PoolId": "[POOL_ID]",
+```
+Run the `admin-create-user` command to create a new user
+```
+aws cognito-idp admin-create-user --user-pool-id [POOL_ID] --username [USERNAME]
+```
+Run the `admin-set-user-password` command to confirm the user
+```
+aws cognito-idp admin-set-user-password --user-pool-id [POOL_ID] --username [USERNAME] --password [PASSWORD] --permanent
+```
+See https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/index.html#cli-aws-cognito-idp for more details using AWS CLI. 
+
+6. In `AWSS3StoragePluginTests-credentials.json`, create a json object containing `user1`, `user2`, and `password`.
 
 ```json
 {
-    "user1": "<USER1 EMAIL>",
-    "user2": "<USER1 EMAIL>",
-    "password": "<PASSWORD>"
+    "user1": "[USERNAME]",
+    "user2": "[USERNAME]",
+    "password": "[PASSWORD]"
 }
 ```
-
-6. You can now run most of the integration tests. 
-
-7. To successfully run AWSS3StoragePluginAccessLevelTests, sign up two users.
-
-8. `amplify console auth`
-```perl
-? Which console `User Pool`
-```
-
-9. Click on `Users and groups`, Sign up a new user with the email and password specified in step 4, and click on Confirm User.
-
-10. Run the rest of the tests.
 
 You should now be able to run all of the tests from AWSS3StoragePluginAccessLevelTests 

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Configuration/AWSS3PluginPrefixResolverTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Configuration/AWSS3PluginPrefixResolverTests.swift
@@ -1,0 +1,57 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSS3StoragePlugin
+
+class AWSS3PluginPrefixResolverTests: XCTestCase {
+
+    func testPassthroughPrefixResolver() {
+        let prefixResolver = PassThroughPrefixResolver()
+
+        assertPrefixEquals(prefixResolver.resolvePrefix(for: .guest, targetIdentityId: nil), expectedPrefix: "")
+        assertPrefixEquals(prefixResolver.resolvePrefix(for: .protected, targetIdentityId: nil), expectedPrefix: "")
+        assertPrefixEquals(prefixResolver.resolvePrefix(for: .private, targetIdentityId: nil), expectedPrefix: "")
+        assertPrefixEquals(prefixResolver.resolvePrefix(for: .guest, targetIdentityId: "identityId"),
+                           expectedPrefix: "")
+        assertPrefixEquals(prefixResolver.resolvePrefix(for: .protected, targetIdentityId: "identityId"),
+                           expectedPrefix: "")
+        assertPrefixEquals(prefixResolver.resolvePrefix(for: .private, targetIdentityId: "identityId"),
+                           expectedPrefix: "")
+    }
+
+    func testStorageAccessLevelAwarePrefixResolver() {
+        let mockAuthService = MockAWSAuthService()
+        mockAuthService.identityId = "userId"
+        let prefixResolver = StorageAccessLevelAwarePrefixResolver(authService: mockAuthService)
+
+        assertPrefixEquals(prefixResolver.resolvePrefix(for: .guest, targetIdentityId: nil),
+                           expectedPrefix: "public/")
+        assertPrefixEquals(prefixResolver.resolvePrefix(for: .protected, targetIdentityId: nil),
+                           expectedPrefix: "protected/userId/")
+        assertPrefixEquals(prefixResolver.resolvePrefix(for: .private, targetIdentityId: nil),
+                           expectedPrefix: "private/userId/")
+        assertPrefixEquals(prefixResolver.resolvePrefix(for: .guest, targetIdentityId: "targetUserId"),
+                           expectedPrefix: "public/")
+        assertPrefixEquals(prefixResolver.resolvePrefix(for: .protected, targetIdentityId: "targetUserId"),
+                           expectedPrefix: "protected/targetUserId/")
+        assertPrefixEquals(prefixResolver.resolvePrefix(for: .private, targetIdentityId: "targetUserId"),
+                           expectedPrefix: "private/targetUserId/")
+
+    }
+
+    func assertPrefixEquals(_ result: Result<String, StorageError>, expectedPrefix: String) {
+        switch result {
+        case .success(let prefix):
+            XCTAssertEqual(prefix, expectedPrefix)
+        case .failure(let error):
+            XCTFail("\(error)")
+        }
+    }
+}

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Configuration/AWSS3StoragePluginConfigurationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Configuration/AWSS3StoragePluginConfigurationTests.swift
@@ -1,0 +1,26 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSS3StoragePlugin
+
+class AWSS3StoragePluginConfigurationTests: XCTestCase {
+
+    func testConfiguration() {
+        let storagePlugin = AWSS3StoragePlugin(configuration: .prefixResolver(MockPrefixResolver()))
+        XCTAssertNotNil(storagePlugin.storageConfiguration.prefixResolver as? MockPrefixResolver)
+    }
+
+    struct MockPrefixResolver: AWSS3PluginPrefixResolver {
+        func resolvePrefix(for accessLevel: StorageAccessLevel,
+                           targetIdentityId: String?) -> Result<String, StorageError> {
+            .success("")
+        }
+    }
+}

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageDownloadFileOperationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageDownloadFileOperationTests.swift
@@ -20,6 +20,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
                                                  options: StorageDownloadFileRequest.Options())
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageDownloadFileOperation(request,
+                                                          storageConfiguration: testStorageConfiguration,
                                                           storageService: mockStorageService,
                                                           authService: mockAuthService,
                                                           progressListener: nil) { result in
@@ -47,6 +48,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
                                                  options: StorageDownloadFileRequest.Options())
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageDownloadFileOperation(request,
+                                                          storageConfiguration: testStorageConfiguration,
                                                           storageService: mockStorageService,
                                                           authService: mockAuthService,
                                                           progressListener: nil) { result in
@@ -82,6 +84,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
         let completeInvoked = expectation(description: "complete was invoked on operation")
         let operation = AWSS3StorageDownloadFileOperation(
             request,
+            storageConfiguration: testStorageConfiguration,
             storageService: mockStorageService,
             authService: mockAuthService,
             progressListener: { _ in
@@ -116,6 +119,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageDownloadFileOperation(
             request,
+            storageConfiguration: testStorageConfiguration,
             storageService: mockStorageService,
             authService: mockAuthService,
             progressListener: { _ in
@@ -152,6 +156,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
         let completeInvoked = expectation(description: "complete was invoked on operation")
         let operation = AWSS3StorageDownloadFileOperation(
             request,
+            storageConfiguration: testStorageConfiguration,
             storageService: mockStorageService,
             authService: mockAuthService,
             progressListener: { _ in

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageGetDataOperationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageGetDataOperationTests.swift
@@ -18,6 +18,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
         let request = StorageDownloadDataRequest(key: "", options: StorageDownloadDataRequest.Options())
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageDownloadDataOperation(request,
+                                                          storageConfiguration: testStorageConfiguration,
                                                           storageService: mockStorageService,
                                                           authService: mockAuthService,
                                                           progressListener: nil) { event in
@@ -43,6 +44,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
         let request = StorageDownloadDataRequest(key: testKey, options: StorageDownloadDataRequest.Options())
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageDownloadDataOperation(request,
+                                                          storageConfiguration: testStorageConfiguration,
                                                           storageService: mockStorageService,
                                                           authService: mockAuthService,
                                                           progressListener: nil) { event in
@@ -75,6 +77,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
         let completeInvoked = expectation(description: "complete was invoked on operation")
         let operation = AWSS3StorageDownloadDataOperation(
             request,
+            storageConfiguration: testStorageConfiguration,
             storageService: mockStorageService,
             authService: mockAuthService,
             progressListener: { _ in
@@ -106,6 +109,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
         let failInvoked = expectation(description: "fail was invoked on operation")
         let operation = AWSS3StorageDownloadDataOperation(
             request,
+            storageConfiguration: testStorageConfiguration,
             storageService: mockStorageService,
             authService: mockAuthService,
             progressListener: { _ in
@@ -139,6 +143,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
         let completeInvoked = expectation(description: "complete was invoked on operation")
         let operation = AWSS3StorageDownloadDataOperation(
             request,
+            storageConfiguration: testStorageConfiguration,
             storageService: mockStorageService,
             authService: mockAuthService,
             progressListener: { _ in

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageGetURLOperationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageGetURLOperationTests.swift
@@ -21,6 +21,7 @@ class AWSS3StorageGetURLOperationTests: AWSS3StorageOperationTestBase {
         let request = StorageGetURLRequest(key: "", options: options)
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageGetURLOperation(request,
+                                                    storageConfiguration: testStorageConfiguration,
                                                     storageService: mockStorageService,
                                                     authService: mockAuthService) { result in
             switch result {
@@ -48,8 +49,9 @@ class AWSS3StorageGetURLOperationTests: AWSS3StorageOperationTestBase {
 
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageGetURLOperation(request,
-                                                 storageService: mockStorageService,
-                                                 authService: mockAuthService) { result in
+                                                    storageConfiguration: testStorageConfiguration,
+                                                    storageService: mockStorageService,
+                                                    authService: mockAuthService) { result in
             switch result {
             case .failure(let error):
                 guard case .authError = error else {
@@ -80,6 +82,7 @@ class AWSS3StorageGetURLOperationTests: AWSS3StorageOperationTestBase {
         let expectedServiceKey = StorageAccessLevel.protected.rawValue + "/" + testIdentityId + "/" + testKey
         let completeInvoked = expectation(description: "complete was invoked on operation")
         let operation = AWSS3StorageGetURLOperation(request,
+                                                    storageConfiguration: testStorageConfiguration,
                                                     storageService: mockStorageService,
                                                     authService: mockAuthService) { result in
             switch result {
@@ -110,6 +113,7 @@ class AWSS3StorageGetURLOperationTests: AWSS3StorageOperationTestBase {
         let expectedServiceKey = StorageAccessLevel.protected.rawValue + "/" + testIdentityId + "/" + testKey
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageGetURLOperation(request,
+                                                    storageConfiguration: testStorageConfiguration,
                                                     storageService: mockStorageService,
                                                     authService: mockAuthService) { result in
             switch result {
@@ -138,6 +142,7 @@ class AWSS3StorageGetURLOperationTests: AWSS3StorageOperationTestBase {
         let expectedServiceKey = StorageAccessLevel.protected.rawValue + "/" + testTargetIdentityId + "/" + testKey
         let completeInvoked = expectation(description: "complete was invoked on operation")
         let operation = AWSS3StorageGetURLOperation(request,
+                                                    storageConfiguration: testStorageConfiguration,
                                                     storageService: mockStorageService,
                                                     authService: mockAuthService) { event in
             switch event {

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageListOperationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageListOperationTests.swift
@@ -20,6 +20,7 @@ class AWSS3StorageListOperationTests: AWSS3StorageOperationTestBase {
 
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageListOperation(request,
+                                                  storageConfiguration: testStorageConfiguration,
                                                   storageService: mockStorageService,
                                                   authService: mockAuthService) { result in
                                                     switch result {
@@ -48,6 +49,7 @@ class AWSS3StorageListOperationTests: AWSS3StorageOperationTestBase {
 
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageListOperation(request,
+                                                  storageConfiguration: testStorageConfiguration,
                                                   storageService: mockStorageService,
                                                   authService: mockAuthService) { result in
                                                       switch result {
@@ -76,6 +78,7 @@ class AWSS3StorageListOperationTests: AWSS3StorageOperationTestBase {
         let expectedPrefix = StorageAccessLevel.guest.serviceAccessPrefix + "/"
         let completeInvoked = expectation(description: "complete was invoked on operation")
         let operation = AWSS3StorageListOperation(request,
+                                                  storageConfiguration: testStorageConfiguration,
                                                   storageService: mockStorageService,
                                                   authService: mockAuthService) { result in
                                                     switch result {
@@ -101,6 +104,7 @@ class AWSS3StorageListOperationTests: AWSS3StorageOperationTestBase {
         let expectedPrefix = StorageAccessLevel.guest.serviceAccessPrefix + "/"
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageListOperation(request,
+                                                  storageConfiguration: testStorageConfiguration,
                                                   storageService: mockStorageService,
                                                   authService: mockAuthService) { result in
                                                     switch result {
@@ -128,6 +132,7 @@ class AWSS3StorageListOperationTests: AWSS3StorageOperationTestBase {
         let expectedPrefix = StorageAccessLevel.protected.rawValue + "/" + testTargetIdentityId + "/"
         let completeInvoked = expectation(description: "complete was invoked on operation")
         let operation = AWSS3StorageListOperation(request,
+                                                  storageConfiguration: testStorageConfiguration,
                                                   storageService: mockStorageService,
                                                   authService: mockAuthService) { result in
                                                     switch result {

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageOperationTestBase.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageOperationTestBase.swift
@@ -25,6 +25,7 @@ class AWSS3StorageOperationTestBase: XCTestCase {
     let testContentType = "TestContentType"
     let testExpires = 10
     let testURL = URL(fileURLWithPath: "path")
+    let testStorageConfiguration = AWSS3StoragePluginConfiguration()
 
     override func setUp() {
         let mockAmplifyConfig = AmplifyConfiguration()

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StoragePutDataOperationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StoragePutDataOperationTests.swift
@@ -21,6 +21,7 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
 
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageUploadDataOperation(request,
+                                                        storageConfiguration: testStorageConfiguration,
                                                         storageService: mockStorageService,
                                                         authService: mockAuthService,
                                                         progressListener: nil) { result in
@@ -50,9 +51,10 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
 
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageUploadDataOperation(request,
-                                                     storageService: mockStorageService,
-                                                     authService: mockAuthService,
-                                                     progressListener: nil) { result in
+                                                        storageConfiguration: testStorageConfiguration,
+                                                        storageService: mockStorageService,
+                                                        authService: mockAuthService,
+                                                        progressListener: nil) { result in
             switch result {
             case .failure(let error):
                 guard case .authError = error else {
@@ -92,6 +94,7 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
         let completeInvoked = expectation(description: "complete was invoked on operation")
         let operation = AWSS3StorageUploadDataOperation(
             request,
+            storageConfiguration: testStorageConfiguration,
             storageService: mockStorageService,
             authService: mockAuthService,
             progressListener: { _ in
@@ -134,6 +137,7 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
         let failInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageUploadDataOperation(
             request,
+            storageConfiguration: testStorageConfiguration,
             storageService: mockStorageService,
             authService: mockAuthService,
             progressListener: { _ in
@@ -187,6 +191,7 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
         let completeInvoked = expectation(description: "complete was invoked on operation")
         let operation = AWSS3StorageUploadDataOperation(
             request,
+            storageConfiguration: testStorageConfiguration,
             storageService: mockStorageService,
             authService: mockAuthService,
             progressListener: { _ in

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageRemoveOperationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageRemoveOperationTests.swift
@@ -19,6 +19,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
 
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageRemoveOperation(request,
+                                                    storageConfiguration: testStorageConfiguration,
                                                     storageService: mockStorageService,
                                                     authService: mockAuthService) { result in
             switch result {
@@ -46,6 +47,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
         let request = StorageRemoveRequest(key: testKey, options: options)
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageRemoveOperation(request,
+                                                    storageConfiguration: testStorageConfiguration,
                                                     storageService: mockStorageService,
                                                     authService: mockAuthService) { result in
             switch result {
@@ -74,6 +76,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
         let expectedServiceKey = StorageAccessLevel.guest.serviceAccessPrefix + "/" + testKey
         let completeInvoked = expectation(description: "complete was invoked on operation")
         let operation = AWSS3StorageRemoveOperation(request,
+                                                    storageConfiguration: testStorageConfiguration,
                                                     storageService: mockStorageService,
                                                     authService: mockAuthService) { result in
             switch result {
@@ -99,6 +102,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
         let expectedServiceKey = StorageAccessLevel.guest.serviceAccessPrefix + "/" + testKey
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageRemoveOperation(request,
+                                                    storageConfiguration: testStorageConfiguration,
                                                     storageService: mockStorageService,
                                                     authService: mockAuthService) { result in
             switch result {
@@ -125,6 +129,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
         let expectedServiceKey = StorageAccessLevel.private.rawValue + "/" + testIdentityId + "/" + testKey
         let completeInvoked = expectation(description: "complete was invoked on operation")
         let operation = AWSS3StorageRemoveOperation(request,
+                                                    storageConfiguration: testStorageConfiguration,
                                                     storageService: mockStorageService,
                                                     authService: mockAuthService) { result in
             switch result {

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests.swift
@@ -20,6 +20,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
 
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageUploadFileOperation(request,
+                                                        storageConfiguration: testStorageConfiguration,
                                                         storageService: mockStorageService,
                                                         authService: mockAuthService,
                                                         progressListener: nil) { result in
@@ -43,11 +44,15 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
 
     func testUploadFileOperationGetIdentityIdError() {
         mockAuthService.getIdentityIdError = AuthError.service("", "", "")
+        let filePath = NSTemporaryDirectory() + UUID().uuidString + ".tmp"
+        let fileURL = URL(fileURLWithPath: filePath)
+        FileManager.default.createFile(atPath: filePath, contents: testData, attributes: nil)
         let options = StorageUploadFileRequest.Options(accessLevel: .protected)
-        let request = StorageUploadFileRequest(key: testKey, local: testURL, options: options)
+        let request = StorageUploadFileRequest(key: testKey, local: fileURL, options: options)
 
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageUploadFileOperation(request,
+                                                        storageConfiguration: testStorageConfiguration,
                                                         storageService: mockStorageService,
                                                         authService: mockAuthService,
                                                         progressListener: nil) { result in
@@ -76,6 +81,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
 
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageUploadFileOperation(request,
+                                                        storageConfiguration: testStorageConfiguration,
                                                         storageService: mockStorageService,
                                                         authService: mockAuthService,
                                                         progressListener: nil) { event in
@@ -121,6 +127,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
         let completeInvoked = expectation(description: "complete was invoked on operation")
         let operation = AWSS3StorageUploadFileOperation(
             request,
+            storageConfiguration: testStorageConfiguration,
             storageService: mockStorageService,
             authService: mockAuthService,
             progressListener: { _ in
@@ -166,6 +173,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
         let failInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageUploadFileOperation(
             request,
+            storageConfiguration: testStorageConfiguration,
             storageService: mockStorageService,
             authService: mockAuthService,
             progressListener: { _ in
@@ -218,6 +226,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
         let completeInvoked = expectation(description: "complete was invoked on operation")
         let operation = AWSS3StorageUploadFileOperation(
             request,
+            storageConfiguration: testStorageConfiguration,
             storageService: mockStorageService,
             authService: mockAuthService,
             progressListener: { _ in

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsGetterTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsGetterTests.swift
@@ -13,66 +13,9 @@ class StorageRequestUtilsGetterTests: XCTestCase {
 
     let testIdentityId = "TestIdentityId"
     let testTargetIdentityId = "TestTargetIdentityId"
-    let testKey = "TestKey"
     let guestAccessLevel = StorageAccessLevel.guest
     let protectedAccessLevel = StorageAccessLevel.protected
     let privateAccessLevel = StorageAccessLevel.private
-
-    // MARK: GetServiceKey tests
-
-    func testGetServiceKeyWithPublic() {
-        let expected = guestAccessLevel.serviceAccessPrefix + "/" + testKey
-        let result = StorageRequestUtils.getServiceKey(accessLevel: guestAccessLevel,
-                                                       identityId: testIdentityId,
-                                                       key: testKey,
-                                                       targetIdentityId: nil)
-        XCTAssertEqual(result, expected)
-    }
-
-    func testGetServiceKeyWithProtected() {
-        let expected = protectedAccessLevel.serviceAccessPrefix + "/" + testIdentityId + "/" + testKey
-        let result = StorageRequestUtils.getServiceKey(accessLevel: protectedAccessLevel,
-                                                       identityId: testIdentityId,
-                                                       key: testKey,
-                                                       targetIdentityId: nil)
-        XCTAssertEqual(result, expected)
-    }
-
-    func testGetServiceKeyWithPrivate() {
-        let expected = privateAccessLevel.serviceAccessPrefix + "/" + testIdentityId + "/" + testKey
-        let result = StorageRequestUtils.getServiceKey(accessLevel: privateAccessLevel,
-                                                       identityId: testIdentityId,
-                                                       key: testKey,
-                                                       targetIdentityId: nil)
-        XCTAssertEqual(result, expected)
-    }
-
-    func testGetServiceKeyWithPublicAndTargetIdentityId() {
-        let expected = guestAccessLevel.serviceAccessPrefix + "/" + testKey
-        let result = StorageRequestUtils.getServiceKey(accessLevel: guestAccessLevel,
-                                                       identityId: testIdentityId,
-                                                       key: testKey,
-                                                       targetIdentityId: testTargetIdentityId)
-        XCTAssertEqual(result, expected)
-    }
-
-    func testGetServiceKeyWithProtectedAndTargetIdentityId() {
-        let expected = protectedAccessLevel.serviceAccessPrefix + "/" + testTargetIdentityId + "/" + testKey
-        let result = StorageRequestUtils.getServiceKey(accessLevel: protectedAccessLevel,
-                                                       identityId: testIdentityId,
-                                                       key: testKey,
-                                                       targetIdentityId: testTargetIdentityId)
-        XCTAssertEqual(result, expected)
-    }
-
-    func testGetServiceKeywithPrivateAndTargetIdentityId() {
-        let expected = privateAccessLevel.serviceAccessPrefix + "/" + testTargetIdentityId + "/" + testKey
-        let result = StorageRequestUtils.getServiceKey(accessLevel: privateAccessLevel,
-                                                       identityId: testIdentityId,
-                                                       key: testKey,
-                                                       targetIdentityId: testTargetIdentityId)
-        XCTAssertEqual(result, expected)
-    }
 
     // MARK: GetAccessLevelPrefix tests
 

--- a/AmplifyPlugins/Storage/StoragePlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Storage/StoragePlugin.xcodeproj/project.pbxproj
@@ -19,8 +19,13 @@
 		2149E6C8238CA47500873955 /* AWSS3StoragePluginAccessLevelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FEB7092375DA2200818CD2 /* AWSS3StoragePluginAccessLevelTests.swift */; };
 		2149E6C9238CA47500873955 /* AWSS3StoragePluginOptionsUsabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FEB7052375DA2200818CD2 /* AWSS3StoragePluginOptionsUsabilityTests.swift */; };
 		2149E6CA238CA47500873955 /* AWSS3StoragePluginConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FEB7042375DA2200818CD2 /* AWSS3StoragePluginConfigurationTests.swift */; };
+		21635BE52678344B00CCE0A2 /* AWSS3StoragePluginPrefixKeyResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21635BE42678344B00CCE0A2 /* AWSS3StoragePluginPrefixKeyResolverTests.swift */; };
 		21A3EFC423A939D70095D8E6 /* AWSS3StoragePluginTests-credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = 21A3EFC323A939D70095D8E6 /* AWSS3StoragePluginTests-credentials.json */; };
 		21F40A3623A293DE0074678E /* AWSS3StoragePluginTests-amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21F40A3423A293DE0074678E /* AWSS3StoragePluginTests-amplifyconfiguration.json */; };
+		21FF4E38268B8F68009F5E5E /* AWSS3StoragePluginConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FF4E37268B8F68009F5E5E /* AWSS3StoragePluginConfiguration.swift */; };
+		21FF4E3B268B9920009F5E5E /* AWSS3PluginPrefixResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FF4E3A268B9920009F5E5E /* AWSS3PluginPrefixResolver.swift */; };
+		21FF4E3E268B9D78009F5E5E /* AWSS3PluginPrefixResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FF4E3D268B9D78009F5E5E /* AWSS3PluginPrefixResolverTests.swift */; };
+		21FF4E40268B9D8E009F5E5E /* AWSS3StoragePluginConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FF4E3F268B9D8E009F5E5E /* AWSS3StoragePluginConfigurationTests.swift */; };
 		4A615AC1A34E1BA883AE760F /* Pods_HostApp_AWSS3StoragePluginFunctionalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC784A86501873255662D8C7 /* Pods_HostApp_AWSS3StoragePluginFunctionalTests.framework */; };
 		81E7E9D6821EF0A560A93627 /* Pods_AWSS3StoragePlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B046927AA82214FE8EBAD505 /* Pods_AWSS3StoragePlugin.framework */; };
 		B478F64E2374DCE700C4F92B /* AWSS3StoragePlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B478F5FB2374DBF400C4F92B /* AWSS3StoragePlugin.framework */; };
@@ -146,8 +151,13 @@
 		1CC23DFF3F8AB7DF86A7A4C2 /* Pods-HostApp-AWSPinpointAnalyticsPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSPinpointAnalyticsPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSPinpointAnalyticsPluginTests/Pods-HostApp-AWSPinpointAnalyticsPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		2149E6B4238CA23900873955 /* AWSS3StoragePluginFunctionalTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSS3StoragePluginFunctionalTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2149E6B8238CA23900873955 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		21635BE42678344B00CCE0A2 /* AWSS3StoragePluginPrefixKeyResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3StoragePluginPrefixKeyResolverTests.swift; sourceTree = "<group>"; };
 		21A3EFC323A939D70095D8E6 /* AWSS3StoragePluginTests-credentials.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "AWSS3StoragePluginTests-credentials.json"; sourceTree = "<group>"; };
 		21F40A3423A293DE0074678E /* AWSS3StoragePluginTests-amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "AWSS3StoragePluginTests-amplifyconfiguration.json"; sourceTree = "<group>"; };
+		21FF4E37268B8F68009F5E5E /* AWSS3StoragePluginConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3StoragePluginConfiguration.swift; sourceTree = "<group>"; };
+		21FF4E3A268B9920009F5E5E /* AWSS3PluginPrefixResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3PluginPrefixResolver.swift; sourceTree = "<group>"; };
+		21FF4E3D268B9D78009F5E5E /* AWSS3PluginPrefixResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3PluginPrefixResolverTests.swift; sourceTree = "<group>"; };
+		21FF4E3F268B9D8E009F5E5E /* AWSS3StoragePluginConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3StoragePluginConfigurationTests.swift; sourceTree = "<group>"; };
 		27E93DA4BD82FC2FD4DF47FF /* Pods-HostApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp.debug.xcconfig"; path = "Target Support Files/Pods-HostApp/Pods-HostApp.debug.xcconfig"; sourceTree = "<group>"; };
 		2A7357AE068121E124484319 /* Pods_AWSS3StoragePlugin_AWSS3StoragePluginTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSS3StoragePlugin_AWSS3StoragePluginTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C4E592238332FBE98A8EFCC /* Pods_HostApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -319,10 +329,11 @@
 			children = (
 				B4FEB7092375DA2200818CD2 /* AWSS3StoragePluginAccessLevelTests.swift */,
 				B4FEB7082375DA2200818CD2 /* AWSS3StoragePluginBasicIntegrationTests.swift */,
-				FA106A3E261F9B2B00032EF8 /* AWSS3StoragePluginProgressTests.swift */,
 				B4FEB7042375DA2200818CD2 /* AWSS3StoragePluginConfigurationTests.swift */,
+				21635BE42678344B00CCE0A2 /* AWSS3StoragePluginPrefixKeyResolverTests.swift */,
 				B4FEB7072375DA2200818CD2 /* AWSS3StoragePluginNegativeTests.swift */,
 				B4FEB7052375DA2200818CD2 /* AWSS3StoragePluginOptionsUsabilityTests.swift */,
+				FA106A3E261F9B2B00032EF8 /* AWSS3StoragePluginProgressTests.swift */,
 				B4FEB7012375DA2200818CD2 /* AWSS3StoragePluginTestBase.swift */,
 				21F40A3423A293DE0074678E /* AWSS3StoragePluginTests-amplifyconfiguration.json */,
 				21A3EFC323A939D70095D8E6 /* AWSS3StoragePluginTests-credentials.json */,
@@ -331,6 +342,24 @@
 				B4FEB70A2375DA2200818CD2 /* ResumabilityTests */,
 			);
 			path = AWSS3StoragePluginFunctionalTests;
+			sourceTree = "<group>";
+		};
+		21FF4E39268B98FE009F5E5E /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				21FF4E3A268B9920009F5E5E /* AWSS3PluginPrefixResolver.swift */,
+				21FF4E37268B8F68009F5E5E /* AWSS3StoragePluginConfiguration.swift */,
+			);
+			path = Configuration;
+			sourceTree = "<group>";
+		};
+		21FF4E3C268B9D46009F5E5E /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				21FF4E3D268B9D78009F5E5E /* AWSS3PluginPrefixResolverTests.swift */,
+				21FF4E3F268B9D8E009F5E5E /* AWSS3StoragePluginConfigurationTests.swift */,
+			);
+			path = Configuration;
 			sourceTree = "<group>";
 		};
 		58AE86B816C1A3D8125AD432 /* Frameworks */ = {
@@ -441,6 +470,7 @@
 				B4FEB6692375DA0600818CD2 /* AWSS3StoragePlugin+ClientBehavior.swift */,
 				B4FEB66A2375DA0600818CD2 /* AWSS3StoragePlugin+Configure.swift */,
 				B4FEB6502375DA0600818CD2 /* AWSS3StoragePlugin+Reset.swift */,
+				21FF4E39268B98FE009F5E5E /* Configuration */,
 				B4FEB6532375DA0600818CD2 /* Dependency */,
 				B4FEB6482375DA0600818CD2 /* Operation */,
 				B4FEB66B2375DA0600818CD2 /* Request */,
@@ -530,12 +560,12 @@
 		B4FEB66B2375DA0600818CD2 /* Request */ = {
 			isa = PBXGroup;
 			children = (
-				B4FEB66C2375DA0600818CD2 /* StorageDownloadFileRequest+Validate.swift */,
 				B4FEB6702375DA0600818CD2 /* StorageDownloadDataRequest+Validate.swift */,
+				B4FEB66C2375DA0600818CD2 /* StorageDownloadFileRequest+Validate.swift */,
 				B4FEB6722375DA0600818CD2 /* StorageGetURLRequest+Validate.swift */,
 				B4FEB66F2375DA0600818CD2 /* StorageListRequest+Validate.swift */,
-				B4FEB66E2375DA0600818CD2 /* StorageUploadDataRequest+Validate.swift */,
 				B4FEB6712375DA0600818CD2 /* StorageRemoveRequest+Validate.swift */,
+				B4FEB66E2375DA0600818CD2 /* StorageUploadDataRequest+Validate.swift */,
 				B4FEB66D2375DA0600818CD2 /* StorageUploadFileRequest+Validate.swift */,
 			);
 			path = Request;
@@ -568,12 +598,13 @@
 		B4FEB6AA2375DA1500818CD2 /* AWSS3StoragePluginTests */ = {
 			isa = PBXGroup;
 			children = (
-				FA11225B24944BEB00492048 /* AWSS3StoragePluginBaseConfigTests.swift */,
 				FA1C820725868F46006160E9 /* AWSS3StoragePluginAmplifyVersionableTests.swift */,
+				FA11225B24944BEB00492048 /* AWSS3StoragePluginBaseConfigTests.swift */,
 				B4FEB6C12375DA1500818CD2 /* AWSS3StoragePluginClientBehaviorTests.swift */,
 				B4FEB6C02375DA1500818CD2 /* AWSS3StoragePluginConfigureTests.swift */,
 				B4FEB6BF2375DA1500818CD2 /* AWSS3StoragePluginResetTests.swift */,
 				B4FEB6BC2375DA1500818CD2 /* AWSS3StoragePluginTestBase.swift */,
+				21FF4E3C268B9D46009F5E5E /* Configuration */,
 				B4FEB6AB2375DA1500818CD2 /* Mocks */,
 				B4FEB6B12375DA1500818CD2 /* Operation */,
 				B4FEB6C72375DA1500818CD2 /* Request */,
@@ -1124,6 +1155,7 @@
 				2149E6C9238CA47500873955 /* AWSS3StoragePluginOptionsUsabilityTests.swift in Sources */,
 				2149E6C6238CA47500873955 /* AWSS3StoragePluginBasicIntegrationTests.swift in Sources */,
 				2149E6C8238CA47500873955 /* AWSS3StoragePluginAccessLevelTests.swift in Sources */,
+				21635BE52678344B00CCE0A2 /* AWSS3StoragePluginPrefixKeyResolverTests.swift in Sources */,
 				2149E6C5238CA46B00873955 /* AWSS3StoragePluginTestBase.swift in Sources */,
 				2139A2402390688300A9AC4D /* AWSS3StoragePluginPutDataResumabilityTests.swift in Sources */,
 				FA106A3F261F9B2B00032EF8 /* AWSS3StoragePluginProgressTests.swift in Sources */,
@@ -1160,6 +1192,7 @@
 				B4FEB6852375DA0600818CD2 /* AWSS3StoragePlugin+Reset.swift in Sources */,
 				B4FEB6832375DA0600818CD2 /* AWSS3StorageRemoveOperation.swift in Sources */,
 				B4FEB69C2375DA0600818CD2 /* StorageUploadDataRequest+Validate.swift in Sources */,
+				21FF4E3B268B9920009F5E5E /* AWSS3PluginPrefixResolver.swift in Sources */,
 				B4FEB6992375DA0600818CD2 /* AWSS3StoragePlugin+Configure.swift in Sources */,
 				B4FEB6A42375DA0600818CD2 /* AWSS3StorageService+GetPreSignedURLBehavior.swift in Sources */,
 				B4FEB67F2375DA0600818CD2 /* AWSS3StorageUploadFileOperation.swift in Sources */,
@@ -1180,6 +1213,7 @@
 				B4FEB6A52375DA0600818CD2 /* AWSS3StorageServiceBehaviour.swift in Sources */,
 				B4FEB6A12375DA0600818CD2 /* AWSS3StorageService+UploadBehavior.swift in Sources */,
 				B4FEB6A72375DA0600818CD2 /* AWSS3StorageService+DownloadBehavior.swift in Sources */,
+				21FF4E38268B8F68009F5E5E /* AWSS3StoragePluginConfiguration.swift in Sources */,
 				B4FEB6922375DA0600818CD2 /* StorageOperationReference.swift in Sources */,
 				B4FEB69B2375DA0600818CD2 /* StorageUploadFileRequest+Validate.swift in Sources */,
 			);
@@ -1222,9 +1256,11 @@
 				B4FEB6E32375DA1500818CD2 /* AWSS3StorageDownloadFileOperationTests.swift in Sources */,
 				B4FEB6DE2375DA1500818CD2 /* MockAWSS3PreSignedURLBuilder.swift in Sources */,
 				B4FEB6FB2375DA1600818CD2 /* AWSS3StorageServiceListBehaviorTests.swift in Sources */,
+				21FF4E3E268B9D78009F5E5E /* AWSS3PluginPrefixResolverTests.swift in Sources */,
 				B4FEB6EF2375DA1500818CD2 /* StorageRequestUtilsTests.swift in Sources */,
 				B4FEB6F42375DA1600818CD2 /* AWSS3StorageDownloadFileRequestTests.swift in Sources */,
 				B4FEB6F02375DA1600818CD2 /* AWSS3StorageGetURLRequestTests.swift in Sources */,
+				21FF4E40268B9D8E009F5E5E /* AWSS3StoragePluginConfigurationTests.swift in Sources */,
 				FA1C820825868F46006160E9 /* AWSS3StoragePluginAmplifyVersionableTests.swift in Sources */,
 				B4FEB6E22375DA1500818CD2 /* AWSS3StorageGetDataOperationTests.swift in Sources */,
 			);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
**What is changing?**
This PR introduces a mechanism to provide a prefix resolver for S3 requests when performing storage APIs. Currently the storage request (`StorageAccessLevel`, targetIdentityId) is used to perform S3 prefix resolution and maps closely with the Amplify CLI configured S3 bucket policies (https://docs.amplify.aws/lib/storage/configureaccess/q/platform/ios). This allows a hook into the plugin for developers to provide their own logic for resolving the the prefix string.

**Why are we introducing this change?**
1. We have seen customer requests to allow them to change the prefix added by the plugin to align with their own S3 bucket rules
  a. iOS Issue: https://github.com/aws-amplify/amplify-ios/issues/916
  b. Android Issue: https://github.com/aws-amplify/amplify-android/issues/910
  c. Flutter Issue: https://github.com/aws-amplify/amplify-flutter/issues/416

2. JS has a similar mechanism (https://docs.amplify.aws/lib/storage/configureaccess/q/platform/js#customization)

3. CLI provides the ability to import their own S3 bucket. This allows developers to successfully use the plugin by making use of the mechanism to provide their own prefixes prepended to the key to make requests to S3. (https://docs.amplify.aws/cli/storage/import)

**Who is impacted?**
Developers who have a S3 bucket with existing IAM policies will be unblocked to use the plugin to provide their own prefix resolution.

**What do I have to do?**
Define your custom prefix resolution logic
```swift
struct DeveloperDefinedPrefixKeyResolver: AWSS3PluginPrefixResolver {
      func resolvePrefix(for accessLevel: StorageAccessLevel,
                         targetIdentityId: String?) -> Result<String, StorageError> {
          switch accessLevel {
          case .guest:
              return .success("customPublic/")
          case .protected:
              return .success("customProtected/")
          case .private:
              return .failure(.configuration("`.private` StorageAccessLevel is not used", "", nil))
          }
      }
  }
```

or if you are performing operations to the S3 root, create one like:
```swift
public func resolvePrefix(for accessLevel: StorageAccessLevel,
                          targetIdentityId: String?) -> Result<String, StorageError> {
    return .success("")
}
```

Then pass the resolver when configuring the plugin
```swift
Amplify.add(plugin: AWSS3StoragePlugin(
                                configuration: .prefixResolver(DeveloperDefinedPrefixKeyResolver())))
```

*Check points:*

- [x] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [x] All integration tests pass
- [x] Documentation update for the change if required (https://github.com/aws-amplify/docs/pull/3321)
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
