### PR TITLE
feat(AWSPluginsCore): Add non-blocking methods to AWSAuthServiceBehavior / deprecate existing blocking methods  

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		76C0F4EC26797F4500F0E6AB /* AuthModeStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76C0F4EA26797F3C00F0E6AB /* AuthModeStrategyTests.swift */; };
 		76FFFC91267966D9001EC92B /* RetryableGraphQLOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FFFC90267966D9001EC92B /* RetryableGraphQLOperationTests.swift */; };
 		8484A17AAAFE78545A932849 /* Pods_Amplify.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A1769ED39B45A981FD1D8AC /* Pods_Amplify.framework */; };
+		90A8901327619D780042C3C1 /* AWSAuthServiceBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A8901227619D780042C3C1 /* AWSAuthServiceBehaviorTests.swift */; };
 		950A26DB23D15D7E00D92B19 /* PredictionsTranslateTextOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950A26D823D15D7E00D92B19 /* PredictionsTranslateTextOperation.swift */; };
 		950A26DC23D15D7E00D92B19 /* PredictionsTextToSpeechOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950A26D923D15D7E00D92B19 /* PredictionsTextToSpeechOperation.swift */; };
 		950A26DD23D15D7E00D92B19 /* PredictionsSpeechToTextOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950A26DA23D15D7E00D92B19 /* PredictionsSpeechToTextOperation.swift */; };
@@ -1147,6 +1148,7 @@
 		7D502982E80B9B2796D71A48 /* Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon/Pods-Amplify-AWSPluginsCore-AWSPluginsTestConfigs-AWSPluginsTestCommon.debug.xcconfig"; sourceTree = "<group>"; };
 		852B5530E9E8794DAC86E44E /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.release.xcconfig"; path = "Target Support Files/Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon/Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.release.xcconfig"; sourceTree = "<group>"; };
 		8E125EAA66C26B6F0705BB0C /* Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.release.xcconfig"; path = "Target Support Files/Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests/Pods-Amplify-AmplifyTestConfigs-AmplifyFunctionalTests.release.xcconfig"; sourceTree = "<group>"; };
+		90A8901227619D780042C3C1 /* AWSAuthServiceBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAuthServiceBehaviorTests.swift; sourceTree = "<group>"; };
 		950A26D823D15D7E00D92B19 /* PredictionsTranslateTextOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredictionsTranslateTextOperation.swift; sourceTree = "<group>"; };
 		950A26D923D15D7E00D92B19 /* PredictionsTextToSpeechOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredictionsTextToSpeechOperation.swift; sourceTree = "<group>"; };
 		950A26DA23D15D7E00D92B19 /* PredictionsSpeechToTextOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredictionsSpeechToTextOperation.swift; sourceTree = "<group>"; };
@@ -2372,6 +2374,7 @@
 				76C0F4EA26797F3C00F0E6AB /* AuthModeStrategyTests.swift */,
 				211A82002718631800C5483D /* AWSAuthorizationTypeTests.swift */,
 				6BEE0816253114FD00133961 /* AWSAuthServiceTests.swift */,
+				90A8901227619D780042C3C1 /* AWSAuthServiceBehaviorTests.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -4676,6 +4679,7 @@
 				21A3FDB9246494CD00E76120 /* GraphQLRequestAuthRuleTests.swift in Sources */,
 				21A3FDB62464590600E76120 /* ModelMultipleOwnerAuthRuleTests.swift in Sources */,
 				6B5087BD2565E5AD000AB673 /* QueryPredicateEvaluateGeneratedDoubleTests.swift in Sources */,
+				90A8901327619D780042C3C1 /* AWSAuthServiceBehaviorTests.swift in Sources */,
 				6B5087C5256632D3000AB673 /* QueryPredicateEvaluateGeneratedStringTests.swift in Sources */,
 				76C0F4EC26797F4500F0E6AB /* AuthModeStrategyTests.swift in Sources */,
 				2129BE3A2394828B006363A1 /* QueryPredicateGraphQLTests.swift in Sources */,
