### PR TITLE
fix(amplify-xcode): add files to primary target

### DIFF
--- a/AmplifyTools/AmplifyXcode/AmplifyXcode.xcodeproj/project.pbxproj
+++ b/AmplifyTools/AmplifyXcode/AmplifyXcode.xcodeproj/project.pbxproj
@@ -1117,7 +1117,7 @@
 
 /* Begin PBXFileReference section */
 		"AEXML::AEXML::Product" /* AEXML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AEXML.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"AmplifyXcode::AmplifyXcode::Product" /* AmplifyXcode */ = {isa = PBXFileReference; lastKnownFileType = text; path = AmplifyXcode; sourceTree = BUILT_PRODUCTS_DIR; };
+		"AmplifyXcode::AmplifyXcode::Product" /* amplify-xcode */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = "amplify-xcode"; sourceTree = BUILT_PRODUCTS_DIR; };
 		"AmplifyXcode::AmplifyXcodeCore::Product" /* AmplifyXcodeCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AmplifyXcodeCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"AmplifyXcode::AmplifyXcodeCoreTests::Product" /* AmplifyXcodeCoreTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = AmplifyXcodeCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		"AmplifyXcode::AmplifyXcodeTests::Product" /* AmplifyXcodeTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = AmplifyXcodeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2353,7 +2353,7 @@
 				"PathKit::PathKit::Product" /* PathKit.framework */,
 				"Version::Version::Product" /* Version.framework */,
 				"GraphViz::GraphViz::Product" /* GraphViz.framework */,
-				"AmplifyXcode::AmplifyXcode::Product" /* AmplifyXcode */,
+				"AmplifyXcode::AmplifyXcode::Product" /* amplify-xcode */,
 				"XcodeGen::ProjectSpec::Product" /* ProjectSpec.framework */,
 				"JSONUtilities::JSONUtilities::Product" /* JSONUtilities.framework */,
 				"AEXML::AEXML::Product" /* AEXML.framework */,
@@ -2413,7 +2413,7 @@
 			path = Mocks;
 			sourceTree = "<group>";
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -2424,7 +2424,6 @@
 				OBJ_400 /* BuildTools */,
 				OBJ_401 /* README.md */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_53 /* Support */ = {
@@ -2675,7 +2674,7 @@
 			);
 			name = AmplifyXcode;
 			productName = AmplifyXcode;
