### PR TITLE
chore(DataStore): Internal Delete API rename (predicate to condition and filter)

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -121,7 +121,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                  where predicate: QueryPredicate? = nil,
                                  completion: @escaping DataStoreCallback<Void>) {
         initStorageEngineAndStartSync()
-        storageEngine.delete(modelType, modelSchema: modelSchema, withId: id, predicate: predicate) { result in
+        storageEngine.delete(modelType, modelSchema: modelSchema, withId: id, condition: predicate) { result in
             self.onDeleteCompletion(result: result, modelSchema: modelSchema, completion: completion)
         }
     }
@@ -140,7 +140,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
         storageEngine.delete(type(of: model),
                              modelSchema: modelSchema,
                              withId: model.id,
-                             predicate: predicate) { result in
+                             condition: predicate) { result in
             self.onDeleteCompletion(result: result, modelSchema: modelSchema, completion: completion)
         }
     }
@@ -169,7 +169,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
         }
         storageEngine.delete(modelType,
                              modelSchema: modelSchema,
-                             predicate: predicate,
+                             filter: predicate,
                              completion: onCompletion)
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/ModelStorageBehavior.swift
@@ -24,12 +24,12 @@ protocol ModelStorageBehavior {
     func delete<M: Model>(_ modelType: M.Type,
                           modelSchema: ModelSchema,
                           withId id: Model.Identifier,
-                          predicate: QueryPredicate?,
+                          condition: QueryPredicate?,
                           completion: @escaping DataStoreCallback<M?>)
 
     func delete<M: Model>(_ modelType: M.Type,
                           modelSchema: ModelSchema,
-                          predicate: QueryPredicate,
+                          filter: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>)
 
     func query<M: Model>(_ modelType: M.Type,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -195,14 +195,14 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
 
     func delete<M: Model>(_ modelType: M.Type,
                           modelSchema: ModelSchema,
-                          predicate: QueryPredicate,
+                          filter: QueryPredicate,
                           completion: (DataStoreResult<[M]>) -> Void) {
         guard let connection = connection else {
             completion(.failure(DataStoreError.nilSQLiteConnection()))
             return
         }
         do {
-            let statement = DeleteStatement(modelSchema: modelSchema, predicate: predicate)
+            let statement = DeleteStatement(modelSchema: modelSchema, predicate: filter)
             _ = try connection.prepare(statement.stringValue).run(statement.variables)
             completion(.success([]))
         } catch {
@@ -213,9 +213,9 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
     func delete<M: Model>(_ modelType: M.Type,
                           modelSchema: ModelSchema,
                           withId id: Model.Identifier,
-                          predicate: QueryPredicate? = nil,
+                          condition: QueryPredicate? = nil,
                           completion: (DataStoreResult<M?>) -> Void) {
-        delete(untypedModelType: modelType, modelSchema: modelSchema, withId: id, predicate: predicate) { result in
+        delete(untypedModelType: modelType, modelSchema: modelSchema, withId: id, condition: condition) { result in
             switch result {
             case .success:
                 completion(.success(nil))
@@ -228,14 +228,14 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
     func delete(untypedModelType modelType: Model.Type,
                 modelSchema: ModelSchema,
                 withId id: Model.Identifier,
-                predicate: QueryPredicate? = nil,
+                condition: QueryPredicate? = nil,
                 completion: DataStoreCallback<Void>) {
         guard let connection = connection else {
             completion(.failure(DataStoreError.nilSQLiteConnection()))
             return
         }
         do {
-            let statement = DeleteStatement(modelSchema: modelSchema, withId: id, predicate: predicate)
+            let statement = DeleteStatement(modelSchema: modelSchema, withId: id, predicate: condition)
             _ = try connection.prepare(statement.stringValue).run(statement.variables)
             completion(.emptyResult)
         } catch {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngineAdapter.swift
@@ -19,18 +19,18 @@ protocol StorageEngineAdapter: AnyObject, ModelStorageBehavior, ModelStorageErro
     func delete<M: Model>(_ modelType: M.Type,
                           modelSchema: ModelSchema,
                           withId id: Model.Identifier,
-                          predicate: QueryPredicate?,
+                          condition: QueryPredicate?,
                           completion: @escaping DataStoreCallback<M?>)
 
     func delete(untypedModelType modelType: Model.Type,
                 modelSchema: ModelSchema,
                 withId id: Model.Identifier,
-                predicate: QueryPredicate?,
+                condition: QueryPredicate?,
                 completion: DataStoreCallback<Void>)
 
     func delete<M: Model>(_ modelType: M.Type,
                           modelSchema: ModelSchema,
-                          predicate: QueryPredicate,
+                          filter: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>)
 
     func query(modelSchema: ModelSchema,
@@ -72,26 +72,26 @@ protocol StorageEngineMigrationAdapter {
 extension StorageEngineAdapter {
 
     func delete<M: Model>(_ modelType: M.Type,
-                          predicate: QueryPredicate,
+                          filter predicate: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>) {
-        delete(modelType, modelSchema: modelType.schema, predicate: predicate, completion: completion)
+        delete(modelType, modelSchema: modelType.schema, filter: predicate, completion: completion)
     }
 
     func delete<M: Model>(_ modelType: M.Type,
                           withId id: Model.Identifier,
-                          predicate: QueryPredicate? = nil,
+                          condition: QueryPredicate? = nil,
                           completion: @escaping DataStoreCallback<M?>) {
-        delete(modelType, modelSchema: modelType.schema, withId: id, predicate: predicate, completion: completion)
+        delete(modelType, modelSchema: modelType.schema, withId: id, condition: condition, completion: completion)
     }
 
     func delete(untypedModelType modelType: Model.Type,
                 withId id: Model.Identifier,
-                predicate: QueryPredicate? = nil,
+                condition: QueryPredicate? = nil,
                 completion: DataStoreCallback<Void>) {
         delete(untypedModelType: modelType,
                modelSchema: modelType.schema,
                withId: id,
-               predicate: predicate,
+               condition: condition,
                completion: completion)
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
@@ -150,7 +150,7 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
                 storageAdapter.delete(MutationEvent.self,
                                       modelSchema: MutationEvent.schema,
                                       withId: $0.id,
-                                      predicate: nil) { _ in group.leave() }
+                                      condition: nil) { _ in group.leave() }
             }
             group.wait()
             completionPromise(.success(candidate))
@@ -174,7 +174,7 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
                     .forEach { storageAdapter.delete(MutationEvent.self,
                                                      modelSchema: MutationEvent.schema,
                                                      withId: $0.id,
-                                                     predicate: nil) { _ in } }
+                                                     condition: nil) { _ in } }
             }
 
             let resolvedEvent = getResolvedEvent(for: eventToUpdate, applying: candidate)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
@@ -322,7 +322,7 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
         storageAdapter.delete(untypedModelType: modelType,
                               modelSchema: modelSchema,
                               withId: id,
-                              predicate: nil) { response in
+                              condition: nil) { response in
             switch response {
             case .failure(let dataStoreError):
                 let error = DataStoreError.unknown("Delete failed \(dataStoreError)", "")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -345,7 +345,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
             storageAdapter.delete(untypedModelType: modelType,
                                   modelSchema: self.modelSchema,
                                   withId: remoteModel.model.id,
-                                  predicate: nil) { response in
+                                  condition: nil) { response in
                 switch response {
                 case .failure(let dataStoreError):
                     if storageAdapter.shouldIgnoreError(error: dataStoreError) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
@@ -444,7 +444,7 @@ class SQLiteStorageEngineAdapterJsonTests: XCTestCase {
                                                         operator: .greaterThan(dateTestStart.iso8601String))
                 self.storageAdapter.delete(DynamicModel.self,
                                            modelSchema: Post.schema,
-                                           predicate: predicate) { result in
+                                           filter: predicate) { result in
                     switch result {
                     case .success:
                         deleteExpectation.fulfill()
@@ -490,7 +490,7 @@ class SQLiteStorageEngineAdapterJsonTests: XCTestCase {
                         saveExpectation.fulfill()
                         self.storageAdapter.delete(DynamicModel.self,
                                                    modelSchema: schema,
-                                                   predicate: QueryPredicateConstant.all) { result in
+                                                   filter: QueryPredicateConstant.all) { result in
                             switch result {
                             case .success:
                                 deleteExpectation.fulfill()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -402,7 +402,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                 self.storageAdapter.delete(Post.self,
                                            modelSchema: Post.schema,
                                            withId: post.id,
-                                           predicate: predicate) { result in
+                                           condition: predicate) { result in
                     switch result {
                     case .success:
                         deleteExpectation.fulfill()
@@ -437,7 +437,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                 self.storageAdapter.delete(Post.self,
                                            modelSchema: Post.schema,
                                            withId: post.id,
-                                           predicate: predicate) { result in
+                                           condition: predicate) { result in
                     switch result {
                     case .success:
                         deleteCompleteExpectation.fulfill()
@@ -469,7 +469,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                 saveExpectation.fulfill()
                 let postKeys = Post.keys
                 let predicate = postKeys.createdAt.gt(dateTestStart)
-                self.storageAdapter.delete(Post.self, modelSchema: Post.schema, predicate: predicate) { result in
+                self.storageAdapter.delete(Post.self, modelSchema: Post.schema, filter: predicate) { result in
                     switch result {
                     case .success:
                         deleteExpectation.fulfill()
@@ -510,7 +510,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                         saveExpectation.fulfill()
                         self.storageAdapter.delete(Post.self,
                                                    modelSchema: Post.schema,
-                                                   predicate: QueryPredicateConstant.all) { result in
+                                                   filter: QueryPredicateConstant.all) { result in
                             switch result {
                             case .success:
                                 deleteExpectation.fulfill()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/StorageEngineTestsBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/StorageEngineTestsBase.swift
@@ -102,7 +102,7 @@ class StorageEngineTestsBase: XCTestCase {
         storageEngine.delete(modelType,
                              modelSchema: modelType.schema,
                              withId: id,
-                             predicate: predicate,
+                             condition: predicate,
                              completion: { dResult in
             result = dResult
             deleteFinished.fulfill()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -84,14 +84,14 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
     func delete<M: Model>(_ modelType: M.Type,
                           modelSchema: ModelSchema,
                           withId id: Model.Identifier,
-                          predicate: QueryPredicate? = nil,
+                          condition: QueryPredicate? = nil,
                           completion: DataStoreCallback<M?>) {
         XCTFail("Not expected to execute")
     }
 
     func delete<M: Model>(_ modelType: M.Type,
                           modelSchema: ModelSchema,
-                          predicate: QueryPredicate,
+                          filter: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>) {
         XCTFail("Not expected to execute")
     }
@@ -99,7 +99,7 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
     func delete(untypedModelType modelType: Model.Type,
                 modelSchema: ModelSchema,
                 withId id: String,
-                predicate: QueryPredicate? = nil,
+                condition: QueryPredicate? = nil,
                 completion: (Result<Void, DataStoreError>) -> Void) {
         if let responder = responders[.deleteUntypedModel] as? DeleteUntypedModelCompletionResponder {
             let result = responder.callback((modelType, id))
@@ -325,14 +325,14 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
     func delete<M: Model>(_ modelType: M.Type,
                           modelSchema: ModelSchema,
                           withId id: Model.Identifier,
-                          predicate: QueryPredicate?,
+                          condition: QueryPredicate?,
                           completion: DataStoreCallback<M?>) {
         completion(.success(nil))
     }
 
     func delete<M: Model>(_ modelType: M.Type,
                           modelSchema: ModelSchema,
-                          predicate: QueryPredicate,
+                          filter: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>) {
         XCTFail("Not expected to execute")
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Delete API has the following use cases
1. Delete model instance / delete model type by id (`DataStore.delete(model)` / `DataStore.delete(modelType:withId)`)
2. Delete model instance conditionally / delete model type by id and condition (`DataStore.delete(model:where)` / `DataStore.delete(modelType:withId:where)`)
3. Delete model type with filter (`DataStore.delete(modelType:where)`)

This internally renames `predicate` to `condition` for use case 2 and `filter` for use case 3 for better clarity on the type of `predicate` the parameter is. Also refactor some the caller code that calls `queryAndDeleteTransaction` 

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
