### PR TITLE
feat(datastore): clear should be successful if engine is not running

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -21,7 +21,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                where condition: QueryPredicate? = nil,
                                completion: @escaping DataStoreCallback<M>) {
         log.verbose("Saving: \(model) with condition: \(String(describing: condition))")
-        reinitStorageEngineIfNeeded()
+        initStorageEngineAndStartSync()
 
         // TODO: Refactor this into a proper request/result where the result includes metadata like the derived
         // mutation type
@@ -63,7 +63,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     public func query<M: Model>(_ modelType: M.Type,
                                 byId id: String,
                                 completion: DataStoreCallback<M?>) {
-        reinitStorageEngineIfNeeded()
+        initStorageEngineAndStartSync()
         let predicate: QueryPredicate = field("id") == id
         query(modelType, where: predicate, paginate: .firstResult) {
             switch $0 {
@@ -99,7 +99,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                 sort sortInput: [QuerySortDescriptor]? = nil,
                                 paginate paginationInput: QueryPaginationInput? = nil,
                                 completion: DataStoreCallback<[M]>) {
-        reinitStorageEngineIfNeeded()
+        initStorageEngineAndStartSync()
         storageEngine.query(modelType,
                             modelSchema: modelSchema,
                             predicate: predicate,
@@ -120,7 +120,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                  withId id: String,
                                  where predicate: QueryPredicate? = nil,
                                  completion: @escaping DataStoreCallback<Void>) {
-        reinitStorageEngineIfNeeded()
+        initStorageEngineAndStartSync()
         storageEngine.delete(modelType, modelSchema: modelSchema, withId: id, predicate: predicate) { result in
             self.onDeleteCompletion(result: result, modelSchema: modelSchema, completion: completion)
         }
@@ -136,7 +136,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                  modelSchema: ModelSchema,
                                  where predicate: QueryPredicate? = nil,
                                  completion: @escaping DataStoreCallback<Void>) {
-        reinitStorageEngineIfNeeded()
+        initStorageEngineAndStartSync()
         storageEngine.delete(type(of: model),
                              modelSchema: modelSchema,
                              withId: model.id,
@@ -155,7 +155,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                  modelSchema: ModelSchema,
                                  where predicate: QueryPredicate,
                                  completion: @escaping DataStoreCallback<Void>) {
-        reinitStorageEngineIfNeeded()
+        initStorageEngineAndStartSync()
         let onCompletion: DataStoreCallback<[M]> = { result in
             switch result {
             case .success(let models):
@@ -174,7 +174,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
 
     public func start(completion: @escaping DataStoreCallback<Void>) {
-        reinitStorageEngineIfNeeded(completion: completion)
+        initStorageEngineAndStartSync(completion: completion)
     }
 
     public func stop(completion: @escaping DataStoreCallback<Void>) {
@@ -192,13 +192,10 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
 
     public func clear(completion: @escaping DataStoreCallback<Void>) {
-        storageEngineInitSemaphore.wait()
-        if storageEngine == nil {
-            storageEngineInitSemaphore.signal()
-            completion(.successfulVoid)
+        if case let .failure(error) = initStorageEngine() {
+            completion(.failure(causedBy: error))
             return
         }
-        storageEngineInitSemaphore.signal()
         storageEngine.clear { result in
             self.storageEngine = nil
             completion(result)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
@@ -12,7 +12,7 @@ extension AWSDataStorePlugin: DataStoreSubscribeBehavior {
 
     @available(iOS 13.0, *)
     public var publisher: AnyPublisher<MutationEvent, DataStoreError> {
-        reinitStorageEngineIfNeeded()
+        initStorageEngineAndStartSync()
         // Force-unwrapping: The optional 'dataStorePublisher' is expected
         // to exist for deployment targets >=iOS13.0
         return dataStorePublisher!.publisher

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSAPICategoryPluginTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSAPICategoryPluginTests.swift
@@ -458,4 +458,33 @@ class AWSAPICategoryPluginTests: XCTestCase {
             XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
         }
     }
+
+    /// - Given: Datastore plugin is NOT initialized
+    /// - When:
+    ///     - plugin.clear() is called
+    /// - Then: StorageEngine.clear is called
+    func testClearStorageWhenEngineIsNotStarted() {
+        let storageEngine = MockStorageEngineBehavior()
+        let pluginClearExpectation = expectation(description: "DataStore plugin .clear should called")
+        let storageClearExpectation = expectation(description: "StorageEngine .clear should be called")
+        storageEngine.responders[.clear] = ClearResponder { _ in
+            storageClearExpectation.fulfill()
+        }
+        let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+            return storageEngine
+        }
+        let dataStorePublisher = DataStorePublisher()
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        storageEngineBehaviorFactory: storageEngineBehaviorFactory,
+                                        dataStorePublisher: dataStorePublisher,
+                                        validAPIPluginKey: "MockAPICategoryPlugin",
+                                        validAuthPluginKey: "MockAuthCategoryPlugin")
+
+        plugin.clear {
+            if case .success = $0 {
+                pluginClearExpectation.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 1.0)
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
#1402 

*Description of changes:*
This PR updates the behaviour of `DataStore.clear` which was being treated as a no-op if the underlying engine wasn't running.
The changes introduced in this PR make `DataStore.clear` to always succeed and break down the method used to initialize the engine and start the sync process in two different methods with a more clear meaning:
- `initStorageEngineAndStartSync`
- `initStorageEngine`


*Check points:*

- [ ] Added new tests to cover change, if needed
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
