### PR TITLE
chore(datastore): fix outdated hub integration tests

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreHubEventsTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreHubEventsTests.swift
@@ -62,7 +62,7 @@ class DataStoreHubEventTests: HubEventsIntegrationTestBase {
                     XCTFail("Failed to cast payload data as SyncQueriesStartedEvent")
                     return
                 }
-                XCTAssertEqual(syncQueriesStartedEvent.models.count, 21)
+                XCTAssertEqual(syncQueriesStartedEvent.models.count, 22)
                 syncQueriesStartedReceived.fulfill()
             }
 


### PR DESCRIPTION
*Description of changes:*
Fix outdated DataStore Hub integration tests.
`TestModels` are 22
https://github.com/aws-amplify/amplify-ios/blob/main/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/TestModelRegistration.swift

*Check points:*
- [x] All integration tests pass
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
