### PR TITLE
fix(DataStore): ObserveQueryOperation missing import for SPM

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStoreObserveQueryOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStoreObserveQueryOperation.swift
@@ -8,6 +8,7 @@
 import Amplify
 import AWSPluginsCore
 import Combine
+import Foundation
 
 protocol DataStoreObserveQueryOperation {
     func resetState()


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/1466

*Description of changes:*
- open project using `open Package.swift`
- switch to DataStore target, build to see error
- add `import Foundation`

We've been caught by this before and need to add SPM build step into the pipeline or add to "check points" for each PR to build from the package.swift project

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
