### PR TITLE
feat(DataStore): observe query API

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		210DBC142332B3C6009B9E51 /* StorageGetURLOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210DBC132332B3C6009B9E51 /* StorageGetURLOperation.swift */; };
 		210DBC162332B3CB009B9E51 /* StorageDownloadDataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210DBC152332B3CB009B9E51 /* StorageDownloadDataOperation.swift */; };
 		210DBC472332F0C5009B9E51 /* StorageError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210DBC462332F0C5009B9E51 /* StorageError.swift */; };
+		211FFEE326CD650500F0DB75 /* DataStoreQuerySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211FFEE226CD650500F0DB75 /* DataStoreQuerySnapshot.swift */; };
 		2125E2542319EC3100B3DEB5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2125E2532319EC3100B3DEB5 /* AppDelegate.swift */; };
 		2125E2562319EC3100B3DEB5 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2125E2552319EC3100B3DEB5 /* ViewController.swift */; };
 		2125E2592319EC3100B3DEB5 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2125E2572319EC3100B3DEB5 /* Main.storyboard */; };
@@ -159,6 +160,8 @@
 		21A905372616446F00EC141D /* EnumTestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A9052A2616446F00EC141D /* EnumTestModel.swift */; };
 		21A905382616446F00EC141D /* TestEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A9052B2616446F00EC141D /* TestEnum.swift */; };
 		21A905602616484A00EC141D /* Scalar+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A9055F2616484A00EC141D /* Scalar+Equatable.swift */; };
+		21AAE24026DFE94B007BA909 /* ModelSyncMetadata+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AAE23E26DFE94B007BA909 /* ModelSyncMetadata+Schema.swift */; };
+		21AAE24126DFE94B007BA909 /* ModelSyncMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AAE23F26DFE94B007BA909 /* ModelSyncMetadata.swift */; };
 		21AD424B249BF0DA0016FE95 /* AnyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACBAD522386160100E29E56 /* AnyModel.swift */; };
 		21AD424C249BF0DE0016FE95 /* AnyModel+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8EE776238626D60097E4F1 /* AnyModel+Codable.swift */; };
 		21AD424D249BF0E50016FE95 /* AnyModel+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8EE78223862DDB0097E4F1 /* AnyModel+Schema.swift */; };
@@ -847,6 +850,7 @@
 		210DBC132332B3C6009B9E51 /* StorageGetURLOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageGetURLOperation.swift; sourceTree = "<group>"; };
 		210DBC152332B3CB009B9E51 /* StorageDownloadDataOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageDownloadDataOperation.swift; sourceTree = "<group>"; };
 		210DBC462332F0C5009B9E51 /* StorageError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageError.swift; sourceTree = "<group>"; };
+		211FFEE226CD650500F0DB75 /* DataStoreQuerySnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreQuerySnapshot.swift; sourceTree = "<group>"; };
 		2125E2102318D73B00B3DEB5 /* awsconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = awsconfiguration.json; sourceTree = "<group>"; };
 		2125E2512319EC3000B3DEB5 /* AmplifyTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AmplifyTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2125E2532319EC3100B3DEB5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -1001,6 +1005,8 @@
 		21A9052A2616446F00EC141D /* EnumTestModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumTestModel.swift; sourceTree = "<group>"; };
 		21A9052B2616446F00EC141D /* TestEnum.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEnum.swift; sourceTree = "<group>"; };
 		21A9055F2616484A00EC141D /* Scalar+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Scalar+Equatable.swift"; sourceTree = "<group>"; };
+		21AAE23E26DFE94B007BA909 /* ModelSyncMetadata+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ModelSyncMetadata+Schema.swift"; sourceTree = "<group>"; };
+		21AAE23F26DFE94B007BA909 /* ModelSyncMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelSyncMetadata.swift; sourceTree = "<group>"; };
 		21AD4255249BFFDF0016FE95 /* DeprecatedTodo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DeprecatedTodo.swift; path = Deprecated/DeprecatedTodo.swift; sourceTree = "<group>"; };
 		21C395B2245729EC00597EA2 /* AppSyncErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncErrorType.swift; sourceTree = "<group>"; };
 		21D79FD9237617C60057D00D /* SubscriptionEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionEvent.swift; sourceTree = "<group>"; };
@@ -1935,6 +1941,7 @@
 		2129BE3F23948909006363A1 /* Sync */ = {
 			isa = PBXGroup;
 			children = (
+				21AAE23D26DFE94B007BA909 /* ModelSync */,
 				2129BE4023948912006363A1 /* MutationSync */,
 				2129BE542395CAEF006363A1 /* PaginatedList.swift */,
 			);
@@ -2178,6 +2185,15 @@
 				21A9052B2616446F00EC141D /* TestEnum.swift */,
 			);
 			path = Scalar;
