### PR TITLE
chore: bump swift sdk and clientruntime version to support Swift 5.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -316,12 +316,12 @@ let package = Package(
         .package(
             name: "ClientRuntime",
             url: "https://github.com/awslabs/smithy-swift.git",
-            .exact("0.1.3")
+            .exact("0.1.4")
         ),
         .package(
             name: "AWSSwiftSDK",
             url: "https://github.com/awslabs/aws-sdk-swift",
-            .exact("0.1.3")
+            .exact("0.1.4")
         ),
         .package(
             name: "CwlPreconditionTesting",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/1697

*Description of changes:*
Bumps Swift SDK and ClientRuntime versions to `0.1.4` to support Swift 5.6

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
