### PR TITLE
fix(Datastore): deadlock in sqlite Connection.sync

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -126,6 +126,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
         do {
             try storageAdapter.transaction {
                 queryPendingMutations(forModelIds: remoteModelIds)
+                    .subscribe(on: workQueue)
                     .flatMap { mutationEvents -> Future<([RemoteModel], [LocalMetadata]), DataStoreError> in
                         let remoteModelsToApply = self.reconcile(remoteModels, pendingMutations: mutationEvents)
                         return self.queryLocalMetadata(remoteModelsToApply)


### PR DESCRIPTION
Fix deadlock in sqlite Connection.sync by moving publishers off of "SQLite.Database" queue as described in https://github.com/aws-amplify/amplify-ios/issues/1405

*Description of changes:*
use `subscribe(on:)` in the transaction completion handler to move work off of the sqlite synchronous queue to the datastore's work queue.

A `receive(on:)` before the sink would probably work as well, but it seems like this work should be on the work queue rather than sqlite's queue.

I've validated this fixes my issue, but have no idea how to construct a test this would resolve.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
