### PR TITLE
feat(DataStore): DataStore.delete(modelType:where:) API

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior+Combine.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior+Combine.swift
@@ -41,6 +41,22 @@ public extension DataStoreBaseBehavior {
         }.eraseToAnyPublisher()
     }
 
+    /// Deletes models matching the `predicate` from the DataStore. If sync is enabled, this will delete the
+    /// model from the remote store as well.
+    ///
+    /// - Parameters:
+    ///   - modelType: The type of the model to delete
+    ///   - predicate: The models that match this predicate to be deleted
+    /// - Returns: A DataStorePublisher with the results of the operation
+    func delete<M: Model>(
+        _ modelType: M.Type,
+        where predicate: QueryPredicate
+    ) -> DataStorePublisher<Void> {
+        Future { promise in
+            self.delete(modelType, where: predicate) { promise($0) }
+        }.eraseToAnyPublisher()
+    }
+
     /// Deletes the specified model instance from the DataStore. If sync is enabled, this will delete the
     /// model from the remote store as well.
     ///

--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
@@ -39,6 +39,12 @@ extension DataStoreCategory: DataStoreBaseBehavior {
         plugin.delete(modelType, withId: id, where: predicate, completion: completion)
     }
 
+    public func delete<M: Model>(_ modelType: M.Type,
+                                 where predicate: QueryPredicate,
+                                 completion: @escaping DataStoreCallback<Void>) {
+        plugin.delete(modelType, where: predicate, completion: completion)
+    }
+
     public func start(completion: @escaping DataStoreCallback<Void>) {
         plugin.start(completion: completion)
     }

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -34,6 +34,11 @@ public protocol DataStoreBaseBehavior {
                           withId id: String,
                           where predicate: QueryPredicate?,
                           completion: @escaping DataStoreCallback<Void>)
