### PR TITLE
chore: Update changelog, remove observeQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Features
 
 - **Storage**: AWSS3PluginPrefixResolver (#1277)
-- **DataStore**: observe query API (#1389)
 
 ### Bug Fixes
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove PR that was reverted from `main` branch. Automation picked it up even though there was a revert commit. This seems like a very low occurance scenario that I don't think we need to complicate the release process to account for reverts

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
