### PR TITLE
fix(DataStore): Use Sqlite int values over static variable

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/SQLiteResultError.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/SQLiteResultError.swift
@@ -12,6 +12,9 @@ import Amplify
 /// See https://sqlite.org/rescode.html#primary_result_code_list
 enum SQLiteResultError {
 
+    /// [(19) SQLITE_CONSTRAINT](https://sqlite.org/rescode.html#constraint)
+    static let SQLiteConstraint: Int32 = 19
+
     /// Constraint Violation, such as foreign key constraint violation, occurs when trying to process a SQL statement
     /// where the insert/update statement is performed for a child object and its parent does not exist.
     /// See https://sqlite.org/rescode.html#constraint for more details
@@ -31,7 +34,7 @@ enum SQLiteResultError {
             return nil
         }
 
-        if code == SQLITE_CONSTRAINT {
+        if code == SQLiteResultError.SQLiteConstraint {
             self = .constraintViolation(statement: statement)
             return
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -648,7 +648,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
 
     func testShouldIgnoreConstraintViolationError() {
         let constraintViolationError = Result.error(message: "Foreign Key Constraint Violation",
-                                                    code: SQLITE_CONSTRAINT,
+                                                    code: SQLiteResultError.SQLiteConstraint,
                                                     statement: nil)
         let dataStoreError = DataStoreError.invalidOperation(causedBy: constraintViolationError)
 


### PR DESCRIPTION
*Issue #, if available:*
to mitigate this issue: https://github.com/aws-amplify/amplify-ios/issues/1364

*Description of changes:*

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
