### PR TITLE
chore: Add LockAndExecute util

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -3685,9 +3685,9 @@
 			isa = PBXGroup;
 			children = (
 				FACA35EA2326B217000E74F6 /* AmplifyConfigurationInitializationTests.swift */,
-				FA1B964D24BF5FA70002B90A /* AmplifyOperationCombineTests.swift */,
-				FA58456824DA29B00028D65A /* AmplifyInProcessReportingOperationCombineTests.swift */,
 				FA58456A24DA31370028D65A /* AmplifyInProcessReportingOperationChainedTests.swift */,
+				FA58456824DA29B00028D65A /* AmplifyInProcessReportingOperationCombineTests.swift */,
+				FA1B964D24BF5FA70002B90A /* AmplifyOperationCombineTests.swift */,
 				B9DCA262240F217C00075E22 /* AnyEncodableTests.swift */,
 				FACF520823298C1200646E10 /* AtomicDictionaryTests.swift */,
 				FAAFAF3023904B75002CF932 /* AtomicValue+BoolTests.swift */,

--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -601,6 +601,7 @@
 		FA6BC87F235F5DAE0001A882 /* APICategoryInterceptorBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6BC87E235F5DAE0001A882 /* APICategoryInterceptorBehavior.swift */; };
 		FA76A2D12342B1A600B91ADB /* StorageCategory+HubPayloadEventName.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA76A2D02342B1A600B91ADB /* StorageCategory+HubPayloadEventName.swift */; };
 		FA76A2D32342B47100B91ADB /* HubPayloadEventName.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA76A2D22342B47100B91ADB /* HubPayloadEventName.swift */; };
+		FA81688226BB2E07007CEBB6 /* NSLocking+Execute.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA81688126BB2E07007CEBB6 /* NSLocking+Execute.swift */; };
 		FA87609324E45091004148C6 /* AmplifyConfigurationInitFromFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA87609024E44CCC004148C6 /* AmplifyConfigurationInitFromFileTests.swift */; };
 		FA8EE779238627040097E4F1 /* Model+ModelName.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8EE778238627040097E4F1 /* Model+ModelName.swift */; };
 		FA8EE77D238627350097E4F1 /* Model+Subscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8EE77C238627350097E4F1 /* Model+Subscript.swift */; };
@@ -1582,6 +1583,7 @@
 		FA6BC87E235F5DAE0001A882 /* APICategoryInterceptorBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICategoryInterceptorBehavior.swift; sourceTree = "<group>"; };
 		FA76A2D02342B1A600B91ADB /* StorageCategory+HubPayloadEventName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StorageCategory+HubPayloadEventName.swift"; sourceTree = "<group>"; };
 		FA76A2D22342B47100B91ADB /* HubPayloadEventName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubPayloadEventName.swift; sourceTree = "<group>"; };
+		FA81688126BB2E07007CEBB6 /* NSLocking+Execute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLocking+Execute.swift"; sourceTree = "<group>"; };
 		FA87609024E44CCC004148C6 /* AmplifyConfigurationInitFromFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplifyConfigurationInitFromFileTests.swift; sourceTree = "<group>"; };
 		FA8EE772238621320097E4F1 /* AnyModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyModelTests.swift; sourceTree = "<group>"; };
 		FA8EE776238626D60097E4F1 /* AnyModel+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnyModel+Codable.swift"; sourceTree = "<group>"; };
@@ -3305,7 +3307,6 @@
 				FA5704C8245F3C6900392C19 /* AmplifyInProcessReportingOperation.swift */,
 				FA249EE624C5FA49009B3CE8 /* AmplifyInProcessReportingOperation+Combine.swift */,
 				FA56F72622B14BF70039754A /* AmplifyOperation.swift */,
-				FA9F939526BAF73F00805607 /* OperationCancelledError.swift */,
 				FAA7A5A524C0CC8F00CA863F /* AmplifyOperation+Combine.swift */,
 				FA5704CA245F58C600392C19 /* AmplifyOperation+Hub.swift */,
 				FAB9D810233BF5F600928AA9 /* AmplifyOperationContext.swift */,
