### PR TITLE
chore(DataStore): Add SyncToCloudOperation sequence

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.mmd
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.mmd
@@ -1,0 +1,56 @@
+%% SyncToCloudOperation
+sequenceDiagram
+    participant OutgoingMutationQueue
+    participant StorageAdapter
+    participant ProcessMutationErrorFromCloudOperation
+    participant SyncToCloudOperation
+    participant API
+    participant RequestRetryablePolicy
+    participant NetworkReachability
+    participant MutationRetryNotifier
+    participant Hub
+    
+    OutgoingMutationQueue->>SyncToCloudOperation: Add SyncToCloudOperation(MutationEvent, authType)
+    SyncToCloudOperation->>SyncToCloudOperation: Create GraphQL request (mutationType, authType)
+    SyncToCloudOperation->>API: API.mutate(request)
+    
+    alt Success
+        API->>SyncToCloudOperation: GraphQL response
+        SyncToCloudOperation->>OutgoingMutationQueue: finish
+        OutgoingMutationQueue->>StorageAdapter: delete MutationEvent
+    else Failure
+        loop while shouldRetry=true
+            API->>SyncToCloudOperation: GraphQL response
+            SyncToCloudOperation->>RequestRetryablePolicy: getRetryAdviceIfRetryable  
+            alt NetworkError (notConnected, dnsLookupFailed, cannotConnectToHost, cannotFindHost, timedOut, etc.), HttpStatusError (Retry-After header, 500-599, 429)
+                RequestRetryablePolicy->>RequestRetryablePolicy: retryInterval = 2^attempt * 100 + jitter
+                RequestRetryablePolicy->>SyncToCloudOperation: retryAdvice=(shouldRetry=true, retryInterval)
+                SyncToCloudOperation->>MutationRetryNotifier: schedule next mutation (retryInterval)
+                MutationRetryNotifier->>NetworkReachability: get last network status
+                alt NetworkReachability(isOnline=true)
+                    NetworkReachability->>MutationRetryNotifier: immediately perform next mutation
+                end
+                MutationRetryNotifier->>SyncToCloudOperation: perform next mutation
+                SyncToCloudOperation->>API: API.mutate(request)
+            else HttpStatusError (401) / OperationError (AuthError)
+                RequestRetryablePolicy->>SyncToCloudOperation: retry with next auth type immediately 
+                SyncToCloudOperation->>API: API.mutate(request, authType[+1])
+            else
+                RequestRetryablePolicy->>SyncToCloudOperation: retryAdvice=false
+                SyncToCloudOperation->>OutgoingMutationQueue: finish(result)
+            end
+        end
+    end
+
+    alt SyncToCloudOperation finish with AppSync error
+        OutgoingMutationQueue->>ProcessMutationErrorFromCloudOperation: process AppSync error
+        alt conditional check failed
+            ProcessMutationErrorFromCloudOperation->>Hub: Event: conditionSaveFailed
+            ProcessMutationErrorFromCloudOperation->>OutgoingMutationQueue: finish
+        else conflict unhandled
+            ProcessMutationErrorFromCloudOperation->>ProcessMutationErrorFromCloudOperation: ProcessConflictUnhandled()
+        else unauthorized, operation disabled, unhandled errorType, unknown
+            ProcessMutationErrorFromCloudOperation->>OutgoingMutationQueue: finish
+        end
+    end
+    

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
@@ -279,7 +279,7 @@ class SyncMutationToCloudOperation: AsynchronousOperation {
     /// - Warning: Must be invoked from a locking context
     private func scheduleRetry(advice: RequestRetryAdvice,
                                withAuthType authType: AWSAuthorizationType? = nil) {
-        log.verbose("\(#function) scheduling retry for mutation")
+        log.verbose("\(#function) scheduling retry for mutation \(advice)")
         mutationRetryNotifier = MutationRetryNotifier(
             advice: advice,
             networkReachabilityPublisher: networkReachabilityPublisher


### PR DESCRIPTION
*Issue #, if available:*
Related: https://github.com/aws-amplify/amplify-js/pull/9724

*Description of changes:*
Analyze the sequence for sending mutations to AppSync

```mermaid
%% SyncToCloudOperation
sequenceDiagram
    participant OutgoingMutationQueue
    participant StorageAdapter
    participant ProcessMutationErrorFromCloudOperation
    participant SyncToCloudOperation
    participant API
    participant RequestRetryablePolicy
    participant NetworkReachability
    participant MutationRetryNotifier
    participant Hub

    OutgoingMutationQueue->>SyncToCloudOperation: Add SyncToCloudOperation(MutationEvent, authType)
    SyncToCloudOperation->>SyncToCloudOperation: Create GraphQL request (mutationType, authType)
    SyncToCloudOperation->>API: API.mutate(request)

    alt Success
        API->>SyncToCloudOperation: GraphQL response
        SyncToCloudOperation->>OutgoingMutationQueue: finish
        OutgoingMutationQueue->>StorageAdapter: delete MutationEvent
    else Failure
        loop while shouldRetry=true
            API->>SyncToCloudOperation: GraphQL response
            SyncToCloudOperation->>RequestRetryablePolicy: getRetryAdviceIfRetryable  
            alt NetworkError (notConnected, dnsLookupFailed, cannotConnectToHost, cannotFindHost, timedOut, etc.), HttpStatusError (Retry-After header, 500-599, 429)
                RequestRetryablePolicy->>RequestRetryablePolicy: retryInterval = 2^attempt * 100 + jitter
                RequestRetryablePolicy->>SyncToCloudOperation: retryAdvice=(shouldRetry=true, retryInterval)
                SyncToCloudOperation->>MutationRetryNotifier: schedule next mutation (retryInterval)
                MutationRetryNotifier->>NetworkReachability: get last network status
                alt NetworkReachability(isOnline=true)
                    NetworkReachability->>MutationRetryNotifier: immediately perform next mutation
                end
                MutationRetryNotifier->>SyncToCloudOperation: perform next mutation
                SyncToCloudOperation->>API: API.mutate(request)
            else HttpStatusError (401) / OperationError (AuthError)
                RequestRetryablePolicy->>SyncToCloudOperation: retry with next auth type immediately 
                SyncToCloudOperation->>API: API.mutate(request, authType[+1])
            else
                RequestRetryablePolicy->>SyncToCloudOperation: retryAdvice=false
                SyncToCloudOperation->>OutgoingMutationQueue: finish(result)
            end
        end
    end

    alt SyncToCloudOperation finish with AppSync error
        OutgoingMutationQueue->>ProcessMutationErrorFromCloudOperation: process AppSync error
        alt conditional check failed
            ProcessMutationErrorFromCloudOperation->>Hub: conditionSaveFailed
            ProcessMutationErrorFromCloudOperation->>OutgoingMutationQueue: finish
        else conflict unhandled
            ProcessMutationErrorFromCloudOperation->>ProcessMutationErrorFromCloudOperation: ProcessConflictUnhandled()
        else unauthorized, operation disabled, unhandled errorType, unknown
            ProcessMutationErrorFromCloudOperation->>OutgoingMutationQueue: finish
        end
    end
```

# Does DataStore IOS retry indefinitely on network error?

Yes, by setting a breakpoint on the API.mutate call and toggling the wifi to off, the request will fail with a network error. retryAdvice is returned with shouldRetry=true and the retryInterval. the retryInterval is used to schedule the next retry and is calculated using the current attempt number. The shouldRetry is never return as false for network errors, and does not depend on the current attempt count.


```
[SyncMutationToCloudOperation] scheduleRetry(advice:withAuthType:) scheduling retry for mutation RequestRetryAdvice(shouldRetry: true, retryInterval: Dispatch.DispatchTimeInterval.milliseconds(243))
[SyncMutationToCloudOperation] scheduleRetry(advice:withAuthType:) scheduling retry for mutation RequestRetryAdvice(shouldRetry: true, retryInterval: Dispatch.DispatchTimeInterval.milliseconds(466))
[SyncMutationToCloudOperation] scheduleRetry(advice:withAuthType:) scheduling retry for mutation RequestRetryAdvice(shouldRetry: true, retryInterval: Dispatch.DispatchTimeInterval.milliseconds(866))
[SyncMutationToCloudOperation] scheduleRetry(advice:withAuthType:) scheduling retry for mutation RequestRetryAdvice(shouldRetry: true, retryInterval: Dispatch.DispatchTimeInterval.milliseconds(1636))
[SyncMutationToCloudOperation] scheduleRetry(advice:withAuthType:) scheduling retry for mutation RequestRetryAdvice(shouldRetry: true, retryInterval: Dispatch.DispatchTimeInterval.milliseconds(3216))
[SyncMutationToCloudOperation] scheduleRetry(advice:withAuthType:) scheduling retry for mutation RequestRetryAdvice(shouldRetry: true, retryInterval: Dispatch.DispatchTimeInterval.milliseconds(6417))
[SyncMutationToCloudOperation] scheduleRetry(advice:withAuthType:) scheduling retry for mutation RequestRetryAdvice(shouldRetry: true, retryInterval: Dispatch.DispatchTimeInterval.milliseconds(12843))
[SyncMutationToCloudOperation] scheduleRetry(advice:withAuthType:) scheduling retry for mutation RequestRetryAdvice(shouldRetry: true, retryInterval: Dispatch.DispatchTimeInterval.milliseconds(25663))
[SyncMutationToCloudOperation] scheduleRetry(advice:withAuthType:) scheduling retry for mutation RequestRetryAdvice(shouldRetry: true, retryInterval: Dispatch.DispatchTimeInterval.milliseconds(51286))
[SyncMutationToCloudOperation] scheduleRetry(advice:withAuthType:) scheduling retry for mutation RequestRetryAdvice(shouldRetry: true, retryInterval: Dispatch.DispatchTimeInterval.milliseconds(102451))
[SyncMutationToCloudOperation] scheduleRetry(advice:withAuthType:) scheduling retry for mutation RequestRetryAdvice(shouldRetry: true, retryInterval: Dispatch.DispatchTimeInterval.milliseconds(204862))
```
*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
