### PR TITLE
fix(DataStore): ReconcileAndLocalSave schedule on internal queue

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -126,6 +126,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
         do {
             try storageAdapter.transaction {
                 queryPendingMutations(forModelIds: remoteModelIds)
+                    .subscribe(on: workQueue)
                     .flatMap { mutationEvents -> Future<([RemoteModel], [LocalMetadata]), DataStoreError> in
                         let remoteModelsToApply = self.reconcile(remoteModels, pendingMutations: mutationEvents)
                         return self.queryLocalMetadata(remoteModelsToApply)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -342,7 +342,6 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
     ///    - Ensure the expected mutation event with version 2 (synced from cloud) is received
     ///
     func testConcurrentSave() throws {
-
         try startAmplifyAndWaitForReady()
 
         var posts = [Post]()
@@ -365,28 +364,23 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
                 XCTFail("\(error)")
             }
         } receiveValue: { mutationEvent in
-            do {
-                let receivedPost = try mutationEvent.decodeModel(as: Post.self)
-                if mutationEvent.mutationType == MutationEvent.MutationType.create.rawValue,
-                   posts.contains(where: { $0.id == receivedPost.id }),
-                   mutationEvent.version == 1 {
-                    postsSyncedToCloudCount += 1
-                    self.log.debug("Post saved and synced from cloud \(receivedPost.id) \(postsSyncedToCloudCount)")
-                    if postsSyncedToCloudCount == count {
-                        postsSyncedToCloud.fulfill()
-                    }
-                } else if mutationEvent.mutationType == MutationEvent.MutationType.delete.rawValue,
-                          posts.contains(where: { $0.id == receivedPost.id }),
-                          mutationEvent.version == 2 {
-                    postsDeletedFromCloudCount += 1
-                    self.log.debug(
-                        "Post deleted and synced from cloud \(receivedPost.id) \(postsDeletedFromCloudCount)")
-                    if postsDeletedFromCloudCount == count {
-                        postsDeletedFromCloud.fulfill()
-                    }
+            if mutationEvent.mutationType == MutationEvent.MutationType.create.rawValue,
+               posts.contains(where: { $0.id == mutationEvent.modelId }),
+               mutationEvent.version == 1 {
+                postsSyncedToCloudCount += 1
+                self.log.debug("Post saved and synced from cloud \(mutationEvent.modelId) \(postsSyncedToCloudCount)")
+                if postsSyncedToCloudCount == count {
+                    postsSyncedToCloud.fulfill()
                 }
-            } catch {
-                XCTFail("\(error)")
+            } else if mutationEvent.mutationType == MutationEvent.MutationType.delete.rawValue,
+                      posts.contains(where: { $0.id == mutationEvent.modelId }),
+                      mutationEvent.version == 2 {
+                postsDeletedFromCloudCount += 1
+                self.log.debug(
+                    "Post deleted and synced from cloud \(mutationEvent.modelId) \(postsDeletedFromCloudCount)")
+                if postsDeletedFromCloudCount == count {
+                    postsDeletedFromCloud.fulfill()
+                }
             }
         }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -330,6 +330,79 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
         try validateSavePost()
     }
 
+    /// Perform concurrent saves and observe the data successfuly synced from cloud. Then delete the items afterwards
+    /// and ensure they have successfully synced from cloud
+    ///
+    /// - Given: DataStore is in ready state
+    /// - When:
+    ///    - Concurrently perform Save's
+    /// - Then:
+    ///    - Ensure the expected mutation event with version 1 (synced from cloud) is received
+    ///    - Clean up: Concurrently perform Delete's
+    ///    - Ensure the expected mutation event with version 2 (synced from cloud) is received
+    ///
+    func testConcurrentSave() throws {
+
+        try startAmplifyAndWaitForReady()
+
+        var posts = [Post]()
+        let count = 5
+        for _ in 0 ..< count {
+            let post = Post(title: "title",
+                            content: "content",
+                            createdAt: .now())
+            posts.append(post)
+        }
+        let postsSyncedToCloud = expectation(description: "All posts saved and synced to cloud")
+        var postsSyncedToCloudCount = 0
+        let postsDeletedFromCloud = expectation(description: "All posts deleted and synced to cloud")
+        var postsDeletedFromCloudCount = 0
+        let sink = Amplify.DataStore.publisher(for: Post.self).sink { completed in
+            switch completed {
+            case .finished:
+                break
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        } receiveValue: { mutationEvent in
+            do {
+                let receivedPost = try mutationEvent.decodeModel(as: Post.self)
+                if mutationEvent.mutationType == MutationEvent.MutationType.create.rawValue,
+                   posts.contains(where: { $0.id == receivedPost.id }),
+                   mutationEvent.version == 1 {
+                    postsSyncedToCloudCount += 1
+                    self.log.debug("Post saved and synced from cloud \(receivedPost.id) \(postsSyncedToCloudCount)")
+                    if postsSyncedToCloudCount == count {
+                        postsSyncedToCloud.fulfill()
+                    }
+                } else if mutationEvent.mutationType == MutationEvent.MutationType.delete.rawValue,
+                          posts.contains(where: { $0.id == receivedPost.id }),
+                          mutationEvent.version == 2 {
+                    postsDeletedFromCloudCount += 1
+                    self.log.debug(
+                        "Post deleted and synced from cloud \(receivedPost.id) \(postsDeletedFromCloudCount)")
+                    if postsDeletedFromCloudCount == count {
+                        postsDeletedFromCloud.fulfill()
+                    }
+                }
+            } catch {
+                XCTFail("\(error)")
+            }
+        }
+
+        DispatchQueue.concurrentPerform(iterations: count) { index in
+            _ = Amplify.DataStore.save(posts[index])
+        }
+
+        wait(for: [postsSyncedToCloud], timeout: 100)
+
+        DispatchQueue.concurrentPerform(iterations: count) { index in
+            _ = Amplify.DataStore.delete(posts[index])
+        }
+        wait(for: [postsDeletedFromCloud], timeout: 100)
+        sink.cancel()
+    }
+
     // MARK: - Helpers
 
     func validateSavePost() throws {
@@ -370,4 +443,9 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
         Amplify.DataStore.save(newPost) { _ in }
         wait(for: [createReceived], timeout: networkTimeout)
     }
+}
+
+@available(iOS 13.0, *)
+extension DataStoreEndToEndTests: DefaultLogger {
+
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update ReconcileAndLocalSave to use internal dispatch queue, to avoid using the SQL queue as described in https://github.com/aws-amplify/amplify-ios/pull/1406 and https://github.com/aws-amplify/amplify-ios/issues/1405

Add integration test for concurrently saving posts.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