@@ -3323,11 +3324,13 @@
 				FA09B9402321BB78000E064D /* JSONValue.swift */,
 				FACD264F2386E9410068FBE6 /* JSONValue+KeyPath.swift */,
 				FACD264E2386E9410068FBE6 /* JSONValue+Subscript.swift */,
+				FA9F939526BAF73F00805607 /* OperationCancelledError.swift */,
 				FAE4145E23999BC900CE94C2 /* Result+Void.swift */,
 				FA56F72422B14B6A0039754A /* Resumable.swift */,
 				B9FAA174238EFC59009414B4 /* String+Extensions.swift */,
 				B9A329CB243559BF00C5B80C /* TimeInterval+Helper.swift */,
 				219A88EC23F3309800BBC5F2 /* Tree.swift */,
+				FA81688326BB3B40007CEBB6 /* Internal */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -3382,6 +3385,14 @@
 				FA6BC87C235F5D490001A882 /* APICategoryRESTBehavior.swift */,
 			);
 			path = ClientBehavior;
+			sourceTree = "<group>";
+		};
+		FA81688326BB3B40007CEBB6 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				FA81688126BB2E07007CEBB6 /* NSLocking+Execute.swift */,
+			);
+			path = Internal;
 			sourceTree = "<group>";
 		};
 		FA8EE775238626C70097E4F1 /* AnyModel */ = {
@@ -5205,6 +5216,7 @@
 				6BDD6320256353F0008D70DF /* Evaluable.swift in Sources */,
 				21FFF997230C96CB005878EA /* StorageRemoveOperation.swift in Sources */,
 				FAC2351C227A053D00424678 /* APICategoryPlugin.swift in Sources */,
+				FA81688226BB2E07007CEBB6 /* NSLocking+Execute.swift in Sources */,
 				FA176ED52385012000C5C5F9 /* DataStoreCategory+HubPayloadEventName.swift in Sources */,
 				210DBC162332B3CB009B9E51 /* StorageDownloadDataOperation.swift in Sources */,
 				B9A329CC243559BF00C5B80C /* TimeInterval+Helper.swift in Sources */,

--- a/Amplify/Core/Support/AtomicDictionary.swift
+++ b/Amplify/Core/Support/AtomicDictionary.swift
@@ -17,62 +17,48 @@ final class AtomicDictionary<Key: Hashable, Value> {
     }
 
     var count: Int {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            value.count
         }
-        return value.count
     }
 
     var keys: [Key] {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            Array(value.keys)
         }
-        return Array(value.keys)
     }
 
     var values: [Value] {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            Array(value.values)
         }
-        return Array(value.values)
     }
 
     // MARK: - Functions
 
     func getValue(forKey key: Key) -> Value? {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            value[key]
         }
-        return value[key]
     }
 
     func removeAll() {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            value = [:]
         }
-        value = [:]
     }
 
     @discardableResult
     func removeValue(forKey key: Key) -> Value? {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            value.removeValue(forKey: key)
         }
-        return value.removeValue(forKey: key)
     }
 
     func set(value: Value, forKey key: Key) {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            self.value[key] = value
         }
-        self.value[key] = value
     }
 
 }

--- a/Amplify/Core/Support/AtomicValue+Bool.swift
+++ b/Amplify/Core/Support/AtomicValue+Bool.swift
@@ -16,12 +16,10 @@ extension AtomicValue where Value == Bool {
     /// print(atomicBool.get()) // prints "false"
     /// ```
     public func getAndToggle() -> Value {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            let oldValue = value
+            value.toggle()
+            return oldValue
         }
-        let oldValue = value
-        value.toggle()
-        return oldValue
     }
 }

--- a/Amplify/Core/Support/AtomicValue+Numeric.swift
+++ b/Amplify/Core/Support/AtomicValue+Numeric.swift
@@ -8,21 +8,17 @@
 extension AtomicValue where Value: Numeric {
     /// Increments the current value by `amount` and returns the incremented value
     public func increment(by amount: Value = 1) -> Value {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            value += amount
+            return value
         }
-        value += amount
-        return value
     }
 
     /// Decrements the current value by `amount` and returns the decremented value
     public func decrement(by amount: Value = 1) -> Value {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            value -= amount
+            return value
         }
