### PR TITLE
chore(DataStore): Remove ireachabilityMap field

### DIFF
--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin.swift
@@ -38,23 +38,9 @@ final public class AWSAPIPlugin: NSObject, APICategoryPlugin, AWSAPIAuthInformat
     /// and is clearable by `reset()`. This is implicitly unwrapped to be destroyed when resetting.
     var subscriptionConnectionFactory: SubscriptionConnectionFactory!
 
-    /// The underlying map that retains instances of NetworkReachabilityNotifier.  Using a computed property
-    /// to work around @available for use on stored properties
-    var iReachabilityMap: [String: Any]?
-
     var authProviderFactory: APIAuthProviderFactory
 
-    var reachabilityMap: [String: NetworkReachabilityNotifier] {
-        get {
-            if iReachabilityMap == nil {
-                iReachabilityMap = [String: NetworkReachabilityNotifier]()
-            }
-            return iReachabilityMap as! [String: NetworkReachabilityNotifier] // swiftlint:disable:this force_cast
-        }
-        set {
-            iReachabilityMap = newValue
-        }
-    }
+    var reachabilityMap: [String: NetworkReachabilityNotifier]
 
     /// Lock used for performing operations atomically when getting and setting `reachabilityMap`.
     let reachabilityMapLock: NSLock
@@ -67,6 +53,7 @@ final public class AWSAPIPlugin: NSObject, APICategoryPlugin, AWSAPIAuthInformat
         self.mapper = OperationTaskMapper()
         self.queue = OperationQueue()
         self.authProviderFactory = apiAuthProviderFactory ?? APIAuthProviderFactory()
+        self.reachabilityMap = [:]
         self.reachabilityMapLock = NSLock()
         super.init()
 


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Follow up PR to https://github.com/aws-amplify/amplify-ios/pull/1705. Remove `iReachabilityMap` field from `AWSAPIPlugin.swift`.

*Check points: (check or cross out if not relevant)*

~~- [ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
~~- [ ] All integration tests pass~~
~~- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