@@ -5508,6 +5512,7 @@
 			baseConfigurationReference = 1FA86170C161C5E46E57A5F9 /* Pods-Amplify-AWSPluginsCore.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
@@ -5536,6 +5541,7 @@
 			baseConfigurationReference = 09D90ABD9EDED6D6B1780253 /* Pods-Amplify-AWSPluginsCore.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
@@ -5564,7 +5570,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = W3DRXD72QU;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = AmplifyPlugins/Core/AWSPluginsCoreTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5608,7 +5614,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = W3DRXD72QU;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -5634,7 +5640,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = W3DRXD72QU;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -5780,7 +5786,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7B9806D365E82306EE138710 /* Pods-Amplify.debug.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
@@ -5807,7 +5813,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D4D30E30A8210AC1B2F74F4C /* Pods-Amplify.release.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
@@ -5915,7 +5921,7 @@
 			baseConfigurationReference = F8459E074A4A470F48829BEE /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
@@ -5948,7 +5954,7 @@
 			baseConfigurationReference = 852B5530E9E8794DAC86E44E /* Pods-Amplify-AmplifyTestConfigs-AmplifyTestCommon.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -16,18 +16,7 @@ public class AWSAuthService: AWSAuthServiceBehavior {
     public func getCredentialsProvider() -> AWSCredentialsProvider {
         return AmplifyAWSCredentialsProvider()
     }
-    
-    #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 13, *)
-    /// Retrieves the identity identifier for this authentication session from Cognito
-    /// - Returns: The identity token or an error.
-    public func getIdentityId() async -> Result<String, AuthError> {
-        await withCheckedContinuation {
-            getIdentityId(completion: $0.resume(returning:))
-        }
-    }
-    #endif
-    
+
     /// Retrieves the identity identifier for this authentication session from Cognito.
     /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
     public func getIdentityId(completion: @escaping (Result<String, AuthError>) -> Void) {
@@ -41,7 +30,7 @@ public class AWSAuthService: AWSAuthServiceBehavior {
                     Did not receive a valid response from fetchAuthSession for identityId.
                     """)))
                 }
-                
+
                 completion(identityID)
             case .failure(let error):
                 completion(.failure(error))
@@ -49,11 +38,7 @@ public class AWSAuthService: AWSAuthServiceBehavior {
         }
     }
 
-    @available(*, deprecated, message: """
-            Use getIdentityId(completion: (Result<String, AuthError>) -> Void)
-            -- or --
-            getIdentityId() async -> Result<String, AuthError> instead.
-            """)
+    @available(*, deprecated, message: "Use getIdentityId(completion: (Result<String, AuthError>) -> Void) instead")
     public func getIdentityId() -> Result<String, AuthError> {
         var result: Result<String, AuthError>?
         let semaphore = DispatchSemaphore(value: 0)
@@ -120,18 +105,7 @@ public class AWSAuthService: AWSAuthServiceBehavior {
         }
         return .success(convertedDictionary)
     }
-    
-    #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 13, *)
-    /// Retrieves the Cognito token from the AuthCognitoTokensProvider
-    /// - Returns: The Cognito token or an error.
-    public func getToken() async -> Result<String, AuthError> {
-        await withCheckedContinuation {
-            getToken(completion: $0.resume(returning:))
-        }
-    }
-    #endif
-    
+
     /// Retrieves the Cognito token from the AuthCognitoTokensProvider
     /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
     public func getToken(completion: @escaping (Result<String, AuthError>) -> Void) {
@@ -152,11 +126,7 @@ public class AWSAuthService: AWSAuthServiceBehavior {
         }
     }
 
-    @available(*, deprecated, message: """
-            Use getToken(completion: (Result<String, AuthError>) -> Void)
-            -- or --
-            getToken() async -> Result<String, AuthError> instead.
-            """)
+    @available(*, deprecated, message: "Use getToken(completion: (Result<String, AuthError>) -> Void) instead")
     public func getToken() -> Result<String, AuthError> {
         var result: Result<String, AuthError>?
         let semaphore = DispatchSemaphore(value: 0)
@@ -194,4 +164,31 @@ public class AWSAuthService: AWSAuthServiceBehavior {
         }
         return nil
     }
+}
+
+// MARK: Swift Concurrency Async Methods
+// These currently cannot be a part of the `AWSAuthServiceBehavior` protocol
+// due to the compiler being unable to handle async overloads in protocol conformance contexts.
+extension AWSAuthService {
+    #if compiler(>=5.5.2)
+    /// Retrieves the identity identifier of for the Auth service.
+    /// - Returns: The identifier or an `AuthError`.
+    /// - Warning: Swift Concurrency langauge features in Amplify are currently in an expiremental phase.
+    @available(iOS 13, *)
+    public func getIdentityId() async -> Result<String, AuthError> {
+        await withCheckedContinuation {
+            getIdentityId(completion: $0.resume(returning:))
+        }
+    }
+
+    /// Retrieves the token from the the Auth token provider.
+    /// - Returns: The token or an `AuthError`.
+    /// - Warning: Swift Concurrency langauge features in Amplify are currently in an expiremental phase.
+    @available(iOS 13, *)
+    public func getToken() async -> Result<String, AuthError> {
+        await withCheckedContinuation {
+            getToken(completion: $0.resume(returning:))
+        }
+    }
+    #endif
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -165,30 +165,3 @@ public class AWSAuthService: AWSAuthServiceBehavior {
         return nil
     }
 }
-
-// MARK: Swift Concurrency Async Methods
-// These currently cannot be a part of the `AWSAuthServiceBehavior` protocol
-// due to the compiler being unable to handle async overloads in protocol conformance contexts.
-extension AWSAuthService {
-    #if compiler(>=5.5.2)
-    /// Retrieves the identity identifier of for the Auth service.
-    /// - Returns: The identifier or an `AuthError`.
-    /// - Warning: Swift Concurrency langauge features in Amplify are currently in an expiremental phase.
-    @available(iOS 13, *)
-    public func getIdentityId() async -> Result<String, AuthError> {
-        await withCheckedContinuation {
-            getIdentityId(completion: $0.resume(returning:))
-        }
-    }
-
-    /// Retrieves the token from the the Auth token provider.
-    /// - Returns: The token or an `AuthError`.
-    /// - Warning: Swift Concurrency langauge features in Amplify are currently in an expiremental phase.
-    @available(iOS 13, *)
-    public func getToken() async -> Result<String, AuthError> {
-        await withCheckedContinuation {
-            getToken(completion: $0.resume(returning:))
-        }
-    }
-    #endif
-}

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -19,7 +19,9 @@ public class AWSAuthService: AWSAuthServiceBehavior {
     
     #if compiler(>=5.5) && canImport(_Concurrency)
     @available(iOS 13, *)
-    public func identityID() async -> Result<String, AuthError> {
+    /// Retrieves the identity identifier for this authentication session from Cognito
+    /// - Returns: The identity token or an error.
+    public func getIdentityId() async -> Result<String, AuthError> {
         await withCheckedContinuation {
             getIdentityId(completion: $0.resume(returning:))
         }
@@ -47,6 +49,11 @@ public class AWSAuthService: AWSAuthServiceBehavior {
         }
     }
 
+    @available(*, deprecated, message: """
+            Use getIdentityId(completion: (Result<String, AuthError>) -> Void)
+            -- or --
+            getIdentityId() async -> Result<String, AuthError> instead.
+            """)
     public func getIdentityId() -> Result<String, AuthError> {
         var result: Result<String, AuthError>?
         let semaphore = DispatchSemaphore(value: 0)
@@ -116,7 +123,9 @@ public class AWSAuthService: AWSAuthServiceBehavior {
     
     #if compiler(>=5.5) && canImport(_Concurrency)
     @available(iOS 13, *)
-    public func token() async -> Result<String, AuthError> {
+    /// Retrieves the Cognito token from the AuthCognitoTokensProvider
+    /// - Returns: The Cognito token or an error.
+    public func getToken() async -> Result<String, AuthError> {
         await withCheckedContinuation {
             getToken(completion: $0.resume(returning:))
         }
@@ -143,6 +152,11 @@ public class AWSAuthService: AWSAuthServiceBehavior {
         }
     }
 
+    @available(*, deprecated, message: """
+            Use getToken(completion: (Result<String, AuthError>) -> Void)
+            -- or --
+            getToken() async -> Result<String, AuthError> instead.
+            """)
     public func getToken() -> Result<String, AuthError> {
         var result: Result<String, AuthError>?
         let semaphore = DispatchSemaphore(value: 0)

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -19,7 +19,7 @@ public class AWSAuthService: AWSAuthServiceBehavior {
 
     /// Retrieves the identity identifier for this authentication session from Cognito.
     /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
-    public func getIdentityId(completion: @escaping (Result<String, AuthError>) -> Void) {
+    public func getIdentityID(completion: @escaping (Result<String, AuthError>) -> Void) {
         Amplify.Auth.fetchAuthSession { event in
             switch event {
             case .success(let session):
@@ -38,7 +38,7 @@ public class AWSAuthService: AWSAuthServiceBehavior {
         }
     }
 
-    @available(*, deprecated, message: "Use getIdentityId(completion: (Result<String, AuthError>) -> Void) instead")
+    @available(*, deprecated, message: "Use getIdentityID(completion:) instead")
     public func getIdentityId() -> Result<String, AuthError> {
         var result: Result<String, AuthError>?
         let semaphore = DispatchSemaphore(value: 0)
@@ -65,21 +65,22 @@ public class AWSAuthService: AWSAuthServiceBehavior {
     }
 
     // This algorithm was heavily based on the implementation here:
-    // https://github.com/aws-amplify/aws-sdk-ios/blob/main/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift#L29
+    // swiftlint:disable:next line_length
+    //  https://github.com/aws-amplify/aws-sdk-ios/blob/main/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift#L29
     public func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
         let tokenSplit = tokenString.split(separator: ".")
         guard tokenSplit.count > 2 else {
             return .failure(.validation("", "Token is not valid base64 encoded string.", "", nil))
         }
 
-        //Add ability to do URL decoding
-        //https://stackoverflow.com/questions/40915607/how-can-i-decode-jwt-json-web-token-token-in-swift
+        // Add ability to do URL decoding
+        // https://stackoverflow.com/questions/40915607/how-can-i-decode-jwt-json-web-token-token-in-swift
         let claims = tokenSplit[1]
             .replacingOccurrences(of: "-", with: "+")
             .replacingOccurrences(of: "_", with: "/")
 
         let paddedLength = claims.count + (4 - (claims.count % 4)) % 4
-        //JWT is not padded with =, pad it if necessary
+        // JWT is not padded with =, pad it if necessary
         let updatedClaims = claims.padding(toLength: paddedLength, withPad: "=", startingAt: 0)
         let encodedData = Data(base64Encoded: updatedClaims, options: .ignoreUnknownCharacters)
 
@@ -108,7 +109,7 @@ public class AWSAuthService: AWSAuthServiceBehavior {
 
     /// Retrieves the Cognito token from the AuthCognitoTokensProvider
     /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
-    public func getToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+    public func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
         Amplify.Auth.fetchAuthSession { [weak self] event in
             switch event {
             case .success(let session):
@@ -126,7 +127,7 @@ public class AWSAuthService: AWSAuthServiceBehavior {
         }
     }
 
-    @available(*, deprecated, message: "Use getToken(completion: (Result<String, AuthError>) -> Void) instead")
+    @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
     public func getToken() -> Result<String, AuthError> {
         var result: Result<String, AuthError>?
         let semaphore = DispatchSemaphore(value: 0)

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -30,6 +30,30 @@ public protocol AWSAuthServiceBehavior: AnyObject {
 }
 
 extension AWSAuthServiceBehavior {
+    // MARK: List of Amplify internal usages of now deprecated AWSAuthServiceBehavior methods.
+    /**
+     `StorageAccessLevelAwarePrefixResolver`
+        - File Path: `AmplifyPlugins/Storage/AWSS3StoragePlugin/Configuration/AWSS3PluginPrefixResolver.swift`
+        - Uses: `getIdentityId()`
+     
+     `IncomingAsyncSubscriptionEventPublisher`
+        - File Path: `AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift`
+        - Uses: `getToken()`
+     
+     `BasicUserPoolTokenProvider`
+        - File Path: `AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift`
+        - Uses: `getToken()`
+     
+     `AWSOIDCAuthProvider`
+        - File Path: `AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift`
+        - Uses: `getToken()`
+     
+     `AWSAuthServiceBehavior` protocol extension. Default implementation of new completion handler APIs to prevent breaking change.
+         - File Path: `AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift`
+         - Uses: `getToken()`, `getIdentityId()`
+     */
+    
+    
     /// Retrieves the identity identifier of for the Auth service
     /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
     /// - Note: This default implementation was added to prevent a breaking change,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -12,9 +12,43 @@ public protocol AWSAuthServiceBehavior: AnyObject {
 
     func getCredentialsProvider() -> AWSCredentialsProvider
 
