### PR TITLE
Initialize AuthSignUpRequest.Options with a Dictionary Literal

### DIFF
--- a/Amplify/Categories/Auth/Request/AuthSignUpRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthSignUpRequest.swift
@@ -45,3 +45,16 @@ public extension AuthSignUpRequest {
         }
     }
 }
+
+extension AuthSignUpRequest.Options: ExpressibleByDictionaryLiteral {
+    /// Intitializes a AuthSignUpRequest.Options object from a dictionary literal
+    ///
+    /// Example:
+    /// ```
+    /// let options = [.givenName: firstName, .familyName: lastName]
+    /// ```
+    public init(dictionaryLiteral elements: (AuthUserAttributeKey, String)...) {
+        let userAttributes = elements.map { AuthUserAttribute($0.0, value: $0.1) }
+        self.init(userAttributes: userAttributes)
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add the option to instantiate a AuthSignUpRequest.Options object from a dictionary to vastly simplify working with the `Amplify.Auth.signUp` function. 

Turns this:

```swift
let userAttributes = [
      AuthUserAttribute(.givenName, value: firstName),
      AuthUserAttribute(.familyName, value: lastName)
]
let options = AuthSignUpRequest.Options(userAttributes: userAttributes)
Amplify.Auth.signUp(username: email, password: password, options: options)
```

Into this: 

```swift
Amplify.Auth.signUp(username: email, password: password, options: [.givenName: firstName, .familyName: lastName])
```

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
