### PR TITLE
fix(DataStore): Debugging - Access DB File path

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -14,8 +14,8 @@ import AWSPluginsCore
 /// an integration layer between the AppSyncLocal `StorageEngine` and SQLite for local storage.
 final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
 
-    internal var connection: Connection?
-    private var dbFilePath: URL?
+    var connection: Connection?
+    var dbFilePath: URL?
     static let dbVersionKey = "com.amazonaws.DataStore.dbVersion"
 
     // TODO benchmark whether a SELECT FROM FOO WHERE ID IN (1, 2, 3...) performs measurably


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
During debugging, I'd like to view the DB file path so that I can view the SQLite contents using a SQLite browser.

This PR moves some of the private fields over to internal so that they can be accessed under `@testable` import.

```swift
import Foundation
import Amplify
@testable import AmplifyPlugins

struct DataStoreDebugger {
    
    static var dbFilePath: URL? { getAdapter()?.dbFilePath }
    
    static func getAdapter() -> SQLiteStorageEngineAdapter? {
        if let dataStorePlugin = tryGetPlugin(),
           let storageEngine = dataStorePlugin.storageEngine as? StorageEngine,
           let adapter = storageEngine.storageAdapter as? SQLiteStorageEngineAdapter {
            return adapter
        }
        
        print("Could not get `SQLiteStorageEngineAdapter` from DataStore")
        return nil
    }
    
    static func tryGetPlugin() -> AWSDataStorePlugin? {
        do {
            return try Amplify.DataStore.getPlugin(for: "awsDataStorePlugin") as? AWSDataStorePlugin
        } catch {
            return nil
        }
    }
}

```

```swift
// print out DB path
func testPrintDBPath() {
    print(DataStoreDebugger.dbFilePath)
}
```

You can use a SQLite viewer [SQLiteStudio](https://sqlitestudio.pl/) to view the DB contents after getting the path.

<img width="706" alt="image" src="https://user-images.githubusercontent.com/1365977/157923796-265a9763-3382-4e94-a9be-ef380429bb68.png">



*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
