### PR TITLE
fix(DataStore): Fix race condition in sync mutation to cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,8 @@ credentials-mc.json
 fastlane/report.xml
 
 # Amplify artifacts, such as used for integ tests
-amplify
+#amplify/
+AmplifyPlugins/**/amplify
 amplify/\#current-cloud-backend
 amplify/.config/local-*
 amplify/logs

--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -609,6 +609,7 @@
 		FA9D6C1B238DEEEB00C7DD9F /* ConcurrentDispatcherPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF1B8872339633C007F1435 /* ConcurrentDispatcherPerformanceTests.swift */; };
 		FA9D6C1E238DEF0E00C7DD9F /* DefaultHubPluginPerformanceTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF1B88A23397791007F1435 /* DefaultHubPluginPerformanceTestHelpers.swift */; };
 		FA9D6C1F238DEF1100C7DD9F /* SerialDispatcherPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA317107232AE8DF009BC140 /* SerialDispatcherPerformanceTests.swift */; };
+		FA9F939626BAF73F00805607 /* OperationCancelledError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9F939526BAF73F00805607 /* OperationCancelledError.swift */; };
 		FA9FB7792329D4D400C04D32 /* HubFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9FB7782329D4D400C04D32 /* HubFilter.swift */; };
 		FA9FB77B2329D4FB00C04D32 /* UnsubscribeToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9FB77A2329D4FB00C04D32 /* UnsubscribeToken.swift */; };
 		FA9FB77D232AA0D800C04D32 /* FilteredListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9FB77C232AA0D800C04D32 /* FilteredListener.swift */; };
@@ -1591,6 +1592,7 @@
 		FA8EE780238628490097E4F1 /* Persistable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistable.swift; sourceTree = "<group>"; };
 		FA8EE78223862DDB0097E4F1 /* AnyModel+Schema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnyModel+Schema.swift"; sourceTree = "<group>"; };
 		FA8F4D232395B1B600861D91 /* MutationEvent+Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MutationEvent+Model.swift"; sourceTree = "<group>"; };
+		FA9F939526BAF73F00805607 /* OperationCancelledError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationCancelledError.swift; sourceTree = "<group>"; };
 		FA9FB7782329D4D400C04D32 /* HubFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubFilter.swift; sourceTree = "<group>"; };
 		FA9FB77A2329D4FB00C04D32 /* UnsubscribeToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsubscribeToken.swift; sourceTree = "<group>"; };
 		FA9FB77C232AA0D800C04D32 /* FilteredListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilteredListener.swift; sourceTree = "<group>"; };
@@ -3303,6 +3305,7 @@
 				FA5704C8245F3C6900392C19 /* AmplifyInProcessReportingOperation.swift */,
 				FA249EE624C5FA49009B3CE8 /* AmplifyInProcessReportingOperation+Combine.swift */,
 				FA56F72622B14BF70039754A /* AmplifyOperation.swift */,
+				FA9F939526BAF73F00805607 /* OperationCancelledError.swift */,
 				FAA7A5A524C0CC8F00CA863F /* AmplifyOperation+Combine.swift */,
 				FA5704CA245F58C600392C19 /* AmplifyOperation+Hub.swift */,
 				FAB9D810233BF5F600928AA9 /* AmplifyOperationContext.swift */,
@@ -5050,6 +5053,7 @@
 				B4B5CC812457B0690019C783 /* AuthFetchUserAttributesRequest.swift in Sources */,
 				B493E69324524E8C00D9E521 /* AuthUserAttribute.swift in Sources */,
 				B450741524115C340098F02D /* AuthSignInResult.swift in Sources */,
+				FA9F939626BAF73F00805607 /* OperationCancelledError.swift in Sources */,
 				B468841A2460A98E00221268 /* AuthForgetDeviceRequest.swift in Sources */,
 				217855C3237F84D700A30D19 /* RESTRequest.swift in Sources */,
 				975751AD24CA35F000FA0A6E /* IssueInfoHelper.swift in Sources */,

