### PR TITLE
fix(DataStore): FatalError accessing SQLite connection

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Migration/MutationSyncMetadataMigrationDelegate+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Migration/MutationSyncMetadataMigrationDelegate+SQLite.swift
@@ -47,8 +47,8 @@ final class SQLiteMutationSyncMetadataMigrationDelegate: MutationSyncMetadataMig
 
     @discardableResult func emptyMutationSyncMetadataStore() throws -> String {
         guard let storageAdapter = storageAdapter else {
-            log.debug("Missing SQLiteStorageEngineAdapter")
-            throw DataStoreError.unknown("Missing storage adapter for model migration", "", nil)
+            log.debug("Missing SQLiteStorageEngineAdapter for model migration")
+            throw DataStoreError.nilStorageAdapter()
         }
 
         return try storageAdapter.emptyStore(for: MutationSyncMetadata.schema)
@@ -56,8 +56,8 @@ final class SQLiteMutationSyncMetadataMigrationDelegate: MutationSyncMetadataMig
 
     @discardableResult func emptyModelSyncMetadataStore() throws -> String {
         guard let storageAdapter = storageAdapter else {
-            log.debug("Missing SQLiteStorageEngineAdapter")
-            throw DataStoreError.unknown("Missing storage adapter for model migration", "", nil)
+            log.debug("Missing SQLiteStorageEngineAdapter for model migration")
+            throw DataStoreError.nilStorageAdapter()
         }
 
         return try storageAdapter.emptyStore(for: ModelSyncMetadata.schema)
@@ -67,8 +67,8 @@ final class SQLiteMutationSyncMetadataMigrationDelegate: MutationSyncMetadataMig
 
     @discardableResult func removeMutationSyncMetadataCopyStore() throws -> String {
         guard let storageAdapter = storageAdapter else {
-            log.debug("Missing SQLiteStorageEngineAdapter")
-            throw DataStoreError.unknown("Missing storage adapter for model migration", "", nil)
+            log.debug("Missing SQLiteStorageEngineAdapter for model migration")
+            throw DataStoreError.nilStorageAdapter()
         }
 
         return try storageAdapter.removeStore(for: MutationSyncMetadataMigration.MutationSyncMetadataCopy.schema)
@@ -76,14 +76,23 @@ final class SQLiteMutationSyncMetadataMigrationDelegate: MutationSyncMetadataMig
 
     @discardableResult func createMutationSyncMetadataCopyStore() throws -> String {
         guard let storageAdapter = storageAdapter else {
-            log.debug("Missing SQLiteStorageEngineAdapter")
-            throw DataStoreError.unknown("Missing storage adapter for model migration", "", nil)
+            log.debug("Missing SQLiteStorageEngineAdapter for model migration")
+            throw DataStoreError.nilStorageAdapter()
         }
 
         return try storageAdapter.createStore(for: MutationSyncMetadataMigration.MutationSyncMetadataCopy.schema)
     }
 
     @discardableResult func backfillMutationSyncMetadata() throws -> String {
+        guard let storageAdapter = storageAdapter else {
+            log.debug("Missing SQLiteStorageEngineAdapter for model migration")
+            throw DataStoreError.nilStorageAdapter()
+        }
+
+        guard let connection = storageAdapter.connection else {
+            throw DataStoreError.nilSQLiteConnection()
+        }
+
         var sql = ""
         for modelSchema in modelSchemas {
             let modelName = modelSchema.name
@@ -96,14 +105,14 @@ final class SQLiteMutationSyncMetadataMigrationDelegate: MutationSyncMetadataMig
         sql = "INSERT INTO \(MutationSyncMetadataMigration.MutationSyncMetadataCopy.modelName) (id,deleted,lastChangedAt,version) " +
         "select models.tableName || '|' || mm.id, mm.deleted, mm.lastChangedAt, mm.version " +
         "from MutationSyncMetadata mm INNER JOIN (" + sql + ") as models on mm.id=models.id"
-        try storageAdapter?.connection.execute(sql)
+        try connection.execute(sql)
         return sql
     }
 
     @discardableResult func removeMutationSyncMetadataStore() throws -> String {
         guard let storageAdapter = storageAdapter else {
-            log.debug("Missing SQLiteStorageEngineAdapter")
-            throw DataStoreError.unknown("Missing storage adapter for model migration", "", nil)
+            log.debug("Missing SQLiteStorageEngineAdapter for model migration")
+            throw DataStoreError.nilStorageAdapter()
         }
 
         return try storageAdapter.removeStore(for: MutationSyncMetadata.schema)
@@ -111,8 +120,8 @@ final class SQLiteMutationSyncMetadataMigrationDelegate: MutationSyncMetadataMig
 
     @discardableResult func renameMutationSyncMetadataCopy() throws -> String {
         guard let storageAdapter = storageAdapter else {
-            log.debug("Missing SQLiteStorageEngineAdapter")
-            throw DataStoreError.unknown("Missing storage adapter for model migration", "", nil)
+            log.debug("Missing SQLiteStorageEngineAdapter for model migration")
+            throw DataStoreError.nilStorageAdapter()
         }
 
         return try storageAdapter.renameStore(from: MutationSyncMetadataMigration.MutationSyncMetadataCopy.schema,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
@@ -11,6 +11,11 @@ import SQLite
 extension SQLiteStorageEngineAdapter {
 
     func save(untypedModel: Model, completion: DataStoreCallback<Model>) {
+        guard let connection = connection else {
+            completion(.failure(.nilSQLiteConnection()))
+            return
+        }
+
         do {
             let modelName: ModelName
             if let jsonModel = untypedModel as? JSONValueHolder,
@@ -46,6 +51,10 @@ extension SQLiteStorageEngineAdapter {
     func query(modelSchema: ModelSchema,
                predicate: QueryPredicate? = nil,
                completion: DataStoreCallback<[Model]>) {
+        guard let connection = connection else {
+            completion(.failure(.nilSQLiteConnection()))
+            return
+        }
         do {
             let statement = SelectStatement(from: modelSchema, predicate: predicate)
             let rows = try connection.prepare(statement.stringValue).run(statement.variables)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineMigrationAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineMigrationAdapter+SQLite.swift
@@ -12,6 +12,9 @@ import SQLite
 extension SQLiteStorageEngineAdapter {
 
     @discardableResult func createStore(for modelSchema: ModelSchema) throws -> String {
+        guard let connection = connection else {
+            throw DataStoreError.nilSQLiteConnection()
+        }
         let createTableStatement = CreateTableStatement(modelSchema: modelSchema).stringValue
         let createIndexStatement = modelSchema.createIndexStatements()
         try connection.execute(createTableStatement)
@@ -20,18 +23,27 @@ extension SQLiteStorageEngineAdapter {
     }
 
     @discardableResult func removeStore(for modelSchema: ModelSchema) throws -> String {
+        guard let connection = connection else {
+            throw DataStoreError.nilSQLiteConnection()
+        }
         let dropStatement = DropTableStatement(modelSchema: modelSchema).stringValue
         try connection.execute(dropStatement)
         return dropStatement
     }
 
     @discardableResult func emptyStore(for modelSchema: ModelSchema) throws -> String {
+        guard let connection = connection else {
+            throw DataStoreError.nilSQLiteConnection()
+        }
         let deleteStatement = DeleteStatement(modelSchema: modelSchema).stringValue
         try connection.execute(deleteStatement)
         return deleteStatement
     }
 
     @discardableResult func renameStore(from: ModelSchema, toModelSchema: ModelSchema) throws -> String {
+        guard let connection = connection else {
+            throw DataStoreError.nilSQLiteConnection()
+        }
         let alterTableStatement = AlterTableStatement(from: from, toModelSchema: toModelSchema).stringValue
         try connection.execute(alterTableStatement)
         return alterTableStatement


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/1459

*Description of changes:*
When `DataStore.clear` is called during sync, `connection = nil` which will close the SQLite connection. If sync process is running, it will access the `connection` object that is force unwrapped. 

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
