### PR TITLE
fix(DataStore): Reconciliation path avoid model.modelName

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -141,7 +141,7 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
     }
 
     func enqueue(_ remoteModels: [MutationSync<AnyModel>]) {
-        guard let remoteModelName = remoteModels.first?.model.modelName else {
+        guard !remoteModels.isEmpty else {
             log.debug("\(#function) skipping reconciliation, no models to enqueue.")
             return
         }
@@ -172,7 +172,7 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
                 }
             })
         reconcileAndLocalSaveOperationSinks.with { $0.insert(reconcileAndLocalSaveOperationSink) }
-        reconcileAndSaveQueue.addOperation(reconcileOp, modelName: remoteModelName)
+        reconcileAndSaveQueue.addOperation(reconcileOp, modelName: modelSchema.name)
     }
 
     private func receive(_ receive: IncomingSubscriptionEventPublisherEvent) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -198,7 +198,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
                                                               pendingMutations: pendingMutations)
 
         for _ in 0 ..< (remoteModels.count - remoteModelsToApply.count) {
-            notifyDropped(modelName: remoteModel.model.modelName)
+            notifyDropped()
         }
 
         return remoteModelsToApply
@@ -246,7 +246,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
         let dispositions = RemoteSyncReconciler.getDispositions(remoteModels,
                                                                 localMetadatas: localMetadatas)
         for _ in 0 ..< (remoteModels.count - dispositions.count) {
-            notifyDropped(modelName: remoteModel.model.modelName)
+            notifyDropped()
         }
 
         return dispositions
@@ -348,7 +348,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
                 switch response {
                 case .failure(let dataStoreError):
                     if storageAdapter.shouldIgnoreError(error: dataStoreError) {
-                        self.notifyDropped(modelName: remoteModel.model.modelName)
+                        self.notifyDropped()
                         promise(.success(.dropped))
                     } else {
                         promise(.failure(dataStoreError))
@@ -367,7 +367,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
                 switch response {
                 case .failure(let dataStoreError):
                     if storageAdapter.shouldIgnoreError(error: dataStoreError) {
-                        self.notifyDropped(modelName: remoteModel.model.modelName)
+                        self.notifyDropped()
                         promise(.success(.dropped))
                     } else {
                         promise(.failure(dataStoreError))
@@ -410,8 +410,8 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
         }
     }
 
-    private func notifyDropped(modelName: String) {
-        mutationEventPublisher.send(.mutationEventDropped(modelName: modelName))
+    private func notifyDropped() {
+        mutationEventPublisher.send(.mutationEventDropped(modelName: modelSchema.name))
     }
 
     private func notify(savedModel: AppliedModel,

--- a/AmplifyPlugins/DataStore/Podfile.lock
+++ b/AmplifyPlugins/DataStore/Podfile.lock
@@ -46,7 +46,7 @@ PODS:
   - SQLite.swift/standard (0.12.2)
   - Starscream (3.1.1)
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.44.0)
+  - SwiftLint (0.45.0)
 
 DEPENDENCIES:
   - Amplify (from `../../`)
@@ -114,7 +114,7 @@ SPEC CHECKSUMS:
   SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
   Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
+  SwiftLint: e5c7f1fba68eccfc51509d5b2ce1699f5502e0c7
 
 PODFILE CHECKSUM: fb973c73bd5a639b441e0a01717635b41533ab26
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/pull/1472#issuecomment-946177935

*Description of changes:*
The issue is when a model is dropped during reconiliation, the `remoteModel.model.modelName` is used. In Flutter, this is "FlutterSerializedModel". Use `modelSchema.name` where possible.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
