### PR TITLE
fix(DataStore): clear ModelSyncMetadata on duplicate ids found

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Migration/MutationSyncMetadataMigrationDelegate+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Migration/MutationSyncMetadataMigrationDelegate+SQLite.swift
@@ -29,7 +29,7 @@ final class SQLiteMutationSyncMetadataMigrationDelegate: MutationSyncMetadataMig
         case .emptyMutationSyncMetadataStore:
             try emptyMutationSyncMetadataStore()
         case .emptyModelSyncMetadataStore:
-            try emptyMutationSyncMetadataStore()
+            try emptyModelSyncMetadataStore()
         case .removeMutationSyncMetadataCopyStore:
             try removeMutationSyncMetadataCopyStore()
         case .createMutationSyncMetadataCopyStore:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The migration script for the scenario where there were duplicate id's found across models were not clearing the ModelSyncMetadata table.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
