### PR TITLE
fix(datastore): fix owner based subscriptions queries w/ multiauth

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
@@ -30,9 +30,17 @@ public enum AuthRuleDecoratorInput {
 public struct AuthRuleDecorator: ModelBasedGraphQLDocumentDecorator {
 
     private let input: AuthRuleDecoratorInput
+    private let authType: AWSAuthorizationType?
 
-    public init(_ authRuleDecoratorInput: AuthRuleDecoratorInput) {
+
+    /// Initializes a new AuthRuleDecorator
+    /// - Parameters:
+    ///   - authRuleDecoratorInput: decorator input
+    ///   - authType: authentication type, if provided will be used to filter the auth rules based on the provider field
+    public init(_ authRuleDecoratorInput: AuthRuleDecoratorInput,
+                authType: AWSAuthorizationType? = nil) {
         self.input = authRuleDecoratorInput
+        self.authType = authType
     }
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
@@ -42,7 +50,7 @@ public struct AuthRuleDecorator: ModelBasedGraphQLDocumentDecorator {
 
     public func decorate(_ document: SingleDirectiveGraphQLDocument,
                          modelSchema: ModelSchema) -> SingleDirectiveGraphQLDocument {
-        let authRules = modelSchema.authRules
+        let authRules = modelSchema.authRules.filterBy(authType: authType)
         guard !authRules.isEmpty else {
             return document
         }
@@ -168,6 +176,21 @@ public struct AuthRuleDecorator: ModelBasedGraphQLDocumentDecorator {
         }
 
         return selectionSet
+    }
+}
+
+private extension AuthRules {
+    func filterBy(authType: AWSAuthorizationType?) -> AuthRules {
+        guard let authType = authType else {
+            return self
+        }
+
+        return filter {
+            guard let provider = $0.provider else {
+                return true
+            }
+            return authType == provider.toAWSAuthorizationType()
+        }
     }
 }
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
@@ -36,7 +36,8 @@ public struct AuthRuleDecorator: ModelBasedGraphQLDocumentDecorator {
     /// Initializes a new AuthRuleDecorator
     /// - Parameters:
     ///   - authRuleDecoratorInput: decorator input
-    ///   - authType: authentication type, if provided will be used to filter the auth rules based on the provider field
+    ///   - authType: authentication type, if provided will be used to filter the auth rules based on the provider field.
+    ///               Only use when multi-auth is enabled.
     public init(_ authRuleDecoratorInput: AuthRuleDecoratorInput,
                 authType: AWSAuthorizationType? = nil) {
         self.input = authRuleDecoratorInput

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/AuthRuleDecorator.swift
@@ -187,6 +187,9 @@ private extension AuthRules {
 
         return filter {
             guard let provider = $0.provider else {
+                // if an authType is available but not a provider
+                // means DataStore is using multi-auth with an outdated
+                // version of models (prior to codegen v2.26.0).
                 return true
             }
             return authType == provider.toAWSAuthorizationType()

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -65,7 +65,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
         documentBuilder.add(decorator: ModelIdDecorator(id: id))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
-        documentBuilder.add(decorator: AuthRuleDecorator(.query))
+        documentBuilder.add(decorator: AuthRuleDecorator(.query, authType: authType))
         let document = documentBuilder.build()
 
         let awsPluginOptions = AWSPluginOptions(authType: authType)
@@ -150,7 +150,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
             documentBuilder.add(decorator: FilterDecorator(filter: filter))
         }
         documentBuilder.add(decorator: ConflictResolutionDecorator(version: version))
-        documentBuilder.add(decorator: AuthRuleDecorator(.mutation))
+        documentBuilder.add(decorator: AuthRuleDecorator(.mutation, authType: authType))
         let document = documentBuilder.build()
 
         let awsPluginOptions = AWSPluginOptions(authType: authType)
@@ -171,7 +171,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                                                operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: subscriptionType))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
-        documentBuilder.add(decorator: AuthRuleDecorator(.subscription(subscriptionType, nil)))
+        documentBuilder.add(decorator: AuthRuleDecorator(.subscription(subscriptionType, nil), authType: authType))
         let document = documentBuilder.build()
 
         let awsPluginOptions = AWSPluginOptions(authType: authType)
@@ -193,7 +193,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                                                operationType: .subscription)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: subscriptionType))
         documentBuilder.add(decorator: ConflictResolutionDecorator())
-        documentBuilder.add(decorator: AuthRuleDecorator(.subscription(subscriptionType, claims)))
+        documentBuilder.add(decorator: AuthRuleDecorator(.subscription(subscriptionType, claims), authType: authType))
         let document = documentBuilder.build()
 
         let awsPluginOptions = AWSPluginOptions(authType: authType)
@@ -220,7 +220,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
         }
         documentBuilder.add(decorator: PaginationDecorator(limit: limit, nextToken: nextToken))
         documentBuilder.add(decorator: ConflictResolutionDecorator(lastSync: lastSync))
-        documentBuilder.add(decorator: AuthRuleDecorator(.query))
+        documentBuilder.add(decorator: AuthRuleDecorator(.query, authType: authType))
         let document = documentBuilder.build()
 
         let awsPluginOptions = AWSPluginOptions(authType: authType)
@@ -249,7 +249,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
             documentBuilder.add(decorator: FilterDecorator(filter: filter))
         }
         documentBuilder.add(decorator: ConflictResolutionDecorator(version: version))
-        documentBuilder.add(decorator: AuthRuleDecorator(.mutation))
+        documentBuilder.add(decorator: AuthRuleDecorator(.mutation, authType: authType))
         let document = documentBuilder.build()
 
         let awsPluginOptions = AWSPluginOptions(authType: authType)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerFieldAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerFieldAuthRuleTests.swift
@@ -333,9 +333,15 @@ public struct ModelWithOwnerField: Model {
 }
 
 /*
+ Example of model with multiple authorization rules,
+ and one of them doesn't require an `owner`.
+ 
  type ModelWithOwnerField
    @model
-   @auth(rules: [ { allow: owner, ownerField: "author" } ])
+   @auth(rules: [
+        { allow: owner, ownerField: "author" },
+        { allow: public, provider: "apiKey" }
+    ])
  {
    id: ID!
    content: String!


### PR DESCRIPTION
*Description of changes:*
This PR fixes an issue when multiple authentication rules with `allow: owner` can override each other.

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
