### PR TITLE
feat:(Core) prevents `Amplify.configure` while running for SwiftUI Previews

### DIFF
--- a/Amplify/Core/Configuration/AmplifyConfiguration.swift
+++ b/Amplify/Core/Configuration/AmplifyConfiguration.swift
@@ -95,6 +95,10 @@ extension Amplify {
     ///
     /// - Parameter configuration: The AmplifyConfiguration for specified Categories
     public static func configure(_ configuration: AmplifyConfiguration? = nil) throws {
+        guard !isRunningForSwiftUIPreviews else {
+            log.info("Running for SwiftUI reviews, skipping configuration.")
+            return
+        }
         log.info("Configuring")
         log.debug("Configuration: \(String(describing: configuration))")
         guard !isConfigured else {
@@ -176,6 +180,11 @@ extension Amplify {
                 log.warn("No plugin found for configuration key `\(unusedPluginKey)`. Add a plugin for that key.")
             }
         }
+    }
+
+    //// Indicates is the runtime is for SwiftUI Previews
+    private static var isRunningForSwiftUIPreviews: Bool {
+        ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != nil
     }
 
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 ## Unreleased
 
+### Features
+
+- **Core**: Supports SwiftUI by not running `Amplify.configure` while running for Previews #1509
+
+
 ## 1.16.1 (2021-11-19)
 
 ## 1.16.0 (2021-11-18)


### PR DESCRIPTION
Previews crash when it is not possible to load `awsconfiguration.json` when `Amplify.configure` is run which prevents this feature from working in Xcode.

*Issue #, if available:*

#1508 

*Description of changes:*

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