-        value -= amount
-        return value
     }
 }

--- a/Amplify/Core/Support/AtomicValue+RangeReplaceableCollection.swift
+++ b/Amplify/Core/Support/AtomicValue+RangeReplaceableCollection.swift
@@ -7,34 +7,26 @@
 
 extension AtomicValue where Value: RangeReplaceableCollection {
     public func append(_ newElement: Value.Element) {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            value.append(newElement)
         }
-        value.append(newElement)
     }
 
     public func append<S>(contentsOf sequence: S) where S: Sequence, S.Element == Value.Element {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            value.append(contentsOf: sequence)
         }
-        value.append(contentsOf: sequence)
     }
 
     public func removeFirst() -> Value.Element {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            value.removeFirst()
         }
-        return value.removeFirst()
     }
 
     public subscript(_ key: Value.Index) -> Value.Element {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            value[key]
         }
-        return value[key]
     }
 }

--- a/Amplify/Core/Support/AtomicValue.swift
+++ b/Amplify/Core/Support/AtomicValue.swift
@@ -17,49 +17,39 @@ public final class AtomicValue<Value> {
     }
 
     public func get() -> Value {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            value
         }
-        return value
     }
 
     public func set(_ newValue: Value) {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            value = newValue
         }
-        value = newValue
     }
 
     /// Sets AtomicValue to `newValue` and returns the old value
     public func getAndSet(_ newValue: Value) -> Value {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            let oldValue = value
+            value = newValue
+            return oldValue
         }
-        let oldValue = value
-        value = newValue
-        return oldValue
     }
 
     /// Performs `block` with the current value, preventing other access until the block exits.
     public func atomicallyPerform(block: (Value) -> Void) {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            block(value)
         }
-        block(value)
     }
 
     /// Performs `block` with an `inout` value, preventing other access until the block exits,
     /// and enabling the block to mutate the value
     public func with(block: (inout Value) -> Void) {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            block(&value)
         }
-        block(&value)
     }
 
 }

--- a/Amplify/Core/Support/AtomicValue.swift
+++ b/Amplify/Core/Support/AtomicValue.swift
@@ -7,12 +7,13 @@
 
 import Foundation
 
