### PR TITLE
fix(DataStore): Clear API should delete local store

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -21,7 +21,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                where condition: QueryPredicate? = nil,
                                completion: @escaping DataStoreCallback<M>) {
         log.verbose("Saving: \(model) with condition: \(String(describing: condition))")
-        reinitStorageEngineIfNeeded()
+        initStorageEngineAndStartSync()
 
         // TODO: Refactor this into a proper request/result where the result includes metadata like the derived
         // mutation type
@@ -63,7 +63,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     public func query<M: Model>(_ modelType: M.Type,
                                 byId id: String,
                                 completion: DataStoreCallback<M?>) {
-        reinitStorageEngineIfNeeded()
+        initStorageEngineAndStartSync()
         let predicate: QueryPredicate = field("id") == id
         query(modelType, where: predicate, paginate: .firstResult) {
             switch $0 {
@@ -99,7 +99,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                 sort sortInput: [QuerySortDescriptor]? = nil,
                                 paginate paginationInput: QueryPaginationInput? = nil,
                                 completion: DataStoreCallback<[M]>) {
-        reinitStorageEngineIfNeeded()
+        initStorageEngineAndStartSync()
         storageEngine.query(modelType,
                             modelSchema: modelSchema,
                             predicate: predicate,
@@ -120,7 +120,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                  withId id: String,
                                  where predicate: QueryPredicate? = nil,
                                  completion: @escaping DataStoreCallback<Void>) {
-        reinitStorageEngineIfNeeded()
+        initStorageEngineAndStartSync()
         storageEngine.delete(modelType, modelSchema: modelSchema, withId: id, predicate: predicate) { result in
             self.onDeleteCompletion(result: result, modelSchema: modelSchema, completion: completion)
         }
@@ -136,7 +136,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                  modelSchema: ModelSchema,
                                  where predicate: QueryPredicate? = nil,
                                  completion: @escaping DataStoreCallback<Void>) {
-        reinitStorageEngineIfNeeded()
+        initStorageEngineAndStartSync()
         storageEngine.delete(type(of: model),
                              modelSchema: modelSchema,
                              withId: model.id,
@@ -155,7 +155,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                  modelSchema: ModelSchema,
                                  where predicate: QueryPredicate,
                                  completion: @escaping DataStoreCallback<Void>) {
-        reinitStorageEngineIfNeeded()
+        initStorageEngineAndStartSync()
         let onCompletion: DataStoreCallback<[M]> = { result in
             switch result {
             case .success(let models):
@@ -174,7 +174,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
 
     public func start(completion: @escaping DataStoreCallback<Void>) {
-        reinitStorageEngineIfNeeded { result in
+        initStorageEngineAndStartSync { result in
             completion(result)
         }
     }
@@ -202,6 +202,11 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
 
     public func clear(completion: @escaping DataStoreCallback<Void>) {
+        if case let .failure(error) = initStorageEngine() {
+            completion(.failure(causedBy: error))
+            return
+        }
+
         storageEngineInitSemaphore.wait()
         operationQueue.operations.forEach { operation in
             if let operation = operation as? DataStoreObserveQueryOperation {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -180,24 +180,25 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
 
     public func stop(completion: @escaping DataStoreCallback<Void>) {
-        storageEngineInitSemaphore.wait()
-        operationQueue.operations.forEach { operation in
-            if let operation = operation as? DataStoreObserveQueryOperation {
-                operation.resetState()
+        storageEngineInitQueue.sync {
+            operationQueue.operations.forEach { operation in
+                if let operation = operation as? DataStoreObserveQueryOperation {
+                    operation.resetState()
+                }
             }
-        }
-        dispatchedModelSyncedEvents.forEach { _, dispatchedModelSynced in
-            dispatchedModelSynced.set(false)
-        }
-        if storageEngine == nil {
-            storageEngineInitSemaphore.signal()
-            completion(.successfulVoid)
-            return
-        }
-        storageEngineInitSemaphore.signal()
-        storageEngine.stopSync { result in
-            self.storageEngine = nil
-            completion(result)
+            dispatchedModelSyncedEvents.forEach { _, dispatchedModelSynced in
+                dispatchedModelSynced.set(false)
+            }
+            if storageEngine == nil {
+
+                completion(.successfulVoid)
+                return
+            }
+
+            storageEngine.stopSync { result in
+                self.storageEngine = nil
+                completion(result)
+            }
         }
     }
 
@@ -207,24 +208,23 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
             return
         }
 
-        storageEngineInitSemaphore.wait()
-        operationQueue.operations.forEach { operation in
-            if let operation = operation as? DataStoreObserveQueryOperation {
-                operation.resetState()
+        storageEngineInitQueue.sync {
+            operationQueue.operations.forEach { operation in
+                if let operation = operation as? DataStoreObserveQueryOperation {
+                    operation.resetState()
+                }
             }
-        }
-        dispatchedModelSyncedEvents.forEach { _, dispatchedModelSynced in
-            dispatchedModelSynced.set(false)
-        }
-        if storageEngine == nil {
-            storageEngineInitSemaphore.signal()
-            completion(.successfulVoid)
-            return
-        }
-        storageEngineInitSemaphore.signal()
-        storageEngine.clear { result in
-            self.storageEngine = nil
-            completion(result)
+            dispatchedModelSyncedEvents.forEach { _, dispatchedModelSynced in
+                dispatchedModelSynced.set(false)
+            }
+            if storageEngine == nil {
+                completion(.successfulVoid)
+                return
+            }
+            storageEngine.clear { result in
+                self.storageEngine = nil
+                completion(result)
+            }
         }
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
@@ -12,7 +12,7 @@ extension AWSDataStorePlugin: DataStoreSubscribeBehavior {
 
     @available(iOS 13.0, *)
     public var publisher: AnyPublisher<MutationEvent, DataStoreError> {
-        reinitStorageEngineIfNeeded()
+        initStorageEngineAndStartSync()
         // Force-unwrapping: The optional 'dataStorePublisher' is expected
         // to exist for deployment targets >=iOS13.0
         return dataStorePublisher!.publisher
@@ -45,7 +45,7 @@ extension AWSDataStorePlugin: DataStoreSubscribeBehavior {
                                        where predicate: QueryPredicate? = nil,
                                        sort sortInput: [QuerySortDescriptor]? = nil)
     -> AnyPublisher<DataStoreQuerySnapshot<M>, DataStoreError> {
-        reinitStorageEngineIfNeeded()
+        initStorageEngineAndStartSync()
 
         guard let dataStorePublisher = dataStorePublisher else {
             return Fail(error: DataStoreError.unknown(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Originally from https://github.com/aws-amplify/amplify-ios/pull/1438 picking this up and making a few more changes
- replacing the semaphore with dispatchqueue, using `sync` to serially access the `storageEngine`. The plugin holds a reference to storageEngine and will nil it out when it's cleared, the deinit chain will close the internal SQLite connection, which is the reason why we need to do this work under a semaphore or `sync` block.
- rebased with `main`

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
