### PR TITLE
test(DataStore): Update schemas for use 'sub' as default identity claim feature

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/DefaultAuthCognito/Models/TodoCustomOwnerExplicit+Schema.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/DefaultAuthCognito/Models/TodoCustomOwnerExplicit+Schema.swift
@@ -26,7 +26,7 @@ extension TodoCustomOwnerExplicit {
     let todoCustomOwnerExplicit = TodoCustomOwnerExplicit.keys
 
     model.authRules = [
-      rule(allow: .owner, ownerField: "dominus", identityClaim: "cognito:username", operations: [.create, .update, .delete, .read])
+      rule(allow: .owner, ownerField: "dominus", identityClaim: "sub", provider: .userPools, operations: [.create, .update, .delete, .read])
     ]
 
     model.pluralName = "TodoCustomOwnerExplicits"

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/DefaultAuthCognito/Models/TodoCustomOwnerImplicit+Schema.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/DefaultAuthCognito/Models/TodoCustomOwnerImplicit+Schema.swift
@@ -25,7 +25,7 @@ extension TodoCustomOwnerImplicit {
     let todoCustomOwnerImplicit = TodoCustomOwnerImplicit.keys
 
     model.authRules = [
-      rule(allow: .owner, ownerField: "dominus", identityClaim: "cognito:username", operations: [.create, .update, .delete, .read])
+      rule(allow: .owner, ownerField: "dominus", identityClaim: "sub", provider: .userPools, operations: [.create, .update, .delete, .read])
     ]
 
     model.pluralName = "TodoCustomOwnerImplicits"

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/DefaultAuthCognito/Models/TodoExplicitOwnerField+Schema.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/DefaultAuthCognito/Models/TodoExplicitOwnerField+Schema.swift
@@ -26,7 +26,7 @@ extension TodoExplicitOwnerField {
     let todoExplicitOwnerField = TodoExplicitOwnerField.keys
 
     model.authRules = [
-      rule(allow: .owner, ownerField: "owner", identityClaim: "cognito:username", operations: [.create, .update, .delete])
+      rule(allow: .owner, ownerField: "owner", identityClaim: "sub", provider: .userPools, operations: [.create, .update, .delete])
     ]
 
     model.pluralName = "TodoExplicitOwnerFields"

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/DefaultAuthCognito/Models/TodoImplicitOwnerField+Schema.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/DefaultAuthCognito/Models/TodoImplicitOwnerField+Schema.swift
@@ -25,7 +25,7 @@ extension TodoImplicitOwnerField {
     let todoImplicitOwnerField = TodoImplicitOwnerField.keys
 
     model.authRules = [
-      rule(allow: .owner, ownerField: "owner", identityClaim: "cognito:username", operations: [.create, .update, .delete, .read])
+      rule(allow: .owner, ownerField: "owner", identityClaim: "sub", provider: .userPools, operations: [.create, .update, .delete, .read])
     ]
 
     model.pluralName = "TodoImplicitOwnerFields"

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/DefaultAuthCognito/README.md
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/DefaultAuthCognito/README.md
@@ -5,7 +5,10 @@ This configuration is used to run the tests in `AWSDataStoreCategoryPluginAuthIn
 
 ### Set-up
 
-1. `amplify init`
+1. `amplify init`. Make sure your amplify CLI version produces ClI.json containing
+```
+"usesubfordefaultidentityclaim": true
+```
 
 2. `amplify add api`
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/MultiAuth/Models/OwnerPrivatePublicUPIAMAPIPost+Schema.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/MultiAuth/Models/OwnerPrivatePublicUPIAMAPIPost+Schema.swift
@@ -25,7 +25,7 @@ extension OwnerPrivatePublicUPIAMAPIPost {
     let ownerPrivatePublicUPIAMAPIPost = OwnerPrivatePublicUPIAMAPIPost.keys
 
     model.authRules = [
-      rule(allow: .owner, ownerField: "owner", identityClaim: "cognito:username", provider: .userPools, operations: [.create, .update, .delete, .read]),
+      rule(allow: .owner, ownerField: "owner", identityClaim: "sub", provider: .userPools, operations: [.create, .update, .delete, .read]),
       rule(allow: .private, provider: .iam, operations: [.create, .update, .delete, .read]),
       rule(allow: .public, provider: .apiKey, operations: [.create, .update, .delete, .read])
     ]

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/MultiAuth/Models/OwnerPrivateUPIAMPost+Schema.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/MultiAuth/Models/OwnerPrivateUPIAMPost+Schema.swift
@@ -25,7 +25,7 @@ extension OwnerPrivateUPIAMPost {
     let ownerPrivateUPIAMPost = OwnerPrivateUPIAMPost.keys
 
     model.authRules = [
-      rule(allow: .owner, ownerField: "owner", identityClaim: "cognito:username", provider: .userPools, operations: [.create, .update, .delete, .read]),
+      rule(allow: .owner, ownerField: "owner", identityClaim: "sub", provider: .userPools, operations: [.create, .update, .delete, .read]),
       rule(allow: .private, provider: .iam, operations: [.create, .update, .delete, .read])
     ]
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/MultiAuth/Models/OwnerPublicUPAPIPost+Schema.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/MultiAuth/Models/OwnerPublicUPAPIPost+Schema.swift
@@ -25,7 +25,7 @@ extension OwnerPublicUPAPIPost {
     let ownerPublicUPAPIPost = OwnerPublicUPAPIPost.keys
 
     model.authRules = [
-      rule(allow: .owner, ownerField: "owner", identityClaim: "cognito:username", provider: .userPools, operations: [.create, .update, .delete, .read]),
+      rule(allow: .owner, ownerField: "owner", identityClaim: "sub", provider: .userPools, operations: [.create, .update, .delete, .read]),
       rule(allow: .public, provider: .apiKey, operations: [.create, .update, .delete, .read])
     ]
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/MultiAuth/Models/OwnerPublicUPIAMPost+Schema.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/MultiAuth/Models/OwnerPublicUPIAMPost+Schema.swift
@@ -25,7 +25,7 @@ extension OwnerPublicUPIAMPost {
     let ownerPublicUPIAMPost = OwnerPublicUPIAMPost.keys
 
     model.authRules = [
-      rule(allow: .owner, ownerField: "owner", identityClaim: "cognito:username", provider: .userPools, operations: [.create, .update, .delete, .read]),
+      rule(allow: .owner, ownerField: "owner", identityClaim: "sub", provider: .userPools, operations: [.create, .update, .delete, .read]),
       rule(allow: .public, provider: .iam, operations: [.create, .update, .delete, .read])
     ]
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/MultiAuth/Models/OwnerUPPost+Schema.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/MultiAuth/Models/OwnerUPPost+Schema.swift
@@ -25,7 +25,7 @@ extension OwnerUPPost {
     let ownerUPPost = OwnerUPPost.keys
 
     model.authRules = [
-      rule(allow: .owner, ownerField: "owner", identityClaim: "cognito:username", provider: .userPools, operations: [.create, .update, .delete, .read])
+      rule(allow: .owner, ownerField: "owner", identityClaim: "sub", provider: .userPools, operations: [.create, .update, .delete, .read])
     ]
 
     model.listPluralName = "OwnerUPPosts"

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/MultiAuth/Models/PrivatePublicComboUPPost+Schema.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/MultiAuth/Models/PrivatePublicComboUPPost+Schema.swift
@@ -25,7 +25,7 @@ extension PrivatePublicComboUPPost {
     let privatePublicComboUPPost = PrivatePublicComboUPPost.keys
 
     model.authRules = [
-      rule(allow: .owner, ownerField: "owner", identityClaim: "cognito:username", provider: .userPools, operations: [.create, .update, .delete, .read])
+      rule(allow: .owner, ownerField: "owner", identityClaim: "sub", provider: .userPools, operations: [.create, .update, .delete, .read])
     ]
 
     model.listPluralName = "PrivatePublicComboUPPosts"

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/MultiAuth/README.md
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/MultiAuth/README.md
@@ -7,7 +7,10 @@
 
 1. create a `schema.graphql` file with the content of  `MultiAuth/schema.graphql`
 
-2. `amplify init`
+2. `amplify init`. Make sure your amplify CLI version produces ClI.json containing
+```
+"usesubfordefaultidentityclaim": true
+```
 
 3. `amplify add api` (when asked, provide **"datastoreintegtestmu"** as API name)
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The change in CLI tagged release `@aws-amplify/cli@7.6.8-sub-identity-claim.1` will provision backends and codegen the default identity claim as "subs", previously "cognito:username".

This PR is running automated tests related to the usage of `@auth` with default owner field in the schema.

The code generated model files contains the explicit identityClaim key, which has been updated from "cognito:username" to "subs" (see model schema file changes in this PR). 

Tests that were in place with regards to these schemas were tested.

There is one failing test related to `TodoExplicitOwnerField`. [TBD CLI issue]



*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
