### PR TITLE
fix(DataStore): drop failed constraint violation reconciliations

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
@@ -44,3 +44,13 @@ protocol ModelStorageBehavior {
                          completion: DataStoreCallback<[M]>)
 
 }
+
+protocol ModelStorageErrorBehavior {
+    func shouldIgnoreError(error: DataStoreError) -> Bool
+}
+
+extension ModelStorageErrorBehavior {
+    func shouldIgnoreError(error: DataStoreError) -> Bool {
+        return false
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -361,7 +361,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
     }
 
     func shouldIgnoreError(error: DataStoreError) -> Bool {
-        if let sqliteError = SQLiteResultError(dataStoreError: error),
+        if let sqliteError = SQLiteResultError(from: error),
            case .constraintViolation = sqliteError {
             return true
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -360,6 +360,15 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
         completion(.successfulVoid)
     }
 
+    func shouldIgnoreError(error: DataStoreError) -> Bool {
+        if let sqliteError = SQLiteResultError(dataStoreError: error),
+           case .constraintViolation = sqliteError {
+            return true
+        }
+
+        return false
+    }
+
     static func clearIfNewVersion(version: String,
                                   dbFilePath: URL,
                                   userDefaults: UserDefaults = UserDefaults.standard,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -9,7 +9,7 @@ import Amplify
 import Foundation
 import AWSPluginsCore
 
-protocol StorageEngineAdapter: AnyObject, ModelStorageBehavior {
+protocol StorageEngineAdapter: AnyObject, ModelStorageBehavior, ModelStorageErrorBehavior {
 
     static var maxNumberOfPredicates: Int { get }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -277,33 +277,33 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
 
             let publishers = dispositions.map { disposition ->
                 Publishers.FlatMap<Future<Void, DataStoreError>,
-                                   Future<ReconcileAndLocalSaveOperation.RemoteModel, DataStoreError>> in
+                                   Future<ReconcileAndLocalSaveOperation.ApplyRemoteModelResult, DataStoreError>> in
 
                 switch disposition {
                 case .create(let remoteModel):
                     let publisher = self.save(storageAdapter: storageAdapter,
                                               remoteModel: remoteModel)
-                        .flatMap { inProcessModel in
+                        .flatMap { applyResult in
                             self.saveMetadata(storageAdapter: storageAdapter,
-                                              inProcessModel: inProcessModel,
+                                              applyResult: applyResult,
                                               mutationType: .create)
                         }
                     return publisher
                 case .update(let remoteModel):
                     let publisher = self.save(storageAdapter: storageAdapter,
                                               remoteModel: remoteModel)
-                        .flatMap { inProcessModel in
+                        .flatMap { applyResult in
                             self.saveMetadata(storageAdapter: storageAdapter,
-                                              inProcessModel: inProcessModel,
+                                              applyResult: applyResult,
                                               mutationType: .update)
                         }
                     return publisher
                 case .delete(let remoteModel):
                     let publisher = self.delete(storageAdapter: storageAdapter,
                                                 remoteModel: remoteModel)
-                        .flatMap { inProcessModel in
+                        .flatMap { applyResult in
                             self.saveMetadata(storageAdapter: storageAdapter,
-                                              inProcessModel: inProcessModel,
+                                              applyResult: applyResult,
                                               mutationType: .delete)
                         }
                     return publisher
@@ -326,9 +326,14 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
         }
     }
 
+    enum ApplyRemoteModelResult {
+        case applied(RemoteModel)
+        case dropped
+    }
+
     private func delete(storageAdapter: StorageEngineAdapter,
-                        remoteModel: RemoteModel) -> Future<RemoteModel, DataStoreError> {
-        Future<RemoteModel, DataStoreError> { promise in
+                        remoteModel: RemoteModel) -> Future<ApplyRemoteModelResult, DataStoreError> {
+        Future<ApplyRemoteModelResult, DataStoreError> { promise in
             guard let modelType = ModelRegistry.modelType(from: self.modelSchema.name) else {
                 let error = DataStoreError.invalidModelName(self.modelSchema.name)
                 promise(.failure(error))
@@ -341,21 +346,31 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
                                   predicate: nil) { response in
                 switch response {
                 case .failure(let dataStoreError):
-                    promise(.failure(dataStoreError))
+                    if SQLiteResultError.isConstraintViolation(dataStoreError) {
+                        self.notifyDropped(modelName: remoteModel.model.modelName)
+                        promise(.success(.dropped))
+                    } else {
+                        promise(.failure(dataStoreError))
+                    }
                 case .success:
-                    promise(.success(remoteModel))
+                    promise(.success(.applied(remoteModel)))
                 }
             }
         }
     }
 
     private func save(storageAdapter: StorageEngineAdapter,
-                      remoteModel: RemoteModel) -> Future<RemoteModel, DataStoreError> {
-        Future<RemoteModel, DataStoreError> { promise in
+                      remoteModel: RemoteModel) -> Future<ApplyRemoteModelResult, DataStoreError> {
+        Future<ApplyRemoteModelResult, DataStoreError> { promise in
             storageAdapter.save(untypedModel: remoteModel.model.instance) { response in
                 switch response {
                 case .failure(let dataStoreError):
-                    promise(.failure(dataStoreError))
+                    if SQLiteResultError.isConstraintViolation(dataStoreError) {
+                        self.notifyDropped(modelName: remoteModel.model.modelName)
+                        promise(.success(.dropped))
+                    } else {
+                        promise(.failure(dataStoreError))
+                    }
                 case .success(let savedModel):
                     let anyModel: AnyModel
                     do {
@@ -366,16 +381,21 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
                         return
                     }
                     let inProcessModel = MutationSync(model: anyModel, syncMetadata: remoteModel.syncMetadata)
-                    promise(.success(inProcessModel))
+                    promise(.success(.applied(inProcessModel)))
                 }
             }
         }
     }
 
     private func saveMetadata(storageAdapter: StorageEngineAdapter,
-                              inProcessModel: AppliedModel,
+                              applyResult: ApplyRemoteModelResult,
                               mutationType: MutationEvent.MutationType) -> Future<Void, DataStoreError> {
         Future<Void, DataStoreError> { promise in
+            guard case let .applied(inProcessModel) = applyResult else {
+                promise(.successfulVoid)
+                return
+            }
+
             storageAdapter.save(inProcessModel.syncMetadata, condition: nil) { result in
                 switch result {
                 case .failure(let dataStoreError):

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -346,7 +346,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
                                   predicate: nil) { response in
                 switch response {
                 case .failure(let dataStoreError):
-                    if SQLiteResultError.isConstraintViolation(dataStoreError) {
+                    if storageAdapter.shouldIgnoreError(error: dataStoreError) {
                         self.notifyDropped(modelName: remoteModel.model.modelName)
                         promise(.success(.dropped))
                     } else {
@@ -365,7 +365,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
             storageAdapter.save(untypedModel: remoteModel.model.instance) { response in
                 switch response {
                 case .failure(let dataStoreError):
-                    if SQLiteResultError.isConstraintViolation(dataStoreError) {
+                    if storageAdapter.shouldIgnoreError(error: dataStoreError) {
                         self.notifyDropped(modelName: remoteModel.model.modelName)
                         promise(.success(.dropped))
                     } else {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/SQLiteResultError.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/SQLiteResultError.swift
@@ -24,7 +24,7 @@ enum SQLiteResultError {
     /// - statement: the statement which produced the error
     case error(message: String, code: Int32, statement: Statement?)
 
-    init?(dataStoreError: DataStoreError) {
+    init?(from dataStoreError: DataStoreError) {
         guard case let .invalidOperation(error) = dataStoreError,
               let resultError = error as? Result,
               case .error(let message, let code, let statement) = resultError else {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/SQLiteResultError.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/SQLiteResultError.swift
@@ -1,0 +1,28 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import SQLite
+import Amplify
+
+/// Checks for specific SQLLite error codes
+/// See https://sqlite.org/rescode.html#primary_result_code_list for more details
+struct SQLiteResultError {
+
+    /// Constraint Violation, such as foreign key constraint violation, occurs when trying to process a SQL statement
+    /// where the insert/update statement is performed for a child object and its parent does not exist.
+    /// See https://sqlite.org/rescode.html#constraint for more details
+    static func isConstraintViolation(_ dataStoreError: DataStoreError) -> Bool {
+        guard case let .invalidOperation(error) = dataStoreError,
+              let resultError = error as? Result,
+              case .error(_, let code, _) = resultError,
+              code == SQLITE_CONSTRAINT else {
+            return false
+        }
+
+        return true
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/SQLiteResultError.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/SQLiteResultError.swift
@@ -9,20 +9,33 @@ import SQLite
 import Amplify
 
 /// Checks for specific SQLLite error codes
-/// See https://sqlite.org/rescode.html#primary_result_code_list for more details
-struct SQLiteResultError {
+/// See https://sqlite.org/rescode.html#primary_result_code_list
+enum SQLiteResultError {
 
     /// Constraint Violation, such as foreign key constraint violation, occurs when trying to process a SQL statement
     /// where the insert/update statement is performed for a child object and its parent does not exist.
     /// See https://sqlite.org/rescode.html#constraint for more details
-    static func isConstraintViolation(_ dataStoreError: DataStoreError) -> Bool {
+    case constraintViolation(statement: Statement?)
+
+    /// Represents a SQLite specific [error code](https://sqlite.org/rescode.html)
+    ///
+    /// - message: English-language text that describes the error
+    /// - code: SQLite [error code](https://sqlite.org/rescode.html#primary_result_code_list)
+    /// - statement: the statement which produced the error
+    case error(message: String, code: Int32, statement: Statement?)
+
+    init?(dataStoreError: DataStoreError) {
         guard case let .invalidOperation(error) = dataStoreError,
               let resultError = error as? Result,
-              case .error(_, let code, _) = resultError,
-              code == SQLITE_CONSTRAINT else {
-            return false
+              case .error(let message, let code, let statement) = resultError else {
+            return nil
         }
 
-        return true
+        if code == SQLITE_CONSTRAINT {
+            self = .constraintViolation(statement: statement)
+            return
+        }
+
+        self = .error(message: message, code: code, statement: statement)
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import SQLite
 
 @testable import Amplify
 @testable import AWSPluginsCore
@@ -643,5 +644,23 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
         }
 
         wait(for: [querySuccess], timeout: 1)
+    }
+
+    func testShouldIgnoreConstraintViolationError() {
+        let constraintViolationError = Result.error(message: "Foreign Key Constraint Violation",
+                                                    code: SQLITE_CONSTRAINT,
+                                                    statement: nil)
+        let dataStoreError = DataStoreError.invalidOperation(causedBy: constraintViolationError)
+
+        XCTAssertTrue(storageAdapter.shouldIgnoreError(error: dataStoreError))
+    }
+
+    func testShouldIgnoreErrorFalse() {
+        let constraintViolationError = Result.error(message: "",
+                                                    code: SQLITE_BUSY,
+                                                    statement: nil)
+        let dataStoreError = DataStoreError.invalidOperation(causedBy: constraintViolationError)
+
+        XCTAssertFalse(storageAdapter.shouldIgnoreError(error: dataStoreError))
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -549,6 +549,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
         storageAdapter.shouldReturnErrorOnDeleteMutation = false
         storageAdapter.responders[.deleteUntypedModel] = DeleteUntypedModelCompletionResponder { _ in
             modelDeletedEvent.fulfill()
+            return .emptyResult
         }
         storageAdapter.responders[.saveModelCompletion] =
             SaveModelCompletionResponder<MutationSyncMetadata> { metadata, completion in

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -8,7 +8,6 @@
 import Foundation
 import XCTest
 import Combine
-import SQLite
 
 @testable import Amplify
 @testable import AmplifyTestCommon
@@ -820,13 +819,11 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
                                                                 .delete(anyPostMutationSync)]
         let expectDropped = expectation(description: "should notify dropped")
         expectDropped.expectedFulfillmentCount = dispositions.count
-        let constraintViolationError = Result.error(message: "Foreign Key Constraint Violation",
-                                                    code: SQLITE_CONSTRAINT,
-                                                    statement: nil)
-        let dataStoreError = DataStoreError.invalidOperation(causedBy: constraintViolationError)
+        let dataStoreError = DataStoreError.internalOperation("Failed to save", "")
         let saveResponder = SaveUntypedModelResponder { _, completion in
             completion(.failure(dataStoreError))
         }
+        storageAdapter.shouldIgnoreError = true
         storageAdapter.responders[.saveUntypedModel] = saveResponder
         let deleteResponder = DeleteUntypedModelCompletionResponder { _, _ in
             return .failure(dataStoreError)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -96,8 +96,8 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
                 predicate: QueryPredicate? = nil,
                 completion: (Result<Void, DataStoreError>) -> Void) {
         if let responder = responders[.deleteUntypedModel] as? DeleteUntypedModelCompletionResponder {
-            responder.callback((modelType, id))
-            completion(.emptyResult)
+            let result = responder.callback((modelType, id))
+            completion(result)
             return
         }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -28,6 +28,7 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
 
     var shouldReturnErrorOnSaveMetadata: Bool
     var shouldReturnErrorOnDeleteMutation: Bool
+    var shouldIgnoreError: Bool
 
     var resultForQueryModelSyncMetadata: ModelSyncMetadata?
     var listenerForModelSyncMetadata: BasicClosure?
@@ -35,6 +36,7 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
     init() {
         self.shouldReturnErrorOnSaveMetadata = false
         self.shouldReturnErrorOnDeleteMutation = false
+        self.shouldIgnoreError = false
         self.resultForQueryMutationSyncMetadatas = [MutationSyncMetadata]()
     }
 
@@ -231,8 +233,13 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
         }
         try basicClosure()
     }
+
     func clear(completion: @escaping DataStoreCallback<Void>) {
         XCTFail("Not expected to execute")
+    }
+
+    func shouldIgnoreError(error: DataStoreError) -> Bool {
+        return shouldIgnoreError
     }
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapterResponders.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapterResponders.swift
@@ -37,7 +37,7 @@ typealias SaveModelCompletionResponder<M: Model> = MockResponder<(M, DataStoreCa
 
 typealias SaveUntypedModelResponder = MockResponder<(Model, DataStoreCallback<Model>), Void>
 
-typealias DeleteUntypedModelCompletionResponder = MockResponder<(Model.Type, String), Void>
+typealias DeleteUntypedModelCompletionResponder = MockResponder<(Model.Type, String), DataStoreResult<Void>>
 
 extension MockStorageEngineBehavior {
     enum ResponderKeys {

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		21233E1324763D0700039337 /* StorageEngine+SyncRequirement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21233E1224763D0700039337 /* StorageEngine+SyncRequirement.swift */; };
 		21233E152476EFC400039337 /* AWSDataStoreCategoryPluginAuthIntegrationTests+Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21233E142476EFC400039337 /* AWSDataStoreCategoryPluginAuthIntegrationTests+Support.swift */; };
 		2129BE4A23948A97006363A1 /* StorageAdapterMutationSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2129BE4923948A97006363A1 /* StorageAdapterMutationSyncTests.swift */; };
+		212B4686269FB10500A0AEE7 /* SQLiteResultError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212B4685269FB10500A0AEE7 /* SQLiteResultError.swift */; };
 		213481BF24213E14001966DE /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 213481BE24213E13001966DE /* README.md */; };
 		213481D4242ABA86001966DE /* ProcessMutationErrorFromCloudOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213481D3242ABA86001966DE /* ProcessMutationErrorFromCloudOperation.swift */; };
 		2149E5C52388684F00873955 /* StorageEngineBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5A82388684F00873955 /* StorageEngineBehavior.swift */; };
@@ -343,6 +344,7 @@
 		21233E1224763D0700039337 /* StorageEngine+SyncRequirement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StorageEngine+SyncRequirement.swift"; sourceTree = "<group>"; };
 		21233E142476EFC400039337 /* AWSDataStoreCategoryPluginAuthIntegrationTests+Support.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSDataStoreCategoryPluginAuthIntegrationTests+Support.swift"; sourceTree = "<group>"; };
 		2129BE4923948A97006363A1 /* StorageAdapterMutationSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageAdapterMutationSyncTests.swift; sourceTree = "<group>"; };
+		212B4685269FB10500A0AEE7 /* SQLiteResultError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteResultError.swift; sourceTree = "<group>"; };
 		213481BE24213E13001966DE /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		213481D3242ABA86001966DE /* ProcessMutationErrorFromCloudOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMutationErrorFromCloudOperation.swift; sourceTree = "<group>"; };
 		2149E59B238867E100873955 /* AWSDataStoreCategoryPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSDataStoreCategoryPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -437,7 +439,6 @@
 		6BE9D6F225A665EA00AB5C9A /* StorageEngineTestsBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageEngineTestsBase.swift; sourceTree = "<group>"; };
 		6BE9D73D25A6800100AB5C9A /* StorageEngineTestsManyToMany.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageEngineTestsManyToMany.swift; sourceTree = "<group>"; };
 		7678B30F25FAD93200B4917F /* InitialSyncOperationSyncExpressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialSyncOperationSyncExpressionTests.swift; sourceTree = "<group>"; };
-		9728F2AF2683D98D00A506A8 /* DataStoreConsecutiveUpdatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreConsecutiveUpdatesTests.swift; sourceTree = "<group>"; };
 		767C398A266EE4DA00CB64B9 /* AWSDataStoreMultiAuthThreeRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreMultiAuthThreeRulesTests.swift; sourceTree = "<group>"; };
 		767C398C266EE59000CB64B9 /* AWSDataStoreMultiAuthThreeRulesTests+Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSDataStoreMultiAuthThreeRulesTests+Models.swift"; sourceTree = "<group>"; };
 		767C398E266EEBFD00CB64B9 /* AWSDataStoreMultiAuthCombinationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreMultiAuthCombinationTests.swift; sourceTree = "<group>"; };
@@ -505,6 +506,7 @@
 		769CF2C6266D79EC007843A0 /* AWSDataStoreMultiAuthSingleRuleTests+Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSDataStoreMultiAuthSingleRuleTests+Models.swift"; sourceTree = "<group>"; };
 		769CF2C8266D7F04007843A0 /* AWSDataStoreMultiAuthTwoRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreMultiAuthTwoRulesTests.swift; sourceTree = "<group>"; };
 		769CF2CA266D7F47007843A0 /* AWSDataStoreMultiAuthTwoRulesTests+Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSDataStoreMultiAuthTwoRulesTests+Models.swift"; sourceTree = "<group>"; };
+		9728F2AF2683D98D00A506A8 /* DataStoreConsecutiveUpdatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreConsecutiveUpdatesTests.swift; sourceTree = "<group>"; };
 		97406B372666DC0200C41E19 /* DataStoreCustomPrimaryKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreCustomPrimaryKeyTests.swift; sourceTree = "<group>"; };
 		9D42A96449A4B73735566C07 /* Pods-AWSDataStoreCategoryPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSDataStoreCategoryPlugin/Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; sourceTree = "<group>"; };
 		9F987EC33AAD7C0904A598CA /* Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1114,6 +1116,7 @@
 				FA8F4D212395B11700861D91 /* MutationEvent+Query.swift */,
 				FA3841E823889D440070AD5B /* StateMachine.swift */,
 				214B6B64264B0D6700A9311D /* Stopwatch.swift */,
+				212B4685269FB10500A0AEE7 /* SQLiteResultError.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -2013,6 +2016,7 @@
 				2102DD47260D87BC00B80FE2 /* ReconcileAndLocalSaveQueue.swift in Sources */,
 				2149E5CE2388684F00873955 /* SQLStatement+CreateTable.swift in Sources */,
 				6B3CC68023F87FA10008ECBC /* RemoteSyncEngine+Retryable.swift in Sources */,
+				212B4686269FB10500A0AEE7 /* SQLiteResultError.swift in Sources */,
 				FACBB2AE238AFAE800C29602 /* AWSDataStorePlugin+DataStoreBaseBehavior.swift in Sources */,
 				6B3CC61523F5E63F0008ECBC /* RemoteSyncEngine+Resolver.swift in Sources */,
 				2149E5D32388684F00873955 /* Statement+Model.swift in Sources */,


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-amplify/amplify-ios/issues/1157 -> cascade delete fails for various reasons causing remote store to be missing the parent object. datastore full sync will fail in ReconcileAndLocalSaveOperation with a foreign key constraint violation when saving the child object. The ready event is not sent due to this failure.

https://github.com/aws-amplify/amplify-ios/issues/1310 -> also related to cascade delete failing, possible a bug in the cascade delete, however this fix will still be applicable to get the system in a ready state.

https://github.com/aws-amplify/amplify-ios/discussions/1097#discussioncomment-471914 -> additional context from @anatomybook. Sounds like "children without parents" scenario is bound to happen, not just in cascade delete. references #1001 

https://github.com/aws-amplify/amplify-ios/issues/1001 -> there are two bugs here. the first one is related to sync-ing models in the correct order but reconciling them concurrently which results in being done in the incorrect order. The first fix was done in #1128 with `ReconcileAndSaveQueue`. The first bug was fixed but the second bug still exists. This PR fix would address the second bug- now that models are reconcilled in the correct order, if there is a missing parent, there wil still be a constraint violation error

https://github.com/aws-amplify/amplify-android/pull/1058 -> Android PR for additional context

*Description of changes:*
`ReconcileAndLocalSaveOperation` will reconcile remote models from different sources (sync query results or subscription events). When the item is reconciled to be applied locally and the SQL operation fails with a constraint violation, the entire operation is fails. As a result of this, the `ready` event is never fired. By dropping the constraint violation errors and emitting a dropped model event, the `ready` event calculation will eventually be emitted once all models have been reconciled successfully (whether it was dropped or applied).

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
