### PR TITLE
fix(datastore): initalSync should be successful in case of unauthorized errors

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
@@ -11,7 +11,7 @@ import Amplify
 public typealias IdentityClaimsDictionary = [String: AnyObject]
 
 public enum AuthRuleDecoratorInput {
-    case subscription(GraphQLSubscriptionType, IdentityClaimsDictionary)
+    case subscription(GraphQLSubscriptionType, IdentityClaimsDictionary?)
     case mutation
     case query
 }
@@ -77,17 +77,30 @@ public struct AuthRuleDecorator: ModelBasedGraphQLDocumentDecorator {
         selectionSet = appendOwnerFieldToSelectionSetIfNeeded(selectionSet: selectionSet, ownerField: ownerField)
 
         if case let .subscription(_, claims) = input,
+           let tokenClaims = claims,
             authRule.isReadRestrictingOwner() &&
-                isNotInReadRestrictingStaticGroup(jwtTokenClaims: claims,
+                isNotInReadRestrictingStaticGroup(jwtTokenClaims: tokenClaims,
                                                   readRestrictingStaticGroups: readRestrictingStaticGroups) {
             var inputs = document.inputs
             let identityClaimValue = resolveIdentityClaimValue(identityClaim: authRule.identityClaimOrDefault(),
-                                                               claims: claims)
+                                                               claims: tokenClaims)
             if let identityClaimValue = identityClaimValue {
                 inputs[ownerField] = GraphQLDocumentInput(type: "String!", value: .scalar(identityClaimValue))
             }
             return document.copy(inputs: inputs, selectionSet: selectionSet)
         }
+
+        // TODO: Subscriptions always require an `owner` field.
+        //       We're sending an invalid owner value to receive a proper response from AppSync,
+        //       when there's no authenticated user.
+        //       We should be instead failing early and don't send the request.
+        //       See: https://github.com/aws-amplify/amplify-ios/issues/1291
+        if case .subscription(_, _) = input, authRule.isReadRestrictingOwner() {
+            var inputs = document.inputs
+            inputs[ownerField] = GraphQLDocumentInput(type: "String!", value: .scalar(""))
+            return document.copy(inputs: inputs, selectionSet: selectionSet)
+        }
+
         return document.copy(selectionSet: selectionSet)
     }
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
@@ -95,7 +95,7 @@ public struct AuthRuleDecorator: ModelBasedGraphQLDocumentDecorator {
         //       when there's no authenticated user.
         //       We should be instead failing early and don't send the request.
         //       See: https://github.com/aws-amplify/amplify-ios/issues/1291
-        if case .subscription(_, _) = input, authRule.isReadRestrictingOwner() {
+        if case let .subscription(_, claims) = input, authRule.isReadRestrictingOwner(), claims == nil {
             var inputs = document.inputs
             inputs[ownerField] = GraphQLDocumentInput(type: "String!", value: .scalar(""))
             return document.copy(inputs: inputs, selectionSet: selectionSet)

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -171,6 +171,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                                                operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: subscriptionType))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
+        documentBuilder.add(decorator: AuthRuleDecorator(.subscription(subscriptionType, nil)))
         let document = documentBuilder.build()
 
         let awsPluginOptions = AWSPluginOptions(authType: authType)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
@@ -154,19 +154,16 @@ final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
     }
 
     private func makeCompletionResult() -> Result<Void, DataStoreError> {
-        if syncErrors.allSatisfy(isUnauthorizedError) {
+        if syncErrors.isEmpty || syncErrors.allSatisfy(isUnauthorizedError) {
             return .successfulVoid
         }
 
-        guard syncErrors.isEmpty else {
-            let allMessages = syncErrors.map { String(describing: $0) }
-            let syncError = DataStoreError.sync(
-                "One or more errors occurred syncing models. See below for detailed error description.",
-                allMessages.joined(separator: "\n")
-            )
-            return .failure(syncError)
-        }
-        return .successfulVoid
+        let allMessages = syncErrors.map { String(describing: $0) }
+        let syncError = DataStoreError.sync(
+            "One or more errors occurred syncing models. See below for detailed error description.",
+            allMessages.joined(separator: "\n")
+        )
+        return .failure(syncError)
     }
 
     private func dispatchSyncQueriesStarted(for modelNames: [String]) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
@@ -122,6 +122,10 @@ final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
                         "",
                         dataStoreError)
                     self.syncErrors.append(syncError)
+
+                    if self.isUnauthorizedError(syncError) {
+                        self.initialSyncOrchestratorTopic.send(.finished(modelName: modelSchema.name))
+                    }
                 }
                 self.initialSyncOperationSinks.removeValue(forKey: modelSchema.name)
                 self.onReceiveCompletion()
@@ -150,6 +154,10 @@ final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
     }
 
     private func makeCompletionResult() -> Result<Void, DataStoreError> {
+        if syncErrors.allSatisfy(isUnauthorizedError) {
+            return .successfulVoid
+        }
+
         guard syncErrors.isEmpty else {
             let allMessages = syncErrors.map { String(describing: $0) }
             let syncError = DataStoreError.sync(
@@ -178,5 +186,40 @@ extension AWSInitialSyncOrchestrator: Resettable {
         syncOperationQueue.cancelAllOperations()
         syncOperationQueue.waitUntilAllOperationsAreFinished()
         onComplete()
+    }
+}
+
+@available(iOS 13.0, *)
+extension AWSInitialSyncOrchestrator {
+    private typealias ResponseType = PaginatedList<AnyModel>
+    private func graphqlErrors(from error: GraphQLResponseError<ResponseType>?) -> [GraphQLError]? {
+        if case let .error(errors) = error {
+            return errors
+        }
+        return nil
+    }
+
+    private func errorTypeValueFrom(graphQLError: GraphQLError) -> String? {
+        guard case let .string(errorTypeValue) = graphQLError.extensions?["errorType"] else {
+            return nil
+        }
+        return errorTypeValue
+    }
+
+    private func isUnauthorizedError(_ error: DataStoreError) -> Bool {
+        guard case let .sync(_, _, underlyingError) = error,
+              let datastoreError = underlyingError as? DataStoreError
+              else {
+            return false
+        }
+
+        if case let .api(apiError, _) = datastoreError,
+           let responseError = apiError as? GraphQLResponseError<ResponseType>,
+           let graphQLError = graphqlErrors(from: responseError)?.first,
+           let errorTypeValue = errorTypeValueFrom(graphQLError: graphQLError),
+           case .unauthorized = AppSyncErrorType(errorTypeValue) {
+            return true
+        }
+        return false
     }
 }


### PR DESCRIPTION
*Description of changes:*
As we support different @auth rules on models, if a model initial sync returns an `unauthorized` error we should consider the sync successful so that DataStore can reach a "ready" state.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
