### PR TITLE
chore: add missing doc comment to Auth signOut API

### DIFF
--- a/Amplify/Categories/Auth/AuthCategoryBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategoryBehavior.swift
@@ -114,6 +114,12 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
                        options: AuthConfirmSignInOperation.Request.Options?,
                        listener: AuthConfirmSignInOperation.ResultListener?) -> AuthConfirmSignInOperation
 
+    /// Sign out the currently logged-in user.
+    ///
+    /// - Parameters:
+    ///   - options: Parameters specific to plugin behavior.
+    ///   - listener: Triggered when the operation completes.
+    /// - Returns: AuthSignOutOperation
     @discardableResult
     func signOut(options: AuthSignOutOperation.Request.Options?,
                  listener: AuthSignOutOperation.ResultListener?) -> AuthSignOutOperation


### PR DESCRIPTION
*Description of changes:*
add missing doc comment to Auth signOut API

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- ~~[ ] Documentation update for the change if required~~
- ~~[ ] PR title conforms to conventional commit style~~
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
