### PR TITLE
fix(datastore): fix has-one associations

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
@@ -108,7 +108,6 @@ public enum ModelAssociation {
     public static func belongsTo(associatedWith: CodingKey?, targetName: String?) -> ModelAssociation {
         return .belongsTo(associatedFieldName: associatedWith?.stringValue, targetName: targetName)
     }
-
 }
 
 extension ModelField {
@@ -207,10 +206,19 @@ extension ModelField {
     ///   application making any change to these `public` types should be backward compatible, otherwise it will be a
     ///   breaking change.
     public var isAssociationOwner: Bool {
-        guard case .belongsTo = association else {
+        switch association {
+        case .belongsTo:
+            return true
+        case .hasOne:
+            // in case of a bi-directional association
+            // we pick the model with a belongs-to
+            if case .belongsTo = associatedField?.association {
+                return false
+            }
+            return true
+        default:
             return false
         }
-        return true
     }
 
     /// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Select.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Select.swift
@@ -28,7 +28,12 @@ struct SelectStatementMetadata {
         let tableName = modelSchema.name
         var columnMapping: ColumnMapping = [:]
         var columns = fields.map { field -> String in
-            columnMapping.updateValue((modelSchema, field), forKey: field.name)
+            /// use the target name instead of the actual field name
+            /// when a field represent a model association (i.e. team: Team => `teamId`)
+            let fieldName = field.hasAssociation
+            ? field.association?.targetName() ?? field.name
+            : field.name
+            columnMapping.updateValue((modelSchema, field), forKey: fieldName)
             return field.columnName(forNamespace: rootNamespace) + " as " + field.columnAlias()
         }
 


### PR DESCRIPTION
*Description of changes:*
This PR addresses different issues related to the `has-one` model relationships in DataStore.

The associated Model in a has-one relationship now is eagerly-loaded as we do for belongs-to (https://github.com/aws-amplify/amplify-ios/issues/1107)

Models generated with the new version of the GraphQL transformer requires consumers to pass the value of the foreign key to the initializer therefore resulting in a poor dx. While a codegen change is needed to fully address this issue, this PR introduces the necessary changes to have the foreign key value persisted even when only an instance of the associated model is passed to the initializer (https://github.com/aws-amplify/amplify-ios/issues/1623).
This change will then restore the previously working dx:

```swift
let team = Team(name: "A-Team")

// a Project has-one `Team` 
let project = Project(name: "SecretSauceProject", team: team)

Amplify.DataStore.save(team) { ... }
Amplify.DataStore.save(project) { ... }

// Querying for a project will resolve also the associated team
let savedProject: Project
savedProject.team // holds an instance of the associated team
```

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
