### PR TITLE
fix(datastore): Sync engine fallback to plugin config

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+SyncRequirement.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine+SyncRequirement.swift
@@ -62,7 +62,7 @@ extension StorageEngine {
             if let rulesRequireAuthPlugin = schema.authRules.requireAuthPlugin {
                 return rulesRequireAuthPlugin
             }
-            
+
 #if canImport(AWSAPIPlugin)
             // Fall back to the plugin configuration if a determination cannot be made from the auth rules.
             guard let awsPlugin = apiPlugin as? AWSAPIPlugin else {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/StorageEngineSyncRequirementsTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/StorageEngineSyncRequirementsTests.swift
@@ -21,7 +21,7 @@ class StorageEngineSyncRequirementsTests: XCTestCase {
             AuthRule(allow: .private, provider: .iam),
             AuthRule(allow: .owner, provider: .userPools)
         ]
-        XCTAssertTrue(authRules.requireAuthPlugin)
+        XCTAssertTrue(authRules.requireAuthPlugin!)
     }
 
     /// Given: a list of auth rules
@@ -32,7 +32,7 @@ class StorageEngineSyncRequirementsTests: XCTestCase {
             AuthRule(allow: .owner, provider: .function),
             AuthRule(allow: .owner, provider: .iam)
         ]
-        XCTAssertTrue(authRules.requireAuthPlugin)
+        XCTAssertTrue(authRules.requireAuthPlugin!)
     }
 
     func testDoesNotRequireAuthPlugin() {
@@ -41,6 +41,6 @@ class StorageEngineSyncRequirementsTests: XCTestCase {
             AuthRule(allow: .owner, provider: .function),
             AuthRule(allow: .public, provider: .apiKey)
         ]
-        XCTAssertFalse(authRules.requireAuthPlugin)
+        XCTAssertFalse(authRules.requireAuthPlugin!)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

Sync engine cannot accurately assess the need for an Auth category plugin when the `provider` field is missing from auth rules. 
- https://github.com/aws-amplify/amplify-ios/issues/1350
- https://github.com/aws-amplify/amplify-flutter/issues/936
- https://github.com/aws-amplify/amplify-flutter/issues/935

*Description of changes:*
- Fallback to plugin config when auth rules lack provider information

*Check points:*

- [ ] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