--- a/Amplify/Categories/API/Error/APIError.swift
+++ b/Amplify/Categories/API/Error/APIError.swift
@@ -47,6 +47,8 @@ extension APIError: AmplifyError {
     ) {
         if let error = error as? Self {
             self = error
+        } else if error.isOperationCancelledError {
+            self = .unknown("Operation cancelled", "", error)
         } else {
             self = .unknown(errorDescription, recoverySuggestion, error)
         }

--- a/Amplify/Categories/Analytics/Error/AnalyticsError.swift
+++ b/Amplify/Categories/Analytics/Error/AnalyticsError.swift
@@ -58,6 +58,8 @@ extension AnalyticsError: AmplifyError {
     ) {
         if let error = error as? Self {
             self = error
+        } else if error.isOperationCancelledError {
+            self = .unknown("Operation cancelled", error)
         } else {
             self = .unknown(errorDescription, error)
         }

--- a/Amplify/Categories/Auth/Error/AuthError.swift
+++ b/Amplify/Categories/Auth/Error/AuthError.swift
@@ -88,6 +88,8 @@ extension AuthError: AmplifyError {
     ) {
         if let error = error as? Self {
             self = error
+        } else if error.isOperationCancelledError {
+            self = .unknown("Operation cancelled", error)
         } else {
             self = .unknown(errorDescription, error)
         }

--- a/Amplify/Categories/DataStore/DataStoreError.swift
+++ b/Amplify/Categories/DataStore/DataStoreError.swift
@@ -108,6 +108,8 @@ extension DataStoreError: AmplifyError {
             self = error
         } else if let amplifyError = error as? AmplifyError {
             self = .api(amplifyError)
+        } else if error.isOperationCancelledError {
+            self = .unknown("Operation cancelled", "", error)
         } else {
             self = .unknown(errorDescription, recoverySuggestion, error)
         }

--- a/Amplify/Categories/Predictions/Error/PredictionsError.swift
+++ b/Amplify/Categories/Predictions/Error/PredictionsError.swift
@@ -80,6 +80,8 @@ extension PredictionsError: AmplifyError {
     ) {
         if let error = error as? Self {
             self = error
+        } else if error.isOperationCancelledError {
+            self = .unknown("Operation cancelled", "", error)
         } else {
             self = .unknown(errorDescription, recoverySuggestion, error)
         }

--- a/Amplify/Categories/Storage/Error/StorageError.swift
+++ b/Amplify/Categories/Storage/Error/StorageError.swift
@@ -86,6 +86,8 @@ extension StorageError: AmplifyError {
     ) {
         if let error = error as? Self {
             self = error
+        } else if error.isOperationCancelledError {
+            self = .unknown("Operation cancelled", error)
         } else {
             self = .unknown(errorDescription, error)
         }

--- a/Amplify/Core/Support/AmplifyOperation+Combine.swift
+++ b/Amplify/Core/Support/AmplifyOperation+Combine.swift
@@ -60,7 +60,7 @@ extension AmplifyOperation {
     /// - Returns: A publisher that either completes successfully (if the underlying
     ///   error of `error` is a cancellation) or re-emits the existing error
     private func interceptCancellation(error: Failure) -> AnyPublisher<Success, Failure> {
-        if error.underlyingError is OperationCancelledError {
+        if error.isOperationCancelledError {
             return Empty<Success, Failure>(completeImmediately: true).eraseToAnyPublisher()
         } else {
             return Fail<Success, Failure>(error: error).eraseToAnyPublisher()

--- a/Amplify/Core/Support/AmplifyOperation.swift
+++ b/Amplify/Core/Support/AmplifyOperation.swift
@@ -18,8 +18,6 @@ import Foundation
 /// Pausable/resumable tasks that do not require Hub dispatching should use AsynchronousOperation instead.
 open class AmplifyOperation<Request: AmplifyOperationRequest, Success, Failure: AmplifyError>: AsynchronousOperation {
 
-    struct OperationCancelledError: Error { }
-
     /// The concrete Request associated with this operation
     public typealias Request = Request
 

--- a/Amplify/Core/Support/OperationCancelledError.swift
+++ b/Amplify/Core/Support/OperationCancelledError.swift
@@ -1,0 +1,40 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// This is public so plugins can use it to indicate cancellations on arbitrary operations.
+///
+/// - Warning: Although this has `public` access, it is intended for internal use
+/// and should not be used   directly by host applications. The behavior of this may
+/// change without warning.
+public struct OperationCancelledError: Error {
+    public init() { }
+}
+
+/// This is public so plugins can use it to indicate cancellations on arbitrary operations.
+///
+/// - Warning: Although this has `public` access, it is intended for internal use
+/// and should not be used   directly by host applications. The behavior of this may
+/// change without warning.
+public extension AmplifyError {
+    var isOperationCancelledError: Bool {
+        guard let underlyingError = underlyingError else {
+            return false
+        }
+        return underlyingError.isOperationCancelledError
+    }
+}
+
+/// This is public so plugins can use it to indicate cancellations on arbitrary operations.
+///
+/// - Warning: Although this has `public` access, it is intended for internal use
+/// and should not be used   directly by host applications. The behavior of this may
+/// change without warning.
+public extension Error {
+    var isOperationCancelledError: Bool {
+        self is OperationCancelledError
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
@@ -117,15 +117,16 @@ final class ModelSyncedEventEmitter {
             case .delete:
                 modelSyncedEventBuilder.deleted += 1
             default:
-                break
-            }
-            if initialSyncOperationFinished && reconciledReceived == recordsReceived {
-                dispatchModelSyncedEvent()
+                log.error("Unexpected mutationType received: \(event.mutationType)")
             }
         case .mutationEventDropped:
             reconciledReceived += 1
         default:
             return
+        }
+
+        if initialSyncOperationFinished && reconciledReceived == recordsReceived {
+            dispatchModelSyncedEvent()
         }
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/MultiAuth/AWSDataStoreMultiAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/MultiAuth/AWSDataStoreMultiAuthBaseTest.swift
@@ -58,6 +58,9 @@ class AWSDataStoreMultiAuthBaseTest: XCTestCase {
         Amplify.DataStore.stop { _ in stopped.fulfill() }
         waitForExpectations(timeout: 1.0)
 
+        requests.forEach { $0.cancel() }
+        requests = []
+
         Amplify.reset()
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
@@ -59,8 +59,6 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         let connection = try getDBConnection(inMemory: true)
         try setUpStorageAdapter(connection: connection)
 
-        try setUpStorageAdapter()
-
         let mutationQueue = OutgoingMutationQueue(
             storageAdapter: storageAdapter,
             dataStoreConfiguration: .default,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
@@ -84,17 +84,15 @@ class OutgoingMutationQueueMockStateTest: XCTestCase {
         eventSource.pushMutationEvent(futureResult: .success(futureResult))
 
         let enqueueEvent = expectation(description: "state requestingEvent, enqueueEvent")
-        let processEvent = expectation(description: "state requestingEvent, processedEvent")
-
         stateMachine.pushExpectActionCriteria { action in
             XCTAssertEqual(action, OutgoingMutationQueue.Action.enqueuedEvent)
             enqueueEvent.fulfill()
         }
 
-        let mutateAPICallExpecation = expectation(description: "Call to api category for mutate")
+        let apiMutationReceived = expectation(description: "API call for mutate received")
         var listenerFromRequest: GraphQLOperation<MutationSync<AnyModel>>.ResultListener!
         let responder = MutateRequestListenerResponder<MutationSync<AnyModel>> { _, eventListener in
-            mutateAPICallExpecation.fulfill()
+            apiMutationReceived.fulfill()
             listenerFromRequest = eventListener
             return nil
         }
@@ -102,8 +100,9 @@ class OutgoingMutationQueueMockStateTest: XCTestCase {
 
         stateMachine.state = .requestingEvent
 
-        wait(for: [enqueueEvent, mutateAPICallExpecation], timeout: 1)
+        wait(for: [enqueueEvent, apiMutationReceived], timeout: 1)
 
+        let processEvent = expectation(description: "state requestingEvent, processedEvent")
         stateMachine.pushExpectActionCriteria { action in
             XCTAssertEqual(action, OutgoingMutationQueue.Action.processedEvent)
             processEvent.fulfill()

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSDataStoreCategoryPluginAuthIntegrationTests.xcscheme
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSDataStoreCategoryPluginAuthIntegrationTests.xcscheme
@@ -29,6 +29,9 @@
                <Test
                   Identifier = "AWSDataStoreMultiAuthSingleRuleTests/testOwnerOIDC()">
                </Test>
+               <Test
+                  Identifier = "AWSDataStoreMultiAuthTwoRulesTests/testOwnerPublicOIDCAPIAuthenticatedUsers()">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSDataStoreCategoryPluginAuthIntegrationTests.xcscheme
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSDataStoreCategoryPluginAuthIntegrationTests.xcscheme
@@ -10,7 +10,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -21,6 +22,14 @@
                BlueprintName = "AWSDataStoreCategoryPluginAuthIntegrationTests"
                ReferencedContainer = "container:DataStoreCategoryPlugin.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "AWSDataStoreMultiAuthSingleRuleTests/testGroupOIDC()">
+               </Test>
+               <Test
+                  Identifier = "AWSDataStoreMultiAuthSingleRuleTests/testOwnerOIDC()">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSDataStoreCategoryPluginIntegrationTests.xcscheme
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/xcshareddata/xcschemes/AWSDataStoreCategoryPluginIntegrationTests.xcscheme
@@ -10,7 +10,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyTests/CoreTests/AtomicValueTests.swift
+++ b/AmplifyTests/CoreTests/AtomicValueTests.swift
@@ -70,12 +70,36 @@ class AtomicValueTests: XCTestCase {
         }
     }
 
+    func testWithNullable() {
+        let deinitialized = expectation(description: "deinitialized")
+        let atomicNotifier = AtomicValue<InvocationCounter?>(
+            initialValue: InvocationCounter(fulfillingOnDeinit: deinitialized)
+        )
+        DispatchQueue.concurrentPerform(iterations: 1_000) { iter in
+            if iter == 500 {
+                atomicNotifier.with { $0 = nil }
+            } else {
+                atomicNotifier.atomicallyPerform { $0?.invoke() }
+            }
+        }
+
+        waitForExpectations(timeout: 1.0)
+    }
 }
 
 final class InvocationCounter {
     private(set) var invocationCount = 0
+    private let deinitExpectation: XCTestExpectation?
+
+    init(fulfillingOnDeinit deinitExpectation: XCTestExpectation? = nil) {
+        self.deinitExpectation = deinitExpectation
+    }
 
     func invoke() {
         invocationCount += 1
+    }
+
+    deinit {
+        deinitExpectation?.fulfill()
     }
 }


### PR DESCRIPTION
*Issue #, if available:* During some investigation into an unrelated issue, I encountered race conditions in the SyncMutationToCloudOperation. My original implementation incorrectly subclassed it as an `Operation` rather than an `AsynchronousOperation`, which meant that after I fixed retain cycles in that class, it was being released before completing the callback. Digging into that fix led to another issue where `ModelSyncedEmitter` wasn't properly invoking the completion callbacks during initial sync when the sync included dropped events.

*Description of changes:*

*Check points:*

- [X] All unit tests pass
- [X] All integration tests pass _(Excepting known failures as noted in https://github.com/aws-amplify/amplify-ios/issues/1354)_
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
