### PR TITLE
fix(DataStore): Remove from snapshot when item no longer matches predicate

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Subscribe/DataStoreObserveQueryOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Subscribe/DataStoreObserveQueryOperationTests.swift
@@ -489,7 +489,7 @@ class DataStoreObserveQueryOperationTests: XCTestCase {
                 do {
                     let itemChange = try createPost(id: post.id)
                     let itemChange2 = try createPost()
-                    operation.onItemsChange(mutationEvents: [itemChange, itemChange2])
+                    operation.onItemsChangeDuringSync(mutationEvents: [itemChange, itemChange2])
                 } catch {
                     XCTFail("Failed to create post")
                 }
@@ -499,11 +499,82 @@ class DataStoreObserveQueryOperationTests: XCTestCase {
         sink.cancel()
     }
 
+    /// When a predicate like `title.beginsWith("title")` is given, the models that matched the predicate
+    /// should be added to the snapshots, like `post` and `post2`. When `post2.title` is updated to no longer
+    /// match the predicate, it should be removed from the snapshot.
+    func testUpdatedModelNoLongerMatchesPredicateRemovedFromSnapshot() throws {
+        let firstSnapshot = expectation(description: "first query snapshots")
+        let secondSnapshot = expectation(description: "second query snapshots")
+        let thirdSnapshot = expectation(description: "third query snapshots")
+        let fourthSnapshot = expectation(description: "fourth query snapshots")
+        var querySnapshots = [DataStoreQuerySnapshot<Post>]()
+        let operation = AWSDataStoreObserveQueryOperation(
+            modelType: Post.self,
+            modelSchema: Post.schema,
+            predicate: Post.keys.title.beginsWith("title"),
+            sortInput: QuerySortInput.ascending(Post.keys.id).asSortDescriptors(),
+            storageEngine: storageEngine,
+            dataStorePublisher: dataStorePublisher,
+            dataStoreConfiguration: .default,
+            dispatchedModelSyncedEvent: AtomicValue(initialValue: true))
+
+        let sink = operation.publisher.sink { completed in
+            switch completed {
+            case .finished:
+                break
+            case .failure(let error):
+                XCTFail("Failed with error \(error)")
+            }
+        } receiveValue: { querySnapshot in
+            querySnapshots.append(querySnapshot)
+            if querySnapshots.count == 1 {
+                firstSnapshot.fulfill()
+            } else if querySnapshots.count == 2 {
+                secondSnapshot.fulfill()
+            } else if querySnapshots.count == 3 {
+                thirdSnapshot.fulfill()
+            } else if querySnapshots.count == 4 {
+                fourthSnapshot.fulfill()
+            }
+        }
+        let queue = OperationQueue()
+        queue.addOperation(operation)
+
+        let post = try createPost(id: "1", title: "title 1")
+        dataStorePublisher.send(input: post)
+        let post2 = try createPost(id: "2", title: "title 2")
+        dataStorePublisher.send(input: post2)
+        var updatedPost2 = try createPost(id: "2", title: "Does not match predicate")
+        updatedPost2.mutationType = MutationEvent.MutationType.update.rawValue
+        dataStorePublisher.send(input: updatedPost2)
+        waitForExpectations(timeout: 1)
+
+        XCTAssertEqual(querySnapshots.count, 4)
+
+        // First snapshot is empty from the initial query
+        XCTAssertEqual(querySnapshots[0].items.count, 0)
+
+        // Second snapshot contains `post` since it matches the predicate
+        XCTAssertEqual(querySnapshots[1].items.count, 1)
+        XCTAssertEqual(querySnapshots[1].items[0].id, "1")
+
+        // Third snapshot contains both posts since they both match the predicate
+        XCTAssertEqual(querySnapshots[2].items.count, 2)
+        XCTAssertEqual(querySnapshots[2].items[0].id, "1")
+        XCTAssertEqual(querySnapshots[2].items[1].id, "2")
+
+        // Fourth snapshot no longer has the post2 since it was updated to not match the predicate
+        // and deleted at the same time.
+        XCTAssertEqual(querySnapshots[3].items.count, 1)
+        XCTAssertEqual(querySnapshots[3].items[0].id, "1")
+        sink.cancel()
+    }
+
     // MARK: - Helpers
 
-    func createPost(id: String = UUID().uuidString) throws -> MutationEvent {
+    func createPost(id: String = UUID().uuidString, title: String? = nil) throws -> MutationEvent {
         try MutationEvent(model: Post(id: id,
-                                      title: "model1",
+                                      title: title ?? "model1",
                                       content: "content1",
                                       createdAt: .now()),
                           modelSchema: Post.schema,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR addresses the issue where an item that is originally added to the snapshot (given a predicate with the observeQuery), won't get removed when it is updated to no longer match the predicate.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