+			sourceTree = "<group>";
+		};
+		21AAE23D26DFE94B007BA909 /* ModelSync */ = {
+			isa = PBXGroup;
+			children = (
+				21AAE23E26DFE94B007BA909 /* ModelSyncMetadata+Schema.swift */,
+				21AAE23F26DFE94B007BA909 /* ModelSyncMetadata.swift */,
+			);
+			path = ModelSync;
 			sourceTree = "<group>";
 		};
 		21AD424A249BEC440016FE95 /* Internal */ = {
@@ -3858,6 +3874,7 @@
 			isa = PBXGroup;
 			children = (
 				FAD393702381FD3C00463F5E /* DataStoreCategory+Subscribe.swift */,
+				211FFEE226CD650500F0DB75 /* DataStoreQuerySnapshot.swift */,
 				FA9FD2332381CD0000A7CAF5 /* MutationEvent.swift */,
 				FA8F4D232395B1B600861D91 /* MutationEvent+Model.swift */,
 				FACBAD4F2386101100E29E56 /* MutationEvent+MutationType.swift */,
@@ -4760,6 +4777,7 @@
 			files = (
 				2129BE4423948951006363A1 /* MutationSyncMetadata.swift in Sources */,
 				B9675A2E24752621002FC843 /* GraphQLRequest+Model.swift in Sources */,
+				21AAE24026DFE94B007BA909 /* ModelSyncMetadata+Schema.swift in Sources */,
 				2129BE1E2394806B006363A1 /* QueryPredicate+GraphQL.swift in Sources */,
 				21420A8F237222A900FA140C /* AWSIAMConfiguration.swift in Sources */,
 				219A888523EB897700BBC5F2 /* GraphQLRequest+AnyModelWithSync.swift in Sources */,
@@ -4793,6 +4811,7 @@
 				7608EE14268142F300FEC9CD /* AWSPluginOptions.swift in Sources */,
 				6BBECD7123ADA7E100C8DFBE /* AmplifyAWSServiceConfiguration.swift in Sources */,
 				21AD424F249BF0EC0016FE95 /* Model+AnyModel.swift in Sources */,
+				21AAE24126DFE94B007BA909 /* ModelSyncMetadata.swift in Sources */,
 				B4EBEB682462050B00D06375 /* AuthCognitoIdentityProvider.swift in Sources */,
 				21AD424C249BF0DE0016FE95 /* AnyModel+Codable.swift in Sources */,
 				212CE6FE23E9E5A2007D8E71 /* GraphQLDocumentnputValue.swift in Sources */,
@@ -5243,6 +5262,7 @@
 				B4251A0124250369007F59EF /* AuthConfirmResetPasswordRequest.swift in Sources */,
 				FAAFAF2F23904B14002CF932 /* AtomicValue+Bool.swift in Sources */,
 				B9B50DC823DA15890086F1E1 /* DataStoreError+Temporal.swift in Sources */,
+				211FFEE326CD650500F0DB75 /* DataStoreQuerySnapshot.swift in Sources */,
 				FA249EEB24C5FE66009B3CE8 /* AmplifyAPICategory+GraphQLBehavior+Combine.swift in Sources */,
 				FACD26502386E9410068FBE6 /* JSONValue+Subscript.swift in Sources */,
 				B450741324115C260098F02D /* AuthSignInRequest.swift in Sources */,

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -65,4 +65,17 @@ public protocol DataStoreSubscribeBehavior {
     /// - Parameter modelType: The model type to observe
     @available(iOS 13.0, *)
     func publisher<M: Model>(for modelType: M.Type) -> AnyPublisher<MutationEvent, DataStoreError>
+
+    /// Returns a Publisher for query snapshots.
+    ///
+    /// - Parameters:
+    ///   - modelType: The model type to observe
+    ///   - predicate: The predicate to match for filtered results
+    ///   - sortInput: The field and order of data to be returned
+    @available(iOS 13.0, *)
+
+    func observeQuery<M: Model>(for modelType: M.Type,
+                                where predicate: QueryPredicate?,
+                                sort sortInput: QuerySortInput?)
+    -> AnyPublisher<DataStoreQuerySnapshot<M>, DataStoreError>
 }

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -73,7 +73,6 @@ public protocol DataStoreSubscribeBehavior {
     ///   - predicate: The predicate to match for filtered results
     ///   - sortInput: The field and order of data to be returned
     @available(iOS 13.0, *)
-
     func observeQuery<M: Model>(for modelType: M.Type,
                                 where predicate: QueryPredicate?,
                                 sort sortInput: QuerySortInput?)

--- a/Amplify/Categories/DataStore/Subscribe/DataStoreCategory+Subscribe.swift
+++ b/Amplify/Categories/DataStore/Subscribe/DataStoreCategory+Subscribe.swift
@@ -12,4 +12,12 @@ extension DataStoreCategory: DataStoreSubscribeBehavior {
     public func publisher<M: Model>(for modelType: M.Type) -> AnyPublisher<MutationEvent, DataStoreError> {
         return plugin.publisher(for: modelType)
     }
+
+    @available(iOS 13.0, *)
+    public func observeQuery<M: Model>(for modelType: M.Type,
+                                       where predicate: QueryPredicate? = nil,
+                                       sort sortInput: QuerySortInput? = nil)
+    -> AnyPublisher<DataStoreQuerySnapshot<M>, DataStoreError> {
+        return plugin.observeQuery(for: modelType, where: predicate, sort: sortInput)
+    }
 }

--- a/Amplify/Categories/DataStore/Subscribe/DataStoreQuerySnapshot.swift
+++ b/Amplify/Categories/DataStore/Subscribe/DataStoreQuerySnapshot.swift
@@ -1,0 +1,26 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public struct DataStoreQuerySnapshot<M: Model> {
+
+    /// All model instances from the local store
+    public let items: [M]
+
+    /// Indicates whether all sync queries for this model are complete, and subscriptions are active
+    public let isSynced: Bool
+
+    /// Latest changes since last snapshot
+    public let itemsChanged: [MutationEvent]
+
+    public init(items: [M], isSynced: Bool, itemsChanged: [MutationEvent]) {
+        self.items = items
+        self.isSynced = isSynced
+        self.itemsChanged = itemsChanged
+    }
+}

--- a/Amplify/Categories/DataStore/Subscribe/DataStoreQuerySnapshot.swift
+++ b/Amplify/Categories/DataStore/Subscribe/DataStoreQuerySnapshot.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+/// A snapshot of the items from DataStore, the changes since last snapshot, and whether this model has
+/// finished syncing and subscriptions are active
 public struct DataStoreQuerySnapshot<M: Model> {
 
     /// All model instances from the local store

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -174,10 +174,17 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
 
     public func start(completion: @escaping DataStoreCallback<Void>) {
-        reinitStorageEngineIfNeeded(completion: completion)
+        reinitStorageEngineIfNeeded { result in
+            completion(result)
+        }
     }
 
     public func stop(completion: @escaping DataStoreCallback<Void>) {
+        operationQueue.operations.forEach { operation in
+            if let operation = operation as? DataStoreObseverQueryOperation {
+                operation.resetState()
+            }
+        }
         storageEngineInitSemaphore.wait()
         if storageEngine == nil {
             storageEngineInitSemaphore.signal()
@@ -192,6 +199,11 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
 
     public func clear(completion: @escaping DataStoreCallback<Void>) {
+        operationQueue.operations.forEach { operation in
+            if let operation = operation as? DataStoreObseverQueryOperation {
+                operation.resetState()
+            }
+        }
         storageEngineInitSemaphore.wait()
         if storageEngine == nil {
             storageEngineInitSemaphore.signal()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -181,7 +181,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
 
     public func stop(completion: @escaping DataStoreCallback<Void>) {
         operationQueue.operations.forEach { operation in
-            if let operation = operation as? DataStoreObseverQueryOperation {
+            if let operation = operation as? DataStoreObserveQueryOperation {
                 operation.resetState()
             }
         }
@@ -200,7 +200,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
 
     public func clear(completion: @escaping DataStoreCallback<Void>) {
         operationQueue.operations.forEach { operation in
-            if let operation = operation as? DataStoreObseverQueryOperation {
+            if let operation = operation as? DataStoreObserveQueryOperation {
                 operation.resetState()
             }
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
@@ -54,8 +54,6 @@ extension AWSDataStorePlugin: DataStoreSubscribeBehavior {
                             "`dataStorePublisher` is expected to exist for deployment targets >=iOS13.0",
                             "", nil)).eraseToAnyPublisher()
         }
-        // Force-unwrapping: The optional 'dataStorePublisher' is expected
-        // to exist for deployment targets >=iOS13.0
         let operation = AWSDataStoreObserveQueryOperation(modelType: modelType,
                                                           modelSchema: modelSchema,
                                                           predicate: predicate,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
@@ -33,8 +33,6 @@ extension AWSDataStorePlugin: DataStoreSubscribeBehavior {
                                        where predicate: QueryPredicate? = nil,
                                        sort sortInput: QuerySortInput? = nil)
     -> AnyPublisher<DataStoreQuerySnapshot<M>, DataStoreError> {
-        reinitStorageEngineIfNeeded()
-
         return observeQuery(for: modelType,
                             modelSchema: modelType.schema,
                             where: predicate,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
@@ -35,14 +35,17 @@ extension AWSDataStorePlugin: DataStoreSubscribeBehavior {
     -> AnyPublisher<DataStoreQuerySnapshot<M>, DataStoreError> {
         reinitStorageEngineIfNeeded()
 
-        return observeQuery(for: modelType, modelSchema: modelType.schema, where: predicate, sort: sortInput)
+        return observeQuery(for: modelType,
+                            modelSchema: modelType.schema,
+                            where: predicate,
+                            sort: sortInput?.asSortDescriptors())
     }
 
     @available(iOS 13.0, *)
     public func observeQuery<M: Model>(for modelType: M.Type,
                                        modelSchema: ModelSchema,
                                        where predicate: QueryPredicate? = nil,
-                                       sort sortInput: QuerySortInput? = nil)
+                                       sort sortInput: [QuerySortDescriptor]? = nil)
     -> AnyPublisher<DataStoreQuerySnapshot<M>, DataStoreError> {
         reinitStorageEngineIfNeeded()
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
@@ -49,14 +49,19 @@ extension AWSDataStorePlugin: DataStoreSubscribeBehavior {
     -> AnyPublisher<DataStoreQuerySnapshot<M>, DataStoreError> {
         reinitStorageEngineIfNeeded()
 
+        guard let dataStorePublisher = dataStorePublisher else {
+            return Fail(error: DataStoreError.unknown(
+                            "`dataStorePublisher` is expected to exist for deployment targets >=iOS13.0",
+                            "", nil)).eraseToAnyPublisher()
+        }
         // Force-unwrapping: The optional 'dataStorePublisher' is expected
         // to exist for deployment targets >=iOS13.0
-        let operation = AWSDataStoreObseverQueryOperation(modelType: modelType,
+        let operation = AWSDataStoreObserveQueryOperation(modelType: modelType,
                                                           modelSchema: modelSchema,
                                                           predicate: predicate,
                                                           sortInput: sortInput,
                                                           storageEngine: storageEngine,
-                                                          dataStorePublisher: dataStorePublisher!)
+                                                          dataStorePublisher: dataStorePublisher)
         operationQueue.addOperation(operation)
         return operation.publisher
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -121,7 +121,7 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
             storageEngine.startSync { result in
 
                 self.operationQueue.operations.forEach { operation in
-                    if let operation = operation as? DataStoreObseverQueryOperation {
+                    if let operation = operation as? DataStoreObserveQueryOperation {
                         operation.startObserveQuery()
                     }
                 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QuerySort+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QuerySort+SQLite.swift
@@ -26,6 +26,15 @@ extension QuerySortBy {
             return QuerySortOrder.descending
         }
     }
+
+    var sortDescriptor: QuerySortDescriptor {
+        switch self {
+        case .ascending(let key):
+            return .init(fieldName: key.stringValue, order: .ascending)
+        case .descending(let key):
+            return .init(fieldName: key.stringValue, order: .descending)
+        }
+    }
 }
 
 extension QuerySortInput {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStoreObserveQueryOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStoreObserveQueryOperation.swift
@@ -102,10 +102,10 @@ extension ObserveQuerySubscription: DefaultLogger { }
 ///     - Subscribe to Item changes
 ///     - Perform initial query to set up the internal state of the items
 ///     - Generate first snapshot based on the internal state
-///     When the operation receives item changs
+///     When the operation receives item changes
 ///     - Batch them into batches of up to 1000 items or when 2 seconds have elapsed (`.collect(2s,1000)`)`
 ///     - Update internal state of items based on the changed items
-///     - Generate new snapshot based on lates state of the items, with the items changed dedupped.
+///     - Generate new snapshot based on latest state of the items, with the items changed dedupped.
 @available(iOS 13.0, *)
 public class AWSDataStoreObserveQueryOperation<M: Model>: AsynchronousOperation, DataStoreObserveQueryOperation {
 
@@ -166,6 +166,10 @@ public class AWSDataStoreObserveQueryOperation<M: Model>: AsynchronousOperation,
     override public func cancel() {
         if let itemsChangedSink = itemsChangedSink {
             itemsChangedSink.cancel()
+        }
+
+        if let dataStoreEventSink = dataStoreEventSink {
+            dataStoreEventSink.cancel()
         }
         passthroughPublisher.send(completion: .finished)
         super.cancel()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStoreObserveQueryOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStoreObserveQueryOperation.swift
@@ -109,7 +109,7 @@ public class AWSDataStoreObseverQueryOperation<M: Model>: AsynchronousOperation,
     let modelType: M.Type
     let modelSchema: ModelSchema
     let predicate: QueryPredicate?
-    let sortInput: QuerySortInput?
+    let sortInput: [QuerySortDescriptor]?
 
     let storageEngine: StorageEngineBehavior
     var dataStorePublisher: ModelSubcriptionBehavior
@@ -132,7 +132,7 @@ public class AWSDataStoreObseverQueryOperation<M: Model>: AsynchronousOperation,
     init(modelType: M.Type,
          modelSchema: ModelSchema,
          predicate: QueryPredicate?,
-         sortInput: QuerySortInput?,
+         sortInput: [QuerySortDescriptor]?,
          storageEngine: StorageEngineBehavior,
          dataStorePublisher: ModelSubcriptionBehavior) {
         self.modelType = modelType
@@ -233,7 +233,7 @@ public class AWSDataStoreObseverQueryOperation<M: Model>: AsynchronousOperation,
             modelType,
             modelSchema: modelSchema,
             predicate: predicate,
-            sort: sortInput?.asSortDescriptors(),
+            sort: sortInput,
             paginationInput: nil,
             completion: { queryResult in
                 if isCancelled || isFinished {
@@ -305,7 +305,7 @@ public class AWSDataStoreObseverQueryOperation<M: Model>: AsynchronousOperation,
         updateCurrentItems(with: itemsChanged)
         var currentItems = Array(currentItemsMap.values.map { $0 }) as [M]
         if let sort = sortInput {
-            sort.inputs.forEach { currentItems.sortModels(by: $0, modelSchema: modelSchema) }
+            sort.forEach { currentItems.sortModels(by: $0, modelSchema: modelSchema) }
         }
         publish(items: currentItems, isSynced: isSynced.get(), itemsChanged: itemsChanged)
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStoreObserveQueryOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStoreObserveQueryOperation.swift
@@ -1,0 +1,364 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import AWSPluginsCore
+import Combine
+
+protocol DataStoreObseverQueryOperation {
+    func resetState()
+    func startObserveQuery()
+}
+
+@available(iOS 13.0, *)
+public class ObserveQueryPublisher<M: Model>: Publisher {
+    public typealias Output = DataStoreQuerySnapshot<M>
+    public typealias Failure = DataStoreError
+
+    weak var operation: AWSDataStoreObseverQueryOperation<M>?
+
+    func configure(operation: AWSDataStoreObseverQueryOperation<M>) {
+        self.operation = operation
+    }
+
+    public func receive<S>(subscriber: S)
+    where S: Subscriber, ObserveQueryPublisher.Failure == S.Failure, ObserveQueryPublisher.Output == S.Input {
+        let subscription = ObserveQuerySubscription<S, M>(operation: operation)
+        subscription.target = subscriber
+        subscriber.receive(subscription: subscription)
+    }
+}
+
+@available(iOS 13.0, *)
+class ObserveQuerySubscription<Target: Subscriber, M: Model>: Subscription
+where Target.Input == DataStoreQuerySnapshot<M>, Target.Failure == DataStoreError {
+
+    private let serialQueue = DispatchQueue(label: "com.amazonaws.ObserveQuerySubscription.serialQueue",
+                                            target: DispatchQueue.global())
+    var target: Target?
+    var sink: AnyCancellable?
+    weak var operation: AWSDataStoreObseverQueryOperation<M>?
+
+    init(operation: AWSDataStoreObseverQueryOperation<M>?) {
+        self.operation = operation
+        self.sink = operation?
+            .passthroughPublisher
+            .sink(receiveCompletion: onReceiveCompletion(completed:),
+                  receiveValue: onReceiveValue(snapshot:))
+    }
+
+    func onReceiveCompletion(completed: Subscribers.Completion<DataStoreError>) {
+        serialQueue.async {
+            self.target?.receive(completion: completed)
+            self.target = nil
+            self.sink = nil
+            self.operation = nil
+        }
+    }
+
+    func onReceiveValue(snapshot: DataStoreQuerySnapshot<M>) {
+        _ = target?.receive(snapshot)
+    }
+
+    /// This subscription doesn't respond to demand, since it'll
+    /// simply emit events according to its underlying operation
+    /// but we still have to implement this method
+    /// in order to conform to the Subscription protocol:
+    func request(_ demand: Subscribers.Demand) {}
+
+    /// When the subscription is cancelled, cancel the underlying operation
+    func cancel() {
+        serialQueue.async {
+            self.operation?.cancel()
+        }
+    }
+
+    /// When app code recreates the subscription, the previous subscription
+    /// will be deallocated. At this time, cancel the underlying operation
+    deinit {
+        self.operation?.cancel()
+        self.target = nil
+        self.sink = nil
+        self.operation = nil
+    }
+}
+
+/// Publishes a stream of `DataStoreQuerySnapshot` events.
+///
+/// Flow: When the operation starts executing
+///     - Subscribe to DataStore hub events
+///     - Subscribe to Item changes
+///     - Perform initial query to set up the internal state of the items
+///     - Generate first snapshot based on the internal state
+///     When the operation receives item changs
+///     - Batch them into batches of up to 1000 items or when 2 seconds have elapsed (`.collect(2s,1000)`)`
+///     - Update internal state of items based on the changed items
+///     - Generate new snapshot based on lates state of the items, with the items changed dedupped.
+@available(iOS 13.0, *)
+public class AWSDataStoreObseverQueryOperation<M: Model>: AsynchronousOperation, DataStoreObseverQueryOperation {
+
+    private let serialQueue = DispatchQueue(label: "com.amazonaws.AWSDataStoreObseverQueryOperation.serialQueue",
+                                            target: DispatchQueue.global())
+    private let itemsChangedPeriodicPublishTimeInSeconds: DispatchQueue.SchedulerTimeType.Stride = 2
+    private let itemsChangedMaxSize = 1_000
+
+    let modelType: M.Type
+    let modelSchema: ModelSchema
+    let predicate: QueryPredicate?
+    let sortInput: QuerySortInput?
+
+    let storageEngine: StorageEngineBehavior
+    var dataStorePublisher: ModelSubcriptionBehavior
+
+    let observeQueryStarted: AtomicValue<Bool>
+    let isSynced: AtomicValue<Bool>
+    var currentItemsMap: [Model.Identifier: M] = [:]
+    var itemsChangedSink: AnyCancellable?
+    var dataStoreEventSink: AnyCancellable?
+
+    /// Internal publisher for `ObserveQueryPublisher` to pass events back to subscribers
+    let passthroughPublisher: PassthroughSubject<DataStoreQuerySnapshot<M>, DataStoreError>
+
+    /// External subscribers subscribe to this publisher
+    private let observeQueryPublisher: ObserveQueryPublisher<M>
+    public var publisher: AnyPublisher<DataStoreQuerySnapshot<M>, DataStoreError> {
+        return observeQueryPublisher.eraseToAnyPublisher()
+    }
+
+    init(modelType: M.Type,
+         modelSchema: ModelSchema,
+         predicate: QueryPredicate?,
+         sortInput: QuerySortInput?,
+         storageEngine: StorageEngineBehavior,
+         dataStorePublisher: ModelSubcriptionBehavior) {
+        self.modelType = modelType
+        self.modelSchema = modelSchema
+        self.predicate = predicate
+        self.sortInput = sortInput
+        self.storageEngine = storageEngine
+        self.dataStorePublisher = dataStorePublisher
+
+        self.observeQueryStarted = AtomicValue(initialValue: false)
+        self.isSynced = AtomicValue(initialValue: false)
+        self.passthroughPublisher = PassthroughSubject<DataStoreQuerySnapshot<M>, DataStoreError>()
+        self.observeQueryPublisher = ObserveQueryPublisher()
+        super.init()
+        observeQueryPublisher.configure(operation: self)
+    }
+
+    override public func main() {
+        startObserveQuery()
+    }
+
+    override public func cancel() {
+        if let itemsChangedSink = itemsChangedSink {
+            itemsChangedSink.cancel()
+        }
+        passthroughPublisher.send(completion: .finished)
+        super.cancel()
+        finish()
+    }
+
+    func resetState() {
+        serialQueue.async {
+            self.log.verbose("Resetting state")
+            self.isSynced.set(false)
+            self.currentItemsMap.removeAll()
+            self.itemsChangedSink = nil
+            self.dataStoreEventSink = nil
+            self.observeQueryStarted.set(false)
+        }
+    }
+
+    func startObserveQuery() {
+        serialQueue.async {
+            if self.isCancelled || self.isFinished {
+                self.finish()
+                return
+            }
+            if self.observeQueryStarted.getAndSet(true) {
+                return
+            }
+            self.log.verbose("Start ObserveQuery")
+            self.dataStoreEventSink = Amplify.Hub.publisher(for: .dataStore)
+                .sink(receiveValue: self.onDataStoreEvent(hubPayload:))
+            self.subscribeToItemChanges()
+            self.setInitialIsSyncedState()
+            self.initialQuery()
+        }
+    }
+
+    // MARK: - Initial IsSynced state
+
+    func setInitialIsSyncedState() {
+        // if the sync engine is active, then `.ready` event has already fired, set isSynced to true
+        if let storageAdapter = storageEngine as? StorageEngine,
+           let remoteSyncEngine = storageAdapter.syncEngine as? RemoteSyncEngine,
+           case .syncEngineActive = remoteSyncEngine.stateMachine.state {
+            isSynced.set(true)
+        }
+    }
+
+    // MARK: - Observe DataStore events
+
+    func onDataStoreEvent(hubPayload: HubPayload) {
+        if isCancelled || isFinished {
+            finish()
+            return
+        }
+
+        if hubPayload.eventName == HubPayload.EventName.DataStore.modelSynced && !isSynced.get(),
+           let modelSynced = hubPayload.data as? ModelSyncedEvent, modelSynced.modelName == modelSchema.name {
+            isSynced.set(true)
+            log.verbose("Received .modelSynced event")
+        } else if hubPayload.eventName == HubPayload.EventName.DataStore.ready && !isSynced.get() {
+            isSynced.set(true)
+            log.verbose("Received .ready event")
+        }
+    }
+
+    // MARK: - Query
+
+    func initialQuery() {
+        if isCancelled || isFinished {
+            finish()
+            return
+        }
+
+        storageEngine.query(
+            modelType,
+            modelSchema: modelSchema,
+            predicate: predicate,
+            sort: sortInput?.asSortDescriptors(),
+            paginationInput: nil,
+            completion: { queryResult in
+                if isCancelled || isFinished {
+                    finish()
+                    return
+                }
+
+                switch queryResult {
+                case .success(let queriedModels):
+                    storeCurrentItems(queriedModels: queriedModels)
+                    generateQuerySnapshot()
+                case .failure(let error):
+                    self.passthroughPublisher.send(completion: .failure(error))
+                    self.finish()
+                    return
+                }
+            })
+    }
+
+    func storeCurrentItems(queriedModels: [M]) {
+        for model in queriedModels {
+            currentItemsMap.updateValue(model, forKey: model.id)
+        }
+    }
+
+    // MARK: Observe item changes
+
+    func subscribeToItemChanges() {
+        itemsChangedSink = dataStorePublisher.publisher
+            .filter(onItemChangedFilter(mutationEvent:))
+            .collect(.byTimeOrCount(serialQueue, itemsChangedPeriodicPublishTimeInSeconds, itemsChangedMaxSize))
+            .sink(receiveCompletion: onReceiveCompletion(completed:),
+                  receiveValue: onItemChanges(mutationEvents:))
+    }
+
+    func onItemChangedFilter(mutationEvent: MutationEvent) -> Bool {
+        guard mutationEvent.modelName == modelSchema.name else {
+            return false
+        }
+
+        guard let predicate = self.predicate else {
+            return true
+        }
+
+        do {
+            let model = try mutationEvent.decodeModel(as: modelType)
+            return predicate.evaluate(target: model)
+        } catch {
+            log.error(error: error)
+            return false
+        }
+    }
+
+    func onItemChanges(mutationEvents: [MutationEvent]) {
+        serialQueue.async {
+            if self.isCancelled || self.isFinished {
+                self.finish()
+                return
+            }
+            guard !mutationEvents.isEmpty else {
+                return
+            }
+
+            self.generateQuerySnapshot(itemsChanged: mutationEvents)
+        }
+    }
+
+    func generateQuerySnapshot(itemsChanged: [MutationEvent] = []) {
+        updateCurrentItems(with: itemsChanged)
+        var currentItems = Array(currentItemsMap.values.map { $0 }) as [M]
+        if let sort = sortInput {
+            sort.inputs.forEach { currentItems.sortModels(by: $0, modelSchema: modelSchema) }
+        }
+        publish(items: currentItems, isSynced: isSynced.get(), itemsChanged: itemsChanged)
+    }
+
+    func updateCurrentItems(with itemsChanged: [MutationEvent]) {
+        for item in itemsChanged {
+            do {
+                let model = try item.decodeModel(as: modelType)
+                if item.mutationType == MutationEvent.MutationType.delete.rawValue {
+                    currentItemsMap.removeValue(forKey: model.id)
+                } else {
+                    currentItemsMap.updateValue(model, forKey: model.id)
+                }
+            } catch {
+                log.error(error: error)
+                continue
+            }
+        }
+    }
+
+    func onReceiveCompletion(completed: Subscribers.Completion<DataStoreError>) {
+        if isCancelled || isFinished {
+            finish()
+            return
+        }
+        switch completed {
+        case .finished:
+            passthroughPublisher.send(completion: .finished)
+        case .failure(let error):
+            passthroughPublisher.send(completion: .failure(error))
+        }
+        finish()
+    }
+
+    // MARK: - Helpers
+
+    func publish(items: [M], isSynced: Bool, itemsChanged: [MutationEvent]) {
+        let querySnapshot = DataStoreQuerySnapshot(items: items,
+                                                   isSynced: isSynced,
+                                                   itemsChanged: dedup(mutationEvents: itemsChanged))
+        log.verbose("items: \(querySnapshot.items.count) changed: \(querySnapshot.itemsChanged.count) isSynced: \(querySnapshot.isSynced)")
+        passthroughPublisher.send(querySnapshot)
+    }
+
+    /// Remove duplicate MutationEvents based on the model identifier, keeping the latest one.
+    func dedup(mutationEvents: [MutationEvent]) -> [MutationEvent] {
+        var itemsChangedMap: [Model.Identifier: MutationEvent] = [:]
+        for mutationEvent in mutationEvents {
+            itemsChangedMap.updateValue(mutationEvent, forKey: mutationEvent.modelId)
+        }
+        return Array(itemsChangedMap.values.map { $0 })
+    }
+}
+
+@available(iOS 13.0, *)
+extension AWSDataStoreObseverQueryOperation: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/Support/Model+Sort.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/Support/Model+Sort.swift
@@ -1,0 +1,156 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import CoreGraphics
+
+extension Array where Element: Model {
+    mutating func sortModels(by sortBy: QuerySortBy, modelSchema: ModelSchema) {
+        sort { modelSchema.comparator(model1: $0, model2: $1, sortBy: sortBy) }
+    }
+}
+
+enum ModelValueCompare<T: Comparable> {
+    case bothNil
+    case leftNil(value2: T)
+    case rightNil(value1: T)
+    case values(value1: T, value2: T)
+    case unknown
+
+    init(value1Optional: T?, value2Optional: T?) {
+        if value1Optional == nil && value2Optional == nil {
+            self = .bothNil
+        } else if value1Optional == nil, let value2 = value2Optional {
+            self = .leftNil(value2: value2)
+        } else if value2Optional == nil, let value1 = value1Optional {
+            self = .rightNil(value1: value1)
+        } else if let value1 = value1Optional, let value2 = value2Optional {
+            self = .values(value1: value1, value2: value2)
+        } else {
+            self = .unknown
+        }
+    }
+
+    /// Treat `nil` as less than non `nil`values, so return asecnding when left side is `nil` and descending when right
+    /// is nil.
+    func sortComparator(sortOrder: QuerySortOrder) -> Bool {
+        switch self {
+        case .bothNil, .leftNil:
+            return sortOrder == .ascending
+        case .rightNil:
+            return sortOrder == .descending
+        case .values(let value1, let value2):
+            return sortOrder == .ascending ? value1 < value2 : value1 > value2
+        case .unknown:
+            return false
+        }
+    }
+}
+
+extension ModelSchema {
+    // swiftlint:disable:next cyclomatic_complexity
+    func comparator(model1: Model,
+                    model2: Model,
+                    sortBy: QuerySortBy) -> Bool {
+        let fieldName = sortBy.fieldName
+        let sortOrder = sortBy.fieldOrder
+        guard let modelField = field(withName: fieldName) else {
+            return false
+        }
+        let value1 = model1[fieldName] ?? nil
+        let value2 = model2[fieldName] ?? nil
+        switch modelField.type {
+        case .string:
+            guard let value1Optional = value1 as? String?, let value2Optional = value2 as? String? else {
+                return false
+            }
+            return ModelValueCompare(value1Optional: value1Optional,
+                                     value2Optional: value2Optional)
+                .sortComparator(sortOrder: sortOrder)
+        case .int, .timestamp:
+            guard let value1Optional = value1 as? Int?, let value2Optional = value2 as? Int? else {
+                return false
+            }
+            return ModelValueCompare(value1Optional: value1Optional,
+                                     value2Optional: value2Optional)
+                .sortComparator(sortOrder: sortOrder)
+
+        case .double:
+            guard let value1Optional = value1 as? Double?, let value2Optional = value2 as? Double? else {
+                return false
+            }
+            return ModelValueCompare(value1Optional: value1Optional,
+                                     value2Optional: value2Optional)
+                .sortComparator(sortOrder: sortOrder)
+
+        case .date:
+            guard let value1Optional = value1 as? Temporal.Date?, let value2Optional = value2 as? Temporal.Date? else {
+                return false
+            }
+            return ModelValueCompare(value1Optional: value1Optional,
+                                     value2Optional: value2Optional)
+                .sortComparator(sortOrder: sortOrder)
+        case .dateTime:
+            guard let value1Optional = value1 as? Temporal.DateTime?,
+                  let value2Optional = value2 as? Temporal.DateTime? else {
+                return false
+            }
+            return ModelValueCompare(value1Optional: value1Optional,
+                                     value2Optional: value2Optional)
+                .sortComparator(sortOrder: sortOrder)
+
+        case .time:
+            guard let value1Optional = value1 as? Temporal.Time?, let value2Optional = value2 as? Temporal.Time? else {
+                return false
+            }
+            return ModelValueCompare(value1Optional: value1Optional,
+                                     value2Optional: value2Optional)
+                .sortComparator(sortOrder: sortOrder)
+        case .bool:
+            guard let value1Optional = value1 as? Bool?, let value2Optional = value2 as? Bool? else {
+                return false
+            }
+            if value1Optional == nil && value2Optional == nil {
+                return sortOrder == .ascending
+            } else if value1Optional == nil, value2Optional != nil {
+                return sortOrder == .ascending
+            } else if value1Optional != nil, value2Optional == nil {
+                return sortOrder == .descending
+            } else if let value1 = value1Optional, let value2 = value2Optional {
+                return sortOrder == .ascending ?
+                    value1.intValue < value2.intValue : value1.intValue > value2.intValue
+            }
+        case .enum:
+            guard case .some(Optional<Any>.some(let value1Optional)) = value1,
+                  case .some(Optional<Any>.some(let value2Optional)) = value2 else {
+                  if value1 == nil && value2 != nil {
+                      return sortOrder == .ascending
+                  } else if value1 != nil && value2 == nil {
+                      return sortOrder == .descending
+                  }
+                  return false
+            }
+            let enumValue1Optional = (value1Optional as? EnumPersistable)?.rawValue
+            let enumValue2Optional = (value2Optional as? EnumPersistable)?.rawValue
+            if enumValue1Optional == nil && enumValue2Optional == nil {
+                return sortOrder == .ascending
+            } else if enumValue1Optional == nil, enumValue2Optional != nil {
+                return sortOrder == .ascending
+            } else if enumValue1Optional != nil, enumValue2Optional == nil {
+                return sortOrder == .descending
+            } else if let enumValue1 = enumValue1Optional, let enumValue2 = enumValue2Optional {
+                return sortOrder == .ascending ?
+                enumValue1 < enumValue2 : enumValue1 > enumValue2
+            }
+        case .embedded, .embeddedCollection, .model, .collection:
+            // Behavior is undetermined
+            return false
+        }
+        return false
+    }
+
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/Support/Model+Sort.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/Support/Model+Sort.swift
@@ -6,7 +6,6 @@
 //
 
 import Amplify
-import CoreGraphics
 
 extension Array where Element: Model {
     mutating func sortModels(by sortBy: QuerySortDescriptor, modelSchema: ModelSchema) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/Support/Model+Sort.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/Support/Model+Sort.swift
@@ -70,7 +70,7 @@ extension ModelSchema {
     ///   - model1: model instance to be compared
     ///   - model2: model instance to be compared
     ///   - sortBy: The field and direction used to compare the two models
-    /// - Returns: The resutting comparison between the two models based on `sortBy`
+    /// - Returns: The resulting comparison between the two models based on `sortBy`
     // swiftlint:disable:next cyclomatic_complexity
     func comparator(model1: Model,
                     model2: Model,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/Support/Model+Sort.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/Support/Model+Sort.swift
@@ -9,7 +9,7 @@ import Amplify
 import CoreGraphics
 
 extension Array where Element: Model {
-    mutating func sortModels(by sortBy: QuerySortBy, modelSchema: ModelSchema) {
+    mutating func sortModels(by sortBy: QuerySortDescriptor, modelSchema: ModelSchema) {
         sort { modelSchema.comparator(model1: $0, model2: $1, sortBy: sortBy) }
     }
 }
@@ -55,9 +55,9 @@ extension ModelSchema {
     // swiftlint:disable:next cyclomatic_complexity
     func comparator(model1: Model,
                     model2: Model,
-                    sortBy: QuerySortBy) -> Bool {
+                    sortBy: QuerySortDescriptor) -> Bool {
         let fieldName = sortBy.fieldName
-        let sortOrder = sortBy.fieldOrder
+        let sortOrder = sortBy.order
         guard let modelField = field(withName: fieldName) else {
             return false
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreObserveQueryTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreObserveQueryTests.swift
@@ -1,0 +1,236 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+import AmplifyPlugins
+import AWSPluginsCore
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+@available(iOS 13.0, *)
+class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
+
+    /// ObserveQuery API will eventually return query snapshot with `isSynced` true
+    ///
+    /// - Given: DataStore is cleared
+    /// - When:
+    ///    - ObserveQuery API is called to start the sync engine
+    /// - Then:
+    ///    - Eventually one of the query snapshots will be returned with `isSynced` true
+    ///
+    func testObserveQueryWithIsSynced() throws {
+        let started = expectation(description: "Amplify started")
+        try startAmplify {
+            started.fulfill()
+        }
+        wait(for: [started], timeout: 2)
+        _ = Amplify.DataStore.clear()
+        let snapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
+        let sink = Amplify.DataStore.observeQuery(for: Post.self).sink { completed in
+            switch completed {
+            case .finished:
+                break
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        } receiveValue: { querySnapshot in
+            if querySnapshot.isSynced {
+                snapshotWithIsSynced.fulfill()
+            }
+        }
+
+        _ = Amplify.DataStore.save(Post(title: "title", content: "content", createdAt: .now()))
+        wait(for: [snapshotWithIsSynced], timeout: 100)
+        sink.cancel()
+    }
+
+    /// A query snapshot with the recently saved post should be the last item when
+    /// sort order is provided as ascending `createdAt`
+    func testObserveQueryWithSort() throws {
+        let started = expectation(description: "Amplify started")
+        try startAmplify {
+            started.fulfill()
+        }
+        wait(for: [started], timeout: 2)
+        _ = Amplify.DataStore.clear()
+        let post = Post(title: "title", content: "content", createdAt: .now())
+        let snapshotWithSavedPost = expectation(description: "query snapshot with saved post")
+        let sink = Amplify.DataStore.observeQuery(for: Post.self,
+                                                  sort: .ascending(Post.keys.createdAt))
+            .sink { completed in
+                switch completed {
+                case .finished:
+                    break
+                case .failure(let error):
+                    XCTFail("\(error)")
+                }
+            } receiveValue: { querySnapshot in
+                if querySnapshot.itemsChanged.contains(where: { mutationEvent in
+                    mutationEvent.modelId == post.id
+                }) {
+
+                    if let lastPost = querySnapshot.items.last {
+                        XCTAssertEqual(lastPost.id, post.id)
+                        snapshotWithSavedPost.fulfill()
+                    }
+                }
+            }
+
+        _ = Amplify.DataStore.save(post)
+        wait(for: [snapshotWithSavedPost], timeout: 100)
+        sink.cancel()
+    }
+
+    ///  Ensure datastore is already in .ready state, observeQuery should return the first snapshot with isSynced true
+    func testObserveQueryAfterDataStoreIsReady() throws {
+        try startAmplifyAndWaitForReady()
+        let snapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
+
+        let sink = Amplify.DataStore.observeQuery(for: Post.self).sink { completed in
+            switch completed {
+            case .finished:
+                break
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        } receiveValue: { querySnapshot in
+            if querySnapshot.isSynced {
+                snapshotWithIsSynced.fulfill()
+            }
+        }
+        wait(for: [snapshotWithIsSynced], timeout: 100)
+        sink.cancel()
+    }
+
+    /// Ensure stopping datastore will not complete the observeQuery subscribers.
+    ///
+    /// - Given: DataStore is ready, first snapshot received.
+    /// - When:
+    ///    - DataStore.stop
+    /// - Then:
+    ///    -  ObserveQuery is not completed.
+    ///
+    func testObserveQueryShouldResetOnDataStoreStop() throws {
+        try startAmplifyAndWaitForReady()
+        let firstSnapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
+        let observeQueryReceivedCompleted = expectation(description: "observeQuery received completed")
+        observeQueryReceivedCompleted.isInverted = true
+        let sink = Amplify.DataStore.observeQuery(for: Post.self).sink { completed in
+            switch completed {
+            case .finished:
+                XCTFail("Should not finish")
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        } receiveValue: { querySnapshot in
+            if querySnapshot.isSynced {
+                firstSnapshotWithIsSynced.fulfill()
+            }
+        }
+        wait(for: [firstSnapshotWithIsSynced], timeout: 100)
+        let stopCompleted = expectation(description: "DataStore stop completed")
+        Amplify.DataStore.stop { result in
+            switch result {
+            case .success:
+                stopCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [stopCompleted, observeQueryReceivedCompleted], timeout: 10)
+        sink.cancel()
+    }
+
+    /// Ensure clearing datastore will not complete the observeQuery subscribers.
+    ///
+    /// - Given: DataStore is ready, first snapshot received.
+    /// - When:
+    ///    - DataStore.clear
+    /// - Then:
+    ///    -  ObserveQuery is not completed.
+    ///
+    func testObserveQueryShouldResetOnDataStoreClear() throws {
+        try startAmplifyAndWaitForReady()
+        let firstSnapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
+        let observeQueryReceivedCompleted = expectation(description: "observeQuery received completed")
+        observeQueryReceivedCompleted.isInverted = true
+        let sink = Amplify.DataStore.observeQuery(for: Post.self).sink { completed in
+            switch completed {
+            case .finished:
+                XCTFail("Should not finish")
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        } receiveValue: { querySnapshot in
+            if querySnapshot.isSynced {
+                firstSnapshotWithIsSynced.fulfill()
+            }
+        }
+        wait(for: [firstSnapshotWithIsSynced], timeout: 100)
+        let clearCompleted = expectation(description: "DataStore clear completed")
+        Amplify.DataStore.clear { result in
+            switch result {
+            case .success:
+                clearCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [clearCompleted, observeQueryReceivedCompleted], timeout: 10)
+        sink.cancel()
+    }
+
+    func testObserveQueryShouldStartOnDataStoreStart() throws {
+        try startAmplifyAndWaitForReady()
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
+        let newPost = Post(title: "title", content: "content", createdAt: .now())
+        let observeQueryReceivedCompleted = expectation(description: "observeQuery received completed")
+        observeQueryReceivedCompleted.isInverted = true
+        var querySnapshots = [DataStoreQuerySnapshot<Post>]()
+        let sink = Amplify.DataStore.observeQuery(for: Post.self).sink { completed in
+            switch completed {
+            case .finished:
+                XCTFail("Should not finish")
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        } receiveValue: { querySnapshot in
+            querySnapshots.append(querySnapshot)
+            if querySnapshots.count == 1 {
+                firstSnapshot.fulfill()
+            } else if querySnapshots.count == 2 {
+                secondSnapshot.fulfill()
+            }
+        }
+        wait(for: [firstSnapshot], timeout: 100)
+        let stopCompleted = expectation(description: "DataStore stop completed")
+        Amplify.DataStore.stop { result in
+            switch result {
+            case .success:
+                stopCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [stopCompleted, observeQueryReceivedCompleted], timeout: 10)
+        let startCompleted = expectation(description: "DataStore stop completed")
+        Amplify.DataStore.start { result in
+            switch result {
+            case .success:
+                startCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [startCompleted, secondSnapshot], timeout: 10)
+        sink.cancel()
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
@@ -70,12 +70,20 @@ class SyncEngineIntegrationTestBase: DataStoreTestBase {
     }
 
     func startAmplifyAndWaitForSync() throws {
-        let syncStarted = expectation(description: "Sync started")
+        try startAmplifyAndWait(for: HubPayload.EventName.DataStore.syncStarted)
+    }
+
+    func startAmplifyAndWaitForReady() throws {
+        try startAmplifyAndWait(for: HubPayload.EventName.DataStore.ready)
+    }
+
+    private func startAmplifyAndWait(for eventName: String) throws {
+        let eventReceived = expectation(description: "DataStore \(eventName) event")
 
         var token: UnsubscribeToken!
         token = Amplify.Hub.listen(to: .dataStore,
-                                   eventName: HubPayload.EventName.DataStore.syncStarted) { _ in
-            syncStarted.fulfill()
+                                   eventName: eventName) { _ in
+            eventReceived.fulfill()
             Amplify.Hub.removeListener(token)
         }
 
@@ -92,7 +100,7 @@ class SyncEngineIntegrationTestBase: DataStoreTestBase {
             }
         }
 
-        wait(for: [syncStarted], timeout: 15.0)
+        wait(for: [eventReceived], timeout: 100.0)
     }
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/AWSDataStorePluginSubscribeBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/AWSDataStorePluginSubscribeBehaviorTests.swift
@@ -1,0 +1,37 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+
+class AWSDataStorePluginSubscribeBehaviorTests: BaseDataStoreTests {
+
+    func testObserveQuery() throws {
+        let snapshotReceived = expectation(description: "query snapshot received")
+        let predicate = Post.keys.content.contains("someValue")
+        let sink = Amplify.DataStore.observeQuery(for: Post.self,
+                                                  where: predicate,
+                                                  sort: .ascending(Post.keys.createdAt))
+            .sink { completed in
+                switch completed {
+                case .finished:
+                    break
+                case .failure(let error):
+                    XCTFail("\(error)")
+                }
+            } receiveValue: { _ in
+                snapshotReceived.fulfill()
+            }
+
+        wait(for: [snapshotReceived], timeout: 3)
+        sink.cancel()
+
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSAPICategoryPluginTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSAPICategoryPluginTests.swift
@@ -229,8 +229,9 @@ class AWSAPICategoryPluginTests: XCTestCase {
         let startExpectationOnQuery = expectation(description: "Start Sync should be called again with Query")
         var count = 0
         let storageEngine = MockStorageEngineBehavior()
-        storageEngine.responders[.query] = QueryResponder { _ in
+        storageEngine.responders[.query] = QueryResponder<ExampleWithEveryType> { _ in
             count = self.expect(startExpectation, count, 1)
+            return .success([])
         }
         storageEngine.responders[.clear] = ClearResponder { _ in
             count = self.expect(clearExpectation, count, 2)
@@ -277,8 +278,9 @@ class AWSAPICategoryPluginTests: XCTestCase {
                 semaphore.signal()
             })
             semaphore.wait()
-            storageEngine.responders[.query] = QueryResponder {_ in
+            storageEngine.responders[.query] = QueryResponder<ExampleWithEveryType> {_ in
                 count = self.expect(startExpectationOnQuery, count, 3)
+                return .success([])
             }
 
             plugin.query(ExampleWithEveryType.self, completion: { _ in

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Subscribe/DataStoreObserveQueryOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Subscribe/DataStoreObserveQueryOperationTests.swift
@@ -431,6 +431,8 @@ class DataStoreObserveQueryOperationTests: XCTestCase {
         sink.cancel()
     }
 
+    /// ObserveQuery operation entry points are `resetState`, `startObserveQuery`, and `onItemChanges(mutationEvents)`.
+    /// Ensure concurrent random sequences of these API calls do not cause issues such as data race.
     func testConcurrent() {
         let completeReceived = expectation(description: "complete received")
         completeReceived.isInverted = true
@@ -454,9 +456,7 @@ class DataStoreObserveQueryOperationTests: XCTestCase {
             case .failure(let error):
                 XCTFail("Failed with error \(error)")
             }
-        } receiveValue: { _ in
-
-        }
+        } receiveValue: { _ in }
         let queue = OperationQueue()
         queue.addOperation(operation)
         DispatchQueue.concurrentPerform(iterations: 3_000) { _ in

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Subscribe/DataStoreObserveQueryOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Subscribe/DataStoreObserveQueryOperationTests.swift
@@ -1,0 +1,444 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+import Combine
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSPluginsCore
+@testable import AWSDataStoreCategoryPlugin
+
+class DataStoreObserveQueryOperationTests: XCTestCase {
+
+    var storageEngine: MockStorageEngineBehavior!
+    var dataStorePublisher: ModelSubcriptionBehavior!
+
+    override func setUp() {
+        ModelRegistry.register(modelType: Post.self)
+        storageEngine = MockStorageEngineBehavior()
+        dataStorePublisher = DataStorePublisher()
+    }
+
+    /// After the query finishes, observed item changes will generate a snapshot.
+    ///
+    /// - Given:  The operation has started and the initial query has completed.
+    /// - When:
+    ///    -  Item change occurs.
+    /// - Then:
+    ///    - Receive a snapshot with the item changed
+    ///
+    func testItemChangedWillGenerateSnapshot() throws {
+        let firstSnapshot = expectation(description: "first query snapshots")
+        let secondSnapshot = expectation(description: "second query snapshots")
+        var querySnapshots = [DataStoreQuerySnapshot<Post>]()
+        let operation = AWSDataStoreObseverQueryOperation(
+            modelType: Post.self,
+            modelSchema: Post.schema,
+            predicate: nil,
+            sortInput: nil,
+            storageEngine: storageEngine,
+            dataStorePublisher: dataStorePublisher)
+
+        let sink = operation.publisher.sink { completed in
+            switch completed {
+            case .finished:
+                break
+            case .failure(let error):
+                XCTFail("Failed with error \(error)")
+            }
+        } receiveValue: { querySnapshot in
+            querySnapshots.append(querySnapshot)
+            if querySnapshots.count == 1 {
+                firstSnapshot.fulfill()
+            } else if querySnapshots.count == 2 {
+                secondSnapshot.fulfill()
+            }
+        }
+        let queue = OperationQueue()
+        queue.addOperation(operation)
+        wait(for: [firstSnapshot], timeout: 1)
+
+        let post = try createPost(id: "1")
+        dataStorePublisher.send(input: post)
+        wait(for: [secondSnapshot], timeout: 10)
+
+        XCTAssertEqual(querySnapshots.count, 2)
+        XCTAssertEqual(querySnapshots[0].itemsChanged.count, 0)
+        XCTAssertEqual(querySnapshots[1].itemsChanged.count, 1)
+        sink.cancel()
+    }
+
+    /// Multiple item changed observed will be returned in a single snapshot
+    ///
+    /// - Given:  The operation has started and the first query has completed.
+    /// - When:
+    ///    -  Observe multiple item changes.
+    /// - Then:
+    ///    - The items observed will be returned in the second snapshot
+    ///
+    func testMultipleItemChangesWillGenerateSecondSnapshot() throws {
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
+
+        var querySnapshots = [DataStoreQuerySnapshot<Post>]()
+        let operation = AWSDataStoreObseverQueryOperation(
+            modelType: Post.self,
+            modelSchema: Post.schema,
+            predicate: nil,
+            sortInput: nil,
+            storageEngine: storageEngine,
+            dataStorePublisher: dataStorePublisher)
+
+        let sink = operation.publisher.sink { completed in
+            switch completed {
+            case .finished:
+                break
+            case .failure(let error):
+                XCTFail("Failed with error \(error)")
+            }
+        } receiveValue: { querySnapshot in
+            querySnapshots.append(querySnapshot)
+            if querySnapshots.count == 1 {
+                firstSnapshot.fulfill()
+            } else if querySnapshots.count == 2 {
+                secondSnapshot.fulfill()
+            }
+        }
+        let queue = OperationQueue()
+        queue.addOperation(operation)
+        wait(for: [firstSnapshot], timeout: 1)
+
+        let post1 = try createPost(id: "1")
+        let post2 = try createPost(id: "2")
+        let post3 = try createPost(id: "3")
+        dataStorePublisher.send(input: post1)
+        dataStorePublisher.send(input: post2)
+        dataStorePublisher.send(input: post3)
+        wait(for: [secondSnapshot], timeout: 10)
+
+        XCTAssertEqual(querySnapshots.count, 2)
+        XCTAssertEqual(querySnapshots[0].itemsChanged.count, 0)
+        XCTAssertEqual(querySnapshots[1].itemsChanged.count, 3)
+        sink.cancel()
+    }
+
+    /// Multiple observed objects (more than the `.collect` count) in a short time window`
+    /// will return first snapshot with the count and the remaining in the second snapshot
+    ///
+    /// - Given:  The operation has started and the first query has completed.
+    /// - When:
+    ///    -  Observe 1100 item changes (beyond the `.collect` count of 1000)
+    /// - Then:
+    ///    - The items observed will perform a query and return 1000  items changed in the second query and the
+    ///     remaining in the third query
+    ///
+    func testCollectOverMaxItemCountLimit() throws {
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
+        let thirdSnapshot = expectation(description: "third query snapshot")
+
+        var querySnapshots = [DataStoreQuerySnapshot<Post>]()
+        let operation = AWSDataStoreObseverQueryOperation(
+            modelType: Post.self,
+            modelSchema: Post.schema,
+            predicate: nil,
+            sortInput: nil,
+            storageEngine: storageEngine,
+            dataStorePublisher: dataStorePublisher)
+
+        let sink = operation.publisher.sink { completed in
+            switch completed {
+            case .finished:
+                break
+            case .failure(let error):
+                XCTFail("Failed with error \(error)")
+            }
+        } receiveValue: { querySnapshot in
+            querySnapshots.append(querySnapshot)
+            if querySnapshots.count == 1 {
+                firstSnapshot.fulfill()
+            } else if querySnapshots.count == 2 {
+                secondSnapshot.fulfill()
+            } else if querySnapshots.count == 3 {
+                thirdSnapshot.fulfill()
+            }
+        }
+        let queue = OperationQueue()
+        queue.addOperation(operation)
+        wait(for: [firstSnapshot], timeout: 1)
+
+        for postId in 1 ... 1_100 {
+            let post = try createPost(id: "\(postId)")
+            dataStorePublisher.send(input: post)
+        }
+
+        wait(for: [secondSnapshot, thirdSnapshot], timeout: 10)
+
+        XCTAssertEqual(querySnapshots.count, 3)
+        XCTAssertEqual(querySnapshots[0].itemsChanged.count, 0)
+        XCTAssertEqual(querySnapshots[1].itemsChanged.count, 1_000)
+        XCTAssertEqual(querySnapshots[2].itemsChanged.count, 100)
+        sink.cancel()
+    }
+
+    /// Cancelling the subscription will no longer receive snapshots
+    ///
+    /// - Given:  subscriber to the operation
+    /// - When:
+    ///    - subscriber is cancelled
+    /// - Then:
+    ///    - no further snapshots are received
+    ///
+    func testSuccessfulSubscriptionCancel() throws {
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
+        secondSnapshot.isInverted = true
+        var querySnapshots = [DataStoreQuerySnapshot<Post>]()
+        let operation = AWSDataStoreObseverQueryOperation(
+            modelType: Post.self,
+            modelSchema: Post.schema,
+            predicate: nil,
+            sortInput: nil,
+            storageEngine: storageEngine,
+            dataStorePublisher: dataStorePublisher)
+
+        let sink = operation.publisher.sink { completed in
+            switch completed {
+            case .finished:
+                break
+            case .failure(let error):
+                XCTFail("Failed with error \(error)")
+            }
+        } receiveValue: { snapshot in
+            querySnapshots.append(snapshot)
+            if querySnapshots.count == 1 {
+                firstSnapshot.fulfill()
+            } else if querySnapshots.count == 2 {
+                secondSnapshot.fulfill()
+                XCTFail("Should not receive second snapshot after cancelling")
+            }
+        }
+
+        let queue = OperationQueue()
+        queue.addOperation(operation)
+        wait(for: [firstSnapshot], timeout: 1)
+        sink.cancel()
+        let post1 = try createPost(id: "1")
+        dataStorePublisher.send(input: post1)
+
+        wait(for: [secondSnapshot], timeout: 1)
+        XCTAssertTrue(operation.isCancelled)
+        XCTAssertTrue(operation.isFinished)
+    }
+
+    /// Cancelling the underlying operation will emit a completion to the subscribers
+    ///
+    /// - Given:  subscriber to the operation
+    /// - When:
+    ///    - operation is cancelled
+    /// - Then:
+    ///    - the subscriber receives a cancellation
+    ///
+    func testSuccessfulOperationCancel() throws {
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
+        secondSnapshot.isInverted = true
+        let completedEvent = expectation(description: "should have completed")
+        var querySnapshots = [DataStoreQuerySnapshot<Post>]()
+        let operation = AWSDataStoreObseverQueryOperation(
+            modelType: Post.self,
+            modelSchema: Post.schema,
+            predicate: nil,
+            sortInput: nil,
+            storageEngine: storageEngine,
+            dataStorePublisher: dataStorePublisher)
+
+        let sink = operation.publisher.sink { completed in
+            switch completed {
+            case .finished:
+                completedEvent.fulfill()
+            case .failure(let error):
+                XCTFail("Failed with error \(error)")
+            }
+        } receiveValue: { snapshot in
+            querySnapshots.append(snapshot)
+            if querySnapshots.count == 1 {
+                firstSnapshot.fulfill()
+            } else if querySnapshots.count == 2 {
+                secondSnapshot.fulfill()
+                XCTFail("Should not receive second snapshot after cancelling")
+            }
+        }
+
+        let queue = OperationQueue()
+        queue.addOperation(operation)
+        wait(for: [firstSnapshot], timeout: 1)
+        operation.cancel()
+        let post1 = try createPost(id: "1")
+        dataStorePublisher.send(input: post1)
+
+        wait(for: [secondSnapshot], timeout: 1)
+        wait(for: [completedEvent], timeout: 1)
+        XCTAssertTrue(operation.isCancelled)
+        XCTAssertTrue(operation.isFinished)
+    }
+
+    ///  ObserveQuery's state should be able to be reset and initial query able to be started again.
+    func testObserveQueryResetStateThenStartObserveQuery() {
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
+        var querySnapshots = [DataStoreQuerySnapshot<Post>]()
+        let operation = AWSDataStoreObseverQueryOperation(
+            modelType: Post.self,
+            modelSchema: Post.schema,
+            predicate: nil,
+            sortInput: nil,
+            storageEngine: storageEngine,
+            dataStorePublisher: dataStorePublisher)
+
+        var sink = operation.publisher.sink { completed in
+            switch completed {
+            case .finished:
+                break
+            case .failure(let error):
+                XCTFail("Failed with error \(error)")
+            }
+        } receiveValue: { querySnapshot in
+            querySnapshots.append(querySnapshot)
+            if querySnapshots.count == 1 {
+                firstSnapshot.fulfill()
+            } else if querySnapshots.count == 2 {
+                secondSnapshot.fulfill()
+            }
+        }
+        let queue = OperationQueue()
+        queue.addOperation(operation)
+
+        wait(for: [firstSnapshot], timeout: 1)
+        operation.resetState()
+        operation.startObserveQuery()
+        wait(for: [secondSnapshot], timeout: 1)
+    }
+
+    /// Multiple calls to start the observeQuery should not start again
+    ///
+    /// - Given: ObserverQuery operation is created, and then reset
+    /// - When:
+    ///    - operation.startObserveQuery twice
+    /// - Then:
+    ///    - Only one query should be performed / only one snapshot should be returned
+    func testObserveQueryStaredShouldNotStartAgain() {
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
+        let thirdSnapshot = expectation(description: "third query snapshot")
+        thirdSnapshot.isInverted = true
+        var querySnapshots = [DataStoreQuerySnapshot<Post>]()
+        let operation = AWSDataStoreObseverQueryOperation(
+            modelType: Post.self,
+            modelSchema: Post.schema,
+            predicate: nil,
+            sortInput: nil,
+            storageEngine: storageEngine,
+            dataStorePublisher: dataStorePublisher)
+
+        var sink = operation.publisher.sink { completed in
+            switch completed {
+            case .finished:
+                break
+            case .failure(let error):
+                XCTFail("Failed with error \(error)")
+            }
+        } receiveValue: { snapshot in
+            querySnapshots.append(snapshot)
+            if querySnapshots.count == 1 {
+                firstSnapshot.fulfill()
+            } else if querySnapshots.count == 2 {
+                secondSnapshot.fulfill()
+            } else if querySnapshots.count == 3 {
+                thirdSnapshot.fulfill()
+            }
+        }
+        let queue = OperationQueue()
+        queue.addOperation(operation)
+        wait(for: [firstSnapshot], timeout: 1)
+
+        operation.resetState()
+
+        operation.startObserveQuery()
+        operation.startObserveQuery()
+        wait(for: [secondSnapshot], timeout: 1)
+        wait(for: [thirdSnapshot], timeout: 1)
+        XCTAssertTrue(operation.observeQueryStarted.get())
+    }
+
+    func testObserveQueryOperationIsRemovedWhenPreviousSubscriptionIsRemoved() {
+        let firstSnapshot = expectation(description: "first query snapshot")
+        var querySnapshots = [DataStoreQuerySnapshot<Post>]()
+
+        let operation1 = AWSDataStoreObseverQueryOperation(
+            modelType: Post.self,
+            modelSchema: Post.schema,
+            predicate: nil,
+            sortInput: nil,
+            storageEngine: storageEngine,
+            dataStorePublisher: dataStorePublisher)
+
+        let operation2 = AWSDataStoreObseverQueryOperation(
+            modelType: Post.self,
+            modelSchema: Post.schema,
+            predicate: nil,
+            sortInput: nil,
+            storageEngine: storageEngine,
+            dataStorePublisher: dataStorePublisher)
+
+        var sink = operation1.publisher.sink { completed in
+            switch completed {
+            case .finished:
+                break
+            case .failure(let error):
+                XCTFail("Failed with error \(error)")
+            }
+        } receiveValue: { _ in
+            XCTFail("Should not receive snapshot when cancelled immediately")
+        }
+
+        sink = operation2.publisher.sink { completed in
+            switch completed {
+            case .finished:
+                break
+            case .failure(let error):
+                XCTFail("Failed with error \(error)")
+            }
+        } receiveValue: { snapshot in
+            querySnapshots.append(snapshot)
+            if querySnapshots.count == 1 {
+                firstSnapshot.fulfill()
+            }
+        }
+        let queue = OperationQueue()
+        queue.addOperation(operation1)
+        queue.addOperation(operation2)
+
+        wait(for: [firstSnapshot], timeout: 10)
+        XCTAssertTrue(operation1.isCancelled)
+        XCTAssertTrue(operation2.isExecuting)
+        sink.cancel()
+    }
+
+    // MARK: - Helpers
+
+    func createPost(id: String) throws -> MutationEvent {
+        try MutationEvent(model: Post(id: id,
+                                      title: "model1",
+                                      content: "content1",
+                                      createdAt: .now()),
+                          modelSchema: Post.schema,
+                          mutationType: MutationEvent.MutationType.create)
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Subscribe/Support/ModelSortTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Subscribe/Support/ModelSortTests.swift
@@ -1,0 +1,325 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+import Combine
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSPluginsCore
+@testable import AWSDataStoreCategoryPlugin
+
+class ModelSortTests: XCTestCase {
+
+    func testSortModelString() throws {
+        var posts = [createPost(id: "1"),
+                     createPost(id: "2"),
+                     createPost(id: "3")]
+        posts.sortModels(by: .ascending(Post.keys.id), modelSchema: Post.schema)
+        XCTAssertEqual(posts[0].id, "1")
+        XCTAssertEqual(posts[1].id, "2")
+        XCTAssertEqual(posts[2].id, "3")
+        posts.sortModels(by: .descending(Post.keys.id), modelSchema: Post.schema)
+        XCTAssertEqual(posts[0].id, "3")
+        XCTAssertEqual(posts[1].id, "2")
+        XCTAssertEqual(posts[2].id, "1")
+    }
+
+    func testSortModelOptionalString() {
+        var models = [QPredGen(name: "name", myString: "1"),
+                      QPredGen(name: "name", myString: nil),
+                      QPredGen(name: "name", myString: "2")]
+        models.sortModels(by: .ascending(QPredGen.keys.myString), modelSchema: QPredGen.schema)
+        XCTAssertEqual(models[0].myString, nil)
+        XCTAssertEqual(models[1].myString, "1")
+        XCTAssertEqual(models[2].myString, "2")
+        models.sortModels(by: .descending(QPredGen.keys.myString), modelSchema: QPredGen.schema)
+        XCTAssertEqual(models[0].myString, "2")
+        XCTAssertEqual(models[1].myString, "1")
+        XCTAssertEqual(models[2].myString, nil)
+    }
+
+    func testSortModelInt() {
+        var models = [MutationSyncMetadata(id: UUID().uuidString, deleted: false, lastChangedAt: 1, version: 1),
+                      MutationSyncMetadata(id: UUID().uuidString, deleted: false, lastChangedAt: 1, version: 2),
+                      MutationSyncMetadata(id: UUID().uuidString, deleted: false, lastChangedAt: 1, version: 3)]
+        models.sortModels(by: .ascending(MutationSyncMetadata.keys.version), modelSchema: MutationSyncMetadata.schema)
+        XCTAssertEqual(models[0].version, 1)
+        XCTAssertEqual(models[1].version, 2)
+        XCTAssertEqual(models[2].version, 3)
+        models.sortModels(by: .descending(MutationSyncMetadata.keys.version), modelSchema: MutationSyncMetadata.schema)
+        XCTAssertEqual(models[0].version, 3)
+        XCTAssertEqual(models[1].version, 2)
+        XCTAssertEqual(models[2].version, 1)
+    }
+
+    func testSortModelOptionalInt() {
+        var models = [QPredGen(name: "name", myInt: 1),
+                      QPredGen(name: "name", myInt: nil),
+                      QPredGen(name: "name", myInt: 2)]
+        models.sortModels(by: .ascending(QPredGen.keys.myInt), modelSchema: QPredGen.schema)
+        XCTAssertEqual(models[0].myInt, nil)
+        XCTAssertEqual(models[1].myInt, 1)
+        XCTAssertEqual(models[2].myInt, 2)
+        models.sortModels(by: .descending(QPredGen.keys.myInt), modelSchema: QPredGen.schema)
+        XCTAssertEqual(models[0].myInt, 2)
+        XCTAssertEqual(models[1].myInt, 1)
+        XCTAssertEqual(models[2].myInt, nil)
+    }
+
+    func testSortModelDouble() {
+        var posts = [createPost(rating: 2.0), createPost(rating: 1.0), createPost(rating: 3.0)]
+        posts.sortModels(by: .ascending(Post.keys.rating), modelSchema: Post.schema)
+        XCTAssertEqual(posts[0].rating, 1.0)
+        XCTAssertEqual(posts[1].rating, 2.0)
+        XCTAssertEqual(posts[2].rating, 3.0)
+        posts.sortModels(by: .descending(Post.keys.rating), modelSchema: Post.schema)
+        XCTAssertEqual(posts[0].rating, 3.0)
+        XCTAssertEqual(posts[1].rating, 2.0)
+        XCTAssertEqual(posts[2].rating, 1.0)
+    }
+
+    func testSortModelOptionalDouble() {
+        var models = [QPredGen(name: "name", myDouble: 1.1),
+                      QPredGen(name: "name", myDouble: nil),
+                      QPredGen(name: "name", myDouble: 2.2)]
+        models.sortModels(by: .ascending(QPredGen.keys.myDouble), modelSchema: QPredGen.schema)
+        XCTAssertEqual(models[0].myDouble, nil)
+        XCTAssertEqual(models[1].myDouble, 1.1)
+        XCTAssertEqual(models[2].myDouble, 2.2)
+        models.sortModels(by: .descending(QPredGen.keys.myDouble), modelSchema: QPredGen.schema)
+        XCTAssertEqual(models[0].myDouble, 2.2)
+        XCTAssertEqual(models[1].myDouble, 1.1)
+        XCTAssertEqual(models[2].myDouble, nil)
+    }
+
+    func testSortModelDate() {
+        let date1 = Temporal.Date.now()
+        let date2 = Temporal.Date.now().add(value: 1, to: .day)
+        let date3 = Temporal.Date.now().add(value: 2, to: .day)
+        var models = [createModel(date: date1),
+                      createModel(date: date2),
+                      createModel(date: date3)]
+        models.sortModels(by: .ascending(ExampleWithEveryType.keys.dateField), modelSchema: ExampleWithEveryType.schema)
+        XCTAssertEqual(models[0].dateField, date1)
+        XCTAssertEqual(models[1].dateField, date2)
+        XCTAssertEqual(models[2].dateField, date3)
+        models.sortModels(by: .descending(ExampleWithEveryType.keys.dateField),
+                          modelSchema: ExampleWithEveryType.schema)
+        XCTAssertEqual(models[0].dateField, date3)
+        XCTAssertEqual(models[1].dateField, date2)
+        XCTAssertEqual(models[2].dateField, date1)
+    }
+
+    func testSortModelOptionalDate() {
+        let date1 = Temporal.Date.now().add(value: 1, to: .day)
+        let date2 = Temporal.Date.now().add(value: 2, to: .day)
+        var models = [QPredGen(name: "name", myDate: date1),
+                      QPredGen(name: "name", myDate: nil),
+                      QPredGen(name: "name", myDate: date2)]
+        models.sortModels(by: .ascending(QPredGen.keys.myDate), modelSchema: QPredGen.schema)
+        XCTAssertEqual(models[0].myDate, nil)
+        XCTAssertEqual(models[1].myDate, date1)
+        XCTAssertEqual(models[2].myDate, date2)
+        models.sortModels(by: .descending(QPredGen.keys.myDate), modelSchema: QPredGen.schema)
+        XCTAssertEqual(models[0].myDate, date2)
+        XCTAssertEqual(models[1].myDate, date1)
+        XCTAssertEqual(models[2].myDate, nil)
+    }
+
+    func testSortModelDateTime() {
+        let dateTime1 = Temporal.DateTime.now()
+        let dateTime2 = Temporal.DateTime.now().add(value: 1, to: .day)
+        let dateTime3 = Temporal.DateTime.now().add(value: 2, to: .day)
+        var posts = [createPost(createdAt: dateTime1),
+                     createPost(createdAt: dateTime2),
+                     createPost(createdAt: dateTime3)]
+        posts.sortModels(by: .ascending(Post.keys.createdAt), modelSchema: Post.schema)
+        XCTAssertEqual(posts[0].createdAt, dateTime1)
+        XCTAssertEqual(posts[1].createdAt, dateTime2)
+        XCTAssertEqual(posts[2].createdAt, dateTime3)
+        posts.sortModels(by: .descending(Post.keys.createdAt), modelSchema: Post.schema)
+        XCTAssertEqual(posts[0].createdAt, dateTime3)
+        XCTAssertEqual(posts[1].createdAt, dateTime2)
+        XCTAssertEqual(posts[2].createdAt, dateTime1)
+    }
+
+    func testSortModelOptionalDateTime() {
+        let datetime1 = Temporal.DateTime.now().add(value: 1, to: .day)
+        let datetime2 = Temporal.DateTime.now().add(value: 2, to: .day)
+        var models = [QPredGen(name: "name", myDateTime: datetime1),
+                      QPredGen(name: "name", myDateTime: nil),
+                      QPredGen(name: "name", myDateTime: datetime2)]
+        models.sortModels(by: .ascending(QPredGen.keys.myDateTime), modelSchema: QPredGen.schema)
+        XCTAssertEqual(models[0].myDateTime, nil)
+        XCTAssertEqual(models[1].myDateTime, datetime1)
+        XCTAssertEqual(models[2].myDateTime, datetime2)
+        models.sortModels(by: .descending(QPredGen.keys.myDateTime), modelSchema: QPredGen.schema)
+        XCTAssertEqual(models[0].myDateTime, datetime2)
+        XCTAssertEqual(models[1].myDateTime, datetime1)
+        XCTAssertEqual(models[2].myDateTime, nil)
+    }
+
+    func testSortModelTime() {
+        let time1 = Temporal.Time.now()
+        let time2 = Temporal.Time.now().add(value: 2, to: .day)
+        let time3 = Temporal.Time.now().add(value: 3, to: .day)
+        var models = [QPredGen(name: "name", myTime: time2),
+                      QPredGen(name: "name", myTime: time1),
+                      QPredGen(name: "name", myTime: time3)]
+
+        models.sortModels(by: .ascending(QPredGen.keys.myTime), modelSchema: QPredGen.schema)
+        XCTAssertEqual(models[0].myTime, time1)
+        XCTAssertEqual(models[1].myTime, time2)
+        XCTAssertEqual(models[2].myTime, time3)
+
+        models.sortModels(by: .descending(QPredGen.keys.myTime), modelSchema: QPredGen.schema)
+        XCTAssertEqual(models[0].myTime, time3)
+        XCTAssertEqual(models[1].myTime, time2)
+        XCTAssertEqual(models[2].myTime, time1)
+    }
+
+    func testSortModelOptionalTime() {
+        let time1 = Temporal.Time.now().add(value: 1, to: .day)
+        let time2 = Temporal.Time.now().add(value: 2, to: .day)
+        var models = [QPredGen(name: "name", myTime: time1),
+                      QPredGen(name: "name", myTime: nil),
+                      QPredGen(name: "name", myTime: time2)]
+
+        models.sortModels(by: .ascending(QPredGen.keys.myTime), modelSchema: QPredGen.schema)
+        XCTAssertEqual(models[0].myTime, nil)
+        XCTAssertEqual(models[1].myTime, time1)
+        XCTAssertEqual(models[2].myTime, time2)
+
+        models.sortModels(by: .descending(QPredGen.keys.myTime), modelSchema: QPredGen.schema)
+        XCTAssertEqual(models[0].myTime, time2)
+        XCTAssertEqual(models[1].myTime, time1)
+        XCTAssertEqual(models[2].myTime, nil)
+    }
+
+    func testSortModelBool() {
+        var models = [createModel(bool: false),
+                      createModel(bool: true),
+                      createModel(bool: false)]
+        models.sortModels(by: .ascending(ExampleWithEveryType.keys.boolField),
+                          modelSchema: ExampleWithEveryType.schema)
+        XCTAssertEqual(models[0].boolField, false)
+        XCTAssertEqual(models[1].boolField, false)
+        XCTAssertEqual(models[2].boolField, true)
+        models.sortModels(by: .descending(ExampleWithEveryType.keys.boolField),
+                          modelSchema: ExampleWithEveryType.schema)
+        XCTAssertEqual(models[0].boolField, true)
+        XCTAssertEqual(models[1].boolField, false)
+        XCTAssertEqual(models[2].boolField, false)
+    }
+
+    func testSortModelOptionalBool() {
+        var models = [QPredGen(name: "name", myBool: true),
+                      QPredGen(name: "name", myBool: nil),
+                      QPredGen(name: "name", myBool: false)]
+        models.sortModels(by: .ascending(QPredGen.keys.myBool), modelSchema: QPredGen.schema)
+        XCTAssertEqual(models[0].myBool, nil)
+        XCTAssertEqual(models[1].myBool, false)
+        XCTAssertEqual(models[2].myBool, true)
+        models.sortModels(by: .descending(QPredGen.keys.myBool), modelSchema: QPredGen.schema)
+        XCTAssertEqual(models[0].myBool, true)
+        XCTAssertEqual(models[1].myBool, false)
+        XCTAssertEqual(models[2].myBool, nil)
+    }
+
+    func testSortModelEnum() {
+        var models = [createModel(enum: .bar),
+                      createModel(enum: .foo),
+                      createModel(enum: .bar)]
+        models.sortModels(by: .ascending(ExampleWithEveryType.keys.enumField),
+                          modelSchema: ExampleWithEveryType.schema)
+        XCTAssertEqual(models[0].enumField, .bar)
+        XCTAssertEqual(models[1].enumField, .bar)
+        XCTAssertEqual(models[2].enumField, .foo)
+        models.sortModels(by: .descending(ExampleWithEveryType.keys.enumField),
+                          modelSchema: ExampleWithEveryType.schema)
+        XCTAssertEqual(models[0].enumField, .foo)
+        XCTAssertEqual(models[1].enumField, .bar)
+        XCTAssertEqual(models[2].enumField, .bar)
+    }
+
+    func testSortModelOptionalEnum() {
+        var posts = [createPost(status: .draft),
+                     createPost(status: .private),
+                     createPost(status: .published),
+                     createPost(status: nil)]
+        posts.sortModels(by: .ascending(Post.keys.status), modelSchema: Post.schema)
+        XCTAssertEqual(posts[0].status, nil)
+        XCTAssertEqual(posts[1].status, .draft)
+        XCTAssertEqual(posts[2].status, .private)
+        XCTAssertEqual(posts[3].status, .published)
+        posts.sortModels(by: .descending(Post.keys.status), modelSchema: Post.schema)
+        XCTAssertEqual(posts[0].status, .published)
+        XCTAssertEqual(posts[1].status, .private)
+        XCTAssertEqual(posts[2].status, .draft)
+        XCTAssertEqual(posts[3].status, nil)
+    }
+
+    func testSortByTwoFields() {
+        let dateTime1 = Temporal.DateTime.now()
+        let dateTime2 = Temporal.DateTime.now().add(value: 1, to: .day)
+        let dateTime3 = Temporal.DateTime.now().add(value: 2, to: .day)
+        var posts = [createPost(rating: 1.0, createdAt: dateTime2),
+                     createPost(rating: 1.0, createdAt: dateTime1),
+                     createPost(rating: 2.0, createdAt: dateTime3)]
+
+        posts.sortModels(by: .ascending(Post.keys.rating), modelSchema: Post.schema)
+        XCTAssertEqual(posts[0].rating, 1.0)
+        XCTAssertEqual(posts[0].createdAt, dateTime2)
+        XCTAssertEqual(posts[1].rating, 1.0)
+        XCTAssertEqual(posts[1].createdAt, dateTime1)
+        XCTAssertEqual(posts[2].rating, 2.0)
+        XCTAssertEqual(posts[2].createdAt, dateTime3)
+
+        posts.sortModels(by: .ascending(Post.keys.createdAt), modelSchema: Post.schema)
+        XCTAssertEqual(posts[0].rating, 1.0)
+        XCTAssertEqual(posts[0].createdAt, dateTime1)
+        XCTAssertEqual(posts[1].rating, 1.0)
+        XCTAssertEqual(posts[1].createdAt, dateTime2)
+        XCTAssertEqual(posts[2].rating, 2.0)
+        XCTAssertEqual(posts[2].createdAt, dateTime3)
+    }
+
+    // MARK: - Helpers
+
+    func createPost(id: String = UUID().uuidString,
+                    draft: Bool = false,
+                    rating: Double = 1.0,
+                    createdAt: Temporal.DateTime = .now(),
+                    status: PostStatus? = .draft) -> Post {
+        Post(id: id,
+             title: "A",
+             content: "content",
+             createdAt: createdAt,
+             updatedAt: .now(),
+             draft: false,
+             rating: rating,
+             status: status,
+             comments: nil)
+    }
+
+    func createModel(date: Temporal.Date = .now(),
+                     bool: Bool = false,
+                     enum: ExampleEnum = .bar) -> ExampleWithEveryType {
+        ExampleWithEveryType(id: UUID().uuidString,
+                             stringField: "string",
+                             intField: 1,
+                             doubleField: 1.0,
+                             boolField: bool,
+                             dateField: date,
+                             enumField: `enum`,
+                             nonModelField: .init(someString: "some string",
+                                                  someEnum: .bar),
+                             arrayOfStringsField: [])
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Subscribe/Support/ModelSortTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Subscribe/Support/ModelSortTests.swift
@@ -283,6 +283,7 @@ class ModelSortTests: XCTestCase {
                      createPost(rating: 2.0, createdAt: dateTime3)]
 
         posts.sortModels(by: QuerySortBy.ascending(Post.keys.rating).sortDescriptor, modelSchema: Post.schema)
+        // order does not change since ratings are already in asecnding order
         XCTAssertEqual(posts[0].rating, 1.0)
         XCTAssertEqual(posts[0].createdAt, dateTime2)
         XCTAssertEqual(posts[1].rating, 1.0)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Subscribe/Support/ModelSortTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Subscribe/Support/ModelSortTests.swift
@@ -20,11 +20,11 @@ class ModelSortTests: XCTestCase {
         var posts = [createPost(id: "1"),
                      createPost(id: "2"),
                      createPost(id: "3")]
-        posts.sortModels(by: .ascending(Post.keys.id), modelSchema: Post.schema)
+        posts.sortModels(by: QuerySortBy.ascending(Post.keys.id).sortDescriptor, modelSchema: Post.schema)
         XCTAssertEqual(posts[0].id, "1")
         XCTAssertEqual(posts[1].id, "2")
         XCTAssertEqual(posts[2].id, "3")
-        posts.sortModels(by: .descending(Post.keys.id), modelSchema: Post.schema)
+        posts.sortModels(by: QuerySortBy.descending(Post.keys.id).sortDescriptor, modelSchema: Post.schema)
         XCTAssertEqual(posts[0].id, "3")
         XCTAssertEqual(posts[1].id, "2")
         XCTAssertEqual(posts[2].id, "1")
@@ -34,11 +34,13 @@ class ModelSortTests: XCTestCase {
         var models = [QPredGen(name: "name", myString: "1"),
                       QPredGen(name: "name", myString: nil),
                       QPredGen(name: "name", myString: "2")]
-        models.sortModels(by: .ascending(QPredGen.keys.myString), modelSchema: QPredGen.schema)
+        models.sortModels(by: QuerySortBy.ascending(QPredGen.keys.myString).sortDescriptor,
+                          modelSchema: QPredGen.schema)
         XCTAssertEqual(models[0].myString, nil)
         XCTAssertEqual(models[1].myString, "1")
         XCTAssertEqual(models[2].myString, "2")
-        models.sortModels(by: .descending(QPredGen.keys.myString), modelSchema: QPredGen.schema)
+        models.sortModels(by: QuerySortBy.descending(QPredGen.keys.myString).sortDescriptor,
+                          modelSchema: QPredGen.schema)
         XCTAssertEqual(models[0].myString, "2")
         XCTAssertEqual(models[1].myString, "1")
         XCTAssertEqual(models[2].myString, nil)
@@ -48,11 +50,13 @@ class ModelSortTests: XCTestCase {
         var models = [MutationSyncMetadata(id: UUID().uuidString, deleted: false, lastChangedAt: 1, version: 1),
                       MutationSyncMetadata(id: UUID().uuidString, deleted: false, lastChangedAt: 1, version: 2),
                       MutationSyncMetadata(id: UUID().uuidString, deleted: false, lastChangedAt: 1, version: 3)]
-        models.sortModels(by: .ascending(MutationSyncMetadata.keys.version), modelSchema: MutationSyncMetadata.schema)
+        models.sortModels(by: QuerySortBy.ascending(MutationSyncMetadata.keys.version).sortDescriptor,
+                          modelSchema: MutationSyncMetadata.schema)
         XCTAssertEqual(models[0].version, 1)
         XCTAssertEqual(models[1].version, 2)
         XCTAssertEqual(models[2].version, 3)
-        models.sortModels(by: .descending(MutationSyncMetadata.keys.version), modelSchema: MutationSyncMetadata.schema)
+        models.sortModels(by: QuerySortBy.descending(MutationSyncMetadata.keys.version).sortDescriptor,
+                          modelSchema: MutationSyncMetadata.schema)
         XCTAssertEqual(models[0].version, 3)
         XCTAssertEqual(models[1].version, 2)
         XCTAssertEqual(models[2].version, 1)
@@ -62,11 +66,11 @@ class ModelSortTests: XCTestCase {
         var models = [QPredGen(name: "name", myInt: 1),
                       QPredGen(name: "name", myInt: nil),
                       QPredGen(name: "name", myInt: 2)]
-        models.sortModels(by: .ascending(QPredGen.keys.myInt), modelSchema: QPredGen.schema)
+        models.sortModels(by: QuerySortBy.ascending(QPredGen.keys.myInt).sortDescriptor, modelSchema: QPredGen.schema)
         XCTAssertEqual(models[0].myInt, nil)
         XCTAssertEqual(models[1].myInt, 1)
         XCTAssertEqual(models[2].myInt, 2)
-        models.sortModels(by: .descending(QPredGen.keys.myInt), modelSchema: QPredGen.schema)
+        models.sortModels(by: QuerySortBy.descending(QPredGen.keys.myInt).sortDescriptor, modelSchema: QPredGen.schema)
         XCTAssertEqual(models[0].myInt, 2)
         XCTAssertEqual(models[1].myInt, 1)
         XCTAssertEqual(models[2].myInt, nil)
@@ -74,11 +78,11 @@ class ModelSortTests: XCTestCase {
 
     func testSortModelDouble() {
         var posts = [createPost(rating: 2.0), createPost(rating: 1.0), createPost(rating: 3.0)]
-        posts.sortModels(by: .ascending(Post.keys.rating), modelSchema: Post.schema)
+        posts.sortModels(by: QuerySortBy.ascending(Post.keys.rating).sortDescriptor, modelSchema: Post.schema)
         XCTAssertEqual(posts[0].rating, 1.0)
         XCTAssertEqual(posts[1].rating, 2.0)
         XCTAssertEqual(posts[2].rating, 3.0)
-        posts.sortModels(by: .descending(Post.keys.rating), modelSchema: Post.schema)
+        posts.sortModels(by: QuerySortBy.descending(Post.keys.rating).sortDescriptor, modelSchema: Post.schema)
         XCTAssertEqual(posts[0].rating, 3.0)
         XCTAssertEqual(posts[1].rating, 2.0)
         XCTAssertEqual(posts[2].rating, 1.0)
@@ -88,11 +92,13 @@ class ModelSortTests: XCTestCase {
         var models = [QPredGen(name: "name", myDouble: 1.1),
                       QPredGen(name: "name", myDouble: nil),
                       QPredGen(name: "name", myDouble: 2.2)]
-        models.sortModels(by: .ascending(QPredGen.keys.myDouble), modelSchema: QPredGen.schema)
+        models.sortModels(by: QuerySortBy.ascending(QPredGen.keys.myDouble).sortDescriptor,
+                          modelSchema: QPredGen.schema)
         XCTAssertEqual(models[0].myDouble, nil)
         XCTAssertEqual(models[1].myDouble, 1.1)
         XCTAssertEqual(models[2].myDouble, 2.2)
-        models.sortModels(by: .descending(QPredGen.keys.myDouble), modelSchema: QPredGen.schema)
+        models.sortModels(by: QuerySortBy.descending(QPredGen.keys.myDouble).sortDescriptor,
+                          modelSchema: QPredGen.schema)
         XCTAssertEqual(models[0].myDouble, 2.2)
         XCTAssertEqual(models[1].myDouble, 1.1)
         XCTAssertEqual(models[2].myDouble, nil)
@@ -105,11 +111,12 @@ class ModelSortTests: XCTestCase {
         var models = [createModel(date: date1),
                       createModel(date: date2),
                       createModel(date: date3)]
-        models.sortModels(by: .ascending(ExampleWithEveryType.keys.dateField), modelSchema: ExampleWithEveryType.schema)
+        models.sortModels(by: QuerySortBy.ascending(ExampleWithEveryType.keys.dateField).sortDescriptor,
+                          modelSchema: ExampleWithEveryType.schema)
         XCTAssertEqual(models[0].dateField, date1)
         XCTAssertEqual(models[1].dateField, date2)
         XCTAssertEqual(models[2].dateField, date3)
-        models.sortModels(by: .descending(ExampleWithEveryType.keys.dateField),
+        models.sortModels(by: QuerySortBy.descending(ExampleWithEveryType.keys.dateField).sortDescriptor,
                           modelSchema: ExampleWithEveryType.schema)
         XCTAssertEqual(models[0].dateField, date3)
         XCTAssertEqual(models[1].dateField, date2)
@@ -122,11 +129,11 @@ class ModelSortTests: XCTestCase {
         var models = [QPredGen(name: "name", myDate: date1),
                       QPredGen(name: "name", myDate: nil),
                       QPredGen(name: "name", myDate: date2)]
-        models.sortModels(by: .ascending(QPredGen.keys.myDate), modelSchema: QPredGen.schema)
+        models.sortModels(by: QuerySortBy.ascending(QPredGen.keys.myDate).sortDescriptor, modelSchema: QPredGen.schema)
         XCTAssertEqual(models[0].myDate, nil)
         XCTAssertEqual(models[1].myDate, date1)
         XCTAssertEqual(models[2].myDate, date2)
-        models.sortModels(by: .descending(QPredGen.keys.myDate), modelSchema: QPredGen.schema)
+        models.sortModels(by: QuerySortBy.descending(QPredGen.keys.myDate).sortDescriptor, modelSchema: QPredGen.schema)
         XCTAssertEqual(models[0].myDate, date2)
         XCTAssertEqual(models[1].myDate, date1)
         XCTAssertEqual(models[2].myDate, nil)
@@ -139,11 +146,11 @@ class ModelSortTests: XCTestCase {
         var posts = [createPost(createdAt: dateTime1),
                      createPost(createdAt: dateTime2),
                      createPost(createdAt: dateTime3)]
-        posts.sortModels(by: .ascending(Post.keys.createdAt), modelSchema: Post.schema)
+        posts.sortModels(by: QuerySortBy.ascending(Post.keys.createdAt).sortDescriptor, modelSchema: Post.schema)
         XCTAssertEqual(posts[0].createdAt, dateTime1)
         XCTAssertEqual(posts[1].createdAt, dateTime2)
         XCTAssertEqual(posts[2].createdAt, dateTime3)
-        posts.sortModels(by: .descending(Post.keys.createdAt), modelSchema: Post.schema)
+        posts.sortModels(by: QuerySortBy.descending(Post.keys.createdAt).sortDescriptor, modelSchema: Post.schema)
         XCTAssertEqual(posts[0].createdAt, dateTime3)
         XCTAssertEqual(posts[1].createdAt, dateTime2)
         XCTAssertEqual(posts[2].createdAt, dateTime1)
@@ -155,11 +162,13 @@ class ModelSortTests: XCTestCase {
         var models = [QPredGen(name: "name", myDateTime: datetime1),
                       QPredGen(name: "name", myDateTime: nil),
                       QPredGen(name: "name", myDateTime: datetime2)]
-        models.sortModels(by: .ascending(QPredGen.keys.myDateTime), modelSchema: QPredGen.schema)
+        models.sortModels(by: QuerySortBy.ascending(QPredGen.keys.myDateTime).sortDescriptor,
+                          modelSchema: QPredGen.schema)
         XCTAssertEqual(models[0].myDateTime, nil)
         XCTAssertEqual(models[1].myDateTime, datetime1)
         XCTAssertEqual(models[2].myDateTime, datetime2)
-        models.sortModels(by: .descending(QPredGen.keys.myDateTime), modelSchema: QPredGen.schema)
+        models.sortModels(by: QuerySortBy.descending(QPredGen.keys.myDateTime).sortDescriptor,
+                          modelSchema: QPredGen.schema)
         XCTAssertEqual(models[0].myDateTime, datetime2)
         XCTAssertEqual(models[1].myDateTime, datetime1)
         XCTAssertEqual(models[2].myDateTime, nil)
@@ -173,12 +182,12 @@ class ModelSortTests: XCTestCase {
                       QPredGen(name: "name", myTime: time1),
                       QPredGen(name: "name", myTime: time3)]
 
-        models.sortModels(by: .ascending(QPredGen.keys.myTime), modelSchema: QPredGen.schema)
+        models.sortModels(by: QuerySortBy.ascending(QPredGen.keys.myTime).sortDescriptor, modelSchema: QPredGen.schema)
         XCTAssertEqual(models[0].myTime, time1)
         XCTAssertEqual(models[1].myTime, time2)
         XCTAssertEqual(models[2].myTime, time3)
 
-        models.sortModels(by: .descending(QPredGen.keys.myTime), modelSchema: QPredGen.schema)
+        models.sortModels(by: QuerySortBy.descending(QPredGen.keys.myTime).sortDescriptor, modelSchema: QPredGen.schema)
         XCTAssertEqual(models[0].myTime, time3)
         XCTAssertEqual(models[1].myTime, time2)
         XCTAssertEqual(models[2].myTime, time1)
@@ -191,12 +200,12 @@ class ModelSortTests: XCTestCase {
                       QPredGen(name: "name", myTime: nil),
                       QPredGen(name: "name", myTime: time2)]
 
-        models.sortModels(by: .ascending(QPredGen.keys.myTime), modelSchema: QPredGen.schema)
+        models.sortModels(by: QuerySortBy.ascending(QPredGen.keys.myTime).sortDescriptor, modelSchema: QPredGen.schema)
         XCTAssertEqual(models[0].myTime, nil)
         XCTAssertEqual(models[1].myTime, time1)
         XCTAssertEqual(models[2].myTime, time2)
 
-        models.sortModels(by: .descending(QPredGen.keys.myTime), modelSchema: QPredGen.schema)
+        models.sortModels(by: QuerySortBy.descending(QPredGen.keys.myTime).sortDescriptor, modelSchema: QPredGen.schema)
         XCTAssertEqual(models[0].myTime, time2)
         XCTAssertEqual(models[1].myTime, time1)
         XCTAssertEqual(models[2].myTime, nil)
@@ -206,12 +215,12 @@ class ModelSortTests: XCTestCase {
         var models = [createModel(bool: false),
                       createModel(bool: true),
                       createModel(bool: false)]
-        models.sortModels(by: .ascending(ExampleWithEveryType.keys.boolField),
+        models.sortModels(by: QuerySortBy.ascending(ExampleWithEveryType.keys.boolField).sortDescriptor,
                           modelSchema: ExampleWithEveryType.schema)
         XCTAssertEqual(models[0].boolField, false)
         XCTAssertEqual(models[1].boolField, false)
         XCTAssertEqual(models[2].boolField, true)
-        models.sortModels(by: .descending(ExampleWithEveryType.keys.boolField),
+        models.sortModels(by: QuerySortBy.descending(ExampleWithEveryType.keys.boolField).sortDescriptor,
                           modelSchema: ExampleWithEveryType.schema)
         XCTAssertEqual(models[0].boolField, true)
         XCTAssertEqual(models[1].boolField, false)
@@ -222,11 +231,11 @@ class ModelSortTests: XCTestCase {
         var models = [QPredGen(name: "name", myBool: true),
                       QPredGen(name: "name", myBool: nil),
                       QPredGen(name: "name", myBool: false)]
-        models.sortModels(by: .ascending(QPredGen.keys.myBool), modelSchema: QPredGen.schema)
+        models.sortModels(by: QuerySortBy.ascending(QPredGen.keys.myBool).sortDescriptor, modelSchema: QPredGen.schema)
         XCTAssertEqual(models[0].myBool, nil)
         XCTAssertEqual(models[1].myBool, false)
         XCTAssertEqual(models[2].myBool, true)
-        models.sortModels(by: .descending(QPredGen.keys.myBool), modelSchema: QPredGen.schema)
+        models.sortModels(by: QuerySortBy.descending(QPredGen.keys.myBool).sortDescriptor, modelSchema: QPredGen.schema)
         XCTAssertEqual(models[0].myBool, true)
         XCTAssertEqual(models[1].myBool, false)
         XCTAssertEqual(models[2].myBool, nil)
@@ -236,12 +245,12 @@ class ModelSortTests: XCTestCase {
         var models = [createModel(enum: .bar),
                       createModel(enum: .foo),
                       createModel(enum: .bar)]
-        models.sortModels(by: .ascending(ExampleWithEveryType.keys.enumField),
+        models.sortModels(by: QuerySortBy.ascending(ExampleWithEveryType.keys.enumField).sortDescriptor,
                           modelSchema: ExampleWithEveryType.schema)
         XCTAssertEqual(models[0].enumField, .bar)
         XCTAssertEqual(models[1].enumField, .bar)
         XCTAssertEqual(models[2].enumField, .foo)
-        models.sortModels(by: .descending(ExampleWithEveryType.keys.enumField),
+        models.sortModels(by: QuerySortBy.descending(ExampleWithEveryType.keys.enumField).sortDescriptor,
                           modelSchema: ExampleWithEveryType.schema)
         XCTAssertEqual(models[0].enumField, .foo)
         XCTAssertEqual(models[1].enumField, .bar)
@@ -253,12 +262,12 @@ class ModelSortTests: XCTestCase {
                      createPost(status: .private),
                      createPost(status: .published),
                      createPost(status: nil)]
-        posts.sortModels(by: .ascending(Post.keys.status), modelSchema: Post.schema)
+        posts.sortModels(by: QuerySortBy.ascending(Post.keys.status).sortDescriptor, modelSchema: Post.schema)
         XCTAssertEqual(posts[0].status, nil)
         XCTAssertEqual(posts[1].status, .draft)
         XCTAssertEqual(posts[2].status, .private)
         XCTAssertEqual(posts[3].status, .published)
-        posts.sortModels(by: .descending(Post.keys.status), modelSchema: Post.schema)
+        posts.sortModels(by: QuerySortBy.descending(Post.keys.status).sortDescriptor, modelSchema: Post.schema)
         XCTAssertEqual(posts[0].status, .published)
         XCTAssertEqual(posts[1].status, .private)
         XCTAssertEqual(posts[2].status, .draft)
@@ -273,7 +282,7 @@ class ModelSortTests: XCTestCase {
                      createPost(rating: 1.0, createdAt: dateTime1),
                      createPost(rating: 2.0, createdAt: dateTime3)]
 
-        posts.sortModels(by: .ascending(Post.keys.rating), modelSchema: Post.schema)
+        posts.sortModels(by: QuerySortBy.ascending(Post.keys.rating).sortDescriptor, modelSchema: Post.schema)
         XCTAssertEqual(posts[0].rating, 1.0)
         XCTAssertEqual(posts[0].createdAt, dateTime2)
         XCTAssertEqual(posts[1].rating, 1.0)
@@ -281,7 +290,7 @@ class ModelSortTests: XCTestCase {
         XCTAssertEqual(posts[2].rating, 2.0)
         XCTAssertEqual(posts[2].createdAt, dateTime3)
 
-        posts.sortModels(by: .ascending(Post.keys.createdAt), modelSchema: Post.schema)
+        posts.sortModels(by: QuerySortBy.ascending(Post.keys.createdAt).sortDescriptor, modelSchema: Post.schema)
         XCTAssertEqual(posts[0].rating, 1.0)
         XCTAssertEqual(posts[0].createdAt, dateTime1)
         XCTAssertEqual(posts[1].rating, 1.0)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -315,9 +315,11 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
                          sort: [QuerySortDescriptor]?,
                          paginationInput: QueryPaginationInput?,
                          completion: DataStoreCallback<[M]>) {
-        completion(.success([]))
-        if let responder = responders[.query] as? QueryResponder {
-            return responder.callback("")
+        if let responder = responders[.query] as? QueryResponder<M> {
+            let result = responder.callback(())
+            completion(result)
+        } else {
+            completion(.success([]))
         }
     }
 
@@ -327,9 +329,12 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
                          sort: [QuerySortDescriptor]?,
                          paginationInput: QueryPaginationInput?,
                          completion: (DataStoreResult<[M]>) -> Void) {
-        completion(.success([]))
-        if let responder = responders[.query] as? QueryResponder {
-            return responder.callback("")
+
+        if let responder = responders[.query] as? QueryResponder<M> {
+            let result = responder.callback(())
+            completion(result)
+        } else {
+            completion(.success([]))
         }
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapterResponders.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapterResponders.swift
@@ -51,4 +51,4 @@ extension MockStorageEngineBehavior {
 typealias StartSyncResponder = MockResponder<String, Void>
 typealias StopSyncResponder = MockResponder<String, Void>
 typealias ClearResponder = MockResponder<String, Void>
-typealias QueryResponder = MockResponder<String, Void>
+typealias QueryResponder<M: Model> = MockResponder<Void, DataStoreResult<[M]>>

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		2102DD47260D87BC00B80FE2 /* ReconcileAndLocalSaveQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2102DD46260D87BB00B80FE2 /* ReconcileAndLocalSaveQueue.swift */; };
 		2102DD53260E2BC800B80FE2 /* ReconcileAndSaveQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2102DD52260E2BC800B80FE2 /* ReconcileAndSaveQueueTests.swift */; };
 		210E218226601C1C00D90ED8 /* MutationEventQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210E218126601C1C00D90ED8 /* MutationEventQueryTests.swift */; };
+		211FFEDA26CC270100F0DB75 /* DataStoreObserveQueryOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211FFED926CC270100F0DB75 /* DataStoreObserveQueryOperation.swift */; };
+		211FFEDD26CD621400F0DB75 /* DataStoreObserveQueryOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211FFEDC26CD621300F0DB75 /* DataStoreObserveQueryOperationTests.swift */; };
 		21233DD8247591D100039337 /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 21233DD7247591D100039337 /* amplifyconfiguration.json */; };
 		21233DE02475935600039337 /* AWSDataStoreCategoryPluginAuthIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21233DDF2475935600039337 /* AWSDataStoreCategoryPluginAuthIntegrationTests.swift */; };
 		21233DE22475935600039337 /* AWSDataStoreCategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2149E59B238867E100873955 /* AWSDataStoreCategoryPlugin.framework */; };
@@ -25,6 +27,7 @@
 		212B4686269FB10500A0AEE7 /* SQLiteResultError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212B4685269FB10500A0AEE7 /* SQLiteResultError.swift */; };
 		213481BF24213E14001966DE /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 213481BE24213E13001966DE /* README.md */; };
 		213481D4242ABA86001966DE /* ProcessMutationErrorFromCloudOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213481D3242ABA86001966DE /* ProcessMutationErrorFromCloudOperation.swift */; };
+		2145314026CDAD6400CDEACB /* AWSDataStorePluginSubscribeBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2145313F26CDAD6400CDEACB /* AWSDataStorePluginSubscribeBehaviorTests.swift */; };
 		2149E5C52388684F00873955 /* StorageEngineBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5A82388684F00873955 /* StorageEngineBehavior.swift */; };
 		2149E5C62388684F00873955 /* StorageEngineAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5A92388684F00873955 /* StorageEngineAdapter.swift */; };
 		2149E5C72388684F00873955 /* StorageEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E5AA2388684F00873955 /* StorageEngine.swift */; };
@@ -61,6 +64,9 @@
 		2149E62D23886D3900873955 /* SyncMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2149E62B23886D3900873955 /* SyncMetadataTests.swift */; };
 		214B6B65264B0D6700A9311D /* Stopwatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214B6B64264B0D6700A9311D /* Stopwatch.swift */; };
 		214B6B68264B157500A9311D /* StopwatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214B6B67264B157500A9311D /* StopwatchTests.swift */; };
+		216B69D326DD542D005D97AD /* Model+Sort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216B69D226DD542D005D97AD /* Model+Sort.swift */; };
+		216B69D626DD594E005D97AD /* ModelSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216B69D526DD594E005D97AD /* ModelSortTests.swift */; };
+		2178C0A126D3F1E200C53065 /* DataStoreObserveQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2178C0A026D3F1E200C53065 /* DataStoreObserveQueryTests.swift */; };
 		217D61752578AF85009F0639 /* DataStoreConnectionScenario2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217D61742578AF85009F0639 /* DataStoreConnectionScenario2Tests.swift */; };
 		217D622225798ED3009F0639 /* DataStoreConnectionScenario1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217D622125798ED3009F0639 /* DataStoreConnectionScenario1Tests.swift */; };
 		217D622B2579E15F009F0639 /* DataStoreConnectionScenario5Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217D62282579E15F009F0639 /* DataStoreConnectionScenario5Tests.swift */; };
@@ -336,6 +342,8 @@
 		2102DD46260D87BB00B80FE2 /* ReconcileAndLocalSaveQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcileAndLocalSaveQueue.swift; sourceTree = "<group>"; };
 		2102DD52260E2BC800B80FE2 /* ReconcileAndSaveQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcileAndSaveQueueTests.swift; sourceTree = "<group>"; };
 		210E218126601C1C00D90ED8 /* MutationEventQueryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEventQueryTests.swift; sourceTree = "<group>"; };
+		211FFED926CC270100F0DB75 /* DataStoreObserveQueryOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreObserveQueryOperation.swift; sourceTree = "<group>"; };
+		211FFEDC26CD621300F0DB75 /* DataStoreObserveQueryOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreObserveQueryOperationTests.swift; sourceTree = "<group>"; };
 		21233DD7247591D100039337 /* amplifyconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = amplifyconfiguration.json; sourceTree = "<group>"; };
 		21233DDD2475935600039337 /* AWSDataStoreCategoryPluginAuthIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSDataStoreCategoryPluginAuthIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		21233DDF2475935600039337 /* AWSDataStoreCategoryPluginAuthIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreCategoryPluginAuthIntegrationTests.swift; sourceTree = "<group>"; };
@@ -351,6 +359,7 @@
 		212B4685269FB10500A0AEE7 /* SQLiteResultError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteResultError.swift; sourceTree = "<group>"; };
 		213481BE24213E13001966DE /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		213481D3242ABA86001966DE /* ProcessMutationErrorFromCloudOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMutationErrorFromCloudOperation.swift; sourceTree = "<group>"; };
+		2145313F26CDAD6400CDEACB /* AWSDataStorePluginSubscribeBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStorePluginSubscribeBehaviorTests.swift; sourceTree = "<group>"; };
 		2149E59B238867E100873955 /* AWSDataStoreCategoryPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSDataStoreCategoryPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2149E5A82388684F00873955 /* StorageEngineBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageEngineBehavior.swift; sourceTree = "<group>"; };
 		2149E5A92388684F00873955 /* StorageEngineAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageEngineAdapter.swift; sourceTree = "<group>"; };
@@ -393,6 +402,9 @@
 		2149E62B23886D3900873955 /* SyncMetadataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncMetadataTests.swift; sourceTree = "<group>"; };
 		214B6B64264B0D6700A9311D /* Stopwatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stopwatch.swift; sourceTree = "<group>"; };
 		214B6B67264B157500A9311D /* StopwatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopwatchTests.swift; sourceTree = "<group>"; };
+		216B69D226DD542D005D97AD /* Model+Sort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Model+Sort.swift"; sourceTree = "<group>"; };
+		216B69D526DD594E005D97AD /* ModelSortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelSortTests.swift; sourceTree = "<group>"; };
+		2178C0A026D3F1E200C53065 /* DataStoreObserveQueryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreObserveQueryTests.swift; sourceTree = "<group>"; };
 		217D61742578AF85009F0639 /* DataStoreConnectionScenario2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreConnectionScenario2Tests.swift; sourceTree = "<group>"; };
 		217D622125798ED3009F0639 /* DataStoreConnectionScenario1Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataStoreConnectionScenario1Tests.swift; sourceTree = "<group>"; };
 		217D62282579E15F009F0639 /* DataStoreConnectionScenario5Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataStoreConnectionScenario5Tests.swift; sourceTree = "<group>"; };
@@ -674,6 +686,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		211FFEDB26CD61DD00F0DB75 /* Subscribe */ = {
+			isa = PBXGroup;
+			children = (
+				211FFEDC26CD621300F0DB75 /* DataStoreObserveQueryOperationTests.swift */,
+				216B69D426DD5933005D97AD /* Support */,
+			);
+			path = Subscribe;
+			sourceTree = "<group>";
+		};
 		21233DDE2475935600039337 /* AWSDataStoreCategoryPluginAuthIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -772,7 +793,9 @@
 		2149E5B82388684F00873955 /* Subscribe */ = {
 			isa = PBXGroup;
 			children = (
+				211FFED926CC270100F0DB75 /* DataStoreObserveQueryOperation.swift */,
 				2149E5B92388684F00873955 /* DataStorePublisher.swift */,
+				216B69D126DD541C005D97AD /* Support */,
 			);
 			path = Subscribe;
 			sourceTree = "<group>";
@@ -801,10 +824,12 @@
 		2149E5E42388692E00873955 /* AWSDataStoreCategoryPluginTests */ = {
 			isa = PBXGroup;
 			children = (
-				2149E5E72388692E00873955 /* Info.plist */,
+				2145313F26CDAD6400CDEACB /* AWSDataStorePluginSubscribeBehaviorTests.swift */,
 				FAD2BDF423957F35006EB065 /* Core */,
+				2149E5E72388692E00873955 /* Info.plist */,
 				B996FC4523FF3C41006D0F68 /* Models */,
 				6B7743E5259071AB001469F5 /* Storage */,
+				211FFEDB26CD61DD00F0DB75 /* Subscribe */,
 				FAD2BDF223957EE8006EB065 /* Sync */,
 				2149E5EE238869CF00873955 /* TestSupport */,
 			);
@@ -849,6 +874,7 @@
 				FAB571412395A3E80006A5F8 /* DataStoreEndToEndTests.swift */,
 				D8E9992325013C2F0006170A /* DataStoreHubEventsTests.swift */,
 				D888E80924A65B3800F4CE3E /* DataStoreLocalStoreTests.swift */,
+				2178C0A026D3F1E200C53065 /* DataStoreObserveQueryTests.swift */,
 				21A905B9261651FA00EC141D /* DataStoreScalarTests.swift */,
 				2149E62123886CEE00873955 /* Info.plist */,
 				213481BE24213E13001966DE /* README.md */,
@@ -865,6 +891,22 @@
 				210E218126601C1C00D90ED8 /* MutationEventQueryTests.swift */,
 				214B6B67264B157500A9311D /* StopwatchTests.swift */,
 				97DB735A26B4A229004708B8 /* MutationEventExtensionsTests.swift */,
+			);
+			path = Support;
+			sourceTree = "<group>";
+		};
+		216B69D126DD541C005D97AD /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				216B69D226DD542D005D97AD /* Model+Sort.swift */,
+			);
+			path = Support;
+			sourceTree = "<group>";
+		};
+		216B69D426DD5933005D97AD /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				216B69D526DD594E005D97AD /* ModelSortTests.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -1982,6 +2024,7 @@
 				2149E5CF2388684F00873955 /* SQLStatement+Delete.swift in Sources */,
 				B47532F02540DF640032098E /* QuerySortDescriptor.swift in Sources */,
 				2149E5C92388684F00873955 /* SQLStatement+Insert.swift in Sources */,
+				216B69D326DD542D005D97AD /* Model+Sort.swift in Sources */,
 				D8079A73251656A200826E8F /* SyncEventEmitter.swift in Sources */,
 				2149E5D42388684F00873955 /* DataStorePublisher.swift in Sources */,
 				FA3841E723889D340070AD5B /* ReconcileAndLocalSaveOperation.swift in Sources */,
@@ -2000,6 +2043,7 @@
 				FAED573E238B4C2F008EBED8 /* StorageEngineAdapter+UntypedModel.swift in Sources */,
 				B9334BA22433AF3E00C9F407 /* DataStoreConfiguration.swift in Sources */,
 				FA4A9559239ACC1B008E876E /* IncomingSubscriptionEventPublisher.swift in Sources */,
+				211FFEDA26CC270100F0DB75 /* DataStoreObserveQueryOperation.swift in Sources */,
 				FA8F4D222395B11700861D91 /* MutationEvent+Query.swift in Sources */,
 				FAF7CECB238C72830095547B /* OutgoingMutationQueue.swift in Sources */,
 				2149E5CC2388684F00873955 /* SQLStatement+Select.swift in Sources */,
@@ -2051,6 +2095,7 @@
 				FA3841ED23889D8F0070AD5B /* StateMachineTests.swift in Sources */,
 				B9E010E4239167E000DCE8C8 /* TestModelRegistration.swift in Sources */,
 				6B3381BC239778E90036F046 /* AWSMutationDatabaseAdapterTests.swift in Sources */,
+				216B69D626DD594E005D97AD /* ModelSortTests.swift in Sources */,
 				2149E5FC238869CF00873955 /* LocalSubscriptionTests.swift in Sources */,
 				B40EF02824BF68C900F2264C /* ConfigurationTests.swift in Sources */,
 				FA23345C23955CEF009BEFE9 /* NoOpMutationQueue.swift in Sources */,
@@ -2087,6 +2132,7 @@
 				FAC010F2239570D300FCE7BB /* SyncEngineTestBase.swift in Sources */,
 				2149E5FA238869CF00873955 /* APICategoryDependencyTests.swift in Sources */,
 				219F796A25B8D268007107D3 /* StorageEngineTestsDelete.swift in Sources */,
+				211FFEDD26CD621400F0DB75 /* DataStoreObserveQueryOperationTests.swift in Sources */,
 				FA4B8E942391C2CD009FC10F /* MutationIngesterConflictResolutionTests.swift in Sources */,
 				FA4A9557239ACAD7008E876E /* ModelReconciliationQueueBehaviorTests.swift in Sources */,
 				6BE7431C2575B8B000009FCB /* AWSAPICategoryPluginTests.swift in Sources */,
@@ -2101,6 +2147,7 @@
 				B9FAA142238C6082009414B4 /* BaseDataStoreTests.swift in Sources */,
 				6B7743E7259071C8001469F5 /* StorageEngineTestsHasMany.swift in Sources */,
 				6BE9D6F125A6643100AB5C9A /* StorageEngineTestsHasOne.swift in Sources */,
+				2145314026CDAD6400CDEACB /* AWSDataStorePluginSubscribeBehaviorTests.swift in Sources */,
 				214B6B68264B157500A9311D /* StopwatchTests.swift in Sources */,
 				6B52DC9624478E75007F5AD3 /* MockModelReconciliationQueue.swift in Sources */,
 				FA4A955B239AD3F4008E876E /* Foundation+TestExtensions.swift in Sources */,
@@ -2136,6 +2183,7 @@
 			files = (
 				D8E9992425013C2F0006170A /* DataStoreHubEventsTests.swift in Sources */,
 				D8C5BA59249815A6007C3A68 /* DataStoreConfigurationTests.swift in Sources */,
+				2178C0A126D3F1E200C53065 /* DataStoreObserveQueryTests.swift in Sources */,
 				2149E62D23886D3900873955 /* SyncMetadataTests.swift in Sources */,
 				217D622D2579E15F009F0639 /* DataStoreConnectionScenario3Tests.swift in Sources */,
 				FAD2BDF6239583B2006EB065 /* TestModelRegistration.swift in Sources */,

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -136,6 +136,15 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         return Result.Publisher(mutationEvent).eraseToAnyPublisher()
     }
 
+    @available(iOS 13.0, *)
+    public func observeQuery<M: Model>(for modelType: M.Type,
+                                       where predicate: QueryPredicate? = nil,
+                                       sort sortInput: QuerySortInput? = nil)
+    -> AnyPublisher<DataStoreQuerySnapshot<M>, DataStoreError> {
+        notify("observeQuery")
+        let snapshot = DataStoreQuerySnapshot<M>(items: [], isSynced: false, itemsChanged: [])
+        return Result.Publisher(snapshot).eraseToAnyPublisher()
+    }
 }
 
 class MockSecondDataStoreCategoryPlugin: MockDataStoreCategoryPlugin {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding DataStore ObserveQuery API to provide a API that combines both the real-time update API (`Amplify.DataStore.publisher`) and the query API (`Amplify.DataStore.query`) to stream query snapshot events.

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] Sample app with at scale data (for example, 10k entries) and using observe query API

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
