### PR TITLE
fix(auth): handle deleted account when fetching signed in session

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedInSession.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedInSession.swift
@@ -59,7 +59,6 @@ extension AuthorizationProviderAdapter {
                                                   completionHandler)
                     }
                 } else if (error as NSError?)?.userInfo["__type"] as? String == "UserNotFoundException" {
-                    print("boom")
                     self.awsMobileClient.signOutLocally()
                     self.fetchSignedOutSession(completionHandler)
                 } else {

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedInSession.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedInSession.swift
@@ -61,6 +61,7 @@ extension AuthorizationProviderAdapter {
                 } else if (error as NSError?)?.userInfo["__type"] as? String == "UserNotFoundException" {
                     self.awsMobileClient.signOutLocally()
                     self.fetchSignedOutSession(completionHandler)
+                    Amplify.Hub.dispatch(to: .auth, payload: HubPayload(eventName: HubPayload.EventName.Auth.signedOut))
                 } else {
                     self.fetchSignedInSession(withError: AuthErrorHelper.toAuthError(error!), completionHandler)
                 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedInSession.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthorizationProviderAdapter+SignedInSession.swift
@@ -58,6 +58,10 @@ extension AuthorizationProviderAdapter {
                         self.fetchSignedInSession(withError: AuthErrorHelper.toAuthError(error!),
                                                   completionHandler)
                     }
+                } else if (error as NSError?)?.userInfo["__type"] as? String == "UserNotFoundException" {
+                    print("boom")
+                    self.awsMobileClient.signOutLocally()
+                    self.fetchSignedOutSession(completionHandler)
                 } else {
                     self.fetchSignedInSession(withError: AuthErrorHelper.toAuthError(error!), completionHandler)
                 }


### PR DESCRIPTION
*Description of changes:*
When fetching a session for a user account that is signed in, but has been deleted, perform the following actions:

1. Sign out locally
2. Emit signedOut hub event
3. Return a signed out session

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
