### PR TITLE
fix: storage engine doesn't need auth plugin for api key

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AuthModeStrategyTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AuthModeStrategyTests.swift
@@ -212,7 +212,7 @@ private struct ModelWithCustomStrategy: Model {
         model.authRules = [
             rule(allow: .public, provider: .iam, operations: [.create, .read, .update, .delete]),
             rule(allow: .custom, provider: .function, operations: [.create, .read, .update, .delete]),
-            rule(allow: .owner, provider: .userPools, operations: [.create, .read, .update, .delete]),
+            rule(allow: .owner, provider: .userPools, operations: [.create, .read, .update, .delete])
         ]
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+SyncRequirement.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+SyncRequirement.swift
@@ -65,11 +65,11 @@ extension StorageEngine {
 internal extension AuthRule {
     var requiresAuthPlugin: Bool {
         switch provider {
-        // OIDC and Function providers don't need
+        // OIDC, Function and API key providers don't need
         // Auth plugin
-        case .oidc, .function, .none:
+        case .oidc, .function, .apiKey, .none:
             return false
-        case .apiKey, .userPools, .iam:
+        case .userPools, .iam:
             return true
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/StorageEngineSyncRequirementsTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/StorageEngineSyncRequirementsTests.swift
@@ -38,7 +38,8 @@ class StorageEngineSyncRequirementsTests: XCTestCase {
     func testDoesNotRequireAuthPlugin() {
         let authRules: AuthRules = [
             AuthRule(allow: .owner, provider: .oidc),
-            AuthRule(allow: .owner, provider: .function)
+            AuthRule(allow: .owner, provider: .function),
+            AuthRule(allow: .public, provider: .apiKey)
         ]
         XCTAssertFalse(authRules.requireAuthPlugin)
     }


### PR DESCRIPTION
*Description of changes:*
API key authentication mode doesn't require an auth plugin

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [ ] All integration tests pass
~- [ ] Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
