### PR TITLE
fix(datastore): Fixes SPM build error due to missing import foundation

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/SyncEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/SyncEventEmitter.swift
@@ -8,6 +8,7 @@
 import Amplify
 import AWSPluginsCore
 import Combine
+import Foundation
 
 enum IncomingSyncEventEmitterEvent {
     case mutationEventApplied(MutationEvent)


### PR DESCRIPTION
*Description of changes:* fix(datastore): Fixes SPM build error due to missing import foundation in SyncEventEmitter.swift

*Check points:*

- [ ] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