-			productReference = "AmplifyXcode::AmplifyXcode::Product" /* AmplifyXcode */;
+			productReference = "AmplifyXcode::AmplifyXcode::Product" /* amplify-xcode */;
 			productType = "com.apple.product-type.tool";
 		};
 		"AmplifyXcode::AmplifyXcodeCore" /* AmplifyXcodeCore */ = {
@@ -3186,7 +3185,7 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_380 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -4622,6 +4621,7 @@
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_NAME = "amplify-xcode";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
 				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
@@ -4651,6 +4651,7 @@
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_NAME = "amplify-xcode";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
 				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;

--- a/AmplifyTools/AmplifyXcode/AmplifyXcode.xcodeproj/xcshareddata/xcschemes/AmplifyXcode-Package.xcscheme
+++ b/AmplifyTools/AmplifyXcode/AmplifyXcode.xcodeproj/xcshareddata/xcschemes/AmplifyXcode-Package.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "AmplifyXcode::AmplifyXcode"
-               BuildableName = "AmplifyXcode"
+               BuildableName = "amplify-xcode"
                BlueprintName = "AmplifyXcode"
                ReferencedContainer = "container:AmplifyXcode.xcodeproj">
             </BuildableReference>

--- a/AmplifyTools/AmplifyXcode/AmplifyXcode.xcodeproj/xcshareddata/xcschemes/AmplifyXcode.xcscheme
+++ b/AmplifyTools/AmplifyXcode/AmplifyXcode.xcodeproj/xcshareddata/xcschemes/AmplifyXcode.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyTools/AmplifyXcode/AmplifyXcode.xcodeproj/xcshareddata/xcschemes/AmplifyXcode.xcscheme
+++ b/AmplifyTools/AmplifyXcode/AmplifyXcode.xcodeproj/xcshareddata/xcschemes/AmplifyXcode.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "AmplifyXcode::AmplifyXcode"
-               BuildableName = "AmplifyXcode"
+               BuildableName = "amplify-xcode"
                BlueprintName = "AmplifyXcode"
                ReferencedContainer = "container:AmplifyXcode.xcodeproj">
             </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "AmplifyXcode::AmplifyXcode"
-            BuildableName = "AmplifyXcode"
+            BuildableName = "amplify-xcode"
             BlueprintName = "AmplifyXcode"
             ReferencedContainer = "container:AmplifyXcode.xcodeproj">
          </BuildableReference>

--- a/AmplifyTools/AmplifyXcode/Sources/AmplifyXcode/CLICommandReportable.swift
+++ b/AmplifyTools/AmplifyXcode/Sources/AmplifyXcode/CLICommandReportable.swift
@@ -17,9 +17,9 @@ extension CLICommandReportable {
         for task in tasks {
             switch task {
             case .success(let message):
-                print("-- ✅ \(message)")
+                print("-- \(message)")
             case .failure(let error):
-                print("-- 🚫 \(error)")
+                print("-- \(error)")
             }
         }
     }

--- a/AmplifyTools/AmplifyXcode/Sources/AmplifyXcodeCore/Commands/CommandImportConfig.swift
+++ b/AmplifyTools/AmplifyXcode/Sources/AmplifyXcodeCore/Commands/CommandImportConfig.swift
@@ -44,7 +44,8 @@ enum ImportConfigTasks {
         do {
             try environment.addFilesToXcodeProject(projectPath: projectPath,
                                                    files: configFiles,
-                                                   toGroup: args.configGroup)
+                                                   toGroup: args.configGroup,
+                                                   inTarget: .primary)
             return .success("Successfully updated project \(projectPath).")
         } catch {
             if let underlyingError = error as? AmplifyCommandError {

--- a/AmplifyTools/AmplifyXcode/Sources/AmplifyXcodeCore/Commands/CommandImportModels.swift
+++ b/AmplifyTools/AmplifyXcode/Sources/AmplifyXcodeCore/Commands/CommandImportModels.swift
@@ -33,7 +33,8 @@ enum CommandImportModelsTasks {
             try environment.addFilesToXcodeProject(
                 projectPath: environment.basePath,
                 files: models,
-                toGroup: args.modelsGroup)
+                toGroup: args.modelsGroup,
+                inTarget: .primary)
 
             let addedModels = models.map { Path($0.path).lastComponent }
             return .success("Successfully added models \(addedModels) to '\(args.modelsGroup)' group.")

--- a/AmplifyTools/AmplifyXcode/Sources/AmplifyXcodeCore/Environment/AmplifyCommandEnvironment.swift
+++ b/AmplifyTools/AmplifyXcode/Sources/AmplifyXcodeCore/Environment/AmplifyCommandEnvironment.swift
@@ -45,9 +45,12 @@ public protocol AmplifyCommandEnvironmentXcode {
     /// Given a file path, returns an XcodeProjectFile reference
     func createXcodeFile(withPath path: String, ofType type: XcodeProjectFileType) -> XcodeProjectFile
 
-    /// Reads an Xcode project file at `projectPath`, read or create a group `group` if it doesn't exist
+    /// Reads an Xcode project file at `projectPath`, retrieves or creates a group `group` if it doesn't exist
     /// and adds `files` to it
-    func addFilesToXcodeProject(projectPath: String, files: [XcodeProjectFile], toGroup group: String) throws
+    func addFilesToXcodeProject(projectPath: String,
+                                files: [XcodeProjectFile],
+                                toGroup group: String,
+                                inTarget target: XcodeProjectTarget) throws
 }
 
 public typealias AmplifyCommandEnvironment = AmplifyCommandEnvironmentFileManager & AmplifyCommandEnvironmentXcode

--- a/AmplifyTools/AmplifyXcode/Sources/AmplifyXcodeCore/Environment/CommandEnvironment.swift
+++ b/AmplifyTools/AmplifyXcode/Sources/AmplifyXcodeCore/Environment/CommandEnvironment.swift
@@ -103,12 +103,18 @@ extension CommandEnvironment {
     public func addFilesToXcodeProject(
         projectPath path: String,
         files: [XcodeProjectFile],
-        toGroup group: String) throws {
+        toGroup group: String,
+        inTarget target: XcodeProjectTarget) throws {
         do {
             let xcodeProject = try loadFirstXcodeProject(fromDirectory: path)
-            try xcodeProject.add(files: files, toGroup: group)
+            try xcodeProject.add(files: files, toGroup: group, inTarget: target)
             try xcodeProject.synchronize()
         } catch {
+            if case let XcodeProjectError.targetNotFound(name: targetName) = error {
+                throw AmplifyCommandError(.xcodeProject,
+                                          errorDescription: "Target \(targetName) not found",
+                                          recoverySuggestion: "Manually add Amplify files to your Xcode project.")
+            }
             throw AmplifyCommandError(.xcodeProject, error: error)
         }
     }

--- a/AmplifyTools/AmplifyXcode/Sources/AmplifyXcodeCore/Support/XcodeProj+Helpers.swift
+++ b/AmplifyTools/AmplifyXcode/Sources/AmplifyXcodeCore/Support/XcodeProj+Helpers.swift
@@ -36,15 +36,18 @@ extension XcodeProj {
     }
 }
 
-// MARK: addBuildFileTo
+// MARK: Add files to project
 extension XcodeProj {
-    func addBuildFileToResources(_ file: PBXBuildFile) {
-        // TODO: should we find the proper build phase?
-        pbxproj.resourcesBuildPhases.first?.files?.append(file)
+    func targets(named targetName: String,
+                 ofType productType: PBXProductType) -> [PBXTarget] {
+        pbxproj.targets(named: targetName).filter { $0.productType == productType }
     }
 
-    func addBuildFileToSources(_ file: PBXBuildFile) {
-        // TODO: should we find the proper build phase?
-        pbxproj.sourcesBuildPhases.first?.files?.append(file)
+    func addResourceFile(_ file: PBXBuildFile, toTarget target: PBXTarget) throws {
+        try target.resourcesBuildPhase()?.files?.append(file)
+    }
+
+    func addSourceFile(_ file: PBXBuildFile, toTarget target: PBXTarget) throws {
+        try target.sourcesBuildPhase()?.files?.append(file)
     }
 }

--- a/AmplifyTools/AmplifyXcode/Sources/AmplifyXcodeCore/Support/XcodeProj+Helpers.swift
+++ b/AmplifyTools/AmplifyXcode/Sources/AmplifyXcodeCore/Support/XcodeProj+Helpers.swift
@@ -44,10 +44,16 @@ extension XcodeProj {
     }
 
     func addResourceFile(_ file: PBXBuildFile, toTarget target: PBXTarget) throws {
+        if let files = try target.resourcesBuildPhase()?.files, files.contains(file) {
+            return
+        }
         try target.resourcesBuildPhase()?.files?.append(file)
     }
 
     func addSourceFile(_ file: PBXBuildFile, toTarget target: PBXTarget) throws {
+        if let files = try target.sourcesBuildPhase()?.files, files.contains(file) {
+            return
+        }
         try target.sourcesBuildPhase()?.files?.append(file)
     }
 }

--- a/AmplifyTools/AmplifyXcode/Sources/AmplifyXcodeCore/Support/XcodeProject.swift
+++ b/AmplifyTools/AmplifyXcode/Sources/AmplifyXcodeCore/Support/XcodeProject.swift
@@ -9,7 +9,7 @@ import Foundation
 import PathKit
 import XcodeProj
 
-/// XCode project error
+/// Xcode project error
 public enum XcodeProjectError: Error {
     case notFound(path: String)
     case noPbxProjFound

--- a/AmplifyTools/AmplifyXcode/Sources/AmplifyXcodeCore/Support/XcodeProject.swift
+++ b/AmplifyTools/AmplifyXcode/Sources/AmplifyXcodeCore/Support/XcodeProject.swift
@@ -9,15 +9,29 @@ import Foundation
 import PathKit
 import XcodeProj
 
+/// XCode project error
 public enum XcodeProjectError: Error {
     case notFound(path: String)
     case noPbxProjFound
     case groupNotFound(group: String)
     case addFileFailed
+    case targetNotFound(name: String)
 }
 
+/// Xcode project target
+public enum XcodeProjectTarget {
+    /// primary target (name matches project file)
+    case primary
+    case named(String)
+}
+
+/// Xcode project file type
 public enum XcodeProjectFileType {
-    case resource, source
+    /// resource file
+    case resource
+
+    /// source file (i.e. Swift, Obj-C)
+    case source
 }
 
 public struct XcodeProjectFile: Equatable {
@@ -48,21 +62,40 @@ struct XcodeProject {
     func synchronize() throws {
         try project.pbxproj.write(path: Path(pbxProjFilePath), override: true)
     }
+
+    private func resolveTarget(_ target: XcodeProjectTarget) throws -> PBXTarget {
+        let targetName: String
+        switch target {
+        case .primary:
+            targetName = project.mainProject()?.name ?? "primary"
+        case .named(let name):
+            targetName = name
+        }
+
+        if let targetRef = project.targets(named: targetName, ofType: .application).first {
+            return targetRef
+        }
+
+        throw XcodeProjectError.targetNotFound(name: targetName)
+    }
 }
 
 // MARK: Add files
 extension XcodeProject {
-    func add(files: [XcodeProjectFile], toGroup group: String) throws {
+    func add(files: [XcodeProjectFile],
+             toGroup group: String,
+             inTarget target: XcodeProjectTarget) throws {
         guard let mainProject = project.mainProject() else {
             throw XcodeProjectError.noPbxProjFound
         }
 
         let sourceRoot = Path(basePath)
 
-        // TODO: unwrap and check targetGroup before proceeding
         guard let targetGroup = try project.getOrCreateGroup(named: group, in: mainProject.mainGroup) else {
             throw XcodeProjectError.groupNotFound(group: group)
         }
+
+        let targetRef = try resolveTarget(target)
 
         for file in files {
             let path = Path(file.path)
@@ -73,9 +106,9 @@ extension XcodeProject {
 
             switch file.type {
             case .resource:
-                project.addBuildFileToResources(buildFile)
+                try project.addResourceFile(buildFile, toTarget: targetRef)
             case .source:
-                project.addBuildFileToSources(buildFile)
+                try project.addSourceFile(buildFile, toTarget: targetRef)
             }
         }
     }

--- a/AmplifyTools/AmplifyXcode/Tests/AmplifyXcodeCoreTests/Core/AmplifyCommandEnvironmentTests.swift
+++ b/AmplifyTools/AmplifyXcode/Tests/AmplifyXcodeCoreTests/Core/AmplifyCommandEnvironmentTests.swift
@@ -149,6 +149,9 @@ class AmplifyCommandEnvironmentTests: XCTestCase {
         }
         let environment = CommandEnvironment(basePath: basePath, fileManager: DirNotFoundFileManager())
         let file = environment.createXcodeFile(withPath: "File.swift", ofType: .source)
-        XCTAssertThrowsError(try environment.addFilesToXcodeProject(projectPath: "project", files: [file], toGroup: "group"))
+        XCTAssertThrowsError(try environment.addFilesToXcodeProject(projectPath: "project",
+                                                                    files: [file],
+                                                                    toGroup: "group",
+                                                                    inTarget: .primary))
     }
 }

--- a/AmplifyTools/AmplifyXcode/Tests/AmplifyXcodeCoreTests/Mocks/MockAmplifyCommandEnvironment.swift
+++ b/AmplifyTools/AmplifyXcode/Tests/AmplifyXcodeCoreTests/Mocks/MockAmplifyCommandEnvironment.swift
@@ -66,7 +66,10 @@ class MockAmplifyCommandEnvironment: Mock, AmplifyCommandEnvironment {
         return XcodeProjectFile(path, type: type)
     }
 
-    func addFilesToXcodeProject(projectPath path: String, files: [XcodeProjectFile], toGroup group: String) throws {
+    func addFilesToXcodeProject(projectPath path: String,
+                                files: [XcodeProjectFile],
+                                toGroup group: String,
+                                inTarget: XcodeProjectTarget) throws {
         captureCall("addFilesToXcodeProject")
     }
 }


### PR DESCRIPTION
*Issue:* https://github.com/aws-amplify/amplify-codegen/issues/190 

*Description of changes:*
This PR introduces changes to `amplify-xcode` necessary to add Amplify files only to the Xcode "primary" target.
A target is considered "primary" if has the same name as the project and has type "application".
In the future we should expand on this to consider more platforms and target types (i.e. macOS and WatchOS).

*Check points:*

- [ ] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
