### PR TITLE
fix(DataStore): ObserveQuery InitialQuery empty modelIds set

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStoreObserveQueryOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStoreObserveQueryOperation.swift
@@ -195,7 +195,7 @@ public class AWSDataStoreObserveQueryOperation<M: Model>: AsynchronousOperation,
                 self.observeQueryStarted = false
             }
             self.log.verbose("Resetting state")
-            self.currentItems.sortedModels.removeAll()
+            self.currentItems.reset()
             self.itemsChangedSink = nil
             self.batchItemsChangedSink = nil
         }
@@ -249,7 +249,7 @@ public class AWSDataStoreObserveQueryOperation<M: Model>: AsynchronousOperation,
 
                 switch queryResult {
                 case .success(let queriedModels):
-                    currentItems.sortedModels = queriedModels
+                    currentItems.set(sortedModels: queriedModels)
                     sendSnapshot()
                 case .failure(let error):
                     self.passthroughPublisher.send(completion: .failure(error))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Subscribe/Support/SortedListTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Subscribe/Support/SortedListTests.swift
@@ -16,6 +16,24 @@ import Combine
 
 class SortedListTests: XCTestCase {
 
+    func testSortedListSetAndReset() {
+        let posts = [createPost(id: "1", rating: 5.0),
+                     createPost(id: "2", rating: 5.0),
+                     createPost(id: "3", rating: 5.0),
+                     createPost(id: "4", rating: 5.0)]
+
+        let list = SortedList<Post>(sortInput: [QuerySortBy.ascending(Post.keys.rating).sortDescriptor],
+                                    modelSchema: Post.schema)
+        list.set(sortedModels: posts)
+
+        assertPosts(list.sortedModels, expectedIds: ["1", "2", "3", "4"])
+        XCTAssertEqual(list.modelIds.count, 4)
+
+        list.reset()
+        XCTAssertTrue(list.sortedModels.isEmpty)
+        XCTAssertTrue(list.modelIds.isEmpty)
+    }
+
     func testSortedListSingleSort() {
         let posts = [createPost(id: "1"),
                      createPost(id: "2"),
@@ -24,15 +42,18 @@ class SortedListTests: XCTestCase {
         let sortInput = [QuerySortBy.ascending(Post.keys.id).sortDescriptor]
         let list = SortedList<Post>(sortInput: sortInput,
                                     modelSchema: Post.schema)
-        list.sortedModels = posts
+
+        list.set(sortedModels: posts)
 
         // insert into the middle of the sorted list
         list.add(model: createPost(id: "3"), sortInputs: sortInput)
         assertPosts(list.sortedModels, expectedIds: ["1", "2", "3", "5", "6"])
+        XCTAssertEqual(list.modelIds.count, 5)
 
         // insert into the middle
         list.add(model: createPost(id: "4"), sortInputs: sortInput)
         assertPosts(list.sortedModels, expectedIds: ["1", "2", "3", "4", "5", "6"])
+        XCTAssertEqual(list.modelIds.count, 6)
 
         // insert at the beginning
         list.add(model: createPost(id: "0"), sortInputs: sortInput)
@@ -68,7 +89,7 @@ class SortedListTests: XCTestCase {
                          QuerySortBy.ascending(Post.keys.id).sortDescriptor]
         let list = SortedList<Post>(sortInput: sortInput,
                                     modelSchema: Post.schema)
-        list.sortedModels = posts
+        list.set(sortedModels: posts)
 
         // After id: "1", rating: 5.0
         list.add(model: createPost(id: "1", rating: 10.0), sortInputs: sortInput)
@@ -107,7 +128,7 @@ class SortedListTests: XCTestCase {
         let sortInput = [QuerySortBy.ascending(Post.keys.rating).sortDescriptor]
         let list = SortedList<Post>(sortInput: [QuerySortBy.ascending(Post.keys.rating).sortDescriptor],
                                     modelSchema: Post.schema)
-        list.sortedModels = posts
+        list.set(sortedModels: posts)
 
         // Since this is a binary search, the first index where the predicate returns `nil` is the middle index
         list.add(model: createPost(id: "5", rating: 5.0), sortInputs: sortInput)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-ios/issues/1627

*Description of changes:*

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
