### PR TITLE
Auth plugin: Add support of custom endpoint for CognitoUserPool

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -119,22 +119,22 @@ extension AWSCognitoAuthPlugin {
         using authConfiguration: JSONValue,
         region: AWSRegionType) throws -> AWSEndpoint? {
 
-        let endpointKeyPath = "CognitoUserPool.Default.Endpoint"
-        guard case .string(let endpointString) = authConfiguration.value(at: endpointKeyPath) else {
-            return nil
-        }
+            let endpointKeyPath = "CognitoUserPool.Default.Endpoint"
+            guard case .string(let endpointString) = authConfiguration.value(at: endpointKeyPath) else {
+                return nil
+            }
             guard let components = URLComponents(string: endpointString),
                   let url = components.url,
-                    components.scheme == "https" || components.scheme == "http" else {
-            let amplifyError = AuthError.configuration(
-                "Error configuring \(String(describing: self))",
+                  components.scheme == "https" || components.scheme == "http" else {
+                let amplifyError = AuthError.configuration(
+                    "Error configuring \(String(describing: self))",
                 """
                 Invalid Endpoint value \(endpointString). Expected a fully-qualified hostname.
                 """)
-            throw amplifyError
+                throw amplifyError
+            }
+            return AWSEndpoint(region: region, service: .CognitoIdentityProvider, url: url)
         }
-        return AWSEndpoint(region: region, service: .CognitoIdentityProvider, url: url)
-    }
 
     // MARK: Internal
 

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -110,8 +110,7 @@ extension AWSCognitoAuthPlugin {
 
         let endpointKeyPath = "CognitoUserPool.Default.Endpoint"
         if case .string(let endpointString) = authConfiguration.value(at: endpointKeyPath) {
-            return AmplifyAWSServiceConfiguration(region: region, endpoint: .init(urlString: endpointString)
-            )
+            return AmplifyAWSServiceConfiguration(region: region, endpoint: .init(urlString: endpointString))
         } else {
             return AmplifyAWSServiceConfiguration(region: region)
         }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -107,7 +107,14 @@ extension AWSCognitoAuthPlugin {
             return nil
         }
         let region = (regionString as NSString).aws_regionTypeValue()
-        return AmplifyAWSServiceConfiguration(region: region)
+
+        let endpointKeyPath = "CognitoUserPool.Default.Endpoint"
+        if case .string(let endpointString) = authConfiguration.value(at: endpointKeyPath) {
+            return AmplifyAWSServiceConfiguration(region: region, endpoint: .init(urlString: endpointString)
+            )
+        } else {
+            return AmplifyAWSServiceConfiguration(region: region)
+        }
     }
 
     // MARK: Internal

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -123,16 +123,26 @@ extension AWSCognitoAuthPlugin {
             guard case .string(let endpointString) = authConfiguration.value(at: endpointKeyPath) else {
                 return nil
             }
-            guard let components = URLComponents(string: endpointString),
-                  let url = components.url,
-                  components.scheme == "https" || components.scheme == "http" else {
-                let amplifyError = AuthError.configuration(
-                    "Error configuring \(String(describing: self))",
-                """
-                Invalid Endpoint value \(endpointString). Expected a fully-qualified hostname.
-                """)
+
+            let amplifyError = AuthError.configuration(
+                "Error configuring \(String(describing: self))",
+            """
+            Invalid Endpoint value \(endpointString). Expected a fully-qualified hostname.
+            """)
+
+            guard (URLComponents(string: endpointString)?.scheme ?? "").isEmpty else {
                 throw amplifyError
             }
+
+            let endpointStringWithScheme = "https://" + endpointString
+            guard
+                let components = URLComponents(string: endpointStringWithScheme),
+                components.path == "",
+                let url = components.url
+            else {
+                throw amplifyError
+            }
+
             return AWSEndpoint(region: region, service: .CognitoIdentityProvider, url: url)
         }
 

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
@@ -63,7 +63,7 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
                     "Region": "us-east-1",
                     "AppClientId": "xx",
                     "AppClientSecret": "xx",
-                    "Endpoint": "xx"]]
+                    "Endpoint": "https://aws.amazon.com"]]
             ]
         ])
         let amplifyConfig = AmplifyConfiguration(auth: categoryConfig)
