### PR TITLE
update sqlite.swift

### DIFF
--- a/AmplifyPlugins/DataStore/Podfile
+++ b/AmplifyPlugins/DataStore/Podfile
@@ -8,7 +8,7 @@ include_build_tools!
 target 'AWSDataStoreCategoryPlugin' do
   pod 'Amplify', :path => '../../'
   pod 'AWSPluginsCore', :path => '../../'
-  pod "SQLite.swift", "0.12.2"
+  pod "SQLite.swift", "0.13.0"
 
   target "AWSDataStoreCategoryPluginTests" do
     inherit! :complete


### PR DESCRIPTION
Set SQLite.swift version to 0.13.0 to get the fix for https://github.com/stephencelis/SQLite.swift/pull/1030 (fixes a crash we're seeing in datastore).

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
