### PR TITLE
fix(API): Memory leak in GraphQLOperation

### DIFF
--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSAPIOperation+APIOperation.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSAPIOperation+APIOperation.swift
@@ -45,6 +45,8 @@ extension AWSRESTOperation: APIOperation {
             return
         }
 
+        mapper.removePair(for: self)
+
         let apiOperationResponse = APIOperationResponse(error: error, response: response)
         do {
             try apiOperationResponse.validate()

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLOperation+APIOperation.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSGraphQLOperation+APIOperation.swift
@@ -45,6 +45,8 @@ extension AWSGraphQLOperation: APIOperation {
             return
         }
 
+        mapper.removePair(for: self)
+
         let apiOperationResponse = APIOperationResponse(error: error, response: response)
         do {
             try apiOperationResponse.validate()

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/OperationTaskMapper.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/OperationTaskMapper.swift
@@ -74,6 +74,7 @@ class OperationTaskMapper {
 
     /// Not inherently thread safe--this must be called from `concurrencyQueue`
     private func removePair(operationId: UUID?, taskId: Int?) {
+        dispatchPrecondition(condition: .onQueue(Self.concurrencyQueue))
         if let operationId = operationId {
             operations[operationId] = nil
             taskIdsByOperationId[operationId] = nil

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/OperationTaskMapper.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/OperationTaskMapper.swift
@@ -74,15 +74,13 @@ class OperationTaskMapper {
 
     /// Not inherently thread safe--this must be called from `concurrencyQueue`
     private func removePair(operationId: UUID?, taskId: Int?) {
-        OperationTaskMapper.concurrencyQueue.sync {
-            if let operationId = operationId {
-                operations[operationId] = nil
-                taskIdsByOperationId[operationId] = nil
-            }
-            if let taskId = taskId {
-                tasks[taskId] = nil
-                operationIdsByTaskId[taskId] = nil
-            }
+        if let operationId = operationId {
+            operations[operationId] = nil
+            taskIdsByOperationId[operationId] = nil
+        }
+        if let taskId = taskId {
+            tasks[taskId] = nil
+            operationIdsByTaskId[taskId] = nil
         }
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSGraphQLOperationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSGraphQLOperationTests.swift
@@ -10,33 +10,32 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSAPICategoryPlugin
 
-class AWSGraphQLOperationTests: XCTestCase {
+@available(iOS 13.0, *)
+class AWSGraphQLOperationTests: AWSAPICategoryPluginTestBase {
 
-    // TODO: Complete the implementation below
+    /// Tests that upon completion, the operation is removed from the task mapper.
+    func testOperationCleanup() {
+        let request = GraphQLRequest(apiName: apiName,
+                                     document: testDocument,
+                                     variables: nil,
+                                     responseType: JSONValue.self)
 
-    //    override func setUp() {
-    //    }
-    //
-    //    override func tearDown() {
-    //    }
-    //
-    //    func testGraphQLOperationSuccess() {
-    //        XCTFail("Not yet implemented.")
-    //    }
-    //
-    //    func testGraphQLOperationValidationError() {
-    //        XCTFail("Not yet implemented.")
-    //    }
-    //
-    //    func testGraphQLOperationEndpointConfigurationError() {
-    //        XCTFail("Not yet implemented.")
-    //    }
-    //
-    //    func testGraphQLOperationJSONSerializationError() {
-    //        XCTFail("Not yet implemented.")
-    //    }
-    //
-    //    func testGraphQLOperationInterceptorError() {
-    //        XCTFail("Not yet implemented.")
-    //    }
+        let operation = apiPlugin.query(request: request, listener: nil)
+
+        guard let operation = operation as? AWSGraphQLOperation else {
+            XCTFail("Operation is not an AWSGraphQLOperation")
+            return
+        }
+
+        let receivedCompletion = expectation(description: "Received completion")
+        let sink = operation.resultPublisher.sink { _ in
+            receivedCompletion.fulfill()
+        } receiveValue: { _ in }
+        defer { sink.cancel() }
+
+        wait(for: [receivedCompletion], timeout: 1)
+        let task = operation.mapper.task(for: operation)
+        XCTAssertNil(task)
+    }
+
 }


### PR DESCRIPTION
*Issue #, if available:*
- `GraphQLOperation` is being retained by `OperationTaskMapper` causing memory leakage for large sync operations

*Description of changes:*
- Remove `GraphQLOperation` from `OperationTaskMapper` upon completion

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