@@ -121,7 +121,7 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
                     "Region": "us-east-1",
                     "AppClientId": "xx",
                     "AppClientSecret": "xx",
-                    "Endpoint": "xx"]]
+                    "Endpoint": "https://aws.amazon.com"]]
             ]
         ])
         let amplifyConfig = AmplifyConfiguration(auth: categoryConfig)
@@ -163,6 +163,41 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
         } catch {
             guard case AuthError.configuration = error else {
                 XCTFail("Should have thrown a AuthError.configuration error if both cognito service config are invalid")
+                return
+            }
+        }
+    }
+
+    /// Test Auth configuration with invalid endpoint url for user pool
+    ///
+    /// - Given: Given invalid endpoint url for user pool
+    /// - When:
+    ///    - I configure auth with the given configuration
+    /// - Then:
+    ///    - I should get an exception.
+    ///
+    func testConfigWithInvalidUserPoolEndpoint() throws {
+        let plugin = AWSCognitoAuthPlugin()
+        try Amplify.add(plugin: plugin)
+
+        let categoryConfig = AuthCategoryConfiguration(plugins: [
+            "awsCognitoAuthPlugin": [
+                "CognitoUserPool": ["Default": [
+                    "PoolId": "xx",
+                    "Region": "us-east-1",
+                    "AppClientId": "xx",
+                    "AppClientSecret": "xx",
+                    "Endpoint": "xx"]]
+            ]
+        ])
+
+        let amplifyConfig = AmplifyConfiguration(auth: categoryConfig)
+        do {
+            try Amplify.configure(amplifyConfig)
+            XCTFail("Should have thrown a AuthError.configuration error for invalid endpoint url")
+        } catch {
+            guard case AuthError.configuration = error else {
+                XCTFail("Should have thrown a AuthError.configuration error for invalid endpoint url")
                 return
             }
         }
@@ -213,7 +248,7 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
                     "Region": "us-east-1",
                     "AppClientId": "xx",
                     "AppClientSecret": "xx",
-                    "Endpoint": "xx"]]
+                    "Endpoint": "https://aws.amazon.com"]]
             ]
         ])
         let amplifyConfig = AmplifyConfiguration(auth: categoryConfig)

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
@@ -62,7 +62,9 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
                     "PoolId": "xx",
                     "Region": "us-east-1",
                     "AppClientId": "xx",
-                    "AppClientSecret": "xx"]]
+                    "AppClientSecret": "xx",
+                    "Endpoint": "xx"
+                ]]
             ]
         ])
         let amplifyConfig = AmplifyConfiguration(auth: categoryConfig)
@@ -119,7 +121,8 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
                     "PoolId": "xx",
                     "Region": "us-east-1",
                     "AppClientId": "xx",
-                    "AppClientSecret": "xx"]]
+                    "AppClientSecret": "xx",
+                    "Endpoint": "xx"]]
             ]
         ])
         let amplifyConfig = AmplifyConfiguration(auth: categoryConfig)
@@ -210,7 +213,8 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
                     "PoolId": "xx",
                     "Region": "us-east-1",
                     "AppClientId": "xx",
-                    "AppClientSecret": "xx"]]
+                    "AppClientSecret": "xx",
+                    "Endpoint": "xx"]]
             ]
         ])
         let amplifyConfig = AmplifyConfiguration(auth: categoryConfig)

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
@@ -63,7 +63,7 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
                     "Region": "us-east-1",
                     "AppClientId": "xx",
                     "AppClientSecret": "xx",
-                    "Endpoint": "https://aws.amazon.com"]]
+                    "Endpoint": "example.org"]]
             ]
         ])
         let amplifyConfig = AmplifyConfiguration(auth: categoryConfig)
