### PR TITLE
fix(DataStore): add logging with model name for failed subscription request

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -45,6 +45,8 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
 
     private let consistencyQueue: DispatchQueue
 
+    private let modelName: ModelName
+
     init(modelSchema: ModelSchema,
          api: APICategoryGraphQLBehavior,
          modelPredicate: QueryPredicate?,
@@ -57,6 +59,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
         self.consistencyQueue = DispatchQueue(
             label: "com.amazonaws.Amplify.RemoteSyncEngine.\(modelSchema.name)"
         )
+        self.modelName = modelSchema.name
 
         self.connectionStatusQueue = OperationQueue()
         connectionStatusQueue.name
@@ -185,6 +188,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
         case .success:
             incomingSubscriptionEvents.send(completion: .finished)
         case .failure(let apiError):
+            log.verbose("API Subscription failed for model `\(modelName)` with error: \(apiError.errorDescription)")
             let dataStoreError = DataStoreError(error: apiError)
             incomingSubscriptionEvents.send(completion: .failure(dataStoreError))
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add additional logging around which model failed the subscription request.

```
API Subscription failed for model `User5` with error: Subscription item event failed with error
```

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
