### PR TITLE
fix: added iOSApplicationExtension unavailable flag 

### DIFF
--- a/Amplify/DevMenu/View/IssueReporter.swift
+++ b/Amplify/DevMenu/View/IssueReporter.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import UIKit
 
 /// Issue report screen in developer menu
-@available(iOS 13.0, *)
+@available(iOSApplicationExtension, unavailable)
 struct IssueReporter: View {
     @State var issueDescription: String = ""
     @State var includeLogs = true

--- a/Amplify/DevMenu/View/IssueReporter.swift
+++ b/Amplify/DevMenu/View/IssueReporter.swift
@@ -10,6 +10,7 @@ import UIKit
 
 /// Issue report screen in developer menu
 @available(iOSApplicationExtension, unavailable)
+
 struct IssueReporter: View {
     @State var issueDescription: String = ""
     @State var includeLogs = true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
in order to allow users to continue testing using Amplify with Xcode 13 betas, I've added the `@available(iOSApplicationExtnesion, unavailable)` flag to `IssueReporter.swift`

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
