### PR TITLE
fix(analytics): Set `pinpointConfiguration.debug` for APNS sandbox

### DIFF
--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAdapter.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAdapter.swift
@@ -29,6 +29,11 @@ class AWSPinpointAdapter: AWSPinpointBehavior {
         pinpointConfiguration.targetingServiceConfiguration = targetingServiceConfiguration
         pinpointConfiguration.enableAutoSessionRecording = true
 
+        #if DEBUG
+        pinpointConfiguration.debug = true
+        Amplify.Logging.verbose("Setting pinpointConfiguration.debug to true")
+        #endif
+
         let pinpoint = AWSPinpoint(configuration: pinpointConfiguration)
 
         self.init(pinpoint: pinpoint)


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-amplify/amplify-ios/issues/1307
https://github.com/aws-amplify/amplify-ios/issues/662

*Description of changes:*

The current version makes it impossible to use APNS sandbox during development.
Changing the config from outside works but it updates the endpoint in an unstable way. Something like this:

```swift
let plugin = try Amplify.Analytics.getPlugin(for: PluginKey("awsPinpointAnalyticsPlugin")) as! AWSPinpointAnalyticsPlugin
let pinpoint = plugin.getEscapeHatch()
pinpoint.configuration.debug = true
```

This PR uses Xcode's `DEBUG` directive to turn on pinpoint debug mode.

*Check points: (check or cross out if not relevant)*

- [ ] ~~Added new tests to cover change, if needed~~
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] ~~Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- [ ] ~~If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
