### PR TITLE
fix(DataStore): add missing SQLite3 import

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/SQLiteResultError.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/SQLiteResultError.swift
@@ -6,6 +6,7 @@
 //
 
 import SQLite
+import SQLite3
 import Amplify
 
 /// Checks for specific SQLLite error codes

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -7,6 +7,7 @@
 
 import XCTest
 import SQLite
+import SQLite3
 
 @testable import Amplify
 @testable import AWSPluginsCore


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/1364

*Description of changes:*
Add missing imports for use of the sqlite3 constants. Able to reproduce this when building using the swift package over the pod workspace

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
