### PR TITLE
fix: GraphQLBuilder use model name from schema instead of model

### DIFF
--- a/Amplify/Categories/Analytics/AnalyticsCategory+HubPayloadEventName.swift
+++ b/Amplify/Categories/Analytics/AnalyticsCategory+HubPayloadEventName.swift
@@ -6,7 +6,7 @@
 //
 
 public extension HubPayload.EventName {
-    
+
     /// Analytics hub events
     struct Analytics { }
 }

--- a/Amplify/Categories/Analytics/AnalyticsCategoryConfiguration.swift
+++ b/Amplify/Categories/Analytics/AnalyticsCategoryConfiguration.swift
@@ -11,7 +11,7 @@ import Foundation
 public struct AnalyticsCategoryConfiguration: CategoryConfiguration {
     /// Plugins
     public let plugins: [String: JSONValue]
-    
+
     /// Initializer
     /// - Parameter plugins: Plugins
     public init(plugins: [String: JSONValue] = [:]) {

--- a/Amplify/Categories/Analytics/AnalyticsProfile.swift
+++ b/Amplify/Categories/Analytics/AnalyticsProfile.swift
@@ -24,7 +24,7 @@ public struct AnalyticsUserProfile {
 
     /// Properties of the user profile
     public var properties: AnalyticsProperties?
-    
+
     /// Initializer
     /// - Parameters:
     ///   - name: Name of user
@@ -49,10 +49,10 @@ extension AnalyticsUserProfile {
 
     /// Location specific data
     public struct Location {
-        
+
         /// The user's latitude
         public var latitude: Double?
-        
+
         /// The user's longitude
         public var longitude: Double?
 

--- a/Amplify/Categories/Analytics/Error/AnalyticsError.swift
+++ b/Amplify/Categories/Analytics/Error/AnalyticsError.swift
@@ -45,7 +45,7 @@ extension AnalyticsError: AmplifyError {
             return error
         }
     }
-    
+
     /// Initializer
     /// - Parameters:
     ///   - errorDescription: Error Description

--- a/Amplify/Categories/Analytics/Event/BasicAnalyticsEvent.swift
+++ b/Amplify/Categories/Analytics/Event/BasicAnalyticsEvent.swift
@@ -15,7 +15,7 @@ public struct BasicAnalyticsEvent: AnalyticsEvent {
 
     /// Properties of the event
     public var properties: AnalyticsProperties?
-    
+
     /// Initializer
     /// - Parameters:
     ///   - name: The name of the event

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Configuration/AWSAuthorizationConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Configuration/AWSAuthorizationConfiguration.swift
@@ -47,8 +47,8 @@ extension AWSAuthorizationConfiguration {
             let config = APIKeyConfiguration(apiKey: apiKey)
             return .apiKey(config)
     }
-    
-    
+
+
     /// Instantiates a new configuration conforming to AWSAuthorizationConfiguration
     /// - Parameters:
     ///   - authType: authentication type

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -114,7 +114,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                       modelSchema: ModelSchema,
                                       where filter: GraphQLFilter? = nil,
                                       version: Int? = nil) -> GraphQLRequest<MutationSyncResult> {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: model.modelName, operationType: .mutation)
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: modelSchema.name, operationType: .mutation)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .delete))
         documentBuilder.add(decorator: ModelIdDecorator(model: model))
         if let filter = filter {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The issue on flutter side shows that getting the name from the model is not working as expected:
```
AWSPluginsCore/ModelBasedGraphQLDocumentBuilder.swift:20: Fatal error: Missing ModelSchema in ModelRegistry for model name: FlutterSerializedModel
```

This changes the code in the delete mutation path to be the same as the create/update mutation,  that gets the modelName from the schema, ie. `modelSchema.name` instead of `model.modelName`
*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
