### PR TITLE
 chore: Run api and datastore integ test as different jobs

### DIFF
--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -1,7 +1,7 @@
 name: IntegrationTest
 on:
   push:
-    branches: [main] # Will change to main
+    branches: [royjit.parallelCI]
 
 permissions:
     id-token: write
@@ -56,7 +56,7 @@ jobs:
           project_path: ./AmplifyPlugins/Analytics/
           workspace: AnalyticsCategoryPlugin.xcworkspace
           scheme: AWSPinpointAnalyticsPluginIntegrationTests
-          
+
   api-integration-test:
     needs: prepare-for-test
     runs-on: macos-latest
@@ -78,15 +78,33 @@ jobs:
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
-      - name: List the copied configurations
-        run: ls ~/.aws-amplify/amplify-ios/testconfiguration/
-
       - name: Run Integration test
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           project_path: ./AmplifyPlugins/API/
           workspace: APICategoryPlugin.xcworkspace
           scheme: AWSAPICategoryPluginFunctionalTests
+
+  api-graphqliam-integration-test:
+    needs: [api-integration-test]
+    runs-on: macos-latest
+    environment: IntegrationTest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
+
+      - name: Make directory
+        run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
+
+      - name: Copy integration test resouces
+        uses: ./.github/composite_actions/download_test_configuration
+        with:
+          resource_subfolder: api
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
       - name: Run Integration test
         uses: ./.github/composite_actions/run_xcodebuild_test
@@ -95,12 +113,54 @@ jobs:
           workspace: APICategoryPlugin.xcworkspace
           scheme: GraphQLWithIAMIntegrationTests
 
+  api-graphqluserpool-integration-test:
+    needs: [api-integration-test]
+    runs-on: macos-latest
+    environment: IntegrationTest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
+
+      - name: Make directory
+        run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
+
+      - name: Copy integration test resouces
+        uses: ./.github/composite_actions/download_test_configuration
+        with:
+          resource_subfolder: api
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
+
       - name: Run Integration test
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           project_path: ./AmplifyPlugins/API/
           workspace: APICategoryPlugin.xcworkspace
           scheme: GraphQLWithUserPoolIntegrationTests
+
+  api-restiam-integration-test:
+    needs: [api-integration-test]
+    runs-on: macos-latest
+    environment: IntegrationTest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
+
+      - name: Make directory
+        run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
+
+      - name: Copy integration test resouces
+        uses: ./.github/composite_actions/download_test_configuration
+        with:
+          resource_subfolder: api
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
       - name: Run Integration test
         uses: ./.github/composite_actions/run_xcodebuild_test
@@ -109,12 +169,54 @@ jobs:
           workspace: APICategoryPlugin.xcworkspace
           scheme: RESTWithIAMIntegrationTests
 
+  api-restuserpool-integration-test:
+    needs: [api-integration-test]
+    runs-on: macos-latest
+    environment: IntegrationTest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
+
+      - name: Make directory
+        run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
+
+      - name: Copy integration test resouces
+        uses: ./.github/composite_actions/download_test_configuration
+        with:
+          resource_subfolder: api
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
+
       - name: Run Integration test
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           project_path: ./AmplifyPlugins/API/
           workspace: APICategoryPlugin.xcworkspace
           scheme: RESTWithUserPoolIntegrationTests
+
+  api-graphqllambda-integration-test:
+    needs: [api-integration-test]
+    runs-on: macos-latest
+    environment: IntegrationTest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
+
+      - name: Make directory
+        run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
+
+      - name: Copy integration test resouces
+        uses: ./.github/composite_actions/download_test_configuration
+        with:
+          resource_subfolder: api
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
       - name: Run Integration test
         uses: ./.github/composite_actions/run_xcodebuild_test
@@ -172,9 +274,6 @@ jobs:
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
-      - name: List the copied configurations
-        run: ls ~/.aws-amplify/amplify-ios/testconfiguration/
-
       - name: Run Integration test
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -182,12 +281,54 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreCategoryPluginIntegrationTests
 
+  datastore-auth-integration-test:
+    needs: [datastore-integration-test]
+    runs-on: macos-latest
+    environment: IntegrationTest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
+
+      - name: Make directory
+        run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
+
+      - name: Copy integration test resouces
+        uses: ./.github/composite_actions/download_test_configuration
+        with:
+          resource_subfolder: datastore
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
+
       - name: Run Integration test
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           project_path: ./AmplifyPlugins/DataStore/
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreCategoryPluginAuthIntegrationTests
+
+  datastore-flutter-integration-test:
+    needs: [datastore-integration-test]
+    runs-on: macos-latest
+    environment: IntegrationTest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
+
+      - name: Make directory
+        run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
+
+      - name: Copy integration test resouces
+        uses: ./.github/composite_actions/download_test_configuration
+        with:
+          resource_subfolder: datastore
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
       - name: Run Integration test
         uses: ./.github/composite_actions/run_xcodebuild_test

--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -46,7 +46,6 @@ jobs:
         with:
           resource_subfolder: analytics
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
@@ -74,7 +73,6 @@ jobs:
         with:
           resource_subfolder: api
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
@@ -102,7 +100,6 @@ jobs:
         with:
           resource_subfolder: api
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
@@ -130,7 +127,6 @@ jobs:
         with:
           resource_subfolder: api
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
@@ -158,7 +154,6 @@ jobs:
         with:
           resource_subfolder: api
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
@@ -186,7 +181,6 @@ jobs:
         with:
           resource_subfolder: api
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
@@ -214,7 +208,6 @@ jobs:
         with:
           resource_subfolder: api
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
@@ -242,7 +235,6 @@ jobs:
         with:
           resource_subfolder: auth
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
@@ -270,7 +262,6 @@ jobs:
         with:
           resource_subfolder: datastore
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
@@ -298,7 +289,6 @@ jobs:
         with:
           resource_subfolder: datastore
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
@@ -326,7 +316,6 @@ jobs:
         with:
           resource_subfolder: datastore
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
@@ -354,7 +343,6 @@ jobs:
         with:
           resource_subfolder: geo
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
@@ -382,7 +370,6 @@ jobs:
         with:
           resource_subfolder: predictions
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
@@ -420,7 +407,6 @@ jobs:
         with:
           resource_subfolder: storage
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          external_id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 

--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -1,7 +1,7 @@
 name: IntegrationTest
 on:
   push:
-    branches: [royjit.parallelCI]
+    branches: [main]
 
 permissions:
     id-token: write


### PR DESCRIPTION
*Description of changes:* Fix the github action integration workflow to separate different tests inside datastore and api. 

Before change:
![Screen Shot 2022-04-19 at 8 22 39 AM](https://user-images.githubusercontent.com/51138777/164039069-035b89db-6816-4333-8f76-58f8bbc29d63.png)


After change:

![Screen Shot 2022-04-19 at 8 22 28 AM](https://user-images.githubusercontent.com/51138777/164039053-3df69cc3-d9c9-49ae-aaa2-71ee5c622af4.png)


*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
