### PR TITLE
fix(Datastore): Consecutive Updates (Save, Sync, Update and Immediately Delete Scenario)

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -242,8 +242,8 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
                                      mutationSyncMetadata: MutationSync<AnyModel>?) {
         if let mutationSyncMetadata = mutationSyncMetadata {
             MutationEvent.reconcilePendingMutationEventsVersion(
-                mutationEvent: mutationEvent,
-                mutationSync: mutationSyncMetadata,
+                sent: mutationEvent,
+                received: mutationSyncMetadata,
                 storageAdapter: storageAdapter) { _ in
                 self.completeProcessingEvent(mutationEvent, mutationSyncMetadata: mutationSyncMetadata)
             }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -241,8 +241,8 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
     private func processSuccessEvent(_ mutationEvent: MutationEvent,
                                      mutationSyncMetadata: MutationSync<AnyModel>?) {
         if let mutationSyncMetadata = mutationSyncMetadata {
-            MutationEvent.updatePendingMutationEventVersionIfNil(
-                for: mutationEvent.modelId,
+            MutationEvent.reconcilePendingMutationEventsVersion(
+                mutationEvent: mutationEvent,
                 mutationSync: mutationSyncMetadata,
                 storageAdapter: storageAdapter) { _ in
                 self.completeProcessingEvent(mutationEvent, mutationSyncMetadata: mutationSyncMetadata)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Model+Compare.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Model+Compare.swift
@@ -17,7 +17,7 @@ extension ModelSchema {
     /// Returns true if equal, false otherwise
     /// Currently, schemas where system timestamps fields (createdAt, updatedAt)
     /// are renamed using with `@model`'s `timestamps` attribute and explicitly
-    /// added to the input schema are not supported by this check since they are
+    /// added to the input schema are not supported by this check since they are not
     /// marked as "read-only" fields and will fail the check when the service generates
     /// and returns the value of `createdAt` or `updatedAt`.
     /// for e.g.

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Model+Compare.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Model+Compare.swift
@@ -14,11 +14,9 @@ extension ModelSchema {
 
     /// Compare two `Model` based on a given `ModelSchema`
     /// Returns true if equal, false otherwise
-    public static func isEqual(_ model1: Model,
-                               _ model2: Model,
-                               _ modelSchema: ModelSchema) -> Bool {
-        for (fieldName, modelField) in modelSchema.fields {
-            // skip read only fields
+    public func isEqual(_ model1: Model, _ model2: Model) -> Bool {
+        for (fieldName, modelField) in fields {
+            // read only fields are skipped for eqaulity check as they are created by the service
             if modelField.isReadOnly {
                 continue
             }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Model+Compare.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Model+Compare.swift
@@ -30,21 +30,21 @@ extension ModelSchema {
                 guard let value1Optional = value1 as? String?, let value2Optional = value2 as? String? else {
                     return false
                 }
-                if !modelCompareHelper(value1Optional, value2Optional) {
+                if !isEqual(value1Optional, value2Optional) {
                     return false
                 }
             case .int:
                 guard let value1Optional = value1 as? Int?, let value2Optional = value2 as? Int? else {
                     return false
                 }
-                if !modelCompareHelper(value1Optional, value2Optional) {
+                if !isEqual(value1Optional, value2Optional) {
                     return false
                 }
             case .double:
                 guard let value1Optional = value1 as? Double?, let value2Optional = value2 as? Double? else {
                     return false
                 }
-                if !modelCompareHelper(value1Optional, value2Optional) {
+                if !isEqual(value1Optional, value2Optional) {
                     return false
                 }
             case .date:
@@ -52,7 +52,7 @@ extension ModelSchema {
                       let value2Optional = value2 as? Temporal.Date? else {
                     return false
                 }
-                if !modelCompareHelper(value1Optional, value2Optional) {
+                if !isEqual(value1Optional, value2Optional) {
                     return false
                 }
             case .dateTime:
@@ -60,7 +60,7 @@ extension ModelSchema {
                       let value2Optional = value2 as? Temporal.DateTime? else {
                     return false
                 }
-                if !modelCompareHelper(value1Optional, value2Optional) {
+                if !isEqual(value1Optional, value2Optional) {
                     return false
                 }
             case .time:
@@ -68,21 +68,21 @@ extension ModelSchema {
                       let value2Optional = value2 as? Temporal.Time? else {
                     return false
                 }
-                if !modelCompareHelper(value1Optional, value2Optional) {
+                if !isEqual(value1Optional, value2Optional) {
                     return false
                 }
             case .timestamp:
                 guard let value1Optional = value1 as? String?, let value2Optional = value2 as? String? else {
                     return false
                 }
-                if !modelCompareHelper(value1Optional, value2Optional) {
+                if !isEqual(value1Optional, value2Optional) {
                     return false
                 }
             case .bool:
                 guard let value1Optional = value1 as? Bool?, let value2Optional = value2 as? Bool? else {
                     return false
                 }
-                if !modelCompareHelper(value1Optional?.intValue, value2Optional?.intValue) {
+                if !isEqual(value1Optional?.intValue, value2Optional?.intValue) {
                     return false
                 }
             case .enum:
@@ -95,7 +95,7 @@ extension ModelSchema {
                 }
                 let enumValue1Optional = (value1Optional as? EnumPersistable)?.rawValue
                 let enumValue2Optional = (value2Optional as? EnumPersistable)?.rawValue
-                if !modelCompareHelper(enumValue1Optional, enumValue2Optional) {
+                if !isEqual(enumValue1Optional, enumValue2Optional) {
                     return false
                 }
             case .embedded, .embeddedCollection:
@@ -104,7 +104,7 @@ extension ModelSchema {
                        let encodable2 = value2 as? Encodable {
                         let json1 = try SQLiteModelValueConverter.toJSON(encodable1)
                         let json2 = try SQLiteModelValueConverter.toJSON(encodable2)
-                        if !modelCompareHelper(json1, json2) {
+                        if !isEqual(json1, json2) {
                             return false
                         }
                     }
@@ -123,8 +123,8 @@ extension ModelSchema {
         return true
     }
 
-    private func modelCompareHelper<T: Comparable>(_ optional1: T?, _ optional2: T?) -> Bool {
-        switch (optional1, optional2) {
+    private func isEqual<T: Comparable>(_ value1: T?, _ value2: T?) -> Bool {
+        switch (value1, value2) {
         case(nil, nil):
             return true
         case(nil, .some):

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Model+Compare.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Model+Compare.swift
@@ -11,7 +11,7 @@ import Amplify
 // swiftlint:disable cyclomatic_complexity
 extension ModelSchema {
 
-    private static let serviceUpdatedFields: Set = ["updatedAt"]
+    private static let serviceUpdatedFields: Set = ["updatedAt", "createdAt"]
 
     /// Compare two `Model` based on a given `ModelSchema`
     /// Returns true if equal, false otherwise

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Model+Compare.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Model+Compare.swift
@@ -15,6 +15,18 @@ extension ModelSchema {
 
     /// Compare two `Model` based on a given `ModelSchema`
     /// Returns true if equal, false otherwise
+    /// Currently, schemas where system timestamps fields (createdAt, updatedAt)
+    /// are changed with `timestamps` attribute to model directive and also added
+    /// to model schema are not covered. This will cause `isEqual` to fail in
+    /// such cases.
+    /// for e.g.
+    /// type Post @model(timestamps:{createdAt: "createdOn", updatedAt: "updatedOn"}) {
+    ///  id: ID!
+    ///  title: String!
+    ///  tags: [String!]!
+    ///  createdOn: AWSDateTime
+    ///  updatedOn: AWSDateTime
+    /// }
     func isEqual(_ model1: Model, _ model2: Model) -> Bool {
         for (fieldName, modelField) in fields {
             // read only fields or fields updated from the service are skipped for equality check

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Model+Compare.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Model+Compare.swift
@@ -11,13 +11,15 @@ import Amplify
 // swiftlint:disable cyclomatic_complexity
 extension ModelSchema {
 
+    private static let serviceUpdatedFields: Set = ["updatedAt"]
+
     /// Compare two `Model` based on a given `ModelSchema`
     /// Returns true if equal, false otherwise
     func isEqual(_ model1: Model, _ model2: Model) -> Bool {
         for (fieldName, modelField) in fields {
-            // read only fields are skipped for equality check
+            // read only fields or fields updated from the service are skipped for equality check
             // examples of such fields include `createdAt`, `updatedAt` and `coverId` in `Record`
-            if modelField.isReadOnly {
+            if modelField.isReadOnly || ModelSchema.serviceUpdatedFields.contains(modelField.name) {
                 continue
             }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Model+Compare.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/Model+Compare.swift
@@ -1,0 +1,144 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Amplify
+
+// swiftlint:disable cyclomatic_complexity
+// swiftlint:disable syntactic_sugar
+extension ModelSchema {
+
+    /// Compare two `Model` based on a given `ModelSchema`
+    /// Returns true if equal, false otherwise
+    public static func isEqual(_ model1: Model,
+                               _ model2: Model,
+                               _ modelSchema: ModelSchema) -> Bool {
+        for (fieldName, modelField) in modelSchema.fields {
+            // skip read only fields
+            if modelField.isReadOnly {
+                continue
+            }
+
+            let value1 = model1[fieldName] ?? nil
+            let value2 = model2[fieldName] ?? nil
+
+            // check equality for different `ModelFieldType`
+            switch modelField.type {
+            case .string:
+                guard let value1Optional = value1 as? String?, let value2Optional = value2 as? String? else {
+                    return false
+                }
+                if let value1 = value1Optional, let value2 = value2Optional, value1 != value2 {
+                    return false
+                } else {
+                    continue
+                }
+            case .int:
+                guard let value1Optional = value1 as? Int?, let value2Optional = value2 as? Int? else {
+                    return false
+                }
+                if let value1 = value1Optional, let value2 = value2Optional, value1 != value2 {
+                    return false
+                } else {
+                    continue
+                }
+            case .double:
+                guard let value1Optional = value1 as? Double?, let value2Optional = value2 as? Double? else {
+                    return false
+                }
+                if let value1 = value1Optional, let value2 = value2Optional, value1 != value2 {
+                    return false
+                } else {
+                    continue
+                }
+            case .date:
+                guard let value1Optional = value1 as? Temporal.Date?,
+                      let value2Optional = value2 as? Temporal.Date? else {
+                    return false
+                }
+                if let value1 = value1Optional, let value2 = value2Optional, value1 != value2 {
+                    return false
+                } else {
+                    continue
+                }
+            case .dateTime:
+                guard let value1Optional = value1 as? Temporal.DateTime?,
+                      let value2Optional = value2 as? Temporal.DateTime? else {
+                    return false
+                }
+                if let value1 = value1Optional, let value2 = value2Optional, value1 != value2 {
+                    return false
+                } else {
+                    continue
+                }
+            case .time:
+                guard let value1Optional = value1 as? Temporal.Time?,
+                      let value2Optional = value2 as? Temporal.Time? else {
+                    return false
+                }
+                if let value1 = value1Optional, let value2 = value2Optional, value1 != value2 {
+                    return false
+                } else {
+                    continue
+                }
+            case .timestamp:
+                guard let value1Optional = value1 as? String?, let value2Optional = value2 as? String? else {
+                    return false
+                }
+                if let value1 = value1Optional, let value2 = value2Optional, value1 != value2 {
+                    return false
+                } else {
+                    continue
+                }
+            case .bool:
+                guard let value1Optional = value1 as? Bool?, let value2Optional = value2 as? Bool? else {
+                    return false
+                }
+                if let value1 = value1Optional, let value2 = value2Optional, value1 != value2 {
+                    return false
+                } else {
+                    continue
+                }
+            case .enum:
+                guard case .some(Optional<Any>.some(let value1Optional)) = value1,
+                      case .some(Optional<Any>.some(let value2Optional)) = value2 else {
+                    if value1 == nil && value2 == nil {
+                        continue
+                    }
+                    return false
+                }
+                let enumValue1Optional = (value1Optional as? EnumPersistable)?.rawValue
+                let enumValue2Optional = (value2Optional as? EnumPersistable)?.rawValue
+                if enumValue1Optional != enumValue2Optional {
+                    return false
+                } else {
+                    continue
+                }
+            case .embedded, .embeddedCollection:
+                do {
+                    if let encodable1 = value1 as? Encodable,
+                       let encodable2 = value2 as? Encodable {
+                        let json1 = try SQLiteModelValueConverter.toJSON(encodable1)
+                        let json2 = try SQLiteModelValueConverter.toJSON(encodable2)
+                        if let value1 = json1, let value2 = json2, value1 != value2 {
+                            return false
+                        } else {
+                            continue
+                        }
+                    }
+                } catch {
+                    continue
+                }
+            case .model:
+                continue
+            case .collection:
+                continue
+            }
+        }
+        return true
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Extensions.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Extensions.swift
@@ -11,15 +11,14 @@ import AWSPluginsCore
 
 extension MutationEvent {
 
-    // Updates the head of pending mutation event queue for a given model `id`
-    // if it has a `nil` version, with syncMetadata version in `mutationSync`
-    // and saves it in the mutation event table
-    static func updatePendingMutationEventVersionIfNil(for modelId: Model.Identifier,
-                                                       mutationSync: MutationSync<AnyModel>,
-                                                       storageAdapter: StorageEngineAdapter,
-                                                       completion: @escaping DataStoreCallback<Void>) {
+    // Updates the version of the head of pending mutation event queue for a given model `id`
+    // with syncMetadata version in `mutationSync` and saves it in the mutation event table
+    static func reconcilePendingMutationEventsVersion(mutationEvent: MutationEvent,
+                                                      mutationSync: MutationSync<AnyModel>,
+                                                      storageAdapter: StorageEngineAdapter,
+                                                      completion: @escaping DataStoreCallback<Void>) {
         MutationEvent.pendingMutationEvents(
-            for: modelId,
+            for: mutationEvent.modelId,
             storageAdapter: storageAdapter) { queryResult in
             switch queryResult {
             case .failure(let dataStoreError):
@@ -30,21 +29,34 @@ extension MutationEvent {
                     return
                 }
 
-                if existingEvent.version == nil {
-                    Amplify.log.verbose("""
-                        Replacing existing mutation event having nil version with version from mutation response
-                            \(mutationSync.syncMetadata.version)
-                        """)
-                    existingEvent.version = mutationSync.syncMetadata.version
-                    storageAdapter.save(existingEvent, condition: nil) { result in
-                        switch result {
-                        case .failure(let dataStoreError):
-                            completion(.failure(dataStoreError))
-                        case .success:
-                            completion(.success(()))
+                // check if version returned from API is not nil and <= version sent in the request
+                if existingEvent.version != nil && mutationSync.syncMetadata.version <= existingEvent.version! {
+                    completion(.success(()))
+                    return
+                }
+
+                do {
+                    let responseModel = mutationSync.model.instance
+                    let requestModel = try mutationEvent.decodeModel()
+
+                    // check if the data sent in the request is the same as the response
+                    // if it is, update the pending mutation event version to the response version
+                    if let modelSchema = ModelRegistry.modelSchema(from: mutationEvent.modelName),
+                       ModelSchema.isEqual(responseModel, requestModel, modelSchema) {
+                        existingEvent.version = mutationSync.syncMetadata.version
+                        storageAdapter.save(existingEvent, condition: nil) { result in
+                            switch result {
+                            case .failure(let dataStoreError):
+                                completion(.failure(dataStoreError))
+                            case .success:
+                                completion(.success(()))
+                            }
                         }
+                    } else {
+                        completion(.success(()))
                     }
-                } else {
+                } catch {
+                    Amplify.log.verbose("Error decoding models: \(error)")
                     completion(.success(()))
                 }
             }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Extensions.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Extensions.swift
@@ -10,11 +10,27 @@ import Dispatch
 import AWSPluginsCore
 
 extension MutationEvent {
-    // Reconciles the version of pending mutation events in mutation event table with the
-    // API response version for the following consecutive update scenarios :
-    //  - Save, then update
-    //  - Save, then delete
-    //  - Save, sync, then update and delete
+    // Consecutive operations that modify a model results in a sequence of pending mutation events that
+    // have the current version of the model. The first mutation event has the correct version of the model,
+    // while the subsequent events will have lower versions if the first mutation event is successfully synced
+    // to the cloud. By reconciling the pending mutation events after syncing the first mutation event,
+    // we attempt to update the pending version to the latest version from the response.
+    // The before and after conditions for consecutive update scenarios are as below:
+    //  - Save, then immediately update
+    //      Queue Before - [(version: nil, inprocess: true, type: .create),
+    //                      (version: nil, inprocess: false, type: .update)]
+    //      Response - [version: 1, type: .create]
+    //      Queue After - [(version: 1, inprocess: false, type: .update)]
+    //  - Save, then immediately delete
+    //      Queue Before - [(version: nil, inprocess: true, type: .create),
+    //                      (version: nil, inprocess: false, type: .delete)]
+    //      Response - [version: 1, type: .create]
+    //      Queue After - [(version: 1, inprocess: false, type: .delete)]
+    //  - Save, sync, then immediately update and delete
+    //      Queue Before (After save, sync)
+    //          - [(version: 1, inprocess: true, type: .update), (version: 1, inprocess: false, type: .delete)]
+    //      Response - [version: 2, type: .update]
+    //      Queue After - [(version: 2, inprocess: false, type: .delete)]
     //
     // For a given model `id`, checks the version of the head of pending mutation event queue
     // against the API response version in `mutationSync` and saves it in the mutation event table if
@@ -30,44 +46,57 @@ extension MutationEvent {
             case .failure(let dataStoreError):
                 completion(.failure(dataStoreError))
             case .success(let localMutationEvents):
-                guard var existingEvent = localMutationEvents.first else {
+                guard let existingEvent = localMutationEvents.first else {
                     completion(.success(()))
                     return
                 }
 
-                // return if version of the pending mutation event is not nil and
-                // is >= version contained in the response
-                if existingEvent.version != nil && existingEvent.version! >= mutationSync.syncMetadata.version {
+                guard let reconciledEvent = reconcile(pendingMutationEvent: existingEvent,
+                                                      with: mutationEvent,
+                                                      responseMutationSync: mutationSync) else {
                     completion(.success(()))
                     return
                 }
 
-                do {
-                    let responseModel = mutationSync.model.instance
-                    let requestModel = try mutationEvent.decodeModel()
-
-                    // check if the data sent in the request is the same as the response
-                    // if it is, update the pending mutation event version to the response version
-                    guard let modelSchema = ModelRegistry.modelSchema(from: mutationEvent.modelName),
-                          modelSchema.isEqual(responseModel, requestModel) else {
+                storageAdapter.save(reconciledEvent, condition: nil) { result in
+                    switch result {
+                    case .failure(let dataStoreError):
+                        completion(.failure(dataStoreError))
+                    case .success:
                         completion(.success(()))
-                        return
                     }
-
-                    existingEvent.version = mutationSync.syncMetadata.version
-                    storageAdapter.save(existingEvent, condition: nil) { result in
-                        switch result {
-                        case .failure(let dataStoreError):
-                            completion(.failure(dataStoreError))
-                        case .success:
-                            completion(.success(()))
-                        }
-                    }
-                } catch {
-                    Amplify.log.verbose("Error decoding models: \(error)")
-                    completion(.success(()))
                 }
             }
+        }
+    }
+
+    static func reconcile(pendingMutationEvent: MutationEvent,
+                          with requestMutationEvent: MutationEvent,
+                          responseMutationSync: MutationSync<AnyModel>) -> MutationEvent? {
+        // return if version of the pending mutation event is not nil and
+        // is >= version contained in the response
+        if pendingMutationEvent.version != nil &&
+            pendingMutationEvent.version! >= responseMutationSync.syncMetadata.version {
+            return nil
+        }
+
+        do {
+            let responseModel = responseMutationSync.model.instance
+            let requestModel = try requestMutationEvent.decodeModel()
+
+            // check if the data sent in the request is the same as the response
+            // if it is, update the pending mutation event version to the response version
+            guard let modelSchema = ModelRegistry.modelSchema(from: requestMutationEvent.modelName),
+                  modelSchema.isEqual(responseModel, requestModel) else {
+                return nil
+            }
+
+            var pendingMutationEvent = pendingMutationEvent
+            pendingMutationEvent.version = responseMutationSync.syncMetadata.version
+            return pendingMutationEvent
+        } catch {
+            Amplify.log.verbose("Error decoding models: \(error)")
+            return nil
         }
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Extensions.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Extensions.swift
@@ -10,11 +10,17 @@ import Dispatch
 import AWSPluginsCore
 
 extension MutationEvent {
-
-    // Updates the version of the head of pending mutation event queue for a given model `id`
-    // with syncMetadata version in `mutationSync` and saves it in the mutation event table
-    static func reconcilePendingMutationEventsVersion(mutationEvent: MutationEvent,
-                                                      mutationSync: MutationSync<AnyModel>,
+    // Reconciles the version of pending mutation events in mutation event table with the
+    // API response version for the following consecutive update scenarios :
+    //  - Save, then update
+    //  - Save, then delete
+    //  - Save, sync, then update and delete
+    //
+    // For a given model `id`, checks the version of the head of pending mutation event queue
+    // against the API response version in `mutationSync` and saves it in the mutation event table if
+    // the response version is a newer one
+    static func reconcilePendingMutationEventsVersion(sent mutationEvent: MutationEvent,
+                                                      received mutationSync: MutationSync<AnyModel>,
                                                       storageAdapter: StorageEngineAdapter,
                                                       completion: @escaping DataStoreCallback<Void>) {
         MutationEvent.pendingMutationEvents(

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Extensions.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Extensions.swift
@@ -87,7 +87,7 @@ extension MutationEvent {
             // check if the data sent in the request is the same as the response
             // if it is, update the pending mutation event version to the response version
             guard let modelSchema = ModelRegistry.modelSchema(from: requestMutationEvent.modelName),
-                  modelSchema.isEqual(responseModel, requestModel) else {
+                  modelSchema.compare(responseModel, requestModel) else {
                 return nil
             }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/Support/ModelCompareTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/Support/ModelCompareTests.swift
@@ -39,7 +39,7 @@ class ModelCompareTests: BaseDataStoreTests {
                          draft: draft,
                          rating: rating,
                          status: status)
-        XCTAssertTrue(Post.schema.isEqual(post1, post2))
+        XCTAssertTrue(Post.schema.compare(post1, post2))
     }
 
     func testPostsAreEqualWithSameCollection() {
@@ -69,7 +69,7 @@ class ModelCompareTests: BaseDataStoreTests {
         let comment2 = Comment(id: commentId, content: "This is a comment.", createdAt: createdAt, post: post2)
         post1.comments = [comment1]
         post2.comments = [comment2]
-        XCTAssertTrue(Post.schema.isEqual(post1, post2))
+        XCTAssertTrue(Post.schema.compare(post1, post2))
     }
 
     func testCommentsAreEqualWithDifferentPosts() {
@@ -100,7 +100,7 @@ class ModelCompareTests: BaseDataStoreTests {
         let comment2 = Comment(id: id, content: "This is a comment.", createdAt: createdAt, post: post2)
         post1.comments = [comment1]
         post2.comments = [comment2]
-        XCTAssertTrue(Comment.schema.isEqual(comment1, comment2))
+        XCTAssertTrue(Comment.schema.compare(comment1, comment2))
     }
 
     func testPostsAreNotEqualWithNilFields() {
@@ -127,7 +127,7 @@ class ModelCompareTests: BaseDataStoreTests {
                          draft: draft,
                          rating: nil,
                          status: status)
-        XCTAssertFalse(Post.schema.isEqual(post1, post2))
+        XCTAssertFalse(Post.schema.compare(post1, post2))
     }
 
     func testPostsAreNotEqualWithDifferentId() {
@@ -151,7 +151,7 @@ class ModelCompareTests: BaseDataStoreTests {
                          draft: draft,
                          rating: rating,
                          status: status)
-        XCTAssertFalse(Post.schema.isEqual(post1, post2))
+        XCTAssertFalse(Post.schema.compare(post1, post2))
     }
 
     func testPostsAreNotEqualWithDifferentStringField() {
@@ -177,7 +177,7 @@ class ModelCompareTests: BaseDataStoreTests {
                          draft: draft,
                          rating: rating,
                          status: status)
-        XCTAssertFalse(Post.schema.isEqual(post1, post2))
+        XCTAssertFalse(Post.schema.compare(post1, post2))
     }
 
     func testPostsAreNotEqualWithDifferentDoubleField() {
@@ -203,7 +203,7 @@ class ModelCompareTests: BaseDataStoreTests {
                          draft: draft,
                          rating: rating2,
                          status: status)
-        XCTAssertFalse(Post.schema.isEqual(post1, post2))
+        XCTAssertFalse(Post.schema.compare(post1, post2))
     }
 
     func testQpredGensAreNotEqualWithDifferentDateTimeField() {
@@ -215,7 +215,7 @@ class ModelCompareTests: BaseDataStoreTests {
         let dateTime2 = Temporal.DateTime(formatter.date(from: "2020-09-01")!)
         let qPredGen1 = QPredGen(id: id, name: name, myDateTime: dateTime1)
         let qPredGen2 = QPredGen(id: id, name: name, myDateTime: dateTime2)
-        XCTAssertFalse(QPredGen.schema.isEqual(qPredGen1, qPredGen2))
+        XCTAssertFalse(QPredGen.schema.compare(qPredGen1, qPredGen2))
     }
 
     func testQpredGensAreNotEqualWithDifferentDateField() throws {
@@ -225,7 +225,7 @@ class ModelCompareTests: BaseDataStoreTests {
         let date2 = try Temporal.Date(iso8601String: "2020-09-01")
         let qPredGen1 = QPredGen(id: id, name: name, myDate: date1)
         let qPredGen2 = QPredGen(id: id, name: name, myDate: date2)
-        XCTAssertFalse(QPredGen.schema.isEqual(qPredGen1, qPredGen2))
+        XCTAssertFalse(QPredGen.schema.compare(qPredGen1, qPredGen2))
     }
 
     func testQpredGensAreNotEqualWithDifferentTimeField() throws {
@@ -235,7 +235,7 @@ class ModelCompareTests: BaseDataStoreTests {
         let time2 = try Temporal.Time(iso8601String: "08:01")
         let qPredGen1 = QPredGen(id: id, name: name, myTime: time1)
         let qPredGen2 = QPredGen(id: id, name: name, myTime: time2)
-        XCTAssertFalse(QPredGen.schema.isEqual(qPredGen1, qPredGen2))
+        XCTAssertFalse(QPredGen.schema.compare(qPredGen1, qPredGen2))
     }
 
     func testPostsAreNotEqualWithDifferentEnumField() {
@@ -261,7 +261,7 @@ class ModelCompareTests: BaseDataStoreTests {
                          draft: draft,
                          rating: rating,
                          status: status2)
-        XCTAssertFalse(Post.schema.isEqual(post1, post2))
+        XCTAssertFalse(Post.schema.compare(post1, post2))
     }
 
     func testPostsAreNotEqualWithDifferentBoolField() {
@@ -287,7 +287,7 @@ class ModelCompareTests: BaseDataStoreTests {
                          draft: draft2,
                          rating: rating,
                          status: status)
-        XCTAssertFalse(Post.schema.isEqual(post1, post2))
+        XCTAssertFalse(Post.schema.compare(post1, post2))
     }
 
     func testTodosAreEqualWithSameEmbeddedable() {
@@ -296,7 +296,7 @@ class ModelCompareTests: BaseDataStoreTests {
         let section = Section(name: "MySection", number: 10)
         let todo1 = Todo(id: id, name: name, section: section)
         let todo2 = Todo(id: id, name: name, section: section)
-        XCTAssertTrue(Todo.schema.isEqual(todo1, todo2))
+        XCTAssertTrue(Todo.schema.compare(todo1, todo2))
     }
 
     func testTodosAreNotEqualWithDifferentEmbeddedable() {
@@ -306,7 +306,7 @@ class ModelCompareTests: BaseDataStoreTests {
         let section2 = Section(name: "MySection2", number: 20)
         let todo1 = Todo(id: id, name: name, section: section1)
         let todo2 = Todo(id: id, name: name, section: section2)
-        XCTAssertFalse(Todo.schema.isEqual(todo1, todo2))
+        XCTAssertFalse(Todo.schema.compare(todo1, todo2))
     }
 
     func testTodosAreEqualWithSameEmbeddedableCollection() {
@@ -318,7 +318,7 @@ class ModelCompareTests: BaseDataStoreTests {
         let category2 = Category(name: "Category1", color: color2)
         let todo1 = Todo(id: id, name: name, categories: [category1, category2])
         let todo2 = Todo(id: id, name: name, categories: [category1, category2])
-        XCTAssertTrue(Todo.schema.isEqual(todo1, todo2))
+        XCTAssertTrue(Todo.schema.compare(todo1, todo2))
     }
 
     func testTodosAreNotEqualWithDifferentEmbeddedableCollection() {
@@ -330,7 +330,7 @@ class ModelCompareTests: BaseDataStoreTests {
         let category2 = Category(name: "Category1", color: color2)
         let todo1 = Todo(id: id, name: name, categories: [category1])
         let todo2 = Todo(id: id, name: name, categories: [category2])
-        XCTAssertFalse(Todo.schema.isEqual(todo1, todo2))
+        XCTAssertFalse(Todo.schema.compare(todo1, todo2))
     }
 
     // This tests for equality when two models have different read only fields.
@@ -344,6 +344,13 @@ class ModelCompareTests: BaseDataStoreTests {
         let createdAt2 = Temporal.DateTime(formatter.date(from: "2020-09-01")!)
         let recordCover1 = RecordCover(id: id, artist: artist, createdAt: createdAt1)
         let recordCover2 = RecordCover(id: id, artist: artist, createdAt: createdAt2)
-        XCTAssertTrue(RecordCover.schema.isEqual(recordCover1, recordCover2))
+        XCTAssertTrue(RecordCover.schema.compare(recordCover1, recordCover2))
+    }
+
+    func testModelsAreNotEqualWithDifferentModelTypes() {
+        let post = Post(title: "MyPost", content: "This is a post.", createdAt: .now())
+        let record = Record(name: "MyRecord", description: "This is a record.")
+        XCTAssertFalse(Record.schema.compare(post, record))
+        XCTAssertFalse(Post.schema.compare(post, record))
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/Support/ModelCompareTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/Support/ModelCompareTests.swift
@@ -1,0 +1,304 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import SQLite
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStoreCategoryPlugin
+@testable import AWSPluginsCore
+
+// swiftlint:disable type_body_length
+class ModelCompareTests: BaseDataStoreTests {
+
+    func testPostsAreEqual() {
+        let id = UUID().uuidString
+        let createdAt = Temporal.DateTime.now()
+        let title = "MyFirstPost"
+        let content = "This is my first post."
+        let draft = false
+        let rating = 4.0
+        let status = PostStatus.published
+        let post1 = Post(id: id,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft,
+                         rating: rating,
+                         status: status)
+        let post2 = Post(id: id,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft,
+                         rating: rating,
+                         status: status)
+        XCTAssertTrue(ModelSchema.isEqual(post1, post2, Post.schema))
+    }
+
+    func testPostsAreEqualWithSameCollection() {
+        let id = UUID().uuidString
+        let createdAt = Temporal.DateTime.now()
+        let title = "MyFirstPost"
+        let content = "This is my first post."
+        let draft = false
+        let rating = 4.0
+        let status = PostStatus.published
+        var post1 = Post(id: id,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft,
+                         rating: rating,
+                         status: status)
+        var post2 = Post(id: id,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft,
+                         rating: rating,
+                         status: status)
+        let commentId = UUID().uuidString
+        let comment1 = Comment(id: commentId, content: "This is a comment.", createdAt: createdAt, post: post1)
+        let comment2 = Comment(id: commentId, content: "This is a comment.", createdAt: createdAt, post: post2)
+        post1.comments = [comment1]
+        post2.comments = [comment2]
+        XCTAssertTrue(ModelSchema.isEqual(post1, post2, Post.schema))
+    }
+
+    func testCommentsAreEqualWithDifferentPosts() {
+        let createdAt = Temporal.DateTime.now()
+        let title = "MyFirstPost"
+        let content = "This is my first post."
+        let draft = false
+        let rating = 4.0
+        let status = PostStatus.published
+
+        // creating posts with different id
+        var post1 = Post(id: UUID().uuidString,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft,
+                         rating: rating,
+                         status: status)
+        var post2 = Post(id: UUID().uuidString,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft,
+                         rating: rating,
+                         status: status)
+        let id = UUID().uuidString
+        let comment1 = Comment(id: id, content: "This is a comment.", createdAt: createdAt, post: post1)
+        let comment2 = Comment(id: id, content: "This is a comment.", createdAt: createdAt, post: post2)
+        post1.comments = [comment1]
+        post2.comments = [comment2]
+        XCTAssertTrue(ModelSchema.isEqual(comment1, comment2, Comment.schema))
+    }
+
+    func testPostsAreNotEqualWithDifferentId() {
+        let createdAt = Temporal.DateTime.now()
+        let title = "MyFirstPost"
+        let content = "This is my first post."
+        let draft = false
+        let rating = 4.0
+        let status = PostStatus.published
+        let post1 = Post(id: UUID().uuidString,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft,
+                         rating: rating,
+                         status: status)
+        let post2 = Post(id: UUID().uuidString,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft,
+                         rating: rating,
+                         status: status)
+        XCTAssertFalse(ModelSchema.isEqual(post1, post2, Post.schema))
+    }
+
+    func testPostsAreNotEqualWithDifferentStringField() {
+        let id = UUID().uuidString
+        let createdAt = Temporal.DateTime.now()
+        let title1 = "MyFirstPost"
+        let title2 = "MySecondPost"
+        let content = "This is my first post."
+        let draft = false
+        let rating = 4.0
+        let status = PostStatus.published
+        let post1 = Post(id: id,
+                         title: title1,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft,
+                         rating: rating,
+                         status: status)
+        let post2 = Post(id: id,
+                         title: title2,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft,
+                         rating: rating,
+                         status: status)
+        XCTAssertFalse(ModelSchema.isEqual(post1, post2, Post.schema))
+    }
+
+    func testPostsAreNotEqualWithDifferentDoubleField() {
+        let id = UUID().uuidString
+        let createdAt = Temporal.DateTime.now()
+        let title = "MyFirstPost"
+        let content = "This is my first post."
+        let draft = false
+        let rating1 = 4.0
+        let rating2 = 1.0
+        let status = PostStatus.published
+        let post1 = Post(id: id,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft,
+                         rating: rating1,
+                         status: status)
+        let post2 = Post(id: id,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft,
+                         rating: rating2,
+                         status: status)
+        XCTAssertFalse(ModelSchema.isEqual(post1, post2, Post.schema))
+    }
+
+    func testPostsAreNotEqualWithDifferentDateField() {
+        let id = UUID().uuidString
+        let title = "MyFirstPost"
+        let content = "This is my first post."
+        let draft = false
+        let rating = 4.0
+        let status = PostStatus.published
+        let formatter = DateFormatter()
+        formatter.dateFormat = TemporalFormat.short.dateFormat
+        let createdAt1 = Temporal.DateTime(formatter.date(from: "2021-09-01")!)
+        let createdAt2 = Temporal.DateTime(formatter.date(from: "2020-09-01")!)
+        let post1 = Post(id: id,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt1,
+                         draft: draft,
+                         rating: rating,
+                         status: status)
+        let post2 = Post(id: id,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt2,
+                         draft: draft,
+                         rating: rating,
+                         status: status)
+        XCTAssertFalse(ModelSchema.isEqual(post1, post2, Post.schema))
+    }
+
+    func testPostsAreNotEqualWithDifferentEnumField() {
+        let id = UUID().uuidString
+        let createdAt = Temporal.DateTime.now()
+        let title = "MyFirstPost"
+        let content = "This is my first post."
+        let draft = false
+        let rating = 4.0
+        let status1 = PostStatus.published
+        let status2 = PostStatus.draft
+        let post1 = Post(id: id,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft,
+                         rating: rating,
+                         status: status1)
+        let post2 = Post(id: id,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft,
+                         rating: rating,
+                         status: status2)
+        XCTAssertFalse(ModelSchema.isEqual(post1, post2, Post.schema))
+    }
+
+    func testPostsAreNotEqualWithDifferentBoolField() {
+        let id = UUID().uuidString
+        let createdAt = Temporal.DateTime.now()
+        let title = "MyFirstPost"
+        let content = "This is my first post."
+        let draft1 = false
+        let draft2 = true
+        let rating = 4.0
+        let status = PostStatus.published
+        let post1 = Post(id: id,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft1,
+                         rating: rating,
+                         status: status)
+        let post2 = Post(id: id,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft2,
+                         rating: rating,
+                         status: status)
+        XCTAssertFalse(ModelSchema.isEqual(post1, post2, Post.schema))
+    }
+
+    func testTodosAreEqualWithSameEmbeddedable() {
+        let id = UUID().uuidString
+        let name = "MyTodo"
+        let section = Section(name: "MySection", number: 10)
+        let todo1 = Todo(id: id, name: name, section: section)
+        let todo2 = Todo(id: id, name: name, section: section)
+        XCTAssertTrue(ModelSchema.isEqual(todo1, todo2, Todo.schema))
+    }
+
+    func testTodosAreNotEqualWithDifferentEmbeddedable() {
+        let id = UUID().uuidString
+        let name = "MyTodo"
+        let section1 = Section(name: "MySection1", number: 10)
+        let section2 = Section(name: "MySection2", number: 20)
+        let todo1 = Todo(id: id, name: name, section: section1)
+        let todo2 = Todo(id: id, name: name, section: section2)
+        XCTAssertFalse(ModelSchema.isEqual(todo1, todo2, Todo.schema))
+    }
+
+    func testTodosAreEqualWithSameEmbeddedableCollection() {
+        let id = UUID().uuidString
+        let name = "MyTodo"
+        let color1 = Color(name: "Color1", red: 100, green: 100, blue: 100)
+        let color2 = Color(name: "Color2", red: 200, green: 200, blue: 200)
+        let category1 = Category(name: "Category1", color: color1)
+        let category2 = Category(name: "Category1", color: color2)
+        let todo1 = Todo(id: id, name: name, categories: [category1, category2])
+        let todo2 = Todo(id: id, name: name, categories: [category1, category2])
+        XCTAssertTrue(ModelSchema.isEqual(todo1, todo2, Todo.schema))
+    }
+
+    func testTodosAreNotEqualWithDifferentEmbeddedableCollection() {
+        let id = UUID().uuidString
+        let name = "MyTodo"
+        let color1 = Color(name: "Color1", red: 100, green: 100, blue: 100)
+        let color2 = Color(name: "Color2", red: 200, green: 200, blue: 200)
+        let category1 = Category(name: "Category1", color: color1)
+        let category2 = Category(name: "Category1", color: color2)
+        let todo1 = Todo(id: id, name: name, categories: [category1])
+        let todo2 = Todo(id: id, name: name, categories: [category2])
+        XCTAssertFalse(ModelSchema.isEqual(todo1, todo2, Todo.schema))
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/Support/ModelCompareTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/Support/ModelCompareTests.swift
@@ -103,6 +103,33 @@ class ModelCompareTests: BaseDataStoreTests {
         XCTAssertTrue(Comment.schema.isEqual(comment1, comment2))
     }
 
+    func testPostsAreNotEqualWithNilFields() {
+        let id = UUID().uuidString
+        let createdAt = Temporal.DateTime.now()
+        let title = "MyFirstPost"
+        let content = "This is my first post."
+        let draft = false
+        let rating = 4.0
+        let status = PostStatus.published
+        let post1 = Post(id: id,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft,
+                         rating: rating,
+                         status: status)
+
+        // rating is nil
+        let post2 = Post(id: id,
+                         title: title,
+                         content: content,
+                         createdAt: createdAt,
+                         draft: draft,
+                         rating: nil,
+                         status: status)
+        XCTAssertFalse(Post.schema.isEqual(post1, post2))
+    }
+
     func testPostsAreNotEqualWithDifferentId() {
         let createdAt = Temporal.DateTime.now()
         let title = "MyFirstPost"
@@ -302,6 +329,8 @@ class ModelCompareTests: BaseDataStoreTests {
         XCTAssertFalse(Todo.schema.isEqual(todo1, todo2))
     }
 
+    // This tests for equality when two models have different read only fields.
+    // In this case, `createdAt` is a read only field.
     func testRecordCoversAreEqualWithDifferentReadOnlyFields() {
         let id = UUID().uuidString
         let artist = "Artist"
@@ -312,6 +341,5 @@ class ModelCompareTests: BaseDataStoreTests {
         let recordCover1 = RecordCover(id: id, artist: artist, createdAt: createdAt1)
         let recordCover2 = RecordCover(id: id, artist: artist, createdAt: createdAt2)
         XCTAssertTrue(RecordCover.schema.isEqual(recordCover1, recordCover2))
-
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/Support/ModelCompareTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/Support/ModelCompareTests.swift
@@ -206,32 +206,36 @@ class ModelCompareTests: BaseDataStoreTests {
         XCTAssertFalse(Post.schema.isEqual(post1, post2))
     }
 
-    func testPostsAreNotEqualWithDifferentDateField() {
+    func testQpredGensAreNotEqualWithDifferentDateTimeField() {
         let id = UUID().uuidString
-        let title = "MyFirstPost"
-        let content = "This is my first post."
-        let draft = false
-        let rating = 4.0
-        let status = PostStatus.published
+        let name = "QPredGenName"
         let formatter = DateFormatter()
         formatter.dateFormat = TemporalFormat.short.dateFormat
-        let createdAt1 = Temporal.DateTime(formatter.date(from: "2021-09-01")!)
-        let createdAt2 = Temporal.DateTime(formatter.date(from: "2020-09-01")!)
-        let post1 = Post(id: id,
-                         title: title,
-                         content: content,
-                         createdAt: createdAt1,
-                         draft: draft,
-                         rating: rating,
-                         status: status)
-        let post2 = Post(id: id,
-                         title: title,
-                         content: content,
-                         createdAt: createdAt2,
-                         draft: draft,
-                         rating: rating,
-                         status: status)
-        XCTAssertFalse(Post.schema.isEqual(post1, post2))
+        let dateTime1 = Temporal.DateTime(formatter.date(from: "2021-09-01")!)
+        let dateTime2 = Temporal.DateTime(formatter.date(from: "2020-09-01")!)
+        let qPredGen1 = QPredGen(id: id, name: name, myDateTime: dateTime1)
+        let qPredGen2 = QPredGen(id: id, name: name, myDateTime: dateTime2)
+        XCTAssertFalse(QPredGen.schema.isEqual(qPredGen1, qPredGen2))
+    }
+
+    func testQpredGensAreNotEqualWithDifferentDateField() throws {
+        let id = UUID().uuidString
+        let name = "QPredGenName"
+        let date1 = try Temporal.Date(iso8601String: "2021-09-01")
+        let date2 = try Temporal.Date(iso8601String: "2020-09-01")
+        let qPredGen1 = QPredGen(id: id, name: name, myDate: date1)
+        let qPredGen2 = QPredGen(id: id, name: name, myDate: date2)
+        XCTAssertFalse(QPredGen.schema.isEqual(qPredGen1, qPredGen2))
+    }
+
+    func testQpredGensAreNotEqualWithDifferentTimeField() throws {
+        let id = UUID().uuidString
+        let name = "QPredGenName"
+        let time1 = try Temporal.Time(iso8601String: "08:00")
+        let time2 = try Temporal.Time(iso8601String: "08:01")
+        let qPredGen1 = QPredGen(id: id, name: name, myTime: time1)
+        let qPredGen2 = QPredGen(id: id, name: name, myTime: time2)
+        XCTAssertFalse(QPredGen.schema.isEqual(qPredGen1, qPredGen2))
     }
 
     func testPostsAreNotEqualWithDifferentEnumField() {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/Support/ModelCompareTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/Support/ModelCompareTests.swift
@@ -39,7 +39,7 @@ class ModelCompareTests: BaseDataStoreTests {
                          draft: draft,
                          rating: rating,
                          status: status)
-        XCTAssertTrue(ModelSchema.isEqual(post1, post2, Post.schema))
+        XCTAssertTrue(Post.schema.isEqual(post1, post2))
     }
 
     func testPostsAreEqualWithSameCollection() {
@@ -69,7 +69,7 @@ class ModelCompareTests: BaseDataStoreTests {
         let comment2 = Comment(id: commentId, content: "This is a comment.", createdAt: createdAt, post: post2)
         post1.comments = [comment1]
         post2.comments = [comment2]
-        XCTAssertTrue(ModelSchema.isEqual(post1, post2, Post.schema))
+        XCTAssertTrue(Post.schema.isEqual(post1, post2))
     }
 
     func testCommentsAreEqualWithDifferentPosts() {
@@ -100,7 +100,7 @@ class ModelCompareTests: BaseDataStoreTests {
         let comment2 = Comment(id: id, content: "This is a comment.", createdAt: createdAt, post: post2)
         post1.comments = [comment1]
         post2.comments = [comment2]
-        XCTAssertTrue(ModelSchema.isEqual(comment1, comment2, Comment.schema))
+        XCTAssertTrue(Comment.schema.isEqual(comment1, comment2))
     }
 
     func testPostsAreNotEqualWithDifferentId() {
@@ -124,7 +124,7 @@ class ModelCompareTests: BaseDataStoreTests {
                          draft: draft,
                          rating: rating,
                          status: status)
-        XCTAssertFalse(ModelSchema.isEqual(post1, post2, Post.schema))
+        XCTAssertFalse(Post.schema.isEqual(post1, post2))
     }
 
     func testPostsAreNotEqualWithDifferentStringField() {
@@ -150,7 +150,7 @@ class ModelCompareTests: BaseDataStoreTests {
                          draft: draft,
                          rating: rating,
                          status: status)
-        XCTAssertFalse(ModelSchema.isEqual(post1, post2, Post.schema))
+        XCTAssertFalse(Post.schema.isEqual(post1, post2))
     }
 
     func testPostsAreNotEqualWithDifferentDoubleField() {
@@ -176,7 +176,7 @@ class ModelCompareTests: BaseDataStoreTests {
                          draft: draft,
                          rating: rating2,
                          status: status)
-        XCTAssertFalse(ModelSchema.isEqual(post1, post2, Post.schema))
+        XCTAssertFalse(Post.schema.isEqual(post1, post2))
     }
 
     func testPostsAreNotEqualWithDifferentDateField() {
@@ -204,7 +204,7 @@ class ModelCompareTests: BaseDataStoreTests {
                          draft: draft,
                          rating: rating,
                          status: status)
-        XCTAssertFalse(ModelSchema.isEqual(post1, post2, Post.schema))
+        XCTAssertFalse(Post.schema.isEqual(post1, post2))
     }
 
     func testPostsAreNotEqualWithDifferentEnumField() {
@@ -230,7 +230,7 @@ class ModelCompareTests: BaseDataStoreTests {
                          draft: draft,
                          rating: rating,
                          status: status2)
-        XCTAssertFalse(ModelSchema.isEqual(post1, post2, Post.schema))
+        XCTAssertFalse(Post.schema.isEqual(post1, post2))
     }
 
     func testPostsAreNotEqualWithDifferentBoolField() {
@@ -256,7 +256,7 @@ class ModelCompareTests: BaseDataStoreTests {
                          draft: draft2,
                          rating: rating,
                          status: status)
-        XCTAssertFalse(ModelSchema.isEqual(post1, post2, Post.schema))
+        XCTAssertFalse(Post.schema.isEqual(post1, post2))
     }
 
     func testTodosAreEqualWithSameEmbeddedable() {
@@ -265,7 +265,7 @@ class ModelCompareTests: BaseDataStoreTests {
         let section = Section(name: "MySection", number: 10)
         let todo1 = Todo(id: id, name: name, section: section)
         let todo2 = Todo(id: id, name: name, section: section)
-        XCTAssertTrue(ModelSchema.isEqual(todo1, todo2, Todo.schema))
+        XCTAssertTrue(Todo.schema.isEqual(todo1, todo2))
     }
 
     func testTodosAreNotEqualWithDifferentEmbeddedable() {
@@ -275,7 +275,7 @@ class ModelCompareTests: BaseDataStoreTests {
         let section2 = Section(name: "MySection2", number: 20)
         let todo1 = Todo(id: id, name: name, section: section1)
         let todo2 = Todo(id: id, name: name, section: section2)
-        XCTAssertFalse(ModelSchema.isEqual(todo1, todo2, Todo.schema))
+        XCTAssertFalse(Todo.schema.isEqual(todo1, todo2))
     }
 
     func testTodosAreEqualWithSameEmbeddedableCollection() {
@@ -287,7 +287,7 @@ class ModelCompareTests: BaseDataStoreTests {
         let category2 = Category(name: "Category1", color: color2)
         let todo1 = Todo(id: id, name: name, categories: [category1, category2])
         let todo2 = Todo(id: id, name: name, categories: [category1, category2])
-        XCTAssertTrue(ModelSchema.isEqual(todo1, todo2, Todo.schema))
+        XCTAssertTrue(Todo.schema.isEqual(todo1, todo2))
     }
 
     func testTodosAreNotEqualWithDifferentEmbeddedableCollection() {
@@ -299,6 +299,19 @@ class ModelCompareTests: BaseDataStoreTests {
         let category2 = Category(name: "Category1", color: color2)
         let todo1 = Todo(id: id, name: name, categories: [category1])
         let todo2 = Todo(id: id, name: name, categories: [category2])
-        XCTAssertFalse(ModelSchema.isEqual(todo1, todo2, Todo.schema))
+        XCTAssertFalse(Todo.schema.isEqual(todo1, todo2))
+    }
+
+    func testRecordCoversAreEqualWithDifferentReadOnlyFields() {
+        let id = UUID().uuidString
+        let artist = "Artist"
+        let formatter = DateFormatter()
+        formatter.dateFormat = TemporalFormat.short.dateFormat
+        let createdAt1 = Temporal.DateTime(formatter.date(from: "2021-09-01")!)
+        let createdAt2 = Temporal.DateTime(formatter.date(from: "2020-09-01")!)
+        let recordCover1 = RecordCover(id: id, artist: artist, createdAt: createdAt1)
+        let recordCover2 = RecordCover(id: id, artist: artist, createdAt: createdAt2)
+        XCTAssertTrue(RecordCover.schema.isEqual(recordCover1, recordCover2))
+
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/Support/MutationEventExtensionsTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/Support/MutationEventExtensionsTests.swift
@@ -29,7 +29,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
                                                            version: nil,
                                                            inProcess: true)
         let pendingMutationEvent = try createMutationEvent(model: post, mutationType: .update, version: nil)
-        let responseMutationSync = createMutationSync(model: post, deleted: false, version: 1)
+        let responseMutationSync = createMutationSync(model: post, version: 1)
 
         setUpPendingMutationQueue(modelId, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
 
@@ -88,7 +88,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
             try createMutationEvent(model: post, mutationType: .create, version: nil, inProcess: true)
         let pendingUpdateMutationEvent = try createMutationEvent(model: post, mutationType: .update, version: nil)
         let pendingDeleteMutationEvent = try createMutationEvent(model: post, mutationType: .delete, version: nil)
-        let responseMutationSync = createMutationSync(model: post, deleted: false, version: 1)
+        let responseMutationSync = createMutationSync(model: post, version: 1)
 
         setUpPendingMutationQueue(modelId,
                                   [requestMutationEvent, pendingUpdateMutationEvent, pendingDeleteMutationEvent],
@@ -148,7 +148,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         let requestMutationEvent =
             try createMutationEvent(model: post1, mutationType: .create, version: 2, inProcess: true)
         let pendingMutationEvent = try createMutationEvent(model: post2, mutationType: .update, version: 2)
-        let responseMutationSync = createMutationSync(model: post1, deleted: false, version: 1)
+        let responseMutationSync = createMutationSync(model: post1, version: 1)
 
         setUpPendingMutationQueue(modelId, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
 
@@ -205,7 +205,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         let requestMutationEvent =
             try createMutationEvent(model: post1, mutationType: .update, version: 1, inProcess: true)
         let pendingMutationEvent = try createMutationEvent(model: post2, mutationType: .update, version: 1)
-        let responseMutationSync = createMutationSync(model: post3, deleted: false, version: 2)
+        let responseMutationSync = createMutationSync(model: post3, version: 2)
 
         setUpPendingMutationQueue(modelId, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
 
@@ -261,7 +261,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         let requestMutationEvent =
             try createMutationEvent(model: post1, mutationType: .update, version: 1, inProcess: true)
         let pendingMutationEvent = try createMutationEvent(model: post2, mutationType: .update, version: 1)
-        let responseMutationSync = createMutationSync(model: post1, deleted: false, version: 2)
+        let responseMutationSync = createMutationSync(model: post1, version: 2)
 
         setUpPendingMutationQueue(modelId, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
 
@@ -318,11 +318,9 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
                              inProcess: inProcess)
     }
 
-    private func createMutationSync(model: Model,
-                                    deleted: Bool = false,
-                                    version: Int = 1) -> MutationSync<AnyModel> {
+    private func createMutationSync(model: Model, version: Int = 1) -> MutationSync<AnyModel> {
         let metadata = MutationSyncMetadata(id: model.id,
-                                            deleted: deleted,
+                                            deleted: false,
                                             lastChangedAt: Int(Date().timeIntervalSince1970),
                                             version: version)
         return MutationSync(model: AnyModel(model), syncMetadata: metadata)

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		97406B382666DC0200C41E19 /* DataStoreCustomPrimaryKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97406B372666DC0200C41E19 /* DataStoreCustomPrimaryKeyTests.swift */; };
 		97DB735426B49ED6004708B8 /* MutationEvent+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97DB735326B49ED6004708B8 /* MutationEvent+Extensions.swift */; };
 		97DB735B26B4A229004708B8 /* MutationEventExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97DB735A26B4A229004708B8 /* MutationEventExtensionsTests.swift */; };
+		97ED948A26DEC90A0025FA43 /* Model+Compare.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97ED948926DEC90A0025FA43 /* Model+Compare.swift */; };
 		A209418EED69D7B1BB8A55C2 /* Pods_AWSDataStoreCategoryPlugin_AWSDataStoreCategoryPluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C63AE18F2569D004E94BD550 /* Pods_AWSDataStoreCategoryPlugin_AWSDataStoreCategoryPluginTests.framework */; };
 		A569484A6FBAE7EC7ADF3FD4 /* Pods_AWSDataStoreCategoryPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A1D332BE6CF885805360B3D /* Pods_AWSDataStoreCategoryPlugin.framework */; };
 		B10BF4A52A1C9840C208C8A8 /* Pods_HostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 19AFF6D00CF3AF927BA90382 /* Pods_HostApp.framework */; };
@@ -515,6 +516,7 @@
 		97406B372666DC0200C41E19 /* DataStoreCustomPrimaryKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreCustomPrimaryKeyTests.swift; sourceTree = "<group>"; };
 		97DB735326B49ED6004708B8 /* MutationEvent+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MutationEvent+Extensions.swift"; sourceTree = "<group>"; };
 		97DB735A26B4A229004708B8 /* MutationEventExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEventExtensionsTests.swift; sourceTree = "<group>"; };
+		97ED948926DEC90A0025FA43 /* Model+Compare.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Model+Compare.swift"; sourceTree = "<group>"; };
 		9D42A96449A4B73735566C07 /* Pods-AWSDataStoreCategoryPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; path = "Target Support Files/Pods-AWSDataStoreCategoryPlugin/Pods-AWSDataStoreCategoryPlugin.debug.xcconfig"; sourceTree = "<group>"; };
 		9F987EC33AAD7C0904A598CA /* Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HostApp_AWSDataStoreCategoryPluginIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B40EF02724BF68C900F2264C /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
@@ -1127,6 +1129,7 @@
 				214B6B64264B0D6700A9311D /* Stopwatch.swift */,
 				97DB735326B49ED6004708B8 /* MutationEvent+Extensions.swift */,
 				212B4685269FB10500A0AEE7 /* SQLiteResultError.swift */,
+				97ED948926DEC90A0025FA43 /* Model+Compare.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -2007,6 +2010,7 @@
 				2149E5D82388684F00873955 /* RemoteSyncEngine.swift in Sources */,
 				2149E5CB2388684F00873955 /* Model+SQLite.swift in Sources */,
 				FAAA58902396BC5A008A4DB6 /* CancelAwareBlockOperation.swift in Sources */,
+				97ED948A26DEC90A0025FA43 /* Model+Compare.swift in Sources */,
 				D86B6F7E25167F3A008AC948 /* ModelSyncedEventEmitter.swift in Sources */,
 				FA3B3F03238F22CF002EFDB3 /* OutgoingMutationQueue+State.swift in Sources */,
 				FA5D4CEF238AFCBC00D2F54A /* AWSDataStorePlugin+DataStoreSubscribeBehavior.swift in Sources */,

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 		769CF2CB266D7F47007843A0 /* AWSDataStoreMultiAuthTwoRulesTests+Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 769CF2CA266D7F47007843A0 /* AWSDataStoreMultiAuthTwoRulesTests+Models.swift */; };
 		8141657E756CC7B2EE1CE851 /* Pods_HostApp_AWSDataStoreCategoryPluginAuthIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA320D973669D3843FDF755E /* Pods_HostApp_AWSDataStoreCategoryPluginAuthIntegrationTests.framework */; };
 		9728F2B02683D98D00A506A8 /* DataStoreConsecutiveUpdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9728F2AF2683D98D00A506A8 /* DataStoreConsecutiveUpdatesTests.swift */; };
+		973AF1AF26E016EC00BED353 /* ModelCompareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 973AF1AE26E016EC00BED353 /* ModelCompareTests.swift */; };
 		97406B382666DC0200C41E19 /* DataStoreCustomPrimaryKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97406B372666DC0200C41E19 /* DataStoreCustomPrimaryKeyTests.swift */; };
 		97DB735426B49ED6004708B8 /* MutationEvent+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97DB735326B49ED6004708B8 /* MutationEvent+Extensions.swift */; };
 		97DB735B26B4A229004708B8 /* MutationEventExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97DB735A26B4A229004708B8 /* MutationEventExtensionsTests.swift */; };
@@ -513,6 +514,7 @@
 		769CF2C8266D7F04007843A0 /* AWSDataStoreMultiAuthTwoRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreMultiAuthTwoRulesTests.swift; sourceTree = "<group>"; };
 		769CF2CA266D7F47007843A0 /* AWSDataStoreMultiAuthTwoRulesTests+Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSDataStoreMultiAuthTwoRulesTests+Models.swift"; sourceTree = "<group>"; };
 		9728F2AF2683D98D00A506A8 /* DataStoreConsecutiveUpdatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreConsecutiveUpdatesTests.swift; sourceTree = "<group>"; };
+		973AF1AE26E016EC00BED353 /* ModelCompareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCompareTests.swift; sourceTree = "<group>"; };
 		97406B372666DC0200C41E19 /* DataStoreCustomPrimaryKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreCustomPrimaryKeyTests.swift; sourceTree = "<group>"; };
 		97DB735326B49ED6004708B8 /* MutationEvent+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MutationEvent+Extensions.swift"; sourceTree = "<group>"; };
 		97DB735A26B4A229004708B8 /* MutationEventExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationEventExtensionsTests.swift; sourceTree = "<group>"; };
@@ -867,6 +869,7 @@
 				210E218126601C1C00D90ED8 /* MutationEventQueryTests.swift */,
 				214B6B67264B157500A9311D /* StopwatchTests.swift */,
 				97DB735A26B4A229004708B8 /* MutationEventExtensionsTests.swift */,
+				973AF1AE26E016EC00BED353 /* ModelCompareTests.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -2099,6 +2102,7 @@
 				21A4EE5C259D50C700E1047D /* DataStoreListDecoderTests.swift in Sources */,
 				6B4E3DF42397269C00AD962B /* OutgoingMutationQueueTestsWithMockStateMachine.swift in Sources */,
 				FAE4146A239AA2B700CE94C2 /* RemoteSyncReconcilerTests.swift in Sources */,
+				973AF1AF26E016EC00BED353 /* ModelCompareTests.swift in Sources */,
 				B4B3794B2551CF87007781D6 /* QuerySortDescriptorTests.swift in Sources */,
 				6BE9D73E25A6800100AB5C9A /* StorageEngineTestsManyToMany.swift in Sources */,
 				2149E5FE238869CF00873955 /* RemoteSyncAPIInvocationTests.swift in Sources */,


### PR DESCRIPTION
*Issue #, if available:* #1206

*Description of changes:* This PR contains fix for Consecutive Update (Save, Sync, Update and Immediately Delete Scenario). The head of mutation event table for a given model id is reconciled with the version of the model in the API response after the models in the API request and response are compared for equality.

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
