### PR TITLE
fix(datastore): quote table name in create table-references SQL statement

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateTable.swift
@@ -57,7 +57,7 @@ struct CreateTableStatement: SQLStatement {
             }
             let associatedId = schema.primaryKey
             let associatedModelName = schema.name
-            statement += "references \(associatedModelName)(\"\(associatedId.sqlName)\")\n"
+            statement += "references \"\(associatedModelName)\"(\"\(associatedId.sqlName)\")\n"
             statement += "    on delete cascade"
             let isNotLastKey = index < foreignKeys.endIndex - 1
             if isNotLastKey {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Delete.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Delete.swift
@@ -43,7 +43,7 @@ struct DeleteStatement: SQLStatement {
 
     var stringValue: String {
         let sql = """
-        delete from \(modelSchema.name) as \(namespace)
+        delete from "\(modelSchema.name)" as \(namespace)
         """
 
         if let conditionStatement = conditionStatement {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Insert.swift
@@ -22,7 +22,7 @@ struct InsertStatement: SQLStatement {
     var stringValue: String {
         let fields = modelSchema.columns
         let columns = fields.map { $0.columnName() }
-        var statement = "insert into \(modelSchema.name) "
+        var statement = "insert into \"\(modelSchema.name)\" "
         statement += "(\(columns.joined(separator: ", ")))\n"
 
         let variablePlaceholders = Array(repeating: "?", count: columns.count).joined(separator: ", ")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Select.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Select.swift
@@ -40,7 +40,7 @@ struct SelectStatementMetadata {
         var sql = """
         select
           \(joinedAsSelectedColumns(columns))
-        from \(tableName) as "\(rootNamespace)"
+        from "\(tableName)" as "\(rootNamespace)"
         \(joinStatements.statements.joined(separator: "\n"))
         """.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -117,7 +117,7 @@ struct SelectStatementMetadata {
                 let joinType = foreignKey.isRequired ? "inner" : "left outer"
 
                 joinStatements.append("""
-                \(joinType) join \(associatedTableName) as "\(alias)"
+                \(joinType) join \"\(associatedTableName)\" as "\(alias)"
                   on \(associatedColumn) = \(foreignKeyName)
                 """)
                 visitAssociations(node: associatedSchema, namespace: alias)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -258,7 +258,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
                 withId id: Model.Identifier,
                 predicate: QueryPredicate? = nil) throws -> Bool {
         let primaryKey = modelSchema.primaryKey.sqlName
-        var sql = "select count(\(primaryKey)) from \(modelSchema.name) where \(primaryKey) = ?"
+        var sql = "select count(\(primaryKey)) from \"\(modelSchema.name)\" where \(primaryKey) = ?"
         var variables: [Binding?] = [id]
         if let predicate = predicate {
             let conditionStatement = ConditionStatement(modelSchema: modelSchema, predicate: predicate)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
@@ -85,7 +85,7 @@ class SQLStatementTests: XCTestCase {
           "content" text not null,
           "createdAt" text not null,
           "commentPostId" text not null,
-          foreign key("commentPostId") references Post("id")
+          foreign key("commentPostId") references "Post"("id")
             on delete cascade
         );
         """
@@ -106,7 +106,7 @@ class SQLStatementTests: XCTestCase {
         create table if not exists "UserProfile" (
           "id" text primary key not null,
           "accountId" text not null unique,
-          foreign key("accountId") references UserAccount("id")
+          foreign key("accountId") references "UserAccount"("id")
             on delete cascade
         );
         """
@@ -128,9 +128,9 @@ class SQLStatementTests: XCTestCase {
           "id" text primary key not null,
           "authorId" text not null,
           "bookId" text not null,
-          foreign key("authorId") references Author("id")
+          foreign key("authorId") references "Author"("id")
             on delete cascade
-          foreign key("bookId") references Book("id")
+          foreign key("bookId") references "Book"("id")
             on delete cascade
         );
         """

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
@@ -153,7 +153,7 @@ class SQLStatementTests: XCTestCase {
         let statement = InsertStatement(model: post, modelSchema: post.schema)
 
         let expectedStatement = """
-        insert into Post ("id", "content", "createdAt", "draft", "rating", "status", "title", "updatedAt")
+        insert into "Post" ("id", "content", "createdAt", "draft", "rating", "status", "title", "updatedAt")
         values (?, ?, ?, ?, ?, ?, ?, ?)
         """
         XCTAssertEqual(statement.stringValue, expectedStatement)
@@ -178,7 +178,7 @@ class SQLStatementTests: XCTestCase {
         let statement = InsertStatement(model: comment, modelSchema: comment.schema)
 
         let expectedStatement = """
-        insert into Comment ("id", "content", "createdAt", "commentPostId")
+        insert into "Comment" ("id", "content", "createdAt", "commentPostId")
         values (?, ?, ?, ?)
         """
         XCTAssertEqual(statement.stringValue, expectedStatement)
@@ -265,7 +265,7 @@ class SQLStatementTests: XCTestCase {
         let statement = DeleteStatement(modelSchema: Post.schema, withId: id)
 
         let expectedStatement = """
-        delete from Post as root
+        delete from "Post" as root
         where 1 = 1
           and "root"."id" = ?
         """
@@ -288,7 +288,7 @@ class SQLStatementTests: XCTestCase {
                                         predicate: Post.keys.content == "content")
 
         let expectedStatement = """
-        delete from Post as root
+        delete from "Post" as root
         where 1 = 1
           and (
             "root"."id" = ?
@@ -316,7 +316,7 @@ class SQLStatementTests: XCTestCase {
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
           "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
           "root"."title" as "title", "root"."updatedAt" as "updatedAt"
-        from Post as "root"
+        from "Post" as "root"
         """
         XCTAssertEqual(statement.stringValue, expectedStatement)
     }
@@ -337,7 +337,7 @@ class SQLStatementTests: XCTestCase {
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
           "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
           "root"."title" as "title", "root"."updatedAt" as "updatedAt"
-        from Post as "root"
+        from "Post" as "root"
         where 1 = 1
           and (
             "root"."draft" = ?
@@ -373,8 +373,8 @@ class SQLStatementTests: XCTestCase {
           "root"."commentPostId" as "commentPostId", "post"."id" as "post.id", "post"."content" as "post.content",
           "post"."createdAt" as "post.createdAt", "post"."draft" as "post.draft", "post"."rating" as "post.rating",
           "post"."status" as "post.status", "post"."title" as "post.title", "post"."updatedAt" as "post.updatedAt"
-        from Comment as "root"
-        inner join Post as "post"
+        from "Comment" as "root"
+        inner join "Post" as "post"
           on "post"."id" = "root"."commentPostId"
         where 1 = 1
           and (
@@ -406,8 +406,8 @@ class SQLStatementTests: XCTestCase {
           "root"."commentPostId" as "commentPostId", "post"."id" as "post.id", "post"."content" as "post.content",
           "post"."createdAt" as "post.createdAt", "post"."draft" as "post.draft", "post"."rating" as "post.rating",
           "post"."status" as "post.status", "post"."title" as "post.title", "post"."updatedAt" as "post.updatedAt"
-        from Comment as "root"
-        inner join Post as "post"
+        from "Comment" as "root"
+        inner join "Post" as "post"
           on "post"."id" = "root"."commentPostId"
         """
         XCTAssertEqual(statement.stringValue, expectedStatement)
@@ -429,7 +429,7 @@ class SQLStatementTests: XCTestCase {
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
           "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
           "root"."title" as "title", "root"."updatedAt" as "updatedAt"
-        from Post as "root"
+        from "Post" as "root"
         limit 20 offset 40
         """
         XCTAssertEqual(statement.stringValue, expectedStatement)
@@ -452,7 +452,7 @@ class SQLStatementTests: XCTestCase {
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
           "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
           "root"."title" as "title", "root"."updatedAt" as "updatedAt"
-        from Post as "root"
+        from "Post" as "root"
         order by "root"."id" asc
         """
         XCTAssertEqual(statement.stringValue, expectedStatement)
@@ -475,7 +475,7 @@ class SQLStatementTests: XCTestCase {
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
           "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
           "root"."title" as "title", "root"."updatedAt" as "updatedAt"
-        from Post as "root"
+        from "Post" as "root"
         order by "root"."id" asc, "root"."createdAt" desc
         """
         XCTAssertEqual(statement.stringValue, expectedStatement)
@@ -498,7 +498,7 @@ class SQLStatementTests: XCTestCase {
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
           "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
           "root"."title" as "title", "root"."updatedAt" as "updatedAt"
-        from Post as "root"
+        from "Post" as "root"
         where 1 = 1
           and "root"."rating" > ?
         order by "root"."id" desc
@@ -524,7 +524,7 @@ class SQLStatementTests: XCTestCase {
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
           "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
           "root"."title" as "title", "root"."updatedAt" as "updatedAt"
-        from Post as "root"
+        from "Post" as "root"
         order by "root"."id" desc
         limit 5 offset 0
         """
@@ -551,7 +551,7 @@ class SQLStatementTests: XCTestCase {
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
           "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
           "root"."title" as "title", "root"."updatedAt" as "updatedAt"
-        from Post as "root"
+        from "Post" as "root"
         where 1 = 1
           and "root"."rating" > ?
         order by "root"."id" desc
@@ -701,7 +701,7 @@ class SQLStatementTests: XCTestCase {
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
           "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
           "root"."title" as "title", "root"."updatedAt" as "updatedAt"
-        from Post as "root"
+        from "Post" as "root"
         where 1 = 1
           and (
             (
@@ -736,7 +736,7 @@ class SQLStatementTests: XCTestCase {
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
           "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
           "root"."title" as "title", "root"."updatedAt" as "updatedAt"
-        from Post as "root"
+        from "Post" as "root"
         where 1 = 1
           and (
             (
@@ -771,7 +771,7 @@ class SQLStatementTests: XCTestCase {
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
           "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
           "root"."title" as "title", "root"."updatedAt" as "updatedAt"
-        from Post as "root"
+        from "Post" as "root"
         where 1 = 1
           and (
             (
@@ -810,7 +810,7 @@ class SQLStatementTests: XCTestCase {
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
           "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
           "root"."title" as "title", "root"."updatedAt" as "updatedAt"
-        from Post as "root"
+        from "Post" as "root"
         where 1 = 1
           and (
             (
@@ -850,7 +850,7 @@ class SQLStatementTests: XCTestCase {
           "root"."id" as "id", "root"."content" as "content", "root"."createdAt" as "createdAt",
           "root"."draft" as "draft", "root"."rating" as "rating", "root"."status" as "status",
           "root"."title" as "title", "root"."updatedAt" as "updatedAt"
-        from Post as "root"
+        from "Post" as "root"
         where 1 = 1
           and (
             (

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -671,3 +671,74 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
         XCTAssertFalse(storageAdapter.shouldIgnoreError(error: dataStoreError))
     }
 }
+
+// MARK: Reserved words tests
+extension SQLiteStorageEngineAdapterTests {
+    func testSaveWithReservedWords() {
+        // "Transaction"
+        let transactionSaved = expectation(description: "Transaction model saved")
+        storageAdapter.save(Transaction()) { result in
+            guard case .success = result else {
+                XCTFail("Failed to save transaction")
+                return
+            }
+            transactionSaved.fulfill()
+        }
+
+        // "Group"
+        let groupSaved = expectation(description: "Group model saved")
+        let group = Group()
+        storageAdapter.save(group) { result in
+            guard case .success = result else {
+                XCTFail("Failed to save group")
+                return
+            }
+            groupSaved.fulfill()
+        }
+
+        // "Row"
+        let rowSaved = expectation(description: "Row model saved")
+        storageAdapter.save(Row(group: group)) { result in
+            guard case .success = result else {
+                XCTFail("Failed to save Row")
+                return
+            }
+            rowSaved.fulfill()
+        }
+
+        wait(for: [transactionSaved, groupSaved, rowSaved], timeout: 1)
+    }
+
+    func testQueryWithReservedWords() {
+        // "Transaction"
+        let transactionQueried = expectation(description: "Transaction model queried")
+        storageAdapter.query(Transaction.self) { result in
+            guard case .success = result else {
+                XCTFail("Failed to query Transaction")
+                return
+            }
+            transactionQueried.fulfill()
+        }
+
+        // "Group"
+        let groupQueried = expectation(description: "Group model queried")
+        storageAdapter.query(Group.self) { result in
+            guard case .success = result else {
+                XCTFail("Failed to query Group")
+                return
+            }
+            groupQueried.fulfill()
+        }
+
+        // "Row"
+        let rowQueried = expectation(description: "Row model queried")
+        storageAdapter.query(Row.self) { result in
+            guard case .success = result else {
+                XCTFail("Failed to query Row")
+                return
+            }
+            rowQueried.fulfill()
+        }
+        wait(for: [transactionQueried, groupQueried, rowQueried], timeout: 1)
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Migration/SQLiteMutationSyncMetadataMigrationDelegateTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Migration/SQLiteMutationSyncMetadataMigrationDelegateTests.swift
@@ -39,7 +39,7 @@ class SQLiteMutationSyncMetadataMigrationDelegateTests: MutationSyncMetadataMigr
         let delegate = SQLiteMutationSyncMetadataMigrationDelegate(storageAdapter: storageAdapter,
                                                                    modelSchemas: modelSchemas)
         let sql = try delegate.emptyMutationSyncMetadataStore()
-        XCTAssertEqual(sql, "delete from MutationSyncMetadata as root")
+        XCTAssertEqual(sql, "delete from \"MutationSyncMetadata\" as root")
         guard let mutationSyncMetadatas = queryMutationSyncMetadata() else {
             XCTFail("Could not get metadata")
             return
@@ -61,7 +61,7 @@ class SQLiteMutationSyncMetadataMigrationDelegateTests: MutationSyncMetadataMigr
         let delegate = SQLiteMutationSyncMetadataMigrationDelegate(storageAdapter: storageAdapter,
                                                                    modelSchemas: modelSchemas)
         let sql = try delegate.emptyModelSyncMetadataStore()
-        XCTAssertEqual(sql, "delete from ModelSyncMetadata as root")
+        XCTAssertEqual(sql, "delete from \"ModelSyncMetadata\" as root")
         guard let modelSyncMetadatasDeleted = queryModelSyncMetadata() else {
             XCTFail("Could not get metadata")
             return

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/TestModelRegistration.swift
@@ -26,6 +26,11 @@ struct TestModelRegistration: AmplifyModelRegistration {
 
         // Models for data conversion testing
         registry.register(modelType: ExampleWithEveryType.self)
+
+        // Reserved words models
+        registry.register(modelType: Group.self)
+        registry.register(modelType: Row.self)
+        registry.register(modelType: Transaction.self)
     }
 
     let version: String = "1"

--- a/AmplifyTestCommon/Models/ReservedWords/Group+Schema.swift
+++ b/AmplifyTestCommon/Models/ReservedWords/Group+Schema.swift
@@ -1,0 +1,30 @@
+//
+//  Group+Schema.swift
+//  AmplifyTestCommon
+//
+//  Created by Costantino, Diego on 2021-11-30.
+//
+
+import Foundation
+import Amplify
+
+extension Group {
+    // MARK: - CodingKeys
+    public enum CodingKeys: String, ModelKey {
+        case id
+    }
+
+    public static let keys = CodingKeys.self
+    // MARK: - ModelSchema
+
+    public static let schema = defineSchema { model in
+        let group = Group.keys
+
+        model.listPluralName = "Groups"
+        model.syncPluralName = "Groups"
+
+        model.fields(
+            .id()
+        )
+    }
+}

--- a/AmplifyTestCommon/Models/ReservedWords/Group.swift
+++ b/AmplifyTestCommon/Models/ReservedWords/Group.swift
@@ -1,0 +1,17 @@
+//
+//  Group.swift
+//  AmplifyTestCommon
+//
+//  Created by Costantino, Diego on 2021-11-30.
+//
+
+import Foundation
+import Amplify
+
+public struct Group: Model {
+    public let id: String
+
+    public init(id: String = UUID().uuidString) {
+        self.id = id
+    }
+}

--- a/AmplifyTestCommon/Models/ReservedWords/Row+Schema.swift
+++ b/AmplifyTestCommon/Models/ReservedWords/Row+Schema.swift
@@ -1,0 +1,32 @@
+//
+//  Row+Schema.swift
+//  AmplifyTestCommon
+//
+//  Created by Costantino, Diego on 2021-11-30.
+//
+
+import Foundation
+import Amplify
+
+extension Row {
+    // MARK: - CodingKeys
+    public enum CodingKeys: String, ModelKey {
+        case id
+        case group
+    }
+
+    public static let keys = CodingKeys.self
+    // MARK: - ModelSchema
+
+    public static let schema = defineSchema { model in
+        let row = Row.keys
+
+        model.listPluralName = "Rows"
+        model.syncPluralName = "Rows"
+
+        model.fields(
+            .id(),
+            .belongsTo(row.group, is: .required, ofType: Group.self, targetName: "rowGroupId")
+        )
+    }
+}

--- a/AmplifyTestCommon/Models/ReservedWords/Row.swift
+++ b/AmplifyTestCommon/Models/ReservedWords/Row.swift
@@ -1,0 +1,20 @@
+//
+//  Row.swift
+//  AmplifyTestCommon
+//
+//  Created by Costantino, Diego on 2021-11-30.
+//
+
+import Foundation
+import Amplify
+
+public struct Row: Model {
+    public let id: String
+    public var group: Group
+
+    public init(id: String = UUID().uuidString,
+                group: Group) {
+        self.id = id
+        self.group = group
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
#1477 

*Description of changes:*
Quote table name in create table-references SQL statement. 
Ref: [SQLite keywords](https://www.sqlite.org/lang_keywords.html)

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
~- [ ] Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
