### PR TITLE
test(DataStore): Integration tests to verify eager loading in belongs-to relationship

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario6Tests.swift
@@ -99,7 +99,6 @@ class DataStoreConnectionScenario6Tests: SyncEngineIntegrationTestBase {
             return
         }
 
-        // fetch comment
         let getCommentCompleted = expectation(description: "get comment complete")
         var resultComment: Comment6?
         Amplify.DataStore.query(Comment6.self, byId: comment.id) { result in
@@ -149,7 +148,6 @@ class DataStoreConnectionScenario6Tests: SyncEngineIntegrationTestBase {
             return
         }
 
-        // fetch post
         let getPostCompleted = expectation(description: "get post complete")
         var resultPost: Post6?
         Amplify.DataStore.query(Post6.self, byId: post.id) { result in
@@ -188,7 +186,6 @@ class DataStoreConnectionScenario6Tests: SyncEngineIntegrationTestBase {
             XCTAssertEqual(postsInEagerlyLoadedBlog[0].id, post.id)
         }
 
-
         guard let lazilyLoadedComments = fetchedPost.comments else {
             XCTFail("Could not get comments")
             return
@@ -199,9 +196,7 @@ class DataStoreConnectionScenario6Tests: SyncEngineIntegrationTestBase {
             return
         }
         XCTAssertEqual(lazilyLoadedComments.count, 1)
-        XCTAssertTrue(lazilyLoadedComments.contains(where: { (commentIn) -> Bool in
-            commentIn.id == comment.id
-        }))
+        XCTAssertEqual(lazilyLoadedComments[0].id, comment.id)
         if let fetchedPost = lazilyLoadedComments[0].post {
             XCTAssertEqual(fetchedPost.id, post.id)
             XCTAssertEqual(fetchedPost.comments?.count, 1)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -342,7 +342,7 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
     ///    - Ensure the expected mutation event with version 2 (synced from cloud) is received
     ///
     func testConcurrentSave() throws {
-        try startAmplifyAndWaitForReady()
+        try startAmplifyAndWaitForSync()
 
         var posts = [Post]()
         let count = 5

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -41,10 +41,6 @@ class SyncEngineTestBase: XCTestCase {
 
     // MARK: - Setup
 
-    override func setUp() {
-        Amplify.Logging.logLevel = .verbose
-    }
-
     override func setUpWithError() throws {
         continueAfterFailure = false
 
@@ -77,6 +73,7 @@ class SyncEngineTestBase: XCTestCase {
         authPlugin = MockAuthCategoryPlugin()
         try Amplify.add(plugin: apiPlugin)
         try Amplify.add(plugin: authPlugin)
+        Amplify.Logging.logLevel = .verbose
     }
 
     /// Sets up a StorageAdapter backed by `connection`. Optionally registers and sets up models in

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -41,14 +41,14 @@ class SyncEngineTestBase: XCTestCase {
 
     // MARK: - Setup
 
-    override func tearDown() {
-        Amplify.reset()
+    override func setUp() {
+        Amplify.Logging.logLevel = .verbose
     }
 
     override func setUpWithError() throws {
         continueAfterFailure = false
 
-        Amplify.Logging.logLevel = .verbose
+        Amplify.reset()
 
         let apiConfig = APICategoryConfiguration(plugins: [
             "MockAPICategoryPlugin": true

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -41,10 +41,13 @@ class SyncEngineTestBase: XCTestCase {
 
     // MARK: - Setup
 
+    override func tearDown() {
+        Amplify.reset()
+    }
+
     override func setUpWithError() throws {
         continueAfterFailure = false
 
-        Amplify.reset()
         Amplify.Logging.logLevel = .verbose
 
         let apiConfig = APICategoryConfiguration(plugins: [


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*  
1. add integration tests for verifying eager loading in belongs to relationship between models
2. move `Amplify.reset()` to `teardown()` in `SyncEngineTestBase` for avoid data race on line 47 and 48 in the unit test `ModelReconciliationDeleteTests.testUpdateAfterDelete()`

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
~~- [] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
