### PR TITLE
feat(auth): handle errors returned from Social Sign In sessions

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -260,8 +260,24 @@ extension AuthenticationProviderAdapter {
                 break
             }
         }
+        if self.isErrorCausedByBadRequest(error) {
+            let errorDescription = error._userInfo?["error"]?
+                .description.trimmingCharacters(in: .whitespaces) ?? "unknown error"
+            return AuthError.service(errorDescription,
+                                     AuthPluginErrorConstants.hostedUIBadRequestError,
+                                     error)
+        }
         let authError = AuthErrorHelper.toAuthError(error)
         return authError
+    }
+    
+    private func isErrorCausedByBadRequest(_ error: Error?) -> Bool {
+        if let cognitoAuthError = error as NSError?,
+               cognitoAuthError.domain == AWSCognitoAuthErrorDomain,
+               cognitoAuthError.code == AWSCognitoAuthClientErrorType.errorBadRequest.rawValue {
+            return true
+        }
+        return false
     }
 
     private class ModalPresentingNavigationController: UINavigationController {


### PR DESCRIPTION
*Issue #:* [1617](https://github.com/aws-amplify/amplify-ios/issues/1617)

*Description of changes:*
fix(auth): handle errors returned from Social SignIn sessions

Lambda errors, along with other error types, are returned from Social SignIn sessions as "invalid request" errors.  Currently all these errors are being returned as "unknown error".  This change will wrap these errors in a service error and return them with the appropriate error description.

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