+    @available(*, deprecated, message: "Use getIdentityId(completion: (Result<String, AuthError>) -> Void) instead")
     func getIdentityId() -> Result<String, AuthError>
 
+    @available(*, deprecated, message: "Use getToken(completion: (Result<String, AuthError>) -> Void) instead")
     func getToken() -> Result<String, AuthError>
 
     func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError>
+
+    /// Retrieves the identity identifier of for the Auth service
+    /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
+    func getIdentityId(completion: @escaping (Result<String, AuthError>) -> Void)
+
+    /// Retrieves the token from the Auth token provider
+    /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
+    func getToken(completion: @escaping (Result<String, AuthError>) -> Void)
+}
+
+extension AWSAuthServiceBehavior {
+    /// Retrieves the identity identifier of for the Auth service
+    /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
+    /// - Note: This default implementation was added to prevent a breaking change,
+    /// and will be removed when the blocking API versions are removed.
+    public func getIdentityId(completion: @escaping (Result<String, AuthError>) -> Void) {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            guard let identityIdResult = self?.getIdentityId() else { return }
+            completion(identityIdResult)
+        }
+    }
+
+    /// Retrieves the token from the Auth token provider
+    /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
+    /// - Note: This default implementation was added to prevent a breaking change,
+    ///  and will be removed when the blocking API versions are removed.
+    public func getToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            guard let tokenResult = self?.getToken() else { return }
+            completion(tokenResult)
+        }
+    }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -59,7 +59,7 @@ extension AWSAuthServiceBehavior {
     /// - Note: This default implementation was added to prevent a breaking change,
     /// and will be removed when the blocking API versions are removed.
     public func getIdentityId(completion: @escaping (Result<String, AuthError>) -> Void) {
-        DispatchQueue.global(qos: .utility).async { [weak self] in
+        DispatchQueue.global().async { [weak self] in
             guard let identityIdResult = self?.getIdentityId() else { return }
             completion(identityIdResult)
         }
@@ -70,7 +70,7 @@ extension AWSAuthServiceBehavior {
     /// - Note: This default implementation was added to prevent a breaking change,
     ///  and will be removed when the blocking API versions are removed.
     public func getToken(completion: @escaping (Result<String, AuthError>) -> Void) {
-        DispatchQueue.global(qos: .utility).async { [weak self] in
+        DispatchQueue.global().async { [weak self] in
             guard let tokenResult = self?.getToken() else { return }
             completion(tokenResult)
         }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -12,21 +12,21 @@ public protocol AWSAuthServiceBehavior: AnyObject {
 
     func getCredentialsProvider() -> AWSCredentialsProvider
 
-    @available(*, deprecated, message: "Use getIdentityId(completion: (Result<String, AuthError>) -> Void) instead")
+    @available(*, deprecated, message: "Use getIdentityID(completion:) instead")
     func getIdentityId() -> Result<String, AuthError>
 
-    @available(*, deprecated, message: "Use getToken(completion: (Result<String, AuthError>) -> Void) instead")
+    @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
     func getToken() -> Result<String, AuthError>
 
     func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError>
 
     /// Retrieves the identity identifier of for the Auth service
     /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
-    func getIdentityId(completion: @escaping (Result<String, AuthError>) -> Void)
+    func getIdentityID(completion: @escaping (Result<String, AuthError>) -> Void)
 
     /// Retrieves the token from the Auth token provider
     /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
-    func getToken(completion: @escaping (Result<String, AuthError>) -> Void)
+    func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void)
 }
 
 extension AWSAuthServiceBehavior {
@@ -35,30 +35,30 @@ extension AWSAuthServiceBehavior {
      `StorageAccessLevelAwarePrefixResolver`
         - File Path: `AmplifyPlugins/Storage/AWSS3StoragePlugin/Configuration/AWSS3PluginPrefixResolver.swift`
         - Uses: `getIdentityId()`
-     
+
      `IncomingAsyncSubscriptionEventPublisher`
         - File Path: `AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift`
         - Uses: `getToken()`
-     
+
      `BasicUserPoolTokenProvider`
         - File Path: `AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift`
         - Uses: `getToken()`
-     
+
      `AWSOIDCAuthProvider`
         - File Path: `AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift`
         - Uses: `getToken()`
-     
-     `AWSAuthServiceBehavior` protocol extension. Default implementation of new completion handler APIs to prevent breaking change.
+
+     `AWSAuthServiceBehavior` protocol extension.
+        Default implementation of new completion handler APIs to prevent breaking change.
          - File Path: `AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift`
          - Uses: `getToken()`, `getIdentityId()`
      */
-    
-    
+
     /// Retrieves the identity identifier of for the Auth service
     /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
     /// - Note: This default implementation was added to prevent a breaking change,
     /// and will be removed when the blocking API versions are removed.
-    public func getIdentityId(completion: @escaping (Result<String, AuthError>) -> Void) {
+    public func getIdentityID(completion: @escaping (Result<String, AuthError>) -> Void) {
         DispatchQueue.global().async { [weak self] in
             guard let identityIdResult = self?.getIdentityId() else { return }
             completion(identityIdResult)
@@ -69,7 +69,7 @@ extension AWSAuthServiceBehavior {
     /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
     /// - Note: This default implementation was added to prevent a breaking change,
     ///  and will be removed when the blocking API versions are removed.
-    public func getToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+    public func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
         DispatchQueue.global().async { [weak self] in
             guard let tokenResult = self?.getToken() else { return }
             completion(tokenResult)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AWSAuthServiceBehaviorTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AWSAuthServiceBehaviorTests.swift
@@ -1,0 +1,128 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@testable import Amplify
+@testable import AWSPluginsCore
+import AWSCore
+
+class AWSAuthServiceBehaviorTests: XCTestCase {
+    // MARK: Tests for change from blocking to non-blocking
+    /**
+     Confirm that calling the non-blocking replacements of `getIdentityId()` (`getIdentityID(completion:)`)
+     and `getToken()` (`getUserPoolAccessToken(completion:)`) in `AWSAuthServiceBehavior` conforming
+     objects that have yet to implement the non-blocking methods, will act as a pass through to
+     the existing blocking methods.
+
+     - IMPORTANT: This tests can be removed after the deprecation process of
+     the blocking methods `getIdentityId` and `getToken` is complete
+     */
+
+    func testNonBlockingDefaultImplementationSuccess() {
+        let mockAWSAuthService: AWSAuthServiceBehavior = _MockAWSAuthService.init(
+            identityID: .success("42"),
+            userPoolAccessToken: .success("25")
+        )
+
+        /// Calling `getIdentityID(completion:)` on an `AWSAuthServiceBehavior` conforming type
+        /// without an explicit implementation should use the now deprecated `getIdentityId()` method as a
+        /// default implementation.
+        mockAWSAuthService.getIdentityID {
+            switch $0 {
+            case .success(let id): XCTAssertEqual(id, "42")
+            case .failure: XCTFail("This instance of _MockAWSAuthService should return .success")
+            }
+        }
+
+        /// Calling `getUserPoolAccessToken(completion:)` on an `AWSAuthServiceBehavior` conforming type
+        /// without an explicit implementation should use the now deprecated `getToken()` method as a
+        /// default implementation.
+        mockAWSAuthService.getUserPoolAccessToken {
+            switch $0 {
+            case .success(let id): XCTAssertEqual(id, "25")
+            case .failure: XCTFail("This instance of _MockAWSAuthService should return .success")
+            }
+        }
+    }
+
+    func testNonBlockingDefaultImplementationFailure() {
+        let identityIDErrorDescription = "identityID_description"
+        let identityIDErrorRecovery = "identityID_recovery"
+
+        let userPoolAccessTokenIDErrorDescription = "userPoolAccessToken_description"
+        let userPoolAccessTokenIDErrorRecovery = "userPoolAccessToken_recovery"
+
+        let mockAWSAuthService: AWSAuthServiceBehavior = _MockAWSAuthService.init(
+            identityID: .failure(
+                .notAuthorized(
+                    identityIDErrorDescription,
+                    identityIDErrorRecovery
+                )
+            ),
+            userPoolAccessToken: .failure(
+                .invalidState(
+                    userPoolAccessTokenIDErrorDescription,
+                    userPoolAccessTokenIDErrorRecovery
+                )
+            )
+        )
+
+        /// Calling `getIdentityID(completion:)` on an `AWSAuthServiceBehavior` conforming type
+        /// without an explicit implementation should use the now deprecated `getIdentityId()` method as a
+        /// default implementation.
+        mockAWSAuthService.getIdentityID {
+            switch $0 {
+            case let .failure(.notAuthorized(description, recovery, _)):
+                XCTAssertEqual(description, identityIDErrorDescription)
+                XCTAssertEqual(recovery, identityIDErrorRecovery)
+            default: XCTFail("This instance of _MockAWSAuthService should return .failure(.notAuthorized)")
+            }
+        }
+
+        /// Calling `getUserPoolAccessToken(completion:)` on an `AWSAuthServiceBehavior` conforming type
+        /// without an explicit implementation should use the now deprecated `getToken()` method as a
+        /// default implementation.
+        mockAWSAuthService.getUserPoolAccessToken {
+            switch $0 {
+            case let .failure(.invalidState(description, recovery, _)):
+                XCTAssertEqual(description, userPoolAccessTokenIDErrorDescription)
+                XCTAssertEqual(recovery, userPoolAccessTokenIDErrorRecovery)
+            default: XCTFail("This instance of _MockAWSAuthService should return .failure(.invalidState)")
+            }
+        }
+    }
+}
+
+fileprivate class _MockAWSAuthService: AWSAuthServiceBehavior {
+    let identityID: () -> Result<String, AuthError>
+    let userPoolAccessToken: () -> Result<String, AuthError>
+
+    init(
+        identityID: @escaping @autoclosure () -> Result<String, AuthError>,
+        userPoolAccessToken: @escaping @autoclosure () -> Result<String, AuthError>
+    ) {
+        self.identityID = identityID
+        self.userPoolAccessToken = userPoolAccessToken
+    }
+
+    func getCredentialsProvider() -> AWSCredentialsProvider {
+        AWSCognitoCredentialsProvider()
+    }
+
+    func getIdentityId() -> Result<String, AuthError> {
+        identityID()
+    }
+
+    func getToken() -> Result<String, AuthError> {
+        userPoolAccessToken()
+    }
+
+    func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
+        .success([:])
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AWSAuthServiceTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AWSAuthServiceTests.swift
@@ -5,12 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-//
-// Copyright Amazon.com Inc. or its affiliates.
-// All Rights Reserved.
-//
-// SPDX-License-Identifier: Apache-2.0
-//
 import XCTest
 
 @testable import Amplify

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
     - CwlMachBadInstructionHandler (~> 2.1.0)
     - CwlPosixPreconditionTesting (~> 2.1.0)
   - SwiftFormat/CLI (0.44.17)
-  - SwiftLint (0.45.0)
+  - SwiftLint (0.45.1)
 
 DEPENDENCIES:
   - AWSCore (~> 2.26.5)
@@ -46,7 +46,7 @@ SPEC CHECKSUMS:
   CwlPosixPreconditionTesting: 1ba4471964405941f79b3f06bbcf3c2be782950c
   CwlPreconditionTesting: 73ae5de517a8761e5e40fb4136c6a26365af0440
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
-  SwiftLint: e5c7f1fba68eccfc51509d5b2ce1699f5502e0c7
+  SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761
 
 PODFILE CHECKSUM: 5e20e56b8ef40444b018a3736b7b726ff9772f00
 


### PR DESCRIPTION
*Issue #, if available:* 
443

*Description of changes:*
Add new non-blocking APIs to AWSAuthServiceBehavior and deprecate existing blocking APIs.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