@@ -121,7 +121,7 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
                     "Region": "us-east-1",
                     "AppClientId": "xx",
                     "AppClientSecret": "xx",
-                    "Endpoint": "https://aws.amazon.com"]]
+                    "Endpoint": "example.org"]]
             ]
         ])
         let amplifyConfig = AmplifyConfiguration(auth: categoryConfig)
@@ -168,15 +168,15 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
         }
     }
 
-    /// Test Auth configuration with invalid endpoint url for user pool
+    /// Test Auth configuration with endpoint url containing scheme for user pool
     ///
-    /// - Given: Given invalid endpoint url for user pool
+    /// - Given: Given invalid config with endpoint url containing scheme for user pool
     /// - When:
     ///    - I configure auth with the given configuration
     /// - Then:
     ///    - I should get an exception.
     ///
-    func testConfigWithInvalidUserPoolEndpoint() throws {
+    func testConfigWithInvalidUserPoolEndpointWithScheme() throws {
         let plugin = AWSCognitoAuthPlugin()
         try Amplify.add(plugin: plugin)
 
@@ -187,7 +187,42 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
                     "Region": "us-east-1",
                     "AppClientId": "xx",
                     "AppClientSecret": "xx",
-                    "Endpoint": "xx"]]
+                    "Endpoint": "https://example.org"]]
+            ]
+        ])
+
+        let amplifyConfig = AmplifyConfiguration(auth: categoryConfig)
+        do {
+            try Amplify.configure(amplifyConfig)
+            XCTFail("Should have thrown a AuthError.configuration error for invalid endpoint url")
+        } catch {
+            guard case AuthError.configuration = error else {
+                XCTFail("Should have thrown a AuthError.configuration error for invalid endpoint url")
+                return
+            }
+        }
+    }
+
+    /// Test Auth configuration with endpoint url containing path for user pool
+    ///
+    /// - Given: Given invalid config with endpoint url containing path for user pool
+    /// - When:
+    ///    - I configure auth with the given configuration
+    /// - Then:
+    ///    - I should get an exception.
+    ///
+    func testConfigWithInvalidUserPoolEndpointWithPath() throws {
+        let plugin = AWSCognitoAuthPlugin()
+        try Amplify.add(plugin: plugin)
+
+        let categoryConfig = AuthCategoryConfiguration(plugins: [
+            "awsCognitoAuthPlugin": [
+                "CognitoUserPool": ["Default": [
+                    "PoolId": "xx",
+                    "Region": "us-east-1",
+                    "AppClientId": "xx",
+                    "AppClientSecret": "xx",
+                    "Endpoint": "example.org/path"]]
             ]
         ])
 
@@ -248,7 +283,7 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
                     "Region": "us-east-1",
                     "AppClientId": "xx",
                     "AppClientSecret": "xx",
-                    "Endpoint": "https://aws.amazon.com"]]
+                    "Endpoint": "example.org"]]
             ]
         ])
         let amplifyConfig = AmplifyConfiguration(auth: categoryConfig)

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
@@ -63,8 +63,7 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
                     "Region": "us-east-1",
                     "AppClientId": "xx",
                     "AppClientSecret": "xx",
-                    "Endpoint": "xx"
-                ]]
+                    "Endpoint": "xx"]]
             ]
         ])
         let amplifyConfig = AmplifyConfiguration(auth: categoryConfig)

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -42,6 +42,10 @@ public class AmplifyAWSServiceConfiguration: AWSServiceConfiguration {
         super.init(region: regionType, credentialsProvider: nil)
     }
 
+    public init(region regionType: AWSRegionType, endpoint: AWSEndpoint) {
+        super.init(region: regionType, endpoint: endpoint, credentialsProvider: nil)
+    }
+
     override public init(region regionType: AWSRegionType,
                          endpoint: AWSEndpoint,
                          credentialsProvider: AWSCredentialsProvider,


### PR DESCRIPTION
*Description of changes:*
Android SKD supports custom endpoint for Cognito User Pool, while iOS version isn't. This PR adds support of this.

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