+/// A class that wraps access to its underlying value with an NSLocking instance.
 public final class AtomicValue<Value> {
-    let lock = NSLock()
-
+    let lock: NSLocking
     var value: Value
 
     public init(initialValue: Value) {
+        self.lock = NSLock()
         self.value = initialValue
     }
 
@@ -46,6 +47,11 @@ public final class AtomicValue<Value> {
 
     /// Performs `block` with an `inout` value, preventing other access until the block exits,
     /// and enabling the block to mutate the value
+    ///
+    /// - Warning: The AtomicValue lock is not reentrant. Specifically, it is not
+    /// possible to call outside the block to `get` an AtomicValue (e.g., via a
+    /// convenience property) while inside the `with` block. Attempting to do so will
+    /// cause a deadlock.
     public func with(block: (inout Value) -> Void) {
         lock.execute {
             block(&value)

--- a/Amplify/Core/Support/Internal/NSLocking+Execute.swift
+++ b/Amplify/Core/Support/Internal/NSLocking+Execute.swift
@@ -1,0 +1,50 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// - Warning: Although this has `public` access, it is intended for internal use
+/// and should not be used directly by host applications. The behaviors and names of
+/// this type may change without warning.
+extension NSLocking {
+    /// Execute `block` after obtaining a lock on `lock`.
+    ///
+    /// - Warning: Although this has `public` access, it is intended for internal use
+    /// and should not be used directly by host applications. The behaviors and names of
+    /// this type may change without warning.
+    /// - Parameters:
+    ///   - block: The block to execute
+    public func execute(
+        _ block: BasicThrowableClosure
+    ) rethrows {
+        try execute(input: (), block: block)
+    }
+
+    /// Execute `block` after obtaining a lock on `lock`, returning the output of
+    /// `block`
+    ///
+    /// - Warning: Although this has `public` access, it is intended for internal use
+    /// and should not be used directly by host applications. The behaviors and names of
+    /// this type may change without warning.
+    /// - Parameters:
+    ///   - block: The block to execute
+    public func execute<Output>(
+        _ block: () throws -> Output
+    ) rethrows -> Output {
+        try execute(input: (), block: block)
+    }
+
+    private func execute<Input, Output>(
+        input: Input,
+        block: (Input) throws -> Output
+    ) rethrows -> Output {
+        lock()
+        defer { self.unlock() }
+        return try block(input)
+    }
+
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Reachability.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Reachability.swift
@@ -27,22 +27,20 @@ extension AWSAPIPlugin {
             throw error
         }
 
-        reachabilityMapLock.lock()
-        defer {
-            reachabilityMapLock.unlock()
-        }
-        if let networkReachability = reachabilityMap[hostName] {
-            return networkReachability.publisher
-        }
-        do {
-            let networkReachability = try NetworkReachabilityNotifier(host: hostName,
-                                                                      allowsCellularAccess: true,
-                                                                      reachabilityFactory: AmplifyReachability.self)
-            reachabilityMap[hostName] = networkReachability
-            return networkReachability.publisher
-        } catch {
-            Amplify.API.log.error("Unable to initialize NetworkReachabilityNotifier: \(error)")
-            return nil
+        return LockAndExecute.locking(reachabilityMapLock) {
+            if let networkReachability = reachabilityMap[hostName] {
+                return networkReachability.publisher
+            }
+            do {
+                let networkReachability = try NetworkReachabilityNotifier(host: hostName,
+                                                                          allowsCellularAccess: true,
+                                                                          reachabilityFactory: AmplifyReachability.self)
+                reachabilityMap[hostName] = networkReachability
+                return networkReachability.publisher
+            } catch {
+                Amplify.API.log.error("Unable to initialize NetworkReachabilityNotifier: \(error)")
+                return nil
+            }
         }
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Reachability.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Reachability.swift
@@ -27,7 +27,7 @@ extension AWSAPIPlugin {
             throw error
         }
 
-        return LockAndExecute.locking(reachabilityMapLock) {
+        return reachabilityMapLock.execute {
             if let networkReachability = reachabilityMap[hostName] {
                 return networkReachability.publisher
             }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Resettable.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Resettable.swift
@@ -26,7 +26,7 @@ extension AWSAPIPlugin: Resettable {
         authService = nil
 
         if #available(iOS 13.0, *) {
-            LockAndExecute.locking(reachabilityMapLock) {
+            reachabilityMapLock.execute {
                 reachabilityMap.removeAll()
             }
         }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Resettable.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Resettable.swift
@@ -17,7 +17,7 @@ extension AWSAPIPlugin: Resettable {
 
         let waitForReset = DispatchSemaphore(value: 0)
         session.reset { waitForReset.signal() }
-        _ = waitForReset.wait()
+        waitForReset.wait()
 
         session = nil
 
@@ -26,9 +26,9 @@ extension AWSAPIPlugin: Resettable {
         authService = nil
 
         if #available(iOS 13.0, *) {
-            reachabilityMapLock.lock()
-            reachabilityMap.removeAll()
-            reachabilityMapLock.unlock()
+            LockAndExecute.locking(reachabilityMapLock) {
+                reachabilityMap.removeAll()
+            }
         }
 
         subscriptionConnectionFactory = nil

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -93,8 +93,6 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
 
     func stopSyncingToCloud(_ completion: @escaping BasicClosure) {
         log.verbose(#function)
-        // Technically this should be in a "cancelling" responder, but it's simpler to cancel here and move straight
-        // to .finished. If in the future we need to add more work to the teardown state, move it to a separate method.
         stateMachine.notify(action: .receivedStop(completion))
     }
 
@@ -129,8 +127,8 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
 
     // MARK: - Lifecycle
 
-    /// Responder method for `starting`. Starts the operation queue and subscribes to the publisher. After subscribing to the
-    /// publisher, return actions:
+    /// Responder method for `starting`. Starts the operation queue and subscribes to
+    /// the publisher. After subscribing to the publisher, return actions:
     /// - receivedSubscription
     private func doStart(api: APICategoryGraphQLBehavior,
                          mutationEventPublisher: MutationEventPublisher) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Stopwatch.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Stopwatch.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Amplify
 
 /// A simple implementation of a stopwatch used for gathering metrics of elapsed time.
 class Stopwatch {
@@ -16,50 +17,45 @@ class Stopwatch {
     /// Marks the beginning of the stopwatch.
     /// If called multiple times, the latest call will overwrite the previous start values.
     func start() {
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.execute {
+            startTime = DispatchTime.now()
+            lapStart = startTime
         }
-        startTime = DispatchTime.now()
-        lapStart = startTime
     }
 
     /// Returns the elapsed time since `start()` or the last `lap()` was called.
     ///
     /// - Returns: the elapsed time in seconds
     func lap() -> Double {
-        lock.lock()
-        defer {
-            lock.unlock()
-        }
-        guard let lapStart = lapStart else {
-            return 0
-        }
+        lock.execute {
+            guard let lapStart = lapStart else {
+                return 0
+            }
 
-        let lapEnd = DispatchTime.now()
-        let lapTime = Double(lapEnd.uptimeNanoseconds - lapStart.uptimeNanoseconds) / 1_000_000_000.0
-        self.lapStart = lapEnd
-        return lapTime
+            let lapEnd = DispatchTime.now()
+            let lapTime = Double(lapEnd.uptimeNanoseconds - lapStart.uptimeNanoseconds) / 1_000_000_000.0
+            self.lapStart = lapEnd
+            return lapTime
+        }
     }
 
     /// Returns the total time from the initial `start()` call and resets the stopwatch.
+    /// Returns 0 if the stopwatch has never been started.
     ///
     /// - Returns: the total time in seconds that the stop watch has been running, or 0
     func stop() -> Double {
-        lock.lock()
-        defer {
-            lapStart = nil
-            startTime = nil
-            lock.unlock()
+        return lock.execute {
+            defer {
+                lapStart = nil
+                startTime = nil
+            }
+
+            guard let startTime = startTime else {
+                return 0
+            }
+            let endTime = DispatchTime.now()
+            let total = Double(endTime.uptimeNanoseconds - startTime.uptimeNanoseconds) / 1_000_000_000.0
+            return total
         }
-        guard let startTime = startTime else {
-            lapStart = nil
-            return 0
-        }
-        let endTime = DispatchTime.now()
-        let total = Double(endTime.uptimeNanoseconds - startTime.uptimeNanoseconds) / 1_000_000_000.0
-        self.startTime = nil
-        lapStart = nil
-        return total
     }
 }

--- a/AmplifyTests/CoreTests/AtomicValue+RangeReplaceableCollectionTests.swift
+++ b/AmplifyTests/CoreTests/AtomicValue+RangeReplaceableCollectionTests.swift
@@ -15,7 +15,7 @@ class AtomicValueRangeReplaceableTests: XCTestCase {
         let atomicArray = AtomicValue(initialValue: [Int]())
 
         DispatchQueue.concurrentPerform(iterations: 10_000) { iteration in
-            _ = atomicArray.append(iteration)
+            atomicArray.append(iteration)
         }
 
         XCTAssertEqual(atomicArray.get().count, 10_000)
@@ -26,7 +26,7 @@ class AtomicValueRangeReplaceableTests: XCTestCase {
 
         DispatchQueue.concurrentPerform(iterations: 10_000) { iteration in
             let newArray = [iteration, iteration * 2]
-            _ = atomicArray.append(contentsOf: newArray)
+            atomicArray.append(contentsOf: newArray)
         }
 
         XCTAssertEqual(atomicArray.get().count, 20_000)

--- a/AmplifyTests/CoreTests/AtomicValueTests.swift
+++ b/AmplifyTests/CoreTests/AtomicValueTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import Amplify
+import Amplify
 
 // These tests must be run with ThreadSanitizer enabled
 class AtomicValueTests: XCTestCase {


### PR DESCRIPTION
Per [@kneekey23's suggestion](https://github.com/aws-amplify/amplify-ios/pull/1345#discussion_r679629689) #1345, added a locking utility to encapsulate a bit of the boilerplate around synchronizing code with NSLocking instances.

*Description of changes:*

*Check points:*

- [X] All unit tests pass
- [X] All integration tests pass
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