+
+    func delete<M: Model>(_ modelType: M.Type,
+                          where predicate: QueryPredicate,
+                          completion: @escaping DataStoreCallback<Void>)
+
     /**
      Synchronization starts automatically whenever you run any DataStore operation (query(), save(), delete())
      however, you can explicitly begin the process with DatasStore.start()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreLocalStoreTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreLocalStoreTests.swift
@@ -423,6 +423,17 @@ class DataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
 
     func testDeleteModelTypeWithPredicate() {
         _ = setUpLocalStore(numberOfPosts: 5)
+        let queryOnSetUpSuccess = expectation(description: "query returns non-empty result")
+        Amplify.DataStore.query(Post.self, where: Post.keys.status.eq(PostStatus.draft)) { result in
+            switch result {
+            case .success(let posts):
+                XCTAssertFalse(posts.isEmpty)
+                queryOnSetUpSuccess.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [queryOnSetUpSuccess], timeout: 1)
         let deleteSuccess = expectation(description: "Delete all successful")
         Amplify.DataStore.delete(Post.self, where: Post.keys.status.eq(PostStatus.draft)) { result in
             switch result {
@@ -480,7 +491,8 @@ class DataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
             let post = Post(title: "title\(Int.random(in: 0 ... 5))",
                             content: "content",
                             createdAt: .now(),
-                            rating: Double(Int.random(in: 0 ... 5)))
+                            rating: Double(Int.random(in: 0 ... 5)),
+                            status: .draft)
             savedPosts.append(post)
             print("\(id) \(post.id)")
             Amplify.DataStore.save(post) { result in

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreLocalStoreTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreLocalStoreTests.swift
@@ -421,6 +421,58 @@ class DataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
         sink.cancel()
     }
 
+    func testDeleteModelTypeWithPredicate() {
+        _ = setUpLocalStore(numberOfPosts: 5)
+        let deleteSuccess = expectation(description: "Delete all successful")
+        Amplify.DataStore.delete(Post.self, where: Post.keys.status.eq(PostStatus.draft)) { result in
+            switch result {
+            case .success:
+                deleteSuccess.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [deleteSuccess], timeout: 1)
+
+        let queryComplete = expectation(description: "query returns empty result")
+        Amplify.DataStore.query(Post.self, where: Post.keys.status.eq(PostStatus.draft)) { result in
+            switch result {
+            case .success(let posts):
+                XCTAssertEqual(posts.count, 0)
+                queryComplete.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [queryComplete], timeout: 1)
+    }
+
+    func testDeleteAll() {
+        _ = setUpLocalStore(numberOfPosts: 5)
+        let deleteSuccess = expectation(description: "Delete all successful")
+        Amplify.DataStore.delete(Post.self, where: QueryPredicateConstant.all) { result in
+            switch result {
+            case .success:
+                deleteSuccess.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [deleteSuccess], timeout: 1)
+
+        let queryComplete = expectation(description: "query returns empty result")
+        Amplify.DataStore.query(Post.self) { result in
+            switch result {
+            case .success(let posts):
+                XCTAssertEqual(posts.count, 0)
+                queryComplete.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [queryComplete], timeout: 1)
+    }
+
     func setUpLocalStore(numberOfPosts: Int) -> [Post] {
         var savedPosts = [Post]()
         for id in 0 ..< numberOfPosts {

--- a/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
@@ -69,7 +69,7 @@ class MockAuthCategoryPlugin: MessageReporter, AuthCategoryPlugin {
                         listener: AuthSignOutOperation.ResultListener?) -> AuthSignOutOperation {
         fatalError()
     }
-    
+
     public func deleteUser(listener: AuthDeleteUserOperation.ResultListener?) -> AuthDeleteUserOperation {
         fatalError()
     }

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -80,6 +80,18 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         }
     }
 
+    func delete<M: Model>(_ modelType: M.Type,
+                          where predicate: QueryPredicate,
+                          completion: (DataStoreResult<Void>) -> Void) {
+        notify("deleteModelTypeByPredicate")
+
+        if let responder = responders[.deleteModelTypeListener] as? DeleteModelTypeResponder<M> {
+            if let callback = responder.callback((modelType: modelType, where: predicate)) {
+                completion(callback)
+            }
+        }
+    }
+
     func delete<M: Model>(_ model: M,
                           where predicate: QueryPredicate? = nil,
                           completion: @escaping DataStoreCallback<Void>) {

--- a/AmplifyTestCommon/Mocks/MockDataStoreResponders.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreResponders.swift
@@ -13,6 +13,7 @@ extension MockDataStoreCategoryPlugin {
         case queryByIdListener
         case queryModelsListener
         case deleteByIdListener
+        case deleteModelTypeListener
         case deleteModelListener
         case clearListener
         case startListener
@@ -36,6 +37,11 @@ typealias QueryModelsResponder<M: Model> = MockResponder<
 
 typealias DeleteByIdResponder<M: Model> = MockResponder<
     (modelType: M.Type, id: String),
+    DataStoreResult<Void>?
+>
+
+typealias DeleteModelTypeResponder<M: Model> = MockResponder<
+    (modelType: M.Type, where: QueryPredicate),
     DataStoreResult<Void>?
 >
 


### PR DESCRIPTION
*Issue #, if available:*
Related documentation update https://github.com/aws-amplify/docs/pull/4177

*Description of changes:*
Make `delete(modelType:where:)` API publicly accessible.
- Delete all models of the modelType, according to the `where` predicate.
- the `where` parameter is required, to avoid accidentally deleting all models of the modelType without passing in the predicate to filter down the results, ie. developer cannot do this: `DataStore.delete(ModelType.self)`
- To delete all models of that modelType, pass in `QueryPredicateConstant.all` 
```swift
Amplify.DataStore.delete(Tag.self, where: QueryPredicateConstant.all) { result in
            switch result {
            case .success:
                print("Deleted All")
            case .failure(let error):
                print("\(error)")
            }
        }
```


*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
