### PR TITLE
feat(API): Set AppSyncRTClient log level from Amplify log level

### DIFF
--- a/AmplifyPlugins.podspec
+++ b/AmplifyPlugins.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'AWSAPIPlugin' do |ss|
     ss.source_files = 'AmplifyPlugins/API/AWSAPICategoryPlugin/**/*.swift'
-    ss.dependency 'AppSyncRealTimeClient', "~> 1.4"
+    ss.dependency 'AppSyncRealTimeClient', "~> 1.8"
   end
 
   s.subspec 'AWSCognitoAuthPlugin' do |ss|

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Configure.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Configure.swift
@@ -7,6 +7,7 @@
 
 import Amplify
 import AWSPluginsCore
+import AppSyncRealTimeClient
 
 public extension AWSAPIPlugin {
 
@@ -49,12 +50,14 @@ extension AWSAPIPlugin {
         let authService: AWSAuthServiceBehavior
         let pluginConfig: AWSAPICategoryPluginConfiguration
         let subscriptionConnectionFactory: SubscriptionConnectionFactory
+        let logLevel: LogLevel
 
         init(
             configurationValues: JSONValue,
             apiAuthProviderFactory: APIAuthProviderFactory,
             authService: AWSAuthServiceBehavior? = nil,
-            subscriptionConnectionFactory: SubscriptionConnectionFactory? = nil
+            subscriptionConnectionFactory: SubscriptionConnectionFactory? = nil,
+            logLevel: LogLevel? = nil
         ) throws {
             let authService = authService
                 ?? AWSAuthService()
@@ -68,21 +71,26 @@ extension AWSAPIPlugin {
             let subscriptionConnectionFactory = subscriptionConnectionFactory
                 ?? AWSSubscriptionConnectionFactory()
 
+            let logLevel = logLevel ?? Amplify.Logging.logLevel
+
             self.init(
                 pluginConfig: pluginConfig,
                 authService: authService,
-                subscriptionConnectionFactory: subscriptionConnectionFactory
+                subscriptionConnectionFactory: subscriptionConnectionFactory,
+                logLevel: logLevel
             )
         }
 
         init(
             pluginConfig: AWSAPICategoryPluginConfiguration,
             authService: AWSAuthServiceBehavior,
-            subscriptionConnectionFactory: SubscriptionConnectionFactory
+            subscriptionConnectionFactory: SubscriptionConnectionFactory,
+            logLevel: LogLevel
         ) {
             self.pluginConfig = pluginConfig
             self.authService = authService
             self.subscriptionConnectionFactory = subscriptionConnectionFactory
+            self.logLevel = logLevel
         }
 
     }
@@ -97,6 +105,7 @@ extension AWSAPIPlugin {
         authService = dependencies.authService
         pluginConfig = dependencies.pluginConfig
         subscriptionConnectionFactory = dependencies.subscriptionConnectionFactory
+        AppSyncRealTimeClient.logLevel = AppSyncRealTimeClient.LogLevel(
+            rawValue: dependencies.logLevel.rawValue) ?? .error
     }
-
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Log.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Log.swift
@@ -6,6 +6,7 @@
 //
 
 import Amplify
+import AppSyncRealTimeClient
 
 extension AWSAPIPlugin {
     var log: Logger {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLModelBasedTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLModelBasedTests.swift
@@ -18,6 +18,7 @@ class GraphQLModelBasedTests: XCTestCase {
 
     override func setUp() {
         Amplify.reset()
+        Amplify.Logging.logLevel = .verbose
         let plugin = AWSAPIPlugin(modelRegistration: PostCommentModelRegistration())
 
         do {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ReachabilityTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ReachabilityTests.swift
@@ -37,7 +37,8 @@ class AWSAPICategoryPluginReachabilityTests: XCTestCase {
             let dependencies = AWSAPIPlugin.ConfigurationDependencies(
                 pluginConfig: pluginConfig,
                 authService: MockAWSAuthService(),
-                subscriptionConnectionFactory: AWSSubscriptionConnectionFactory()
+                subscriptionConnectionFactory: AWSSubscriptionConnectionFactory(),
+                logLevel: .error
             )
             apiPlugin.configure(using: dependencies)
         } catch {
@@ -64,7 +65,8 @@ class AWSAPICategoryPluginReachabilityTests: XCTestCase {
             let dependencies = AWSAPIPlugin.ConfigurationDependencies(
                 pluginConfig: pluginConfig,
                 authService: MockAWSAuthService(),
-                subscriptionConnectionFactory: AWSSubscriptionConnectionFactory()
+                subscriptionConnectionFactory: AWSSubscriptionConnectionFactory(),
+                logLevel: .error
             )
             apiPlugin.configure(using: dependencies)
         } catch {
@@ -91,7 +93,8 @@ class AWSAPICategoryPluginReachabilityTests: XCTestCase {
             let dependencies = AWSAPIPlugin.ConfigurationDependencies(
                 pluginConfig: pluginConfig,
                 authService: MockAWSAuthService(),
-                subscriptionConnectionFactory: AWSSubscriptionConnectionFactory()
+                subscriptionConnectionFactory: AWSSubscriptionConnectionFactory(),
+                logLevel: .error
             )
             apiPlugin.configure(using: dependencies)
         } catch {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPluginTestBase.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPluginTestBase.swift
@@ -54,7 +54,8 @@ class AWSAPICategoryPluginTestBase: XCTestCase {
             let dependencies = AWSAPIPlugin.ConfigurationDependencies(
                 pluginConfig: pluginConfig,
                 authService: authService,
-                subscriptionConnectionFactory: AWSSubscriptionConnectionFactory()
+                subscriptionConnectionFactory: AWSSubscriptionConnectionFactory(),
+                logLevel: .error
             )
             apiPlugin.configure(using: dependencies)
         } catch {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
@@ -49,7 +49,8 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
             let dependencies = AWSAPIPlugin.ConfigurationDependencies(
                 pluginConfig: pluginConfig,
                 authService: authService,
-                subscriptionConnectionFactory: subscriptionConnectionFactory
+                subscriptionConnectionFactory: subscriptionConnectionFactory,
+                logLevel: .error
             )
             apiPlugin.configure(using: dependencies)
         } catch {

--- a/AmplifyPlugins/API/Podfile
+++ b/AmplifyPlugins/API/Podfile
@@ -8,7 +8,7 @@ include_build_tools!
 target 'AWSAPICategoryPlugin' do
 	pod 'Amplify', :path => '../../'
   pod 'AWSPluginsCore', :path => '../../'
-  pod "AppSyncRealTimeClient", "~> 1.4"
+  pod "AppSyncRealTimeClient", "~> 1.8"
 
   target "AWSAPICategoryPluginTests" do
     inherit! :complete

--- a/AmplifyPlugins/API/Podfile.lock
+++ b/AmplifyPlugins/API/Podfile.lock
@@ -19,8 +19,8 @@ PODS:
     - AWSMobileClient (~> 2.27.0)
     - AWSPluginsCore (= 1.19.2)
     - CwlPreconditionTesting (~> 2.0)
-  - AppSyncRealTimeClient (1.6.0):
-    - Starscream (~> 3.1.1)
+  - AppSyncRealTimeClient (1.8.0):
+    - Starscream (~> 4.0.4)
   - AWSAuthCore (2.27.1):
     - AWSCore (= 2.27.1)
   - AWSCognitoIdentityProvider (2.27.1):
@@ -46,7 +46,7 @@ PODS:
     - CwlCatchException (~> 2.1.1)
     - CwlMachBadInstructionHandler (~> 2.1.0)
     - CwlPosixPreconditionTesting (~> 2.1.0)
-  - Starscream (3.1.1)
+  - Starscream (4.0.4)
   - SwiftFormat/CLI (0.44.17)
   - SwiftLint (0.46.2)
 
@@ -54,7 +54,7 @@ DEPENDENCIES:
   - Amplify (from `../../`)
   - AmplifyPlugins/AWSCognitoAuthPlugin (from `../../`)
   - AmplifyTestCommon (from `../../`)
-  - AppSyncRealTimeClient (~> 1.4)
+  - AppSyncRealTimeClient (~> 1.8)
   - AWSPluginsCore (from `../../`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `2.1.0`)
   - SwiftFormat/CLI (= 0.44.17)
@@ -96,9 +96,9 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Amplify: cc3adcea085108a52bc3bb8273e5b38034593127
-  AmplifyPlugins: 4b24b838046785cf89d733a579a5c2ce56907c8c
+  AmplifyPlugins: 99bdbfd5d4816ae0d93f9ef04705db1843d7ef47
   AmplifyTestCommon: a4697828d0070451c45d0855857178601396fb68
-  AppSyncRealTimeClient: 8b5ec94085b8ee9bb6fb9d9d76a157beb538ec6f
+  AppSyncRealTimeClient: 463678f3a459c6e77851ca8e23dd7e0108bfb717
   AWSAuthCore: 9528c60ccdac6df6024fb0af1ed6a43782fd2d3d
   AWSCognitoIdentityProvider: 4de7f96340be72c1dca35c0ba835c6b9b69a28c0
   AWSCognitoIdentityProviderASF: 727f7c1c80d667a2da79e408c8c8745eac981d58
@@ -110,10 +110,10 @@ SPEC CHECKSUMS:
   CwlMachBadInstructionHandler: aa1fe9f2d08b29507c150d099434b2890247e7f8
   CwlPosixPreconditionTesting: 1ba4471964405941f79b3f06bbcf3c2be782950c
   CwlPreconditionTesting: 73ae5de517a8761e5e40fb4136c6a26365af0440
-  Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
+  Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 6bc52a21f0fd44cab9aa2dc8e534fb9f5e3ec507
 
-PODFILE CHECKSUM: 0abaf757d71567dcf70f5a3e79b0149917c3bb38
+PODFILE CHECKSUM: 54e87158e45936fe60756d4a417b89eb64ea1c51
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2

--- a/AmplifyPlugins/DataStore/Podfile.lock
+++ b/AmplifyPlugins/DataStore/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - Amplify/Default (= 1.19.2)
   - Amplify/Default (1.19.2)
   - AmplifyPlugins/AWSAPIPlugin (1.19.2):
-    - AppSyncRealTimeClient (~> 1.4)
+    - AppSyncRealTimeClient (~> 1.8)
     - AWSCore (~> 2.27.0)
     - AWSPluginsCore (= 1.19.2)
   - AmplifyPlugins/AWSCognitoAuthPlugin (1.19.2):
@@ -23,8 +23,8 @@ PODS:
     - AWSMobileClient (~> 2.27.0)
     - AWSPluginsCore (= 1.19.2)
     - CwlPreconditionTesting (~> 2.0)
-  - AppSyncRealTimeClient (1.6.0):
-    - Starscream (~> 3.1.1)
+  - AppSyncRealTimeClient (1.8.0):
+    - Starscream (~> 4.0.4)
   - AWSAuthCore (2.27.1):
     - AWSCore (= 2.27.1)
   - AWSCognitoIdentityProvider (2.27.1):
@@ -53,7 +53,7 @@ PODS:
   - SQLite.swift (0.12.2):
     - SQLite.swift/standard (= 0.12.2)
   - SQLite.swift/standard (0.12.2)
-  - Starscream (3.1.1)
+  - Starscream (4.0.4)
   - SwiftFormat/CLI (0.44.17)
   - SwiftLint (0.46.2)
 
@@ -106,9 +106,9 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Amplify: cc3adcea085108a52bc3bb8273e5b38034593127
-  AmplifyPlugins: 4b24b838046785cf89d733a579a5c2ce56907c8c
+  AmplifyPlugins: 99bdbfd5d4816ae0d93f9ef04705db1843d7ef47
   AmplifyTestCommon: a4697828d0070451c45d0855857178601396fb68
-  AppSyncRealTimeClient: 8b5ec94085b8ee9bb6fb9d9d76a157beb538ec6f
+  AppSyncRealTimeClient: 463678f3a459c6e77851ca8e23dd7e0108bfb717
   AWSAuthCore: 9528c60ccdac6df6024fb0af1ed6a43782fd2d3d
   AWSCognitoIdentityProvider: 4de7f96340be72c1dca35c0ba835c6b9b69a28c0
   AWSCognitoIdentityProviderASF: 727f7c1c80d667a2da79e408c8c8745eac981d58
@@ -121,10 +121,10 @@ SPEC CHECKSUMS:
   CwlPosixPreconditionTesting: 1ba4471964405941f79b3f06bbcf3c2be782950c
   CwlPreconditionTesting: 73ae5de517a8761e5e40fb4136c6a26365af0440
   SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
-  Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
+  Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 6bc52a21f0fd44cab9aa2dc8e534fb9f5e3ec507
 
 PODFILE CHECKSUM: 78ccedd30ee5c56d82712b227290345e458bf378
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
         "state": {
           "branch": null,
-          "revision": "73b042998cf91ff3c8f335ca935b504881473a61",
-          "version": "1.6.0"
+          "revision": "1932e1d6289e9f0c9656cefe6218d5097720bf3f",
+          "version": "1.8.0"
         }
       },
       {
@@ -33,17 +33,8 @@
         "repositoryURL": "https://github.com/daltoniam/Starscream",
         "state": {
           "branch": null,
-          "revision": "e6b65c6d9077ea48b4a7bdda8994a1d3c6969c8d",
-          "version": "3.1.1"
-        }
-      },
-      {
-        "package": "swift-nio-zlib-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
-        "state": {
-          "branch": null,
-          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
-          "version": "1.0.0"
+          "revision": "df8d82047f6654d8e4b655d1b1525c64e1059d21",
+          "version": "4.0.4"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "AWSiOSSDKV2", url: "https://github.com/aws-amplify/aws-sdk-ios-spm.git", .upToNextMinor(from: "2.27.0")),
-        .package(name: "AppSyncRealTimeClient", url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git", from: "1.4.3"),
+        .package(name: "AppSyncRealTimeClient", url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git", from: "1.8.0"),
         .package(url: "https://github.com/stephencelis/SQLite.swift.git", .exact("0.12.2"))
     ],
     targets: [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Sets AppSyncRealTimeClient's log level based on Amplify.Logging.logLevel at config time

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
