### PR TITLE
fix(DataStore): Avoid model name from mutation sync in ModelSyncedEventEmitter

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -185,7 +185,7 @@ final class InitialSyncOperation: AsynchronousOperation {
 
         reconciliationQueue.offer(items, modelSchema: modelSchema)
         for item in items {
-            initialSyncOperationTopic.send(.enqueued(item))
+            initialSyncOperationTopic.send(.enqueued(item, modelName: modelSchema.name))
         }
 
         if let nextToken = syncQueryResult.nextToken, recordsReceived < syncMaxRecords {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperationEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperationEvent.swift
@@ -15,7 +15,7 @@ enum InitialSyncOperationEvent {
 
     /// Published when a remote model is enqueued for local store reconciliation.
     /// Used by `ModelSyncedEventEmitter` for record counting.
-    case enqueued(MutationSync<AnyModel>)
+    case enqueued(MutationSync<AnyModel>, modelName: ModelName)
 
     /// Published when the sync operation has completed and all remote models have been enqueued for reconciliation.
     /// Used by `ModelSyncedEventEmitter` to determine when to send `ModelSyncedEvent`

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
@@ -72,8 +72,8 @@ final class ModelSyncedEventEmitter {
         switch value {
         case .started(let modelName, _):
             return modelSchema.name == modelName
-        case .enqueued(let mutationSync):
-            return modelSchema.name == mutationSync.model.modelName
+        case .enqueued(_, let modelName):
+            return modelSchema.name == modelName
         case .finished(let modelName):
             return modelSchema.name == modelName
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -302,8 +302,9 @@ class InitialSyncOperationTests: XCTestCase {
                     XCTAssertEqual(modelName, "MockSynced")
                     XCTAssertEqual(syncType, .fullSync)
                     syncStartedReceived.fulfill()
-                case .enqueued(let returnedValue):
+                case .enqueued(let returnedValue, let modelName):
                     XCTAssertTrue(returnedValue.syncMetadata == mutationSync.syncMetadata)
+                    XCTAssertEqual(modelName, "MockSynced")
                     offeredValueReceived.fulfill()
                 case .finished(modelName: let modelName):
                     XCTAssertEqual(modelName, "MockSynced")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
@@ -83,7 +83,8 @@ class SyncEventEmitterTests: XCTestCase {
 
         initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.started(modelName: Post.modelName,
                                                                             syncType: .fullSync))
-        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.enqueued(anyPostMutationSync))
+        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.enqueued(anyPostMutationSync,
+                                                                             modelName: Post.modelName))
         initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.finished(modelName: Post.modelName))
 
         reconciliationQueue?.incomingEventSubject.send(.mutationEventApplied(postMutationEvent))
@@ -255,12 +256,14 @@ class SyncEventEmitterTests: XCTestCase {
 
         initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.started(modelName: Post.modelName,
                                                                             syncType: .fullSync))
-        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.enqueued(anyPostMutationSync))
+        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.enqueued(anyPostMutationSync,
+                                                                             modelName: Post.modelName))
         initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.finished(modelName: Post.modelName))
 
         initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.started(modelName: Comment.modelName,
                                                                             syncType: .fullSync))
-        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.enqueued(anyCommentMutationSync))
+        initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.enqueued(anyCommentMutationSync,
+                                                                             modelName: Comment.modelName))
         initialSyncOrchestrator?.initialSyncOrchestratorTopic.send(.finished(modelName: Comment.modelName))
 
         reconciliationQueue?.incomingEventSubject.send(.mutationEventApplied(postMutationEvent))


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/1446

*Description of changes:*
When running the iOS code from Flutter, the model name cannot be retrieved from the model. I'm not sure what is the exact failing comparison, it could be that `model.modelName` returns empty string and the string comparsion fails silently. This PR prioritizes the fix for now. 

We have other efforts that is working towards addressing the Flutter integration with iOS and ensuring there are no regressions when new features are being developed, like https://github.com/aws-amplify/amplify-ios/pull/1440 . The issue is  that iOS code allows the modelName to be accessed from the model and there's no context when the iOS developer developing the plugin code to know when it cannot be, so we should audit the code for other incidences of this usage or mark it as something that cannot be used in the code but still allow iOS developers building apps to have the convenience to it. 

The integation tests for `FlutterSerializedModel` can assert that the `modelSyncedEvent` contains expected number of items added when in fullSync. This may deem difficult when written since the integration tests aren't set up to clear the remote database and a full sync will always return more items on each run.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
