### PR TITLE
chore: Build Amplify for SPM in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,19 @@ jobs:
           path: build/reports
       - upload_artifacts
 
+  build_amplify_spm:
+    <<: *defaults
+    working_directory: ~/amplify-ios/.swiftpm/xcode
+    steps:
+      - *restore_repo
+      - pre_start_simulator
+      - restore_gems
+      - check_bundle
+      - make_artifacts_directory
+      - run:
+          name: Build amplify for SPM
+          command: xcodebuild build-for-testing -workspace package.xcworkspace -scheme Amplify-Package -sdk iphonesimulator -destination "${destination}" | tee "artifacts/build-Ampify-for-SPM.log" | xcpretty
+
   build_test_aws_plugins_core:
     <<: *defaults
     steps:
@@ -212,6 +225,7 @@ jobs:
 deploy_requires: &deploy_requires
   requires:
     - build_test_amplify
+    - build_amplify_spm
     - build_test_aws_plugins_core
     - unit_test_analytics
     - unit_test_api
@@ -232,6 +246,9 @@ workflows:
           requires:
             - install_gems
       - build_test_aws_plugins_core:
+          requires:
+            - install_gems
+      - build_amplify_spm:
           requires:
             - install_gems
       - plugin_unit_test:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Thumbs.db
 **/*.xcuserdata
 
 *.xcworkspace/
+!.swiftpm/xcode/package.xcworkspace
 Amplify.xcodeproj/xcuserdata
 Amplify.xcworkspace/xcuserdata
 xcuserdata

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Introducing step to use `xcodebuild` to build the SPM workspace created under `.swiftpm/xcode`. Testing locally with
```
cd .swiftpm/xcode
xcodebuild build-for-testing -workspace package.xcworkspace -scheme Amplify-Package -sdk iphonesimulator -destination "platform=iOS Simulator,name=IPhone 11" | xcpretty
```
Build is successful, then remove `import Foundation` from one of the files in DataStore and build again to see the error.
```
❌  /aws-amplify/amplify-ios/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStoreObserveQueryOperation.swift:117:59: cannot find type 'DispatchQueue' in scope

    private let itemsChangedPeriodicPublishTimeInSeconds: DispatchQueue.SchedulerTimeType.Stride = 2
                                                          ^~~~~~~~~~~~~

** TEST BUILD FAILED **

The following build commands failed:
        CompileSwift normal x86_64 /aws-amplify/amplify-ios/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStoreObserveQueryOperation.swift (in target 'AWSDataStorePlugin' from project 'Amplify')
        CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler (in target 'AWSDataStorePlugin' from project 'Amplify')
(2 failures)
```

- Amplify-Package is a wrapper for all other targets so building this one catches the error in DataStore

- Added CircleCI workflow to parallelize the build and test plugin's unit test along with the SPM build since, ideally this doesn't fail very often and shouldn't spend time waiting for the SPM build to be successful before doing the unit testing. Overall, we'll still catch the issue when the SPM build fails in the pipeline. 
![image](https://user-images.githubusercontent.com/1365977/139460755-3c92c260-7b3c-40fd-95f0-372b43c3f3c5.png)

- removing the import and testing that the CircleCI workflow fails: https://github.com/aws-amplify/amplify-ios/pull/1499

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
