### PR TITLE
fix(DataStore): Reconcile locally sourced mutations while subscriptions are disabled

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -183,7 +183,7 @@ final class InitialSyncOperation: AsynchronousOperation {
         let items = syncQueryResult.items
         recordsReceived += UInt(items.count)
 
-        reconciliationQueue.offer(items, modelSchema: modelSchema)
+        reconciliationQueue.offer(items, modelName: modelSchema.name)
         for item in items {
             initialSyncOperationTopic.send(.enqueued(item, modelName: modelSchema.name))
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Action.swift
@@ -15,7 +15,7 @@ extension OutgoingMutationQueue {
     enum Action {
         // Startup/config actions
         case initialized
-        case receivedStart(APICategoryGraphQLBehavior, MutationEventPublisher)
+        case receivedStart(APICategoryGraphQLBehavior, MutationEventPublisher, IncomingEventReconciliationQueue?)
         case receivedSubscription
 
         // Event loop

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Resolver.swift
@@ -18,8 +18,8 @@ extension OutgoingMutationQueue {
             case (.notInitialized, .initialized):
                 return .stopped
 
-            case (.stopped, .receivedStart(let api, let mutationEventPublisher)):
-                return .starting(api, mutationEventPublisher)
+            case (.stopped, .receivedStart(let api, let mutationEventPublisher, let reconciliationQueue)):
+                return .starting(api, mutationEventPublisher, reconciliationQueue)
 
             case (.starting, .receivedSubscription):
                 return .requestingEvent

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+State.swift
@@ -16,7 +16,7 @@ extension OutgoingMutationQueue {
         // Startup/config states
         case notInitialized
         case stopped
-        case starting(APICategoryGraphQLBehavior, MutationEventPublisher)
+        case starting(APICategoryGraphQLBehavior, MutationEventPublisher, IncomingEventReconciliationQueue?)
 
         // Event loop
         case requestingEvent

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Action.swift
@@ -21,7 +21,7 @@ extension RemoteSyncEngine {
         case clearedStateOutgoingMutations(APICategoryGraphQLBehavior, StorageEngineAdapter)
         case initializedSubscriptions
         case performedInitialSync
-        case activatedCloudSubscriptions(APICategoryGraphQLBehavior, MutationEventPublisher)
+        case activatedCloudSubscriptions(APICategoryGraphQLBehavior, MutationEventPublisher, IncomingEventReconciliationQueue?)
         case activatedMutationQueue
         case notifiedSyncStarted
         case cleanedUp(AmplifyError)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
@@ -42,7 +42,8 @@ extension RemoteSyncEngine {
             remoteSyncTopicPublisher.send(.subscriptionsActivated)
             if let api = self.api {
                 stateMachine.notify(action: .activatedCloudSubscriptions(api,
-                                                                         mutationEventPublisher))
+                                                                         mutationEventPublisher,
+                                                                         reconciliationQueue))
             }
         case .paused:
             remoteSyncTopicPublisher.send(.subscriptionsPaused)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Resolver.swift
@@ -37,8 +37,9 @@ extension RemoteSyncEngine {
                 return .cleaningUp(error)
 
             case (.activatingCloudSubscriptions, .activatedCloudSubscriptions(let api,
-                                                                              let mutationEventPublisher)):
-                return .activatingMutationQueue(api, mutationEventPublisher)
+                                                                              let mutationEventPublisher,
+                                                                              let reconciliationQueue)):
+                return .activatingMutationQueue(api, mutationEventPublisher, reconciliationQueue)
             case (.activatingCloudSubscriptions, .errored(let error)):
                 return .cleaningUp(error)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+State.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+State.swift
@@ -20,7 +20,7 @@ extension RemoteSyncEngine {
         case initializingSubscriptions(APICategoryGraphQLBehavior, StorageEngineAdapter)
         case performingInitialSync
         case activatingCloudSubscriptions
-        case activatingMutationQueue(APICategoryGraphQLBehavior, MutationEventPublisher)
+        case activatingMutationQueue(APICategoryGraphQLBehavior, MutationEventPublisher, IncomingEventReconciliationQueue?)
         case notifyingSyncStarted
 
         case syncEngineActive

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -173,9 +173,10 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
             performInitialSync()
         case .activatingCloudSubscriptions:
             activateCloudSubscriptions()
-        case .activatingMutationQueue(let api, let mutationEventPublisher):
+        case .activatingMutationQueue(let api, let mutationEventPublisher, let reconciliationQueue):
             startMutationQueue(api: api,
-                               mutationEventPublisher: mutationEventPublisher)
+                               mutationEventPublisher: mutationEventPublisher,
+                               reconciliationQueue: reconciliationQueue)
         case .notifyingSyncStarted:
             notifySyncStarted()
 
@@ -359,10 +360,12 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     }
 
     private func startMutationQueue(api: APICategoryGraphQLBehavior,
-                                    mutationEventPublisher: MutationEventPublisher) {
+                                    mutationEventPublisher: MutationEventPublisher,
+                                    reconciliationQueue: IncomingEventReconciliationQueue?) {
         log.debug(#function)
         outgoingMutationQueue.startSyncingToCloud(api: api,
-                                                  mutationEventPublisher: mutationEventPublisher)
+                                                  mutationEventPublisher: mutationEventPublisher,
+                                                  reconciliationQueue: reconciliationQueue)
 
         remoteSyncTopicPublisher.send(.mutationQueueStarted)
         stateMachine.notify(action: .activatedMutationQueue)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -96,7 +96,7 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
         eventReconciliationQueueTopic.send(.paused)
     }
 
-    func offer(_ remoteModels: [MutationSync<AnyModel>], modelName: String) {
+    func offer(_ remoteModels: [MutationSync<AnyModel>], modelName: ModelName) {
         guard let queue = reconciliationQueues[modelName] else {
             // TODO: Error handling
             return

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -96,8 +96,8 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
         eventReconciliationQueueTopic.send(.paused)
     }
 
-    func offer(_ remoteModels: [MutationSync<AnyModel>], modelSchema: ModelSchema) {
-        guard let queue = reconciliationQueues[modelSchema.name] else {
+    func offer(_ remoteModels: [MutationSync<AnyModel>], modelName: String) {
+        guard let queue = reconciliationQueues[modelName] else {
             // TODO: Error handling
             return
         }
@@ -133,9 +133,11 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
         case .disconnected(modelName: let modelName, reason: .operationDisabled),
              .disconnected(modelName: let modelName, reason: .unauthorized):
             connectionStatusSerialQueue.async {
-                self.reconciliationQueues[modelName]?.cancel()
-                self.modelReconciliationQueueSinks[modelName]?.cancel()
-                self.reconciliationQueueConnectionStatus[modelName] = false
+                Amplify.log.debug("Disconnected subscription for \(modelName) reason: \(receiveValue)")
+                // A disconnected subscription due to operation disabled or unauthorized will still contribute
+                // to the overall state of the reconciliation queue system on sending the `.initialized` event
+                // since subscriptions may be disabled and have to reconcile locally sourced mutation evemts.
+                self.reconciliationQueueConnectionStatus[modelName] = true
                 if self.isInitialized {
                     self.eventReconciliationQueueTopic.send(.initialized)
                 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
@@ -25,6 +25,6 @@ enum IncomingEventReconciliationQueueEvent {
 protocol IncomingEventReconciliationQueue: AnyObject, AmplifyCancellable {
     func start()
     func pause()
-    func offer(_ remoteModels: [MutationSync<AnyModel>], modelSchema: ModelSchema)
+    func offer(_ remoteModels: [MutationSync<AnyModel>], modelName: String)
     var publisher: AnyPublisher<IncomingEventReconciliationQueueEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
@@ -25,6 +25,6 @@ enum IncomingEventReconciliationQueueEvent {
 protocol IncomingEventReconciliationQueue: AnyObject, AmplifyCancellable {
     func start()
     func pause()
-    func offer(_ remoteModels: [MutationSync<AnyModel>], modelName: String)
+    func offer(_ remoteModels: [MutationSync<AnyModel>], modelName: ModelName)
     var publisher: AnyPublisher<IncomingEventReconciliationQueueEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/RemoteSyncReconciler.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/RemoteSyncReconciler.swift
@@ -82,7 +82,7 @@ struct RemoteSyncReconciler {
             return remoteModel.syncMetadata.deleted ? nil : .create(remoteModel)
         }
 
-        guard remoteModel.syncMetadata.version >= localMetadata.version else {
+        guard remoteModel.syncMetadata.version > localMetadata.version else {
             return nil
         }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/DataStoreHubEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/DataStoreHubEvent.swift
@@ -1,0 +1,92 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Amplify
+import AWSDataStoreCategoryPlugin
+
+/// Initialize with `HubPayload`'s `eventName: String` and `data: Any?` fields to return an enum of events with their
+/// expected payloads in their respective types
+enum DataStoreHubEvent {
+    case syncStarted
+    case syncReceived(MutationEvent)
+    case conditionalSaveFailed
+    case outboxStatus(OutboxStatusEvent)
+    case subscriptionsEstablished
+    case syncQueriesStarted(SyncQueriesStartedEvent)
+    case modelSynced(ModelSyncedEvent)
+    case syncQueriesReady
+    case ready
+    case networkStatus(NetworkStatusEvent)
+    case outboxMutationEnqueued(OutboxMutationEvent)
+    case outboxMutationProcessed(OutboxMutationEvent)
+    case unknown(HubPayload)
+
+    init(payload: HubPayload) {
+        switch payload.eventName {
+        case HubPayload.EventName.DataStore.syncStarted:
+            Amplify.DataStore.log.verbose("DataStoreEvent: SyncStarted")
+            self = .syncStarted
+        case HubPayload.EventName.DataStore.syncReceived:
+            guard let mutationEvent = payload.data as? MutationEvent else {
+                fatalError("Expected data object not found")
+            }
+            self = .syncReceived(mutationEvent)
+        case HubPayload.EventName.DataStore.conditionalSaveFailed:
+            Amplify.DataStore.log.verbose("DataStoreEvent: Conditional Save Failed")
+            self = .conditionalSaveFailed
+        case HubPayload.EventName.DataStore.outboxStatus:
+            guard let outboxStatusEvent = payload.data as? OutboxStatusEvent else {
+                fatalError("Expected data object not found")
+            }
+            Amplify.DataStore.log.verbose("DataStoreEvent: OutboxStatus isEmpty: \(outboxStatusEvent.isEmpty)")
+            self = .outboxStatus(outboxStatusEvent)
+        case HubPayload.EventName.DataStore.subscriptionsEstablished:
+            Amplify.DataStore.log.verbose("DataStoreEvent: Subscriptions Established")
+            self = .subscriptionsEstablished
+        case HubPayload.EventName.DataStore.syncQueriesStarted:
+            guard let syncQueriesStartedEvent = payload.data as? SyncQueriesStartedEvent else {
+                fatalError("Expected data object not found")
+            }
+            Amplify.DataStore.log.verbose("DataStoreEvent: SyncQueriesStarted \(syncQueriesStartedEvent)")
+            self = .syncQueriesStarted(syncQueriesStartedEvent)
+        case HubPayload.EventName.DataStore.modelSynced:
+            guard let modelSyncedEvent = payload.data as? ModelSyncedEvent else {
+                fatalError("Expected data object not found")
+            }
+            Amplify.DataStore.log.verbose("DataStoreEvent: ModelSynced: \(modelSyncedEvent)")
+            self = .modelSynced(modelSyncedEvent)
+        case HubPayload.EventName.DataStore.syncQueriesReady:
+            Amplify.DataStore.log.verbose("DataStoreEvent: SyncQueriesReady")
+            self = .syncQueriesReady
+        case HubPayload.EventName.DataStore.ready:
+            Amplify.DataStore.log.verbose("DataStoreEvent: Ready")
+            self = .ready
+        case HubPayload.EventName.DataStore.networkStatus:
+            guard let networkStatusEvent = payload.data as? NetworkStatusEvent else {
+                fatalError("Expected data object not found")
+            }
+            Amplify.DataStore.log.verbose("DataStoreEvent: NetworkStatus: \(networkStatusEvent)")
+            self = .networkStatus(networkStatusEvent)
+        case HubPayload.EventName.DataStore.outboxMutationEnqueued:
+            guard let outboxMutationEvent = payload.data as? OutboxMutationEvent else {
+                fatalError("Expected data object not found")
+            }
+            Amplify.DataStore.log.verbose("DataStoreEvent: OutboxMutationEnqueued \(outboxMutationEvent.modelName)")
+            self = .outboxMutationEnqueued(outboxMutationEvent)
+        case HubPayload.EventName.DataStore.outboxMutationProcessed:
+            guard let outboxMutationEvent = payload.data as? OutboxMutationEvent else {
+                fatalError("Expected data object not found")
+            }
+            Amplify.DataStore.log.verbose("DataStoreEvent: OutboxMutationProcessed \(outboxMutationEvent.modelName)")
+            self = .outboxMutationProcessed(outboxMutationEvent)
+        default:
+            Amplify.DataStore.log.verbose("DataStoreEvent: Unknown: \(payload)")
+            self = .unknown(payload)
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/RemoteSyncReconcilerTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/RemoteSyncReconcilerTests.swift
@@ -81,7 +81,7 @@ class RemoteSyncReconcilerTests: XCTestCase {
         let disposition = RemoteSyncReconciler.getDisposition(remoteModel,
                                                               localMetadata: localSyncMetadata)
 
-        XCTAssertEqual(disposition, .update(remoteModel))
+        XCTAssertEqual(disposition, nil)
     }
 
     func testReconcileLocalMetadata_withLocalLowerVersion() {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
@@ -47,7 +47,7 @@ class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue 
         incomingEventSubject.send(.paused)
     }
 
-    func offer(_ remoteModels: [MutationSync<AnyModel>], modelSchema: ModelSchema) {
+    func offer(_ remoteModels: [MutationSync<AnyModel>], modelName: String) {
         // no-op for mock
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
@@ -47,7 +47,7 @@ class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue 
         incomingEventSubject.send(.paused)
     }
 
-    func offer(_ remoteModels: [MutationSync<AnyModel>], modelName: String) {
+    func offer(_ remoteModels: [MutationSync<AnyModel>], modelName: ModelName) {
         // no-op for mock
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockOutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockOutgoingMutationQueue.swift
@@ -18,7 +18,8 @@ class MockOutgoingMutationQueue: OutgoingMutationQueueBehavior {
     }
 
     func startSyncingToCloud(api: APICategoryGraphQLBehavior,
-                             mutationEventPublisher: MutationEventPublisher) {
+                             mutationEventPublisher: MutationEventPublisher,
+                             reconciliationQueue: IncomingEventReconciliationQueue?) {
         // no-op
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
@@ -21,7 +21,7 @@ final class MockReconciliationQueue: MessageReporter, IncomingEventReconciliatio
         notify()
     }
 
-    func offer(_ remoteModels: [MutationSync<AnyModel>], modelSchema: ModelSchema) {
+    func offer(_ remoteModels: [MutationSync<AnyModel>], modelName: String) {
         notify("offer(_:) remoteModels: \(remoteModels)")
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
@@ -21,7 +21,7 @@ final class MockReconciliationQueue: MessageReporter, IncomingEventReconciliatio
         notify()
     }
 
-    func offer(_ remoteModels: [MutationSync<AnyModel>], modelName: String) {
+    func offer(_ remoteModels: [MutationSync<AnyModel>], modelName: ModelName) {
         notify("offer(_:) remoteModels: \(remoteModels)")
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/NoOpMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/NoOpMutationQueue.swift
@@ -17,7 +17,8 @@ class NoOpMutationQueue: OutgoingMutationQueueBehavior {
     }
 
     func startSyncingToCloud(api: APICategoryGraphQLBehavior,
-                             mutationEventPublisher: MutationEventPublisher) {
+                             mutationEventPublisher: MutationEventPublisher,
+                             reconciliationQueue: IncomingEventReconciliationQueue?) {
         // do nothing
     }
 

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		214B6B65264B0D6700A9311D /* Stopwatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214B6B64264B0D6700A9311D /* Stopwatch.swift */; };
 		214B6B68264B157500A9311D /* StopwatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214B6B67264B157500A9311D /* StopwatchTests.swift */; };
 		215D40AD277233340077E7DA /* DataStoreConnectionScenario8V2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215D40AC277233340077E7DA /* DataStoreConnectionScenario8V2Tests.swift */; };
+		216942F427F4E0BC00DE36BC /* DataStoreHubEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216942F327F4E0BC00DE36BC /* DataStoreHubEvent.swift */; };
 		216B69D326DD542D005D97AD /* Model+Sort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216B69D226DD542D005D97AD /* Model+Sort.swift */; };
 		216B69D626DD594E005D97AD /* ModelSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216B69D526DD594E005D97AD /* ModelSortTests.swift */; };
 		2178C0A126D3F1E200C53065 /* DataStoreObserveQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2178C0A026D3F1E200C53065 /* DataStoreObserveQueryTests.swift */; };
@@ -477,6 +478,7 @@
 		214B6B64264B0D6700A9311D /* Stopwatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stopwatch.swift; sourceTree = "<group>"; };
 		214B6B67264B157500A9311D /* StopwatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopwatchTests.swift; sourceTree = "<group>"; };
 		215D40AC277233340077E7DA /* DataStoreConnectionScenario8V2Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataStoreConnectionScenario8V2Tests.swift; sourceTree = "<group>"; };
+		216942F327F4E0BC00DE36BC /* DataStoreHubEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreHubEvent.swift; sourceTree = "<group>"; };
 		216B69D226DD542D005D97AD /* Model+Sort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Model+Sort.swift"; sourceTree = "<group>"; };
 		216B69D526DD594E005D97AD /* ModelSortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelSortTests.swift; sourceTree = "<group>"; };
 		2178C0A026D3F1E200C53065 /* DataStoreObserveQueryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreObserveQueryTests.swift; sourceTree = "<group>"; };
@@ -1588,6 +1590,7 @@
 				218F7890275A82A00042334B /* SyncEngineIntegrationV2TestBase.swift */,
 				FAD2BDF5239583B2006EB065 /* TestModelRegistration.swift */,
 				218F7892275A82C50042334B /* TestModelV2Registration.swift */,
+				216942F327F4E0BC00DE36BC /* DataStoreHubEvent.swift */,
 			);
 			path = TestSupport;
 			sourceTree = "<group>";
@@ -2655,6 +2658,7 @@
 				FAB5714023958C210006A5F8 /* SyncEngineIntegrationTestBase.swift in Sources */,
 				218F78D6275AC7CD0042334B /* DataStoreModelWithCustomTimestampTests.swift in Sources */,
 				218F788D275A81410042334B /* DataStoreConnectionScenario7V2Tests.swift in Sources */,
+				216942F427F4E0BC00DE36BC /* DataStoreHubEvent.swift in Sources */,
 				FA2E6B8D2497C17500779D2F /* AWSDataStorePluginConfigurationTests.swift in Sources */,
 				218F789E275AB2990042334B /* DataStoreConnectionScenario3aV2Tests.swift in Sources */,
 			);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Reconcile locally sourced mutations to save/update/delete the model and metadata into local store. The locally sourced mutation response is identical to the subscription event that would be received on subscriptions, so reuse the reconciliation queue to process it. 

A concern regarding this is the real-time events behavior of the additional event. Currently, locally sourced mutations with subscriptions enabled will emit 2 events, one from the operation on local store and one from the subscription event being reconciled to the local store. By handling the locally sourced mutation event, the subscription event would attribute to a third real-time event. The reconciliation logic has been updated to to ignore the remote model when the local version is equal to the incoming remote model, which will dedup the subscription event.

**OutgoingMutationQueue** gets the `reconciliationQueue`, so upon processing a MutationEvent (`SyncToCloudOperation`), it will pass the successfully mutation response to the reconciliation queue to process, much like as if it were an subscription event.

**ReconcileAndLocalSave**'s `RemoteSyncReconciler` determines the disposition of the remote model, when compared to the local metadata. If the local metadata's version is equal to the remote model's then skip the remote model.

*Manual Testing done*
The manual testing done is by disabling subscriptions, and performing a save. Two events are received by the publisher for that model. Disabling subscriptions can be done via the data resolver for all 3 subscription operations of a model (onCreate, onUpdate, onDelete) with `$util.error("Subscription are disabled.", "OperationDisabled")` on the last line in *Before mapping template.*

The second manual test done is to ensure that there are only two events dispatched to the caller for locally sourced mutations with subscriptions enabled. Two events are observed, since the reconciliation of the subscription event determines it to be dropped.
*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
