### PR TITLE
fix(DataStore): support predicate evaluation on model with Enum

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		214F49CE24898E8500DA616C /* Article+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214F49CC24898E8500DA616C /* Article+Schema.swift */; };
 		21558E3E237BB4BF0032A5BB /* GraphQLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21558E3D237BB4BF0032A5BB /* GraphQLRequest.swift */; };
 		21558E40237CB8640032A5BB /* GraphQLError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21558E3F237CB8640032A5BB /* GraphQLError.swift */; };
+		2163356E273C799900F0DF3F /* QueryPredicateEvaluateGeneratedEnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2163356C273C799000F0DF3F /* QueryPredicateEvaluateGeneratedEnumTests.swift */; };
 		21644B7C2588258100C548A5 /* ModelListDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21644B7A2588258100C548A5 /* ModelListDecoder.swift */; };
 		21665EF5259A947100841696 /* ListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21665EF4259A947100841696 /* ListTests.swift */; };
 		21687A3E236371C4004A056E /* AnalyticsCategory+HubPayloadEventName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21687A3D236371C4004A056E /* AnalyticsCategory+HubPayloadEventName.swift */; };
@@ -932,6 +933,7 @@
 		21558E3D237BB4BF0032A5BB /* GraphQLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRequest.swift; sourceTree = "<group>"; };
 		21558E3F237CB8640032A5BB /* GraphQLError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLError.swift; sourceTree = "<group>"; };
 		215F4BCAAB89FA54AA121BDE /* Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin.release.xcconfig"; path = "Target Support Files/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin/Pods-AmplifyAWSPlugins-AWSPluginsCore-AWSPinpointAnalyticsPlugin.release.xcconfig"; sourceTree = "<group>"; };
+		2163356C273C799000F0DF3F /* QueryPredicateEvaluateGeneratedEnumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPredicateEvaluateGeneratedEnumTests.swift; sourceTree = "<group>"; };
 		21644B7A2588258100C548A5 /* ModelListDecoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelListDecoder.swift; sourceTree = "<group>"; };
 		21665EF4259A947100841696 /* ListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTests.swift; sourceTree = "<group>"; };
 		21687A3D236371C4004A056E /* AnalyticsCategory+HubPayloadEventName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AnalyticsCategory+HubPayloadEventName.swift"; sourceTree = "<group>"; };
@@ -2458,17 +2460,18 @@
 		6B59798B2564DB210038C3E2 /* Query */ = {
 			isa = PBXGroup;
 			children = (
-				6B5087CE25674F99000AB673 /* QueryPredicateEvaluateTests.swift */,
-				6BAF4F37256893B900A811BA /* QueryPredicateEvaluateGenerator.swift */,
 				6B5979CA2565D18B0038C3E2 /* QueryPredicateEvaluateGeneratedBoolTests.swift */,
-				6B5087BC2565E5AD000AB673 /* QueryPredicateEvaluateGeneratedDoubleTests.swift */,
+				6B5087C6256638EA000AB673 /* QueryPredicateEvaluateGeneratedDateTests.swift */,
+				6B5087CA2566F70F000AB673 /* QueryPredicateEvaluateGeneratedDateTimeTests.swift */,
 				6B5087C025662DC3000AB673 /* QueryPredicateEvaluateGeneratedDoubleIntTests.swift */,
+				6B5087BC2565E5AD000AB673 /* QueryPredicateEvaluateGeneratedDoubleTests.swift */,
+				2163356C273C799000F0DF3F /* QueryPredicateEvaluateGeneratedEnumTests.swift */,
 				6B5087C82566F0FF000AB673 /* QueryPredicateEvaluateGeneratedIntDoubleTests.swift */,
 				6B5087C2256630DB000AB673 /* QueryPredicateEvaluateGeneratedIntTests.swift */,
 				6B5087C4256632D3000AB673 /* QueryPredicateEvaluateGeneratedStringTests.swift */,
-				6B5087C6256638EA000AB673 /* QueryPredicateEvaluateGeneratedDateTests.swift */,
-				6B5087CA2566F70F000AB673 /* QueryPredicateEvaluateGeneratedDateTimeTests.swift */,
 				6B5087CC25673AC8000AB673 /* QueryPredicateEvaluateGeneratedTimeTests.swift */,
+				6BAF4F37256893B900A811BA /* QueryPredicateEvaluateGenerator.swift */,
+				6B5087CE25674F99000AB673 /* QueryPredicateEvaluateTests.swift */,
 			);
 			path = Query;
 			sourceTree = "<group>";
@@ -4887,6 +4890,7 @@
 				21AD425B249C0DBE0016FE95 /* AnyModelTests.swift in Sources */,
 				D83C5160248964780091548E /* ModelGraphQLTests.swift in Sources */,
 				21DDCDF7272C3D7400D9B297 /* ModelSchemaGraphQLTests.swift in Sources */,
+				2163356E273C799900F0DF3F /* QueryPredicateEvaluateGeneratedEnumTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Amplify/Categories/DataStore/Query/QueryPredicate.swift
+++ b/Amplify/Categories/DataStore/Query/QueryPredicate.swift
@@ -130,6 +130,7 @@ public class QueryPredicateOperation: QueryPredicate {
         guard let fieldValue = target[field] else {
             return false
         }
+
         guard let value = fieldValue else {
             return false
         }
@@ -145,8 +146,13 @@ public class QueryPredicateOperation: QueryPredicate {
         if let intValue = value as? Int {
             return self.operator.evaluate(target: intValue)
         }
+
         if let timeValue = value as? Temporal.Time {
             return self.operator.evaluate(target: timeValue)
+        }
+
+        if let enumValue = value as? EnumPersistable {
+            return self.operator.evaluate(target: enumValue.rawValue)
         }
 
         return self.operator.evaluate(target: value)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedEnumTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedEnumTests.swift
@@ -13,7 +13,7 @@ import XCTest
 
 class QueryPredicateEvaluateGeneratedEnumTests: XCTestCase {
 
-    func testEnumNotEqual_True() throws {
+    func testEnumNotEqual_False() throws {
         let predicate = Post.keys.status.ne(PostStatus.published)
         let instance = Post(title: "title",
                             content: "content",
@@ -26,7 +26,7 @@ class QueryPredicateEvaluateGeneratedEnumTests: XCTestCase {
         XCTAssertFalse(evaluation)
     }
 
-    func testEnumNotEqual_False() throws {
+    func testEnumNotEqual_True() throws {
         let predicate = Post.keys.status.ne(PostStatus.published)
         let instance = Post(title: "title",
                             content: "content",
@@ -36,7 +36,7 @@ class QueryPredicateEvaluateGeneratedEnumTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssert(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testEnumEquals_True() throws {
@@ -49,7 +49,7 @@ class QueryPredicateEvaluateGeneratedEnumTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssert(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testEnumEquals_False() throws {
@@ -63,5 +63,61 @@ class QueryPredicateEvaluateGeneratedEnumTests: XCTestCase {
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
         XCTAssertFalse(evaluation)
+    }
+
+    /// Draft is not greater than published, evaluates to false
+    func testEnumToStringGreaterThan_False() throws {
+        let predicate = Post.keys.status.gt(PostStatus.published.rawValue)
+        let instance = Post(title: "title",
+                            content: "content",
+                            createdAt: .now(),
+                            updatedAt: .now(),
+                            status: .draft)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    /// Published is greater than draft, evaluates to true
+    func testEnumToStringGreaterThan_True() throws {
+        let predicate = Post.keys.status.gt(PostStatus.draft.rawValue)
+        let instance = Post(title: "title",
+                            content: "content",
+                            createdAt: .now(),
+                            updatedAt: .now(),
+                            status: .published)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertTrue(evaluation)
+    }
+
+    /// Published is not less than draft, evalutates to false
+    func testEnumToStringLessThan_False() throws {
+        let predicate = Post.keys.status.lt(PostStatus.draft.rawValue)
+        let instance = Post(title: "title",
+                            content: "content",
+                            createdAt: .now(),
+                            updatedAt: .now(),
+                            status: .published)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    /// Draft is less than publshed, evaluates to true
+    func testEnumToStringLessThan_True() throws {
+        let predicate = Post.keys.status.lt(PostStatus.published.rawValue)
+        let instance = Post(title: "title",
+                            content: "content",
+                            createdAt: .now(),
+                            updatedAt: .now(),
+                            status: .draft)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertTrue(evaluation)
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedEnumTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedEnumTests.swift
@@ -1,0 +1,67 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+
+class QueryPredicateEvaluateGeneratedEnumTests: XCTestCase {
+
+    func testEnumNotEqual_True() throws {
+        let predicate = Post.keys.status.ne(PostStatus.published)
+        let instance = Post(title: "title",
+                            content: "content",
+                            createdAt: .now(),
+                            updatedAt: .now(),
+                            status: .published)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+
+    func testEnumNotEqual_False() throws {
+        let predicate = Post.keys.status.ne(PostStatus.published)
+        let instance = Post(title: "title",
+                            content: "content",
+                            createdAt: .now(),
+                            updatedAt: .now(),
+                            status: .draft)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testEnumEquals_True() throws {
+        let predicate = Post.keys.status.eq(PostStatus.published)
+        let instance = Post(title: "title",
+                            content: "content",
+                            createdAt: .now(),
+                            updatedAt: .now(),
+                            status: .published)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssert(evaluation)
+    }
+
+    func testEnumEquals_False() throws {
+        let predicate = Post.keys.status.eq(PostStatus.published)
+        let instance = Post(title: "title",
+                            content: "content",
+                            createdAt: .now(),
+                            updatedAt: .now(),
+                            status: .draft)
+
+        let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
+
+        XCTAssertFalse(evaluation)
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Predicate evaluation on a model for a predicate with Enum value was not returning the correct result. For example, a predicate "not equals" to PostStatus.published (`Post.keys.status.eq(PostStatus.published)`) used to evaluate a model with status == published would evaluate to false when it should be true. Debugging the code looks like it was falling into the default case of return false. This PR adds the code necessary to extract the string value from the model correctly so that it can be compared to the predicate's value as a String comparison.

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
