### PR TITLE
chore(DataStore): Remove @available attribute for iOS 13.0

### DIFF
--- a/Amplify/Categories/API/ClientBehavior/APICategoryReachabilityBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategoryReachabilityBehavior.swift
@@ -15,12 +15,10 @@ public protocol APICategoryReachabilityBehavior {
     /// - Parameters:
     ///   - for: The corresponding apiName that maps to the plugin configuration
     /// - Returns: A publisher that receives reachability updates, or nil if the reachability subsystem is unavailable
-    @available(iOS 13.0, *)
     func reachabilityPublisher(for apiName: String?) throws -> AnyPublisher<ReachabilityUpdate, Never>?
 
     /// Attempts to create and start a reachability client for a host that corresponds to the apiName, and then
     /// returns the associated Publisher which vends ReachabiltyUpdates
-    @available(iOS 13.0, *)
     func reachabilityPublisher() throws -> AnyPublisher<ReachabilityUpdate, Never>?
 
 }

--- a/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+ReachabilityBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+ReachabilityBehavior.swift
@@ -11,13 +11,11 @@ import Combine
 extension AmplifyAPICategory: APICategoryReachabilityBehavior {
 
     /// Default implementation of `reachabilityPublisher` to delegate to plugin's method
-    @available(iOS 13.0, *)
     public func reachabilityPublisher(for apiName: String?) throws -> AnyPublisher<ReachabilityUpdate, Never>? {
         return try plugin.reachabilityPublisher(for: apiName)
     }
 
     /// Default implementation of `reachabilityPublisher` to delegate to plugin's method
-    @available(iOS 13.0, *)
     public func reachabilityPublisher() throws -> AnyPublisher<ReachabilityUpdate, Never>? {
         return try plugin.reachabilityPublisher(for: nil)
     }

--- a/Amplify/Categories/API/Operation/AmplifyOperation+APIPublishers.swift
+++ b/Amplify/Categories/API/Operation/AmplifyOperation+APIPublishers.swift
@@ -13,7 +13,6 @@ import Foundation
 // The overrides require a feature and bugfix introduced in Swift 5.2
 #if swift(>=5.2)
 
-@available(iOS 13.0, *)
 public extension GraphQLOperation {
     /// Publishes the final result of the operation
     var resultPublisher: AnyPublisher<Success, Failure> {
@@ -23,7 +22,6 @@ public extension GraphQLOperation {
 
 // MARK: - GraphQLSubscriptionOperation
 
-@available(iOS 13.0, *)
 public extension GraphQLSubscriptionOperation {
 
     /// Publishes the state of the GraphQL subscription's underlying network connection.
@@ -96,7 +94,6 @@ public extension GraphQLSubscriptionOperation {
 
 // MARK: - RESTOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == RESTOperation.Request,

--- a/Amplify/Categories/DataStore/DataStoreCallback+Combine.swift
+++ b/Amplify/Categories/DataStore/DataStoreCallback+Combine.swift
@@ -7,7 +7,6 @@
 
 import Combine
 
-@available(iOS 13.0, *)
 extension DataStoreResult where Success: Any {
 
     public func resolve(promise: Future<Success, DataStoreError>.Promise) {

--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior+Combine.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior+Combine.swift
@@ -8,10 +8,8 @@
 import Combine
 import Foundation
 
-@available(iOS 13.0, *)
 public typealias DataStorePublisher<Output> = AnyPublisher<Output, DataStoreError>
 
-@available(iOS 13.0, *)
 public extension DataStoreBaseBehavior {
 
     /// Clears the local data store

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -63,7 +63,6 @@ public protocol DataStoreBaseBehavior {
 public protocol DataStoreSubscribeBehavior {
     /// Returns a Publisher for model changes (create, updates, delete)
     /// - Parameter modelType: The model type to observe
-    @available(iOS 13.0, *)
     func publisher<M: Model>(for modelType: M.Type) -> AnyPublisher<MutationEvent, DataStoreError>
 
     /// Returns a Publisher for query snapshots.
@@ -72,7 +71,6 @@ public protocol DataStoreSubscribeBehavior {
     ///   - modelType: The model type to observe
     ///   - predicate: The predicate to match for filtered results
     ///   - sortInput: The field and order of data to be returned
-    @available(iOS 13.0, *)
     func observeQuery<M: Model>(for modelType: M.Type,
                                 where predicate: QueryPredicate?,
                                 sort sortInput: QuerySortInput?)

--- a/Amplify/Categories/DataStore/Model/Collection/List+Combine.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+Combine.swift
@@ -7,7 +7,6 @@
 
 import Combine
 
-@available(iOS 13.0, *)
 extension List {
 
     public typealias LazyListPublisher = AnyPublisher<[Element], DataStoreError>

--- a/Amplify/Categories/DataStore/Model/Internal/ModelRegistry+Syncable.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelRegistry+Syncable.swift
@@ -12,10 +12,6 @@ public extension ModelRegistry {
     ///   application making any change to these `public` types should be backward compatible, otherwise it will be a
     ///   breaking change.
     static var hasSyncableModels: Bool {
-        if #available(iOS 13.0, *) {
-            return modelSchemas.contains { !$0.isSystem }
-        } else {
-            return false
-        }
+        return modelSchemas.contains { !$0.isSystem }
     }
 }

--- a/Amplify/Categories/DataStore/Subscribe/DataStoreCategory+Subscribe.swift
+++ b/Amplify/Categories/DataStore/Subscribe/DataStoreCategory+Subscribe.swift
@@ -8,12 +8,10 @@
 import Combine
 
 extension DataStoreCategory: DataStoreSubscribeBehavior {
-    @available(iOS 13.0, *)
     public func publisher<M: Model>(for modelType: M.Type) -> AnyPublisher<MutationEvent, DataStoreError> {
         return plugin.publisher(for: modelType)
     }
 
-    @available(iOS 13.0, *)
     public func observeQuery<M: Model>(for modelType: M.Type,
                                        where predicate: QueryPredicate? = nil,
                                        sort sortInput: QuerySortInput? = nil)

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Reachability.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Reachability.swift
@@ -10,12 +10,10 @@ import Foundation
 import Combine
 
 extension AWSAPIPlugin {
-    @available(iOS 13.0, *)
     public func reachabilityPublisher() throws -> AnyPublisher<ReachabilityUpdate, Never>? {
         return try reachabilityPublisher(for: nil)
     }
 
-    @available(iOS 13.0, *)
     public func reachabilityPublisher(for apiName: String?) throws -> AnyPublisher<ReachabilityUpdate, Never>? {
         let endpoint = try pluginConfig.endpoints.getConfig(for: apiName)
         guard let hostName = endpoint.baseURL.host else {

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Resettable.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Resettable.swift
@@ -24,10 +24,8 @@ extension AWSAPIPlugin: Resettable {
 
         authService = nil
 
-        if #available(iOS 13.0, *) {
-            reachabilityMapLock.execute {
+        reachabilityMapLock.execute {
                 reachabilityMap.removeAll()
-            }
         }
 
         subscriptionConnectionFactory = nil

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin.swift
@@ -44,7 +44,6 @@ final public class AWSAPIPlugin: NSObject, APICategoryPlugin, AWSAPIAuthInformat
 
     var authProviderFactory: APIAuthProviderFactory
 
-    @available(iOS 13.0, *)
     var reachabilityMap: [String: NetworkReachabilityNotifier] {
         get {
             if iReachabilityMap == nil {

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSHTTPURLResponse.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Operation/AWSHTTPURLResponse.swift
@@ -83,7 +83,6 @@ public class AWSHTTPURLResponse: HTTPURLResponse {
         response.allHeaderFields
     }
 
-    @available(iOS 13.0, *)
     public override func value(forHTTPHeaderField field: String) -> String? {
         response.value(forHTTPHeaderField: field)
     }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Reachability/NetworkReachabilityNotifier.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Reachability/NetworkReachabilityNotifier.swift
@@ -9,7 +9,6 @@ import Amplify
 import Foundation
 import Combine
 
-@available(iOS 13.0, *)
 class NetworkReachabilityNotifier {
     private var reachability: NetworkReachabilityProviding?
     private var allowsCellularAccess = true

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ReachabilityTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ReachabilityTests.swift
@@ -14,7 +14,6 @@ import AWSPluginsCore
 @testable import AWSAPIPlugin
 @testable import AWSPluginsTestCommon
 
-@available(iOS 13.0, *)
 class AWSAPICategoryPluginReachabilityTests: XCTestCase {
 
     var apiPlugin: AWSAPIPlugin!

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSGraphQLOperationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSGraphQLOperationTests.swift
@@ -10,7 +10,6 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSAPIPlugin
 
-@available(iOS 13.0, *)
 class AWSGraphQLOperationTests: AWSAPICategoryPluginTestBase {
 
     /// Tests that upon completion, the operation is removed from the task mapper.

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSHTTPURLResponseTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSHTTPURLResponseTests.swift
@@ -27,10 +27,8 @@ class AWSHTTPURLResponseTests: XCTestCase {
             XCTAssertEqual(response.statusCode, 200)
             XCTAssertEqual(response.allHeaderFields.count, 2)
 
-            if #available(iOS 13.0, *) {
-                XCTAssertNotNil(response.value(forHTTPHeaderField: "key1"))
-                XCTAssertNotNil(response.value(forHTTPHeaderField: "key2"))
-            }
+            XCTAssertNotNil(response.value(forHTTPHeaderField: "key1"))
+            XCTAssertNotNil(response.value(forHTTPHeaderField: "key2"))
         } else {
             XCTFail("Failed to initialize `AWSHTTPURLResponse`")
         }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLMutateCombineTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLMutateCombineTests.swift
@@ -11,7 +11,6 @@ import XCTest
 @testable import AWSAPIPlugin
 @testable import AmplifyTestCommon
 
-@available(iOS 13.0, *)
 class GraphQLMutateCombineTests: OperationTestBase {
     let testDocument = "mutate { updateTodo { id name description }}"
 

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLQueryCombineTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLQueryCombineTests.swift
@@ -11,7 +11,6 @@ import XCTest
 @testable import AWSAPIPlugin
 @testable import AmplifyTestCommon
 
-@available(iOS 13.0, *)
 class GraphQLQueryCombineTests: OperationTestBase {
     let testDocument = "query { getTodo { id name description }}"
 

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLSubscribeCombineTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLSubscribeCombineTests.swift
@@ -14,7 +14,6 @@ import Amplify
 
 import AppSyncRealTimeClient
 
-@available(iOS 13.0, *)
 class GraphQLSubscribeCombineTests: OperationTestBase {
 
     // Setup expectations

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/RESTCombineTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/RESTCombineTests.swift
@@ -11,7 +11,6 @@ import XCTest
 @testable import AWSAPIPlugin
 @testable import AmplifyTestCommon
 
-@available(iOS 13.0, *)
 class RESTCombineTests: OperationTestBase {
 
     func testGetSucceeds() throws {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Reachability/NetworkReachabilityNotifierTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Reachability/NetworkReachabilityNotifierTests.swift
@@ -10,7 +10,6 @@ import XCTest
 import Combine
 @testable import AWSAPIPlugin
 
-@available(iOS 13.0, *)
 class NetworkReachabilityNotifierTests: XCTestCase {
     var notification: Notification!
     var notifier: NetworkReachabilityNotifier!

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -248,9 +248,6 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                                 modelSchema: ModelSchema,
                                                 mutationType: MutationEvent.MutationType) {
 
-        guard #available(iOS 13.0, *) else {
-            return
-        }
         let metadata = MutationSyncMetadata.keys
         let metadataId = MutationSyncMetadata.identifier(modelName: modelSchema.name, modelId: model.id)
         storageEngine.query(MutationSyncMetadata.self,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
@@ -10,7 +10,6 @@ import Combine
 
 extension AWSDataStorePlugin: DataStoreSubscribeBehavior {
 
-    @available(iOS 13.0, *)
     public var publisher: AnyPublisher<MutationEvent, DataStoreError> {
         initStorageEngineAndStartSync()
         // Force-unwrapping: The optional 'dataStorePublisher' is expected
@@ -18,17 +17,14 @@ extension AWSDataStorePlugin: DataStoreSubscribeBehavior {
         return dataStorePublisher!.publisher
     }
 
-    @available(iOS 13.0, *)
     public func publisher<M: Model>(for modelType: M.Type) -> AnyPublisher<MutationEvent, DataStoreError> {
         return publisher(for: modelType.modelName)
     }
 
-    @available(iOS 13.0, *)
     public func publisher(for modelName: ModelName) -> AnyPublisher<MutationEvent, DataStoreError> {
         return publisher.filter { $0.modelName == modelName }.eraseToAnyPublisher()
     }
 
-    @available(iOS 13.0, *)
     public func observeQuery<M: Model>(for modelType: M.Type,
                                        where predicate: QueryPredicate? = nil,
                                        sort sortInput: QuerySortInput? = nil)
@@ -39,7 +35,6 @@ extension AWSDataStorePlugin: DataStoreSubscribeBehavior {
                             sort: sortInput?.asSortDescriptors())
     }
 
-    @available(iOS 13.0, *)
     public func observeQuery<M: Model>(for modelType: M.Type,
                                        modelSchema: ModelSchema,
                                        where predicate: QueryPredicate? = nil,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -43,7 +43,6 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
     var storageEngineBehaviorFactory: StorageEngineBehaviorFactory
 
     var iStorageEngineSink: Any?
-    @available(iOS 13.0, *)
     var storageEngineSink: AnyCancellable? {
         get {
             if let iStorageEngineSink = iStorageEngineSink as? AnyCancellable {
@@ -67,11 +66,7 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
         self.validAuthPluginKey = "awsCognitoAuthPlugin"
         self.storageEngineBehaviorFactory =
             StorageEngine.init(isSyncEnabled:dataStoreConfiguration:validAPIPluginKey:validAuthPluginKey:modelRegistryVersion:userDefault:)
-        if #available(iOS 13.0, *) {
-            self.dataStorePublisher = DataStorePublisher()
-        } else {
-            self.dataStorePublisher = nil
-        }
+        self.dataStorePublisher = DataStorePublisher()
         self.dispatchedModelSyncedEvents = [:]
     }
 
@@ -117,10 +112,8 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
             }
             var result: DataStoreResult<Void>
             do {
-                if #available(iOS 13.0, *) {
-                    if self.dataStorePublisher == nil {
-                        self.dataStorePublisher = DataStorePublisher()
-                    }
+                if self.dataStorePublisher == nil {
+                    self.dataStorePublisher = DataStorePublisher()
                 }
                 try resolveStorageEngine(dataStoreConfiguration: dataStoreConfiguration)
                 try storageEngine.setUp(modelSchemas: ModelRegistry.modelSchemas)
@@ -171,20 +164,15 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
                                                          modelRegistration.version,
                                                          UserDefaults.standard)
 
-        if #available(iOS 13.0, *) {
-            setupStorageSink()
-        }
+        setupStorageSink()
     }
 
     // MARK: Private
 
     private func resolveSyncEnabled() {
-        if #available(iOS 13.0, *) {
-            isSyncEnabled = ModelRegistry.hasSyncableModels
-        }
+        isSyncEnabled = ModelRegistry.hasSyncableModels
     }
 
-    @available(iOS 13.0, *)
     private func setupStorageSink() {
         storageEngineSink = storageEngine
             .publisher
@@ -194,7 +182,6 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
             )
     }
 
-    @available(iOS 13.0, *)
     private func onReceiveCompletion(completed: Subscribers.Completion<DataStoreError>) {
         switch completed {
         case .failure(let dataStoreError):
@@ -204,7 +191,6 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
         }
     }
 
-    @available(iOS 13.0, *)
     func onReceiveValue(receiveValue: StorageEngineEvent) {
         guard let dataStorePublisher = self.dataStorePublisher else {
             log.error("Data store publisher not initalized")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineBehavior.swift
@@ -19,7 +19,6 @@ enum StorageEngineEvent {
 
 protocol StorageEngineBehavior: AnyObject, ModelStorageBehavior {
 
-    @available(iOS 13.0, *)
     var publisher: AnyPublisher<StorageEngineEvent, DataStoreError> { get }
 
     /// start remote sync, based on if sync is enabled and/or authentication is required

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStoreObserveQueryOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStoreObserveQueryOperation.swift
@@ -15,7 +15,6 @@ protocol DataStoreObserveQueryOperation {
     func startObserveQuery(with storageEngine: StorageEngineBehavior)
 }
 
-@available(iOS 13.0, *)
 public class ObserveQueryPublisher<M: Model>: Publisher {
     public typealias Output = DataStoreQuerySnapshot<M>
     public typealias Failure = DataStoreError
@@ -34,7 +33,6 @@ public class ObserveQueryPublisher<M: Model>: Publisher {
     }
 }
 
-@available(iOS 13.0, *)
 class ObserveQuerySubscription<Target: Subscriber, M: Model>: Subscription
 where Target.Input == DataStoreQuerySnapshot<M>, Target.Failure == DataStoreError {
 
@@ -93,7 +91,6 @@ where Target.Input == DataStoreQuerySnapshot<M>, Target.Failure == DataStoreErro
     }
 }
 
-@available(iOS 13.0, *)
 extension ObserveQuerySubscription: DefaultLogger { }
 
 /// Publishes a stream of `DataStoreQuerySnapshot` events.
@@ -110,7 +107,7 @@ extension ObserveQuerySubscription: DefaultLogger { }
 ///
 /// This operation should perform its methods under the serial DispatchQueue `serialQueue` to ensure all its properties
 /// remain thread-safe.
-@available(iOS 13.0, *)
+
 public class AWSDataStoreObserveQueryOperation<M: Model>: AsynchronousOperation, DataStoreObserveQueryOperation {
 
     private let serialQueue = DispatchQueue(label: "com.amazonaws.AWSDataStoreObseverQueryOperation.serialQueue",
@@ -421,5 +418,4 @@ public class AWSDataStoreObserveQueryOperation<M: Model>: AsynchronousOperation,
     }
 }
 
-@available(iOS 13.0, *)
 extension AWSDataStoreObserveQueryOperation: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStorePublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Subscribe/DataStorePublisher.swift
@@ -8,7 +8,6 @@
 import Amplify
 import Combine
 
-@available(iOS 13.0, *)
 struct DataStorePublisher: ModelSubcriptionBehavior {
 
     private let subject = PassthroughSubject<MutationEvent, DataStoreError>()
@@ -32,7 +31,6 @@ struct DataStorePublisher: ModelSubcriptionBehavior {
 
 protocol ModelSubcriptionBehavior {
 
-    @available(iOS 13.0, *)
     var publisher: AnyPublisher<MutationEvent, DataStoreError> { get }
 
     func send(input: MutationEvent)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -10,7 +10,6 @@ import AWSPluginsCore
 import Combine
 import Foundation
 
-@available(iOS 13.0, *)
 final class InitialSyncOperation: AsynchronousOperation {
     typealias SyncQueryResult = PaginatedList<AnyModel>
 
@@ -242,5 +241,4 @@ final class InitialSyncOperation: AsynchronousOperation {
 
 }
 
-@available(iOS 13.0, *)
 extension InitialSyncOperation: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
@@ -10,14 +10,12 @@ import AWSPluginsCore
 import Combine
 import Foundation
 
-@available(iOS 13.0, *)
 protocol InitialSyncOrchestrator {
     var publisher: AnyPublisher<InitialSyncOperationEvent, DataStoreError> { get }
     func sync(completion: @escaping (Result<Void, DataStoreError>) -> Void)
 }
 
 // For testing
-@available(iOS 13.0, *)
 typealias InitialSyncOrchestratorFactory =
     (DataStoreConfiguration,
      AuthModeStrategy,
@@ -25,7 +23,6 @@ typealias InitialSyncOrchestratorFactory =
     IncomingEventReconciliationQueue?,
     StorageEngineAdapter?) -> InitialSyncOrchestrator
 
-@available(iOS 13.0, *)
 final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
     typealias SyncOperationResult = Result<Void, DataStoreError>
     typealias SyncOperationResultHandler = (SyncOperationResult) -> Void
@@ -174,10 +171,8 @@ final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
     }
 }
 
-@available(iOS 13.0, *)
 extension AWSInitialSyncOrchestrator: DefaultLogger { }
 
-@available(iOS 13.0, *)
 extension AWSInitialSyncOrchestrator: Resettable {
     func reset(onComplete: @escaping BasicClosure) {
         syncOperationQueue.cancelAllOperations()
@@ -186,7 +181,6 @@ extension AWSInitialSyncOrchestrator: Resettable {
     }
 }
 
-@available(iOS 13.0, *)
 extension AWSInitialSyncOrchestrator {
     private typealias ResponseType = PaginatedList<AnyModel>
     private func graphqlErrors(from error: GraphQLResponseError<ResponseType>?) -> [GraphQLError]? {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
@@ -24,7 +24,6 @@ enum IncomingModelSyncedEmitterEvent {
 /// mutation event which causes the `ModelSyncedEvent` to be emitted afterwards by
 ///     - Check if it `ModelSyncedEvent` should be emitted, if so, emit it.
 ///     - Then send the mutation event which was used in the check above.
-@available(iOS 13.0, *)
 final class ModelSyncedEventEmitter {
     private let queue = DispatchQueue(label: "com.amazonaws.ModelSyncedEventEmitterQueue",
                                       target: DispatchQueue.global())
@@ -177,5 +176,4 @@ final class ModelSyncedEventEmitter {
     }
 }
 
-@available(iOS 13.0, *)
 extension ModelSyncedEventEmitter: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ReadyEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ReadyEventEmitter.swift
@@ -13,7 +13,6 @@ enum IncomingReadyEventEmitter {
     case readyEvent
 }
 
-@available(iOS 13.0, *)
 final class ReadyEventEmitter {
     var readySink: AnyCancellable?
 
@@ -62,5 +61,4 @@ final class ReadyEventEmitter {
     }
 }
 
-@available(iOS 13.0, *)
 extension ReadyEventEmitter: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/SyncEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/SyncEventEmitter.swift
@@ -20,7 +20,6 @@ enum IncomingSyncEventEmitterEvent {
 /// SyncEventEmitter holds onto one ModelSyncedEventEmitter per model. It counts the number of `modelSyncedEvent` to
 /// emit the `syncQueriesReady` and sends back the reconciliation events (`.mutationEventApplied`,
 /// `.mutationEventDropped`) to its subscribers.
-@available(iOS 13.0, *)
 final class SyncEventEmitter {
     private let queue = DispatchQueue(label: "com.amazonaws.SyncEventEmitter",
                                       target: DispatchQueue.global())
@@ -83,5 +82,4 @@ final class SyncEventEmitter {
     }
 }
 
-@available(iOS 13.0, *)
 extension SyncEventEmitter: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
@@ -9,7 +9,6 @@ import Amplify
 import Combine
 import Foundation
 
-@available(iOS 13.0, *)
 extension AWSMutationDatabaseAdapter: MutationEventIngester {
 
     /// Accepts a mutation event without a version, applies the latest version from the MutationSyncMetadata table,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventSource.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventSource.swift
@@ -8,7 +8,6 @@
 import Amplify
 import Combine
 
-@available(iOS 13.0, *)
 extension AWSMutationDatabaseAdapter: MutationEventSource {
     func getNextMutationEvent(completion: @escaping DataStoreCallback<MutationEvent>) {
         log.verbose(#function)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter.swift
@@ -8,7 +8,6 @@
 import Amplify
 import Combine
 
-@available(iOS 13.0, *)
 /// Interface for saving and loading MutationEvents from storage
 final class AWSMutationDatabaseAdapter {
     /// Possible outcomes of a "submit" based on inspecting the locally stored MutationEvents
@@ -41,10 +40,8 @@ final class AWSMutationDatabaseAdapter {
 
 }
 
-@available(iOS 13.0, *)
 extension AWSMutationDatabaseAdapter: DefaultLogger { }
 
-@available(iOS 13.0, *)
 extension AWSMutationDatabaseAdapter: Resettable {
 
     func reset(onComplete: () -> Void) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/AWSMutationEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/AWSMutationEventPublisher.swift
@@ -12,7 +12,6 @@ import Foundation
 /// Note: This publisher accepts only a single subscriber. It retains a weak reference to
 /// its MutationEventSource even after downstream subscribers have issued a `cancel()`,
 /// so that subsequent subscribers will still receive event notifications.
-@available(iOS 13.0, *)
 final class AWSMutationEventPublisher: Publisher {
     typealias Output = MutationEvent
     typealias Failure = DataStoreError
@@ -86,17 +85,14 @@ final class AWSMutationEventPublisher: Publisher {
 
 }
 
-@available(iOS 13.0, *)
 extension AWSMutationEventPublisher: MutationEventPublisher {
     var publisher: AnyPublisher<MutationEvent, DataStoreError> {
         eraseToAnyPublisher()
     }
 }
 
-@available(iOS 13.0, *)
 extension AWSMutationEventPublisher: DefaultLogger { }
 
-@available(iOS 13.0, *)
 extension AWSMutationEventPublisher: Resettable {
     func reset(onComplete: BasicClosure) {
         subscription = nil

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventClearState.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventClearState.swift
@@ -58,5 +58,4 @@ final class MutationEventClearState {
 
 }
 
-@available(iOS 13.0, *)
 extension MutationEventClearState: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventIngester.swift
@@ -9,7 +9,6 @@ import Amplify
 import Combine
 
 /// Ingests MutationEvents from and writes them to the MutationEvent persistent store
-@available(iOS 13.0, *)
 protocol MutationEventIngester: AnyObject {
     func submit(mutationEvent: MutationEvent) -> Future<MutationEvent, DataStoreError>
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventPublisher.swift
@@ -9,7 +9,6 @@ import Amplify
 import Combine
 
 /// Publishes mutation events to downstream subscribers for subsequent sync to the API.
-@available(iOS 13.0, *)
 protocol MutationEventPublisher: AnyObject, AmplifyCancellable {
     var publisher: AnyPublisher<MutationEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventSubscriber.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventSubscriber.swift
@@ -8,7 +8,6 @@
 import Amplify
 import Combine
 
-@available(iOS 13.0, *)
 final class MutationEventSubscriber: Subscriber {
     typealias Input = MutationEvent
     typealias Failure = DataStoreError

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventSubscription.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/MutationEventSubscription.swift
@@ -8,7 +8,6 @@
 import Amplify
 import Combine
 
-@available(iOS 13.0, *)
 final class MutationEventSubscription: Subscription {
 
     private var demand = Subscribers.Demand.none
@@ -33,5 +32,4 @@ final class MutationEventSubscription: Subscription {
     }
 }
 
-@available(iOS 13.0, *)
 extension MutationEventSubscription: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/MutationRetryNotifier.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/MutationRetryNotifier.swift
@@ -10,7 +10,6 @@ import Foundation
 import AWSPluginsCore
 import Combine
 
-@available(iOS 13.0, *)
 final class MutationRetryNotifier {
     private var lock: NSLock
     private var nextSyncTimer: DispatchSourceTimer?
@@ -58,7 +57,6 @@ final class MutationRetryNotifier {
     }
 }
 
-@available(iOS 13.0, *)
 extension MutationRetryNotifier: Subscriber {
     func receive(subscription: Subscription) {
         log.verbose(#function)
@@ -84,5 +82,4 @@ extension MutationRetryNotifier: Subscriber {
     }
 }
 
-@available(iOS 13.0, *)
 extension MutationRetryNotifier: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Action.swift
@@ -8,7 +8,6 @@
 import Amplify
 import Combine
 
-@available(iOS 13.0, *)
 extension OutgoingMutationQueue {
 
     /// Actions are declarative, they say what I just did

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Resolver.swift
@@ -8,7 +8,6 @@
 import Amplify
 import Combine
 
-@available(iOS 13.0, *)
 extension OutgoingMutationQueue {
 
     struct Resolver {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+State.swift
@@ -8,7 +8,6 @@
 import Amplify
 import Combine
 
-@available(iOS 13.0, *)
 extension OutgoingMutationQueue {
 
     /// States are descriptive, they say what is happening in the system right now

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -11,7 +11,6 @@ import Foundation
 import AWSPluginsCore
 
 /// Submits outgoing mutation events to the provisioned API
-@available(iOS 13.0, *)
 protocol OutgoingMutationQueueBehavior: AnyObject {
     func stopSyncingToCloud(_ completion: @escaping BasicClosure)
     func startSyncingToCloud(api: APICategoryGraphQLBehavior,
@@ -19,7 +18,6 @@ protocol OutgoingMutationQueueBehavior: AnyObject {
     var publisher: AnyPublisher<MutationEvent, Never> { get }
 }
 
-@available(iOS 13.0, *)
 final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
 
     private let stateMachine: StateMachine<State, Action>
@@ -369,7 +367,6 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
 
 }
 
-@available(iOS 13.0, *)
 extension OutgoingMutationQueue: Subscriber {
     typealias Input = MutationEvent
     typealias Failure = DataStoreError
@@ -396,12 +393,10 @@ extension OutgoingMutationQueue: Subscriber {
     }
 }
 
-@available(iOS 13.0, *)
 extension OutgoingMutationQueue: Resettable {
     func reset(onComplete: @escaping BasicClosure) {
         doStopWithoutNotifyingStateMachine(completion: onComplete)
     }
 }
 
-@available(iOS 13.0, *)
 extension OutgoingMutationQueue: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
@@ -14,7 +14,6 @@ import AWSPluginsCore
 /// 1. When there is an APIError which is for an unauthenticated user, call the error handler.
 /// 2. When there is a "conditional request failed" error, then emit to the Hub a 'conditionalSaveFailed' event.
 /// 3. When there is a "conflict unahandled" error, trigger the conflict handler and reconcile the state of the system.
-@available(iOS 13.0, *)
 class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
 
     typealias MutationSyncAPIRequest = GraphQLRequest<MutationSyncResult>
@@ -424,5 +423,4 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
     }
 }
 
-@available(iOS 13.0, *)
 extension ProcessMutationErrorFromCloudOperation: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
@@ -13,7 +13,6 @@ import AWSPluginsCore
 /// Publishes a mutation event to the specified Cloud API. Upon receipt of the API response, validates to ensure it is
 /// not a retriable error. If it is, attempts a retry until either success or terminal failure. Upon success or
 /// terminal failure, publishes the event response to the appropriate ModelReconciliationQueue subject.
-@available(iOS 13.0, *)
 class SyncMutationToCloudOperation: AsynchronousOperation {
 
     typealias MutationSyncCloudResult = GraphQLOperation<MutationSync<AnyModel>>.OperationResult
@@ -329,5 +328,4 @@ private extension GraphQLMutationType {
     }
 }
 
-@available(iOS 13.0, *)
 extension SyncMutationToCloudOperation: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
@@ -8,7 +8,6 @@
 import Amplify
 import Combine
 
-@available(iOS 13.0, *)
 extension RemoteSyncEngine {
 
     /// Actions are declarative, they say what I just did

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+AuthModeStrategyDelegate.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+AuthModeStrategyDelegate.swift
@@ -10,7 +10,6 @@ import Combine
 import Foundation
 import AWSPluginsCore
 
-@available(iOS 13.0, *)
 extension RemoteSyncEngine: AuthModeStrategyDelegate {
     func isUserLoggedIn() -> Bool {
         // if OIDC is used as authentication provider

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
@@ -9,7 +9,6 @@ import Amplify
 import Combine
 import Foundation
 
-@available(iOS 13.0, *)
 extension RemoteSyncEngine {
     func onReceiveCompletion(receiveCompletion: Subscribers.Completion<DataStoreError>) {
         switch stateMachine.state {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
@@ -8,7 +8,6 @@
 import Amplify
 import Combine
 
-@available(iOS 13.0, *)
 extension RemoteSyncEngine {
     struct Resolver {
         // swiftlint:disable cyclomatic_complexity

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Retryable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Retryable.swift
@@ -9,7 +9,6 @@ import Amplify
 import Foundation
 
 /// All methods in this extension must be invoked from workQueue (as in during a `respond` call
-@available(iOS 13.0, *)
 extension RemoteSyncEngine {
 
     func resetCurrentAttemptNumber() {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+State.swift
@@ -7,7 +7,7 @@
 
 import Amplify
 import Combine
-@available(iOS 13.0, *)
+
 extension RemoteSyncEngine {
 
     /// States are descriptive, they say what is happening in the system right now

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -10,7 +10,6 @@ import Combine
 import Foundation
 import AWSPluginsCore
 
-@available(iOS 13.0, *)
 class RemoteSyncEngine: RemoteSyncEngineBehavior {
 
     weak var storageAdapter: StorageEngineAdapter?
@@ -413,10 +412,8 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     }
 }
 
-@available(iOS 13.0, *)
 extension RemoteSyncEngine: DefaultLogger { }
 
-@available(iOS 13.0, *)
 extension RemoteSyncEngine: Resettable {
     func reset(onComplete: @escaping BasicClosure) {
         let group = DispatchGroup()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngineBehavior.swift
@@ -45,9 +45,7 @@ protocol RemoteSyncEngineBehavior: AnyObject {
 
     /// Submits a new mutation for synchronization to the remote API. The response will be handled by the appropriate
     /// reconciliation queue
-    @available(iOS 13.0, *)
     func submit(_ mutationEvent: MutationEvent) -> Future<MutationEvent, DataStoreError>
 
-    @available(iOS 13.0, *)
     var publisher: AnyPublisher<RemoteSyncEngineEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -11,7 +11,6 @@ import Combine
 import Foundation
 
 // Used for testing:
-@available(iOS 13.0, *)
 typealias IncomingEventReconciliationQueueFactory =
     ([ModelSchema],
     APICategoryGraphQLBehavior,
@@ -22,7 +21,6 @@ typealias IncomingEventReconciliationQueueFactory =
     ModelReconciliationQueueFactory?
 ) -> IncomingEventReconciliationQueue
 
-@available(iOS 13.0, *)
 final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue {
 
     private var modelReconciliationQueueSinks: [String: AnyCancellable]
@@ -167,7 +165,6 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
 }
 
 // MARK: - Static factory
-@available(iOS 13.0, *)
 extension AWSIncomingEventReconciliationQueue {
     static let factory: IncomingEventReconciliationQueueFactory = { modelSchemas, api, storageAdapter, syncExpressions, auth, authModeStrategy, _ in
         AWSIncomingEventReconciliationQueue(modelSchemas: modelSchemas,
@@ -181,7 +178,6 @@ extension AWSIncomingEventReconciliationQueue {
 }
 
 // MARK: - AWSIncomingEventReconciliationQueue + Resettable
-@available(iOS 13.0, *)
 extension AWSIncomingEventReconciliationQueue: Resettable {
 
     func reset(onComplete: () -> Void) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -12,7 +12,6 @@ import Foundation
 
 /// Facade to hide the AsyncEventQueue/ModelMapper structures from the ModelReconciliationQueue.
 /// Provides a publisher for all incoming subscription types (onCreate, onUpdate, onDelete) for a single Model type.
-@available(iOS 13.0, *)
 final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPublisher {
 
     private let asyncEvents: IncomingAsyncSubscriptionEventPublisher
@@ -70,7 +69,6 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
 }
 
 // MARK: Resettable
-@available(iOS 13.0, *)
 extension AWSIncomingSubscriptionEventPublisher: Resettable {
 
     func reset(onComplete: () -> Void) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -18,7 +18,6 @@ import Foundation
 /// At initialization, the Queue sets up subscriptions, via the provided `APICategoryGraphQLBehavior`, for each type
 /// `GraphQLSubscriptionType` and holds a reference to the returned operation. The operations' listeners enqueue
 /// incoming successful events onto a `Publisher`, that queue processors can subscribe to.
-@available(iOS 13.0, *)
 final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
     typealias Payload = MutationSync<AnyModel>
     typealias Event = SubscriptionEvent<GraphQLResponse<Payload>>
@@ -283,7 +282,6 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
 }
 
 // MARK: - IncomingAsyncSubscriptionEventPublisher + API request factory
-@available(iOS 13.0, *)
 extension IncomingAsyncSubscriptionEventPublisher {
     static func apiRequestFactoryFor(for modelSchema: ModelSchema,
                                      subscriptionType: GraphQLSubscriptionType,
@@ -303,5 +301,4 @@ extension IncomingAsyncSubscriptionEventPublisher {
     }
 }
 
-@available(iOS 13.0, *)
 extension IncomingAsyncSubscriptionEventPublisher: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
@@ -17,7 +17,6 @@ enum IncomingAsyncSubscriptionEvent {
 
 // swiftlint:disable type_name
 /// Subscribes to an IncomingSubscriptionAsyncEventQueue, and publishes AnyModel
-@available(iOS 13.0, *)
 final class IncomingAsyncSubscriptionEventToAnyModelMapper: Subscriber, AmplifyCancellable {
     // swiftlint:enable type_name
 
@@ -94,7 +93,6 @@ final class IncomingAsyncSubscriptionEventToAnyModelMapper: Subscriber, AmplifyC
     }
 }
 
-@available(iOS 13.0, *)
 extension IncomingAsyncSubscriptionEventToAnyModelMapper: Resettable {
     func reset(onComplete: @escaping BasicClosure) {
         log.verbose("Resetting modelsFromSubscription and subscription")
@@ -106,5 +104,4 @@ extension IncomingAsyncSubscriptionEventToAnyModelMapper: Resettable {
     }
 }
 
-@available(iOS 13.0, *)
 extension IncomingAsyncSubscriptionEventToAnyModelMapper: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
@@ -21,7 +21,6 @@ enum IncomingEventReconciliationQueueEvent {
 /// events for create, update, and delete events initiated by remote systems. In addition to pausing and resuming
 /// automatically-configured subscriptions for models, the queue provides an `offer` method for submitting events
 /// directly from other network events such as mutation callbacks or from base/initial sync queries.
-@available(iOS 13.0, *)
 protocol IncomingEventReconciliationQueue: AnyObject, AmplifyCancellable {
     func start()
     func pause()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingSubscriptionEventPublisher.swift
@@ -14,7 +14,6 @@ enum IncomingSubscriptionEventPublisherEvent {
     case mutationEvent(MutationSync<AnyModel>)
 }
 
-@available(iOS 13.0, *)
 protocol IncomingSubscriptionEventPublisher: AmplifyCancellable {
     var publisher: AnyPublisher<IncomingSubscriptionEventPublisherEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -11,7 +11,6 @@ import Combine
 import Foundation
 
 // Used for testing:
-@available(iOS 13.0, *)
 typealias ModelReconciliationQueueFactory = (
     ModelSchema,
     StorageEngineAdapter,
@@ -52,7 +51,6 @@ typealias ModelReconciliationQueueFactory = (
 ///   `incomingSubscriptionEventQueue`.
 /// - `incomingRemoteEventQueue` processes its operations, which are simply to call `enqueue` for each received remote
 ///   event.
-@available(iOS 13.0, *)
 final class AWSModelReconciliationQueue: ModelReconciliationQueue {
     /// Exposes a publisher for incoming subscription events
     private let incomingSubscriptionEvents: IncomingSubscriptionEventPublisher
@@ -215,11 +213,9 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
     }
 }
 
-@available(iOS 13.0, *)
 extension AWSModelReconciliationQueue: DefaultLogger { }
 
 // MARK: Resettable
-@available(iOS 13.0, *)
 extension AWSModelReconciliationQueue: Resettable {
 
     func reset(onComplete: @escaping BasicClosure) {
@@ -251,7 +247,6 @@ extension AWSModelReconciliationQueue: Resettable {
 }
 
 // MARK: Errors handling
-@available(iOS 13.0, *)
 extension AWSModelReconciliationQueue {
     private typealias ResponseType = MutationSync<AnyModel>
     private func graphqlErrors(from error: GraphQLResponseError<ResponseType>?) -> [GraphQLError]? {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
@@ -23,7 +23,6 @@ enum ModelReconciliationQueueEvent {
     case mutationEventDropped(modelName: String)
 }
 
-@available(iOS 13.0, *)
 protocol ModelReconciliationQueue {
     func start()
     func pause()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Action.swift
@@ -7,7 +7,6 @@
 
 import Amplify
 
-@available(iOS 13.0, *)
 extension ReconcileAndLocalSaveOperation {
 
     /// Actions are declarative, they say what I just did

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+Resolver.swift
@@ -7,7 +7,6 @@
 
 import Amplify
 
-@available(iOS 13.0, *)
 extension ReconcileAndLocalSaveOperation {
     struct Resolver {
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+State.swift
@@ -7,7 +7,6 @@
 
 import Amplify
 
-@available(iOS 13.0, *)
 extension ReconcileAndLocalSaveOperation {
 
     /// States are descriptive, they say what is happening in the system right now

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -12,7 +12,6 @@ import AWSPluginsCore
 
 /// Reconciles an incoming model mutation with the stored model. If there is no conflict (e.g., the incoming model has
 /// a later version than the stored model), then write the new data to the store.
-@available(iOS 13.0, *)
 class ReconcileAndLocalSaveOperation: AsynchronousOperation {
 
     /// Disambiguation for the version of the model incoming from the remote API
@@ -451,7 +450,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
     }
 }
 
-@available(iOS 13.0, *)
+
 extension ReconcileAndLocalSaveOperation: DefaultLogger { }
 
 enum ReconcileAndLocalSaveOperationEvent {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveQueue.swift
@@ -10,7 +10,6 @@ import Combine
 import Foundation
 import AWSPluginsCore
 
-@available(iOS 13.0, *)
 protocol ReconcileAndSaveOperationQueue {
     func addOperation(_ operation: ReconcileAndLocalSaveOperation, modelName: String)
 
@@ -42,7 +41,6 @@ enum ReconcileAndSaveQueueEvent {
 /// Additionally, this queue allows per model type cancellations on the operations that are enqueued by calling
 /// `cancelOperations(modelName)`. This allows per model type clean up, while allowing other model reconcilliations to
 /// continue to operate.
-@available(iOS 13.0, *)
 class ReconcileAndSaveQueue: ReconcileAndSaveOperationQueue {
 
     private let serialQueue = DispatchQueue(label: "com.amazonaws.ReconcileAndSaveQueue.serialQueue",

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/RemoteSyncReconciler.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/RemoteSyncReconciler.swift
@@ -8,7 +8,6 @@
 import Amplify
 
 /// Reconciles incoming sync mutations with the state of the local store, and mutation queue.
-@available(iOS 13.0, *)
 struct RemoteSyncReconciler {
     typealias LocalMetadata = ReconcileAndLocalSaveOperation.LocalMetadata
     typealias RemoteModel = ReconcileAndLocalSaveOperation.RemoteModel

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/StateMachine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/StateMachine.swift
@@ -9,7 +9,6 @@ import Amplify
 import Combine
 import Foundation
 
-@available(iOS 13.0, *)
 class StateMachine<State, Action> {
     typealias Reducer = (State, Action) -> State
 
@@ -51,5 +50,4 @@ class StateMachine<State, Action> {
 
 }
 
-@available(iOS 13.0, *)
 extension StateMachine: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginFlutterIntegrationTests/DataStoreFlutterEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginFlutterIntegrationTests/DataStoreFlutterEndToEndTests.swift
@@ -11,7 +11,6 @@ import AWSPluginsCore
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-@available(iOS 13.0, *)
 class DataStoreEndToEndTests: SyncEngineFlutterIntegrationTestBase {
 
     func testCreateMutateDelete() throws {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -13,7 +13,6 @@ import AWSPluginsCore
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-@available(iOS 13.0, *)
 class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
 
     func testCreateMutateDelete() throws {
@@ -438,7 +437,6 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
     }
 }
 
-@available(iOS 13.0, *)
 extension DataStoreEndToEndTests: DefaultLogger {
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreHubEventsTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreHubEventsTests.swift
@@ -13,7 +13,6 @@ import AWSPluginsCore
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-@available(iOS 13.0, *)
 class DataStoreHubEventTests: HubEventsIntegrationTestBase {
 
     /// - Given:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreLocalStoreTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreLocalStoreTests.swift
@@ -384,7 +384,6 @@ class DataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
     ///    - The first snapshot will have initial models and may have additional models
     ///    - There may be subsequent snapshots based on how the items are batched
     ///    - The last snapshot will have a total of initial plus additional models
-    @available(iOS 13.0, *)
     func testObserveQuery() throws {
         let cleared = expectation(description: "DataStore cleared")
         Amplify.DataStore.clear { result in

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreObserveQueryTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreObserveQueryTests.swift
@@ -15,7 +15,6 @@ import AWSPluginsCore
 
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
-@available(iOS 13.0, *)
 class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
 
     /// ObserveQuery API will eventually return query snapshot with `isSynced` true
@@ -585,5 +584,4 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     }
 }
 
-@available(iOS 13.0, *)
 extension DataStoreObserveQueryTests: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/SubscriptionEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/SubscriptionEndToEndTests.swift
@@ -13,7 +13,6 @@ import AWSPluginsCore
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-@available(iOS 13.0, *)
 class SubscriptionEndToEndTests: SyncEngineIntegrationTestBase {
 
     /// - Given: An API-connected DataStore

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -17,7 +17,6 @@ import Combine
 // swiftlint:disable type_body_length
 // swiftlint:disable type_name
 // swiftlint:disable file_length
-@available(iOS 13.0, *)
 class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     // swiftlint:enable type_name
     let defaultAsyncWaitTimeout = 10.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
@@ -14,7 +14,6 @@ import Combine
 @testable import AWSPluginsCore
 @testable import AWSDataStorePlugin
 
-@available(iOS 13.0, *)
 class SyncMutationToCloudOperationTests: XCTestCase {
     let defaultAsyncWaitTimeout = 2.0
     let secondsInADay = 60 * 60 * 24

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockRemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockRemoteSyncEngine.swift
@@ -35,7 +35,6 @@ class MockRemoteSyncEngine: RemoteSyncEngineBehavior {
 
     }
 
-    @available(iOS 13.0, *)
     func submit(_ mutationEvent: MutationEvent) -> Future<MutationEvent, DataStoreError> {
         if let callback = callbackOnSubmit {
             callback(mutationEvent)

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -23,7 +23,6 @@ class MockAPICategoryPlugin: MessageReporter,
 
     private var oidcProvider: Any?
 
-    @available(iOS 13.0, *)
     init(reachabilityPublisher: AnyPublisher<ReachabilityUpdate, Never>) {
         self._reachabilityPublisher = reachabilityPublisher
         super.init()
@@ -126,12 +125,10 @@ class MockAPICategoryPlugin: MessageReporter,
             return operation
     }
 
-    @available(iOS 13.0, *)
     public func reachabilityPublisher(for apiName: String?) -> AnyPublisher<ReachabilityUpdate, Never>? {
         reachabilityPublisher()
     }
 
-    @available(iOS 13.0, *)
     public func reachabilityPublisher() -> AnyPublisher<ReachabilityUpdate, Never>? {
         if let reachabilityPublisher = _reachabilityPublisher as? AnyPublisher<ReachabilityUpdate, Never> {
             return reachabilityPublisher

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -123,7 +123,6 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         }
     }
 
-    @available(iOS 13.0, *)
     func publisher<M: Model>(for modelType: M.Type)
     -> AnyPublisher<MutationEvent, DataStoreError> {
         let mutationEvent = MutationEvent(id: "testevent",
@@ -136,7 +135,6 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         return Result.Publisher(mutationEvent).eraseToAnyPublisher()
     }
 
-    @available(iOS 13.0, *)
     public func observeQuery<M: Model>(for modelType: M.Type,
                                        where predicate: QueryPredicate? = nil,
                                        sort sortInput: QuerySortInput? = nil)

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/awslabs/aws-sdk-swift",
         "state": {
           "branch": null,
-          "revision": "38b749f84923e948d3c0dde99422432e0fa17c32",
-          "version": "0.1.3"
+          "revision": "5593504a259b8136e36ecc47495c3bc506a13c61",
+          "version": "0.1.4"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/awslabs/smithy-swift.git",
         "state": {
           "branch": null,
-          "revision": "53a97bfd80825d9fd83b901e9587e5d762a45b45",
-          "version": "0.1.3"
+          "revision": "db74f688abbfb5d70375959055474ff3601bb1c4",
+          "version": "0.1.4"
         }
       },
       {


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Developer preview bumps the minimum target to iOS 13 which removes the redundant `@available(iOS 13.0, *)` checks.

*Check points: (check or cross out if not relevant)*

~~- [ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
~~- [ ] All integration tests pass~~
~~- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
