### PR TITLE
chore: Add Storage Integration test to pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,34 @@ commands:
       - store_artifacts:
           path: artifacts
 
+  configure_aws:
+    description: >-
+      Install aws cli and configure aws release profile
+    steps:
+      - run:
+          name: Install AWS cli
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli
+      - run:
+          name: Configure AWS profiles
+          command: |
+            aws configure --profile aws_profile set region us-east-1
+            echo -e "[aws_profile]\naws_access_key_id=${AWS_ACCESS_KEY_ID}\naws_secret_access_key=${AWS_SECRET_ACCESS_KEY}\n" >> ~/.aws/credentials
+  skip_job_unless_required:
+    description: >-
+      Skip job unless required
+    steps:
+      - run:
+          name: Skip job if SKIP_JOB flag is set
+          command: |
+              variable_name=SKIP_JOB_${CIRCLE_JOB}
+              skipjob_flag=$(eval "echo $"${variable_name}"")
+              skipjob_flag=$(echo "${skipjob_flag}" | tr '[:upper:]' '[:lower:]')
+              if [ "${skipjob_flag}" == "true" ]
+              then
+                echo "Skipping current job as ${variable_name} environment variable is set"
+                circleci step halt
+              fi
 jobs:
   checkout_code:
     <<: *defaults
@@ -94,7 +122,6 @@ jobs:
           key: *repo_cache_key
           paths:
             - ~/amplify-ios
-
   install_gems:
     <<: *defaults
     steps:
@@ -189,6 +216,47 @@ jobs:
       - store_test_results:
           path: build/reports
       - upload_artifacts
+  
+  plugin_integ_test:
+    <<: *defaults
+    parameters:
+      path:
+        type: string
+      workspace:
+        type: string
+      scheme:
+        type: string
+    working_directory: ~/amplify-ios/AmplifyPlugins/<< parameters.path >>
+    description: << parameters.path >> << parameters.scheme >> integration test
+    steps:
+      - skip_job_unless_required
+      - *restore_repo
+      - restore_plugin_pods:
+          prefix: << parameters.path >>
+      - pre_start_simulator
+      - run: pod install
+      - save_plugin_pods:
+          prefix: << parameters.path >>
+      - restore_gems
+      - check_bundle
+      - make_artifacts_directory
+      - configure_aws
+      - run:
+          name: Download configuration for << parameters.scheme >>
+          command: | 
+            bash ~/amplify-ios/CircleciScripts/backend_resource_management.sh ${BACKEND_BUCKET} << parameters.scheme >>
+      - run:
+          name: Build << parameters.path >>
+          command: xcodebuild build-for-testing -workspace << parameters.workspace >>.xcworkspace -scheme << parameters.scheme >> -sdk iphonesimulator -destination "${destination}" | tee "artifacts/build-<< parameters.scheme >>.log" | xcpretty
+      - run:
+          name: Test << parameters.path >>
+          command: xcodebuild test -workspace << parameters.workspace >>.xcworkspace -scheme << parameters.scheme >> -sdk iphonesimulator -destination "${destination}" | tee "artifacts/test-<< parameters.scheme >>.log" | xcpretty --simple --color --report junit
+      - run:
+          name: Upload << parameters.path >> coverage report to Codecov
+          command: bash ~/amplify-ios/build-support/codecov.sh -F << parameters.path >>_plugin_integ_test -J '^<< parameters.scheme >>$'
+      - store_test_results:
+          path: build/reports
+      - upload_artifacts
 
   deploy:
     <<: *defaults
@@ -220,6 +288,7 @@ deploy_requires: &deploy_requires
     - unit_test_datastore
     - unit_test_predictions
     - unit_test_storage
+    - integ_test_storage_functional
 
 workflows:
   build_test_deploy:
@@ -283,6 +352,17 @@ workflows:
           scheme: AWSS3StoragePlugin
           requires:
             - install_gems
+      - plugin_integ_test:
+          name: integ_test_storage_functional
+          path: Storage
+          workspace: StoragePlugin
+          scheme: AWSS3StoragePluginFunctionalTests
+          requires:
+            - unit_test_storage
+          filters:
+            branches:
+              only:
+                - main
       - deploy:
           name: deploy unstable
           <<: *deploy_requires

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,3 +209,6 @@ If you discover a potential security issue in this project we ask that you notif
 See the [LICENSE](https://github.com/aws-amplify/amplify-ios/blob/main/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.
+
+
+## Integration testing

--- a/CircleciScripts/backend_resource_management.sh
+++ b/CircleciScripts/backend_resource_management.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# This bucket contains a collection of config files that are used by the
+# integration tests. The configuration files contain sensitive
+# tokens/credentials/identifiers, so are not published publicly.
+readonly config_bucket=$1
+readonly schema=$2
+
+if [ $schema == "AWSS3StoragePluginFunctionalTests" ]; then
+    aws s3 cp "s3://$config_bucket/$schema/amplifyconfiguration.json" "$schema/AWSS3StoragePluginTests-amplifyconfiguration.json"
+    aws s3 cp "s3://$config_bucket/$schema/credentials.json" "$schema/AWSS3StoragePluginTests-credentials.json"
+fi
+
+wait


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This adds storage's integration test target to the pipeline and does the following
- depends on the correseponding storage unit test to run 
- configures aws
- pulls backend form s3

*configurability*:
- skip flag allows skipping to keep pipeline unblocked
- aws environment variables added to have access to AWS S3 
- S3 bucket is also required

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
