### PR TITLE
fix(DataStore): dynamic model support for cascade delete

### DIFF
--- a/Amplify/Categories/DataStore/Subscribe/MutationEvent+Model.swift
+++ b/Amplify/Categories/DataStore/Subscribe/MutationEvent+Model.swift
@@ -15,12 +15,21 @@ extension MutationEvent {
             throw dataStoreError
         }
 
+        try self.init(untypedModel: model,
+                      modelName: modelType.schema.name,
+                      mutationType: mutationType,
+                      version: version)
+    }
+  
+    public init(untypedModel model: Model,
+                modelName: ModelName,
+                mutationType: MutationType,
+                version: Int? = nil) throws {
         let json = try model.toJSON()
         self.init(modelId: model.id,
-                  modelName: modelType.schema.name,
+                  modelName: modelName,
                   json: json,
                   mutationType: mutationType,
                   version: version)
     }
-
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Statement+AnyModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Statement+AnyModel.swift
@@ -10,20 +10,20 @@ import SQLite
 import Foundation
 
 extension Statement {
-    func convert(toUntypedModel modelSchema: ModelSchema,
-                 using statement: SelectStatement) throws -> [Model] {
+    func convertToUntypedModel(using modelSchema: ModelSchema,
+                               statement: SelectStatement) throws -> [Model] {
         var models = [Model]()
 
         for row in self {
-            let modelValues = try convert(row: row, to: modelSchema, using: statement)
-            let untypedModel = try convert(toAnyModel: modelSchema, modelDictionary: modelValues)
+            let modelValues = try convert(row: row, withSchema: modelSchema, using: statement)
+            let untypedModel = try convertToAnyModel(using: modelSchema, modelDictionary: modelValues)
             models.append(untypedModel)
         }
 
         return models
     }
 
-    private func convert(toAnyModel modelSchema: ModelSchema, modelDictionary: ModelValues) throws -> Model {
+    private func convertToAnyModel(using modelSchema: ModelSchema, modelDictionary: ModelValues) throws -> Model {
         let data = try JSONSerialization.data(withJSONObject: modelDictionary)
         guard let jsonString = String(data: data, encoding: .utf8) else {
             let error = DataStoreError.decodingError(

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Statement+AnyModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Statement+AnyModel.swift
@@ -10,20 +10,20 @@ import SQLite
 import Foundation
 
 extension Statement {
-    func convert(toUntypedModel modelType: Model.Type,
+    func convert(toUntypedModel modelSchema: ModelSchema,
                  using statement: SelectStatement) throws -> [Model] {
         var models = [Model]()
 
         for row in self {
-            let modelValues = try convert(row: row, to: modelType, using: statement)
-            let untypedModel = try convert(toAnyModel: modelType, modelDictionary: modelValues)
+            let modelValues = try convert(row: row, to: modelSchema, using: statement)
+            let untypedModel = try convert(toAnyModel: modelSchema, modelDictionary: modelValues)
             models.append(untypedModel)
         }
 
         return models
     }
 
-    private func convert(toAnyModel modelType: Model.Type, modelDictionary: ModelValues) throws -> Model {
+    private func convert(toAnyModel modelSchema: ModelSchema, modelDictionary: ModelValues) throws -> Model {
         let data = try JSONSerialization.data(withJSONObject: modelDictionary)
         guard let jsonString = String(data: data, encoding: .utf8) else {
             let error = DataStoreError.decodingError(
@@ -36,7 +36,7 @@ extension Statement {
             throw error
         }
 
-        let instance = try ModelRegistry.decode(modelName: modelType.modelName, from: jsonString)
+        let instance = try ModelRegistry.decode(modelName: modelSchema.name, from: jsonString)
         return instance
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Statement+Model.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Statement+Model.swift
@@ -40,7 +40,7 @@ protocol StatementModelConvertible {
     ///   - statement - the query executed that generated this result
     /// - Returns: an array of `Model` of the specified type
     func convert<M: Model>(to modelType: M.Type,
-                           modelSchema: ModelSchema,
+                           withSchema modelSchema: ModelSchema,
                            using statement: SelectStatement) throws -> [M]
 
 }
@@ -53,13 +53,13 @@ extension Statement: StatementModelConvertible {
     }
 
     func convert<M: Model>(to modelType: M.Type,
-                           modelSchema: ModelSchema,
+                           withSchema modelSchema: ModelSchema,
                            using statement: SelectStatement) throws -> [M] {
         var elements: [ModelValues] = []
 
         // parse each row of the result
         for row in self {
-            let modelDictionary = try convert(row: row, to: modelSchema, using: statement)
+            let modelDictionary = try convert(row: row, withSchema: modelSchema, using: statement)
             elements.append(modelDictionary)
         }
 
@@ -69,7 +69,7 @@ extension Statement: StatementModelConvertible {
     }
 
     func convert(row: Element,
-                 to modelSchema: ModelSchema,
+                 withSchema modelSchema: ModelSchema,
                  using statement: SelectStatement) throws -> ModelValues {
         let columnMapping = statement.metadata.columnMapping
         let modelDictionary = ([:] as ModelValues).mutableCopy()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Statement+Model.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Statement+Model.swift
@@ -36,9 +36,11 @@ protocol StatementModelConvertible {
     ///
     /// - Parameters:
     ///   - modelType - the target `Model` type
+    ///   - modelSchema - the schema for `Model`
     ///   - statement - the query executed that generated this result
     /// - Returns: an array of `Model` of the specified type
     func convert<M: Model>(to modelType: M.Type,
+                           modelSchema: ModelSchema,
                            using statement: SelectStatement) throws -> [M]
 
 }
@@ -51,12 +53,13 @@ extension Statement: StatementModelConvertible {
     }
 
     func convert<M: Model>(to modelType: M.Type,
+                           modelSchema: ModelSchema,
                            using statement: SelectStatement) throws -> [M] {
         var elements: [ModelValues] = []
 
         // parse each row of the result
         for row in self {
-            let modelDictionary = try convert(row: row, to: modelType, using: statement)
+            let modelDictionary = try convert(row: row, to: modelSchema, using: statement)
             elements.append(modelDictionary)
         }
 
@@ -66,7 +69,7 @@ extension Statement: StatementModelConvertible {
     }
 
     func convert(row: Element,
-                 to modelType: Model.Type,
+                 to modelSchema: ModelSchema,
                  using statement: SelectStatement) throws -> ModelValues {
         let columnMapping = statement.metadata.columnMapping
         let modelDictionary = ([:] as ModelValues).mutableCopy()
@@ -75,7 +78,7 @@ extension Statement: StatementModelConvertible {
             guard let (schema, field) = columnMapping[column] else {
                 logger.debug("""
                 A column named \(column) was found in the result set but no field on
-                \(modelType.modelName) could be found with that name and it will be ignored.
+                \(modelSchema.name) could be found with that name and it will be ignored.
                 """)
                 continue
             }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -233,7 +233,9 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
                                             sort: sort,
                                             paginationInput: paginationInput)
             let rows = try connection.prepare(statement.stringValue).run(statement.variables)
-            let result: [M] = try rows.convert(to: modelType, using: statement)
+            let result: [M] = try rows.convert(to: modelType,
+                                               modelSchema: modelSchema,
+                                               using: statement)
             completion(.success(result))
         } catch {
             completion(.failure(causedBy: error))
@@ -286,6 +288,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
         let rows = try connection.prepare(sql).bind(ids)
 
         let syncMetadataList = try rows.convert(to: MutationSyncMetadata.self,
+                                                modelSchema: MutationSyncMetadata.schema,
                                                 using: statement)
         let mutationSyncList = try syncMetadataList.map { syncMetadata -> MutationSync<AnyModel> in
             guard let model = modelById[syncMetadata.id] else {
@@ -304,6 +307,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
 
     func queryMutationSyncMetadata(for modelIds: [Model.Identifier]) throws -> [MutationSyncMetadata] {
         let modelType = MutationSyncMetadata.self
+        let modelSchema = MutationSyncMetadata.schema
         let fields = MutationSyncMetadata.keys
         var results = [MutationSyncMetadata]()
         let chunkedModelIdsArr = modelIds.chunked(into: SQLiteStorageEngineAdapter.maxNumberOfPredicates)
@@ -313,9 +317,10 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
                 queryPredicates.append(QueryPredicateOperation(field: fields.id.stringValue, operator: .equals(id)))
             }
             let groupedQueryPredicates = QueryPredicateGroup(type: .or, predicates: queryPredicates)
-            let statement = SelectStatement(from: modelType.schema, predicate: groupedQueryPredicates)
+            let statement = SelectStatement(from: modelSchema, predicate: groupedQueryPredicates)
             let rows = try connection.prepare(statement.stringValue).run(statement.variables)
             let result = try rows.convert(to: modelType,
+                                          modelSchema: modelSchema,
                                           using: statement)
             results.append(contentsOf: result)
         }
@@ -327,6 +332,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
                                         predicate: field("id").eq(modelSchema.name))
         let rows = try connection.prepare(statement.stringValue).run(statement.variables)
         let result = try rows.convert(to: ModelSyncMetadata.self,
+                                      modelSchema: ModelSyncMetadata.schema,
                                       using: statement)
         return try result.unique()
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -234,7 +234,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
                                             paginationInput: paginationInput)
             let rows = try connection.prepare(statement.stringValue).run(statement.variables)
             let result: [M] = try rows.convert(to: modelType,
-                                               modelSchema: modelSchema,
+                                               withSchema: modelSchema,
                                                using: statement)
             completion(.success(result))
         } catch {
@@ -288,7 +288,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
         let rows = try connection.prepare(sql).bind(ids)
 
         let syncMetadataList = try rows.convert(to: MutationSyncMetadata.self,
-                                                modelSchema: MutationSyncMetadata.schema,
+                                                withSchema: MutationSyncMetadata.schema,
                                                 using: statement)
         let mutationSyncList = try syncMetadataList.map { syncMetadata -> MutationSync<AnyModel> in
             guard let model = modelById[syncMetadata.id] else {
@@ -320,7 +320,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
             let statement = SelectStatement(from: modelSchema, predicate: groupedQueryPredicates)
             let rows = try connection.prepare(statement.stringValue).run(statement.variables)
             let result = try rows.convert(to: modelType,
-                                          modelSchema: modelSchema,
+                                          withSchema: modelSchema,
                                           using: statement)
             results.append(contentsOf: result)
         }
@@ -332,7 +332,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
                                         predicate: field("id").eq(modelSchema.name))
         let rows = try connection.prepare(statement.stringValue).run(statement.variables)
         let result = try rows.convert(to: ModelSyncMetadata.self,
-                                      modelSchema: ModelSyncMetadata.schema,
+                                      withSchema: ModelSyncMetadata.schema,
                                       using: statement)
         return try result.unique()
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
@@ -43,13 +43,13 @@ extension SQLiteStorageEngineAdapter {
         }
     }
 
-    func query(untypedModel modelType: Model.Type,
+    func query(modelSchema: ModelSchema,
                predicate: QueryPredicate? = nil,
                completion: DataStoreCallback<[Model]>) {
         do {
-            let statement = SelectStatement(from: modelType.schema, predicate: predicate)
+            let statement = SelectStatement(from: modelSchema, predicate: predicate)
             let rows = try connection.prepare(statement.stringValue).run(statement.variables)
-            let result: [Model] = try rows.convert(toUntypedModel: modelType, using: statement)
+            let result: [Model] = try rows.convert(toUntypedModel: modelSchema, using: statement)
             completion(.success(result))
         } catch {
             completion(.failure(causedBy: error))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
@@ -49,7 +49,7 @@ extension SQLiteStorageEngineAdapter {
         do {
             let statement = SelectStatement(from: modelSchema, predicate: predicate)
             let rows = try connection.prepare(statement.stringValue).run(statement.variables)
-            let result: [Model] = try rows.convert(toUntypedModel: modelSchema, using: statement)
+            let result: [Model] = try rows.convertToUntypedModel(using: modelSchema, statement: statement)
             completion(.success(result))
         } catch {
             completion(.failure(causedBy: error))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+DeleteTransaction.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+DeleteTransaction.swift
@@ -32,10 +32,10 @@ extension StorageEngine {
 
     func queryAndDeleteTransaction<M: Model>(_ modelType: M.Type,
                                              modelSchema: ModelSchema,
-                                             deleteInput: DeleteInput) -> DataStoreResult<([M], [Model])> {
+                                             deleteInput: DeleteInput) -> DataStoreResult<([M], [ModelName: [Model]])> {
         var queriedResult: DataStoreResult<[M]>?
         var deletedResult: DataStoreResult<[M]>?
-        var associatedModels: [Model] = []
+        var associatedModels: [(ModelName, Model)] = []
 
         let queryCompletionBlock: DataStoreCallback<[M]> = { queryResult in
             queriedResult = queryResult
@@ -93,11 +93,11 @@ extension StorageEngine {
 
         return collapseResults(queryResult: queriedResult,
                                deleteResult: deletedResult,
-                               associatedModels: associatedModels)
+                               associatedModelsMap: getAssociatedModelsMap(associatedModels: associatedModels))
     }
 
-    func recurseQueryAssociatedModels(modelSchema: ModelSchema, ids: [Model.Identifier]) -> [Model] {
-        var associatedModels: [Model] = []
+    func recurseQueryAssociatedModels(modelSchema: ModelSchema, ids: [Model.Identifier]) -> [(ModelName, Model)] {
+        var associatedModels: [(ModelName, Model)] = []
         for (_, modelField) in modelSchema.fields {
             guard modelField.hasAssociation,
                 modelField.isOneToOne || modelField.isOneToMany,
@@ -109,20 +109,23 @@ extension StorageEngine {
             let queriedModels = queryAssociatedModels(modelName: associatedModelName,
                                                       associatedField: associatedField,
                                                       ids: ids)
-            let associatedModelIds = queriedModels.map {$0.id}
+            let associatedModelIds = queriedModels.map { $0.1.id }
             associatedModels.append(contentsOf: queriedModels)
-            associatedModels.append(contentsOf: recurseQueryAssociatedModels(modelSchema: associatedModelSchema, ids: associatedModelIds))
+            associatedModels.append(contentsOf: recurseQueryAssociatedModels(modelSchema: associatedModelSchema,
+                                                                            ids: associatedModelIds))
         }
         return associatedModels
     }
 
-    func queryAssociatedModels(modelName: ModelName, associatedField: ModelField, ids: [Model.Identifier]) -> [Model] {
-        guard let modelType = ModelRegistry.modelType(from: modelName) else {
+    func queryAssociatedModels(modelName: ModelName,
+                               associatedField: ModelField,
+                               ids: [Model.Identifier]) -> [(ModelName, Model)] {
+        guard let modelSchema = ModelRegistry.modelSchema(from: modelName) else {
             log.error("Failed to lookup \(modelName)")
             return []
         }
 
-        var queriedModels: [Model] = []
+        var queriedModels: [(ModelName, Model)] = []
         let chunkedArrays = ids.chunked(into: SQLiteStorageEngineAdapter.maxNumberOfPredicates)
         for chunkedArray in chunkedArrays {
             // TODO: Add conveinence to queryPredicate where we have a list of items, to be all or'ed
@@ -130,19 +133,20 @@ extension StorageEngine {
             for id in chunkedArray {
                 queryPredicates.append(QueryPredicateOperation(field: associatedField.name, operator: .equals(id)))
             }
-            let groupedQueryPredicates =  QueryPredicateGroup(type: .or, predicates: queryPredicates)
+            let groupedQueryPredicates = QueryPredicateGroup(type: .or, predicates: queryPredicates)
 
             let sempahore = DispatchSemaphore(value: 0)
-            storageAdapter.query(untypedModel: modelType, predicate: groupedQueryPredicates) { result in
+            storageAdapter.query(modelSchema: modelSchema, predicate: groupedQueryPredicates) { result in
                 defer {
                     sempahore.signal()
                 }
                 switch result {
                 case .success(let models):
-                    queriedModels.append(contentsOf: models)
-
+                    queriedModels.append(contentsOf: models.map { model in
+                        (modelName, model)
+                    })
                 case .failure(let error):
-                    log.error("Failed to query \(modelType) on mutation event generation: \(error)")
+                    log.error("Failed to query \(modelSchema) on mutation event generation: \(error)")
                 }
             }
             sempahore.wait()
@@ -150,16 +154,31 @@ extension StorageEngine {
         return queriedModels
     }
 
+    private func getAssociatedModelsMap(associatedModels: [(ModelName, Model)]) -> [ModelName: [Model]] {
+        var associatedModelsMap = [ModelName: [Model]]()
+        for associatedModel in associatedModels {
+            let modelName = associatedModel.0
+            let model = associatedModel.1
+            if var models = associatedModelsMap[modelName] {
+                models.append(model)
+                associatedModelsMap.updateValue(models, forKey: modelName)
+            } else {
+                associatedModelsMap.updateValue([model], forKey: modelName)
+            }
+        }
+        return associatedModelsMap
+    }
+
     private func collapseResults<M: Model>(queryResult: DataStoreResult<[M]>?,
                                            deleteResult: DataStoreResult<[M]>?,
-                                           associatedModels: [Model]) -> DataStoreResult<([M], [Model])> {
+                                           associatedModelsMap: [ModelName: [Model]]) -> DataStoreResult<([M], [ModelName: [Model]])> {
         if let queryResult = queryResult {
             switch queryResult {
             case .success(let models):
                 if let deleteResult = deleteResult {
                     switch deleteResult {
                     case .success:
-                        return .success((models, associatedModels))
+                        return .success((models, associatedModelsMap))
                     case .failure(let error):
                         return .failure(error)
                     }
@@ -174,7 +193,7 @@ extension StorageEngine {
         }
     }
 
-    func collapseMResult<M: Model>(_ result: DataStoreResult<([M], [Model])>) -> DataStoreResult<[M]> {
+    func collapseMResult<M: Model>(_ result: DataStoreResult<([M], [ModelName: [Model]])>) -> DataStoreResult<[M]> {
         switch result {
         case .success(let results):
             return .success(results.0)
@@ -183,12 +202,13 @@ extension StorageEngine {
         }
     }
 
-    func resolveAssociatedModels<M: Model>(_ result: DataStoreResult<([M], [Model])>) -> [Model] {
+    func resolveAssociatedModels<M: Model>(
+        _ result: DataStoreResult<([M], [ModelName: [Model]])>) -> [ModelName: [Model]] {
         switch result {
         case .success(let results):
             return results.1
         case .failure:
-            return []
+            return [:]
         }
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+DeleteTransaction.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+DeleteTransaction.swift
@@ -156,15 +156,8 @@ extension StorageEngine {
 
     private func getAssociatedModelsMap(associatedModels: [(ModelName, Model)]) -> [ModelName: [Model]] {
         var associatedModelsMap = [ModelName: [Model]]()
-        for associatedModel in associatedModels {
-            let modelName = associatedModel.0
-            let model = associatedModel.1
-            if var models = associatedModelsMap[modelName] {
-                models.append(model)
-                associatedModelsMap.updateValue(models, forKey: modelName)
-            } else {
-                associatedModelsMap.updateValue([model], forKey: modelName)
-            }
+        for (modelName, model) in associatedModels {
+            associatedModelsMap[modelName, default: []].append(model)
         }
         return associatedModelsMap
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -386,7 +386,7 @@ final class StorageEngine: StorageEngineBehavior {
                                          modelSchema: ModelSchema,
                                          withModels models: [M],
                                          predicate: QueryPredicate? = nil,
-                                         associatedModels: [Model],
+                                         associatedModels: [ModelName: [Model]],
                                          syncEngine: RemoteSyncEngineBehavior,
                                          completion: @escaping DataStoreCallback<Void>) {
         var graphQLFilterJSON: String?
@@ -443,11 +443,11 @@ final class StorageEngine: StorageEngineBehavior {
     }
 
     @available(iOS 13.0, *)
-    private func syncDeletions(of associatedModels: [Model],
+    private func syncDeletions(of associatedModelsMap: [ModelName: [Model]],
                                syncEngine: RemoteSyncEngineBehavior,
                                dataStoreError: DataStoreError?,
                                completion: @escaping DataStoreCallback<Void>) {
-        guard !associatedModels.isEmpty else {
+        guard !associatedModelsMap.isEmpty else {
             if let savedDataStoreError = dataStoreError {
                 completion(.failure(savedDataStoreError))
             } else {
@@ -457,42 +457,48 @@ final class StorageEngine: StorageEngineBehavior {
         }
 
         var mutationEventsSubmitCompleted = 0
+        let associatedModelsCount = associatedModelsMap.values.reduce(0) { totalCount, models in
+            totalCount + models.count
+        }
         var savedDataStoreError = dataStoreError
+        for (modelName, associatedModels) in associatedModelsMap {
+            for associatedModel in associatedModels {
+                let mutationEvent: MutationEvent
+                do {
+                    mutationEvent = try MutationEvent(untypedModel: associatedModel,
+                                                      modelName: modelName,
+                                                      mutationType: .delete)
+                } catch {
+                    let dataStoreError = DataStoreError(error: error)
+                    completion(.failure(dataStoreError))
+                    return
+                }
 
-        for associatedModel in associatedModels {
-            let mutationEvent: MutationEvent
-            do {
-                mutationEvent = try MutationEvent(untypedModel: associatedModel, mutationType: .delete)
-            } catch {
-                let dataStoreError = DataStoreError(error: error)
-                completion(.failure(dataStoreError))
-                return
-            }
-
-            let mutationEventCallback: DataStoreCallback<MutationEvent> = { result in
-                self.serialQueueSyncDeletions.async {
-                    mutationEventsSubmitCompleted += 1
-                    switch result {
-                    case .failure(let dataStoreError):
-                        self.log.error("\(#function) failed to submit to sync engine \(mutationEvent)")
-                        if savedDataStoreError == nil {
-                            savedDataStoreError = dataStoreError
+                let mutationEventCallback: DataStoreCallback<MutationEvent> = { result in
+                    self.serialQueueSyncDeletions.async {
+                        mutationEventsSubmitCompleted += 1
+                        switch result {
+                        case .failure(let dataStoreError):
+                            self.log.error("\(#function) failed to submit to sync engine \(mutationEvent)")
+                            if savedDataStoreError == nil {
+                                savedDataStoreError = dataStoreError
+                            }
+                        case .success(let mutationEvent):
+                            self.log.verbose("\(#function) successfully submitted to sync engine \(mutationEvent)")
                         }
-                    case .success(let mutationEvent):
-                        self.log.verbose("\(#function) successfully submitted to sync engine \(mutationEvent)")
-                    }
-                    if mutationEventsSubmitCompleted == associatedModels.count {
-                        if let lastEmittedDataStoreError = savedDataStoreError {
-                            completion(.failure(lastEmittedDataStoreError))
-                        } else {
-                            completion(.successfulVoid)
+                        if mutationEventsSubmitCompleted == associatedModelsCount {
+                            if let lastEmittedDataStoreError = savedDataStoreError {
+                                completion(.failure(lastEmittedDataStoreError))
+                            } else {
+                                completion(.successfulVoid)
+                            }
                         }
                     }
                 }
+                submitToSyncEngine(mutationEvent: mutationEvent,
+                                   syncEngine: syncEngine,
+                                   completion: mutationEventCallback)
             }
-            submitToSyncEngine(mutationEvent: mutationEvent,
-                               syncEngine: syncEngine,
-                               completion: mutationEventCallback)
         }
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -33,7 +33,7 @@ protocol StorageEngineAdapter: class, ModelStorageBehavior {
                           predicate: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>)
 
-    func query(untypedModel modelType: Model.Type,
+    func query(modelSchema: ModelSchema,
                predicate: QueryPredicate?,
                completion: DataStoreCallback<[Model]>)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/StorageEngineTestsBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/StorageEngineTestsBase.swift
@@ -95,7 +95,7 @@ class StorageEngineTestsBase: XCTestCase {
     func deleteModelSynchronous<M: Model>(modelType: M.Type,
                                           withId id: String,
                                           where predicate: QueryPredicate? = nil,
-                                          timeout: TimeInterval = 1) -> DataStoreResult<M?> {
+                                          timeout: TimeInterval = 10) -> DataStoreResult<M?> {
         let deleteFinished = expectation(description: "Delete Finished")
         var result: DataStoreResult<M?>?
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionWithJSONModelTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionWithJSONModelTests.swift
@@ -315,4 +315,106 @@ class LocalSubscriptionWithJSONModelTests: XCTestCase {
 
         subscription.cancel()
     }
+
+    /// - Given: A configured DataStore, with post and comment
+    /// - When:
+    ///    - I subscribe to model events
+    ///    - Delete the post. This will cascade delete the comments as well
+    /// - Then:
+    ///    - I am notified of `delete` mutations of the post and comments deleted
+    func testDeletePostShouldDeleteComments() {
+        let receivedPostMutationEvent = expectation(description: "Received post delete mutation event")
+
+        let subscriptionPost = dataStorePlugin.publisher(for: "Post").sink(
+            receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    XCTFail("Unexpected error: \(error)")
+                case .finished:
+                    break
+                }
+            }, receiveValue: { mutationEvent in
+                if mutationEvent.mutationType == MutationEvent.MutationType.delete.rawValue {
+                    receivedPostMutationEvent.fulfill()
+                }
+            })
+
+        let title = "a title"
+        let content = "some content"
+        let createdAt = Temporal.DateTime.now().iso8601String
+        let post = ["title": .string(title),
+                    "content": .string(content),
+                    "createdAt": .string(createdAt)] as [String: JSONValue]
+        let model = DynamicModel(values: post)
+        let postSchema = ModelRegistry.modelSchema(from: "Post")!
+        let savedPost = expectation(description: "post saved")
+        dataStorePlugin.save(model, modelSchema: postSchema) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("\(error)")
+            case .success(let model):
+                print(model)
+                savedPost.fulfill()
+            }
+        }
+        wait(for: [savedPost], timeout: 1.0)
+
+        let commentContent = "some content"
+        let comment = ["content": .string(commentContent),
+                       "createdAt": .string(createdAt),
+                       "post": .object(model.values)] as [String: JSONValue]
+        let commentModel = DynamicModel(values: comment)
+        let commentSchema = ModelRegistry.modelSchema(from: "Comment")!
+        let savedComment = expectation(description: "comment saved")
+        dataStorePlugin.save(commentModel, modelSchema: commentSchema) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("\(error)")
+            case .success(let model):
+                print(model)
+                savedComment.fulfill()
+            }
+        }
+        wait(for: [savedComment], timeout: 1.0)
+
+        let queryCommentSuccess = expectation(description: "querying for comment should exist")
+        dataStorePlugin.query(DynamicModel.self,
+                              modelSchema: commentSchema,
+                              where: DynamicModel.keys.id == commentModel.id) { result in
+            switch result {
+            case .success(let comments):
+                XCTAssertEqual(comments.count, 1)
+                queryCommentSuccess.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [queryCommentSuccess], timeout: 10.0)
+
+        let deletePostSuccess = expectation(description: "deleted post successfully")
+        dataStorePlugin.delete(model, modelSchema: postSchema) { result in
+            switch result {
+            case .success:
+                deletePostSuccess.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [receivedPostMutationEvent, deletePostSuccess], timeout: 10.0)
+        subscriptionPost.cancel()
+
+        let queryCommentEmpty = expectation(description: "querying for comment should be empty")
+        dataStorePlugin.query(DynamicModel.self,
+                              modelSchema: commentSchema,
+                              where: DynamicModel.keys.id == commentModel.id) { result in
+            switch result {
+            case .success(let comments):
+                XCTAssertEqual(comments.count, 0)
+                queryCommentEmpty.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [queryCommentEmpty], timeout: 10.0)
+    }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
@@ -80,7 +80,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
         XCTAssertEqual(finalLocalMetadata?.version, 2)
         XCTAssertEqual(finalLocalMetadata?.deleted, true)
 
-        storageAdapter.query(untypedModel: MockSynced.self) { results in
+        storageAdapter.query(modelSchema: MockSynced.schema) { results in
             switch results {
             case .failure(let error):
                 XCTAssertNil(error)
@@ -179,7 +179,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
         XCTAssertEqual(finalLocalMetadata?.version, 2)
         XCTAssertEqual(finalLocalMetadata?.deleted, true)
 
-        storageAdapter.query(untypedModel: MockSynced.self) { results in
+        storageAdapter.query(modelSchema: MockSynced.schema) { results in
             switch results {
             case .failure(let error):
                 XCTAssertNil(error)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -106,7 +106,7 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
             : completion(.emptyResult)
     }
 
-    func query(untypedModel modelType: Model.Type,
+    func query(modelSchema: ModelSchema,
                predicate: QueryPredicate?,
                completion: DataStoreCallback<[Model]>) {
         let result = resultForQuery ?? .failure(DataStoreError.invalidOperation(causedBy: nil))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
@@ -61,8 +61,9 @@ struct TestJsonModelRegistration: AmplifyModelRegistration {
                                               status.name: status,
                                               comments.name: comments])
 
-        ModelRegistry.register(modelType: DynamicModel.self, modelSchema: postSchema) { (_, _) -> Model in
-            DynamicModel(id: "", values: [:])
+        ModelRegistry.register(modelType: DynamicModel.self,
+                               modelSchema: postSchema) { (jsonString, decoder) -> Model in
+            try DynamicModel.from(json: jsonString, decoder: decoder)
         }
 
         // Comment
@@ -81,9 +82,9 @@ struct TestJsonModelRegistration: AmplifyModelRegistration {
                                             commentContent.name: commentContent,
                                             commentCreatedAt.name: commentCreatedAt,
                                             belongsTo.name: belongsTo])
-        ModelRegistry.register(modelType: DynamicModel.self, modelSchema: commentSchema
-        ) { (_, _) -> Model in
-            DynamicModel(id: "", values: [:])
+        ModelRegistry.register(modelType: DynamicModel.self,
+                               modelSchema: commentSchema) { (jsonString, decoder) -> Model in
+            try DynamicModel.from(json: jsonString, decoder: decoder)
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
DataStore.delete API performs cascade delete by first deleting the model from local store. Before performing the delete transaction, it collects all the associated models and it's children recursively, and delete those as well. All local deletes (the parent and child objects) are then synced to the cloud.

The problem can be seen in Flutter when performing a cascade delete. There are various places in the flow where the system gets a model name from the wrong place. Wrong places to get the model name:
- modelType.modelName
- model.modelName (Similar PR fix here: https://github.com/aws-amplify/amplify-ios/pull/1292)

The correct place to get the model name is from the schema `modelSchema.name`. This is difficult to do in the cascade delete logic as currently the `recurseQueryAssociatedModels` method will return an array of `Model` objects, losing the schema in which it relates to. To avoiding accessing the name from the model instance, we store `[ModelName: [Model]]` instead of `[Model]` to perserve the model name that is needed to create the MutationEvent to sync to cloud.

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
