### PR TITLE
bugfix(Auth): Fixing the token expiring logic

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/FetchAuthorizationSession/UserPool/ConfigureUserPoolToken.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/FetchAuthorizationSession/UserPool/ConfigureUserPoolToken.swift
@@ -18,12 +18,11 @@ struct ConfigureUserPoolToken: Action {
         logVerbose("\(#fileID) Starting execution", environment: environment)
 
         switch cognitoSession.cognitoTokensResult {
-        case .success:
+        case .success(let cognitoTokens):
 
             let refreshInterval = AuthPluginConstants.sessionRefreshInterval
             // If the session expires > 2 minutes return it
-            if cognitoSession.areTokensExpiring(in: refreshInterval) {
-
+            if cognitoTokens.areTokensExpiring(in: refreshInterval) {
                 let userPoolTokensEvent = FetchUserPoolTokensEvent(eventType: .fetched)
                 logVerbose("\(#fileID) Sending event \(userPoolTokensEvent.type)", environment: environment)
                 dispatcher.send(userPoolTokensEvent)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/FetchAuthorizationSession/UserPool/ConfigureUserPoolToken.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/FetchAuthorizationSession/UserPool/ConfigureUserPoolToken.swift
@@ -18,11 +18,11 @@ struct ConfigureUserPoolToken: Action {
         logVerbose("\(#fileID) Starting execution", environment: environment)
 
         switch cognitoSession.cognitoTokensResult {
-        case .success(let cognitoUserPoolTokens):
+        case .success:
 
             let refreshInterval = AuthPluginConstants.sessionRefreshInterval
             // If the session expires > 2 minutes return it
-            if cognitoUserPoolTokens.expiration.compare(Date().addingTimeInterval(refreshInterval)) == .orderedDescending {
+            if cognitoSession.areTokensExpiring(in: refreshInterval) {
 
                 let userPoolTokensEvent = FetchUserPoolTokensEvent(eventType: .fetched)
                 logVerbose("\(#fileID) Sending event \(userPoolTokensEvent.type)", environment: environment)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSAuthCognitoSession.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSAuthCognitoSession.swift
@@ -7,6 +7,7 @@
 
 import Amplify
 import AWSPluginsCore
+import Foundation
 
 public struct AWSAuthCognitoSession: AuthSession,
                                      AuthAWSCredentialsProvider,
@@ -75,6 +76,25 @@ public struct AWSAuthCognitoSession: AuthSession,
         }
     }
 
+}
+
+/// Internal Helpers for managing session tokens
+internal extension AWSAuthCognitoSession {
+    func areTokensExpiring(in seconds: TimeInterval? = nil) -> Bool {
+        
+        guard let tokens = try? cognitoTokensResult.get(),
+              let idTokenClaims = try? AWSAuthService().getTokenClaims(tokenString: tokens.idToken).get(),
+              let accessTokenClaims = try? AWSAuthService().getTokenClaims(tokenString: tokens.idToken).get(),
+              let idTokenExpiration = idTokenClaims["exp"]?.doubleValue,
+              let accessTokenExpiration = accessTokenClaims["exp"]?.doubleValue else {
+            return true
+        }
+        
+        // let refreshInterval = AuthPluginConstants.sessionRefreshInterval
+        // If the session expires < X minutes return it
+        return (Date(timeIntervalSince1970: idTokenExpiration).compare(Date(timeIntervalSinceNow: seconds ?? 0)) == .orderedDescending &&
+                Date(timeIntervalSince1970: accessTokenExpiration).compare(Date(timeIntervalSinceNow: seconds ?? 0)) == .orderedDescending)
+    }
 }
 
 /// Helper method to update specific results if needed

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSAuthCognitoSession.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSAuthCognitoSession.swift
@@ -78,24 +78,6 @@ public struct AWSAuthCognitoSession: AuthSession,
 
 }
 
-/// Internal Helpers for managing session tokens
-internal extension AWSAuthCognitoSession {
-    func areTokensExpiring(in seconds: TimeInterval? = nil) -> Bool {
-        
-        guard let tokens = try? cognitoTokensResult.get(),
-              let idTokenClaims = try? AWSAuthService().getTokenClaims(tokenString: tokens.idToken).get(),
-              let accessTokenClaims = try? AWSAuthService().getTokenClaims(tokenString: tokens.idToken).get(),
-              let idTokenExpiration = idTokenClaims["exp"]?.doubleValue,
-              let accessTokenExpiration = accessTokenClaims["exp"]?.doubleValue else {
-            return true
-        }
-        
-        // If the session expires < X minutes return it
-        return (Date(timeIntervalSince1970: idTokenExpiration).compare(Date(timeIntervalSinceNow: seconds ?? 0)) == .orderedDescending &&
-                Date(timeIntervalSince1970: accessTokenExpiration).compare(Date(timeIntervalSinceNow: seconds ?? 0)) == .orderedDescending)
-    }
-}
-
 /// Helper method to update specific results if needed
 extension AWSAuthCognitoSession {
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSAuthCognitoSession.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSAuthCognitoSession.swift
@@ -7,7 +7,6 @@
 
 import Amplify
 import AWSPluginsCore
-import Foundation
 
 public struct AWSAuthCognitoSession: AuthSession,
                                      AuthAWSCredentialsProvider,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSAuthCognitoSession.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSAuthCognitoSession.swift
@@ -90,7 +90,6 @@ internal extension AWSAuthCognitoSession {
             return true
         }
         
-        // let refreshInterval = AuthPluginConstants.sessionRefreshInterval
         // If the session expires < X minutes return it
         return (Date(timeIntervalSince1970: idTokenExpiration).compare(Date(timeIntervalSinceNow: seconds ?? 0)) == .orderedDescending &&
                 Date(timeIntervalSince1970: accessTokenExpiration).compare(Date(timeIntervalSinceNow: seconds ?? 0)) == .orderedDescending)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AuthCognitoTokens+Validation.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AuthCognitoTokens+Validation.swift
@@ -11,7 +11,7 @@ import AWSPluginsCore
 /// Internal Helpers for managing session tokens
 extension AuthCognitoTokens {
     
-    func areTokensExpiring(in seconds: TimeInterval? = nil) -> Bool {
+    func areTokensExpiring(in seconds: TimeInterval = 0) -> Bool {
         
         guard let idTokenClaims = try? AWSAuthService().getTokenClaims(tokenString: idToken).get(),
               let accessTokenClaims = try? AWSAuthService().getTokenClaims(tokenString: accessToken).get(),
@@ -20,9 +20,12 @@ extension AuthCognitoTokens {
             return true
         }
         
-        // If the session expires < X minutes return it
-        return (Date(timeIntervalSince1970: idTokenExpiration).compare(Date(timeIntervalSinceNow: seconds ?? 0)) == .orderedDescending &&
-                Date(timeIntervalSince1970: accessTokenExpiration).compare(Date(timeIntervalSinceNow: seconds ?? 0)) == .orderedDescending)
+        let idTokenExpiry = Date(timeIntervalSince1970: idTokenExpiration)
+        let accessTokenExpiry = Date(timeIntervalSince1970: accessTokenExpiration)
+        
+        let expiryTime = Date(timeIntervalSinceNow: seconds)
+        return (idTokenExpiry.compare(expiryTime) == .orderedDescending &&
+                accessTokenExpiry.compare(expiryTime) == .orderedDescending)
     }
     
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AuthCognitoTokens+Validation.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AuthCognitoTokens+Validation.swift
@@ -1,0 +1,28 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import AWSPluginsCore
+
+/// Internal Helpers for managing session tokens
+extension AuthCognitoTokens {
+    
+    func areTokensExpiring(in seconds: TimeInterval? = nil) -> Bool {
+        
+        guard let idTokenClaims = try? AWSAuthService().getTokenClaims(tokenString: idToken).get(),
+              let accessTokenClaims = try? AWSAuthService().getTokenClaims(tokenString: accessToken).get(),
+              let idTokenExpiration = idTokenClaims["exp"]?.doubleValue,
+              let accessTokenExpiration = accessTokenClaims["exp"]?.doubleValue else {
+            return true
+        }
+        
+        // If the session expires < X minutes return it
+        return (Date(timeIntervalSince1970: idTokenExpiration).compare(Date(timeIntervalSinceNow: seconds ?? 0)) == .orderedDescending &&
+                Date(timeIntervalSince1970: accessTokenExpiration).compare(Date(timeIntervalSinceNow: seconds ?? 0)) == .orderedDescending)
+    }
+    
+}

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchUserPoolTokens/ConfigureUserPoolTokenTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchUserPoolTokens/ConfigureUserPoolTokenTests.swift
@@ -46,8 +46,15 @@ class ConfigureUserPoolTokenTests: XCTestCase {
         let userPoolTokensValidExpectation = expectation(description: "userPoolTokensAreValid")
         let fetchIdentityIdExpectation = expectation(description: "fetchIdentity")
 
-        let cognitoUserPoolTokensInput = AWSCognitoUserPoolTokens(idToken: "idToken",
-                                                                  accessToken: "accessToken",
+        let tokenData = [
+            "sub": "1234567890",
+            "name": "John Doe",
+            "iat": "1516239022",
+            "exp": String(Date(timeIntervalSinceNow: 121).timeIntervalSince1970)
+        ]
+
+        let cognitoUserPoolTokensInput = AWSCognitoUserPoolTokens(idToken: CognitoAuthTestHelper.buildToken(for: tokenData),
+                                                                  accessToken: CognitoAuthTestHelper.buildToken(for: tokenData),
                                                                   refreshToken: "refreshToken",
                                                                   expiresIn: 121)
 
@@ -80,9 +87,16 @@ class ConfigureUserPoolTokenTests: XCTestCase {
     func testUserPoolTokensExpiring() {
 
         let expectation = expectation(description: "refreshUserPoolTokens")
+        
+        let tokenData = [
+            "sub": "1234567890",
+            "name": "John Doe",
+            "iat": "1516239022",
+            "exp": String(Date(timeIntervalSinceNow: 119).timeIntervalSince1970)
+        ]
 
-        let cognitoUserPoolTokensInput = AWSCognitoUserPoolTokens(idToken: "idToken",
-                                                                  accessToken: "accessToken",
+        let cognitoUserPoolTokensInput = AWSCognitoUserPoolTokens(idToken: CognitoAuthTestHelper.buildToken(for: tokenData),
+                                                                  accessToken: CognitoAuthTestHelper.buildToken(for: tokenData),
                                                                   refreshToken: "refreshToken",
                                                                   expiresIn: 119)
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/AWSAuthCognitoSessionTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/AWSAuthCognitoSessionTests.swift
@@ -1,0 +1,61 @@
+//
+//  AWSAuthCognitoSessionTests.swift
+//  
+//
+//  Created by Singh, Harshdeep on 2022-04-28.
+//
+
+@testable import AWSCognitoAuthPlugin
+import XCTest
+import AWSPluginsCore
+
+class AWSAuthCognitoSessionTests: XCTestCase {
+
+    
+    /// Given: a JWT token
+    /// When: expiring in 2 mins
+    /// Then: method should return the correct state
+    func testExpiringTokens() {
+        
+        let tokenData = [
+            "sub": "1234567890",
+            "name": "John Doe",
+            "iat": "1516239022",
+            "exp": String(Date(timeIntervalSinceNow: 121).timeIntervalSince1970)
+        ]
+        
+        let tokens = AWSCognitoUserPoolTokens(idToken: CognitoAuthTestHelper.buildToken(for: tokenData),
+                                              accessToken: CognitoAuthTestHelper.buildToken(for: tokenData),
+                                              refreshToken: "refreshToken",
+                                              expiresIn: 121)
+        
+        let session = AWSAuthCognitoSession.testData.copySessionByUpdating(cognitoTokensResult: .success(tokens))
+        
+        XCTAssertTrue(session.areTokensExpiring(in: 120))
+        XCTAssertFalse(session.areTokensExpiring(in: 122))
+        XCTAssertTrue(session.areTokensExpiring())
+    }
+    
+    /// Given: a JWT token
+    /// When: that has expired
+    /// Then: method should return the correct state
+    func testExpiredTokens() {
+        
+        let tokenData = [
+            "sub": "1234567890",
+            "name": "John Doe",
+            "iat": "1516239022",
+            "exp": String(Date(timeIntervalSinceNow: 1).timeIntervalSince1970)
+        ]
+        
+        let tokens = AWSCognitoUserPoolTokens(idToken: CognitoAuthTestHelper.buildToken(for: tokenData),
+                                              accessToken: CognitoAuthTestHelper.buildToken(for: tokenData),
+                                              refreshToken: "refreshToken",
+                                              expiresIn: 121)
+        
+        let session = AWSAuthCognitoSession.testData.copySessionByUpdating(cognitoTokensResult: .success(tokens))
+        
+        XCTAssertTrue(session.areTokensExpiring())
+    }
+
+}

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/AWSAuthCognitoSessionTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/AWSAuthCognitoSessionTests.swift
@@ -30,10 +30,10 @@ class AWSAuthCognitoSessionTests: XCTestCase {
                                               expiresIn: 121)
         
         let session = AWSAuthCognitoSession.testData.copySessionByUpdating(cognitoTokensResult: .success(tokens))
-        
-        XCTAssertTrue(session.areTokensExpiring(in: 120))
-        XCTAssertFalse(session.areTokensExpiring(in: 122))
-        XCTAssertTrue(session.areTokensExpiring())
+        let cognitoTokens = try! session.getCognitoTokens().get()
+        XCTAssertTrue(cognitoTokens.areTokensExpiring(in: 120))
+        XCTAssertFalse(cognitoTokens.areTokensExpiring(in: 122))
+        XCTAssertTrue(cognitoTokens.areTokensExpiring())
     }
     
     /// Given: a JWT token
@@ -54,8 +54,8 @@ class AWSAuthCognitoSessionTests: XCTestCase {
                                               expiresIn: 121)
         
         let session = AWSAuthCognitoSession.testData.copySessionByUpdating(cognitoTokensResult: .success(tokens))
-        
-        XCTAssertTrue(session.areTokensExpiring())
+        let cognitoTokens = try! session.getCognitoTokens().get()
+        XCTAssertTrue(cognitoTokens.areTokensExpiring())
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/CognitoAuthTestHelper.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/CognitoAuthTestHelper.swift
@@ -18,7 +18,7 @@ struct CognitoAuthTestHelper {
             let typ = "JWT"
         }
         
-        let secret = "your-256-bit-secret"
+        let secret = "256-bit-secret"
         let privateKey = SymmetricKey(data: Data(secret.utf8))
 
         let headerJSONData = try! JSONEncoder().encode(Header())

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/CognitoAuthTestHelper.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/CognitoAuthTestHelper.swift
@@ -1,0 +1,49 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import CryptoKit
+import Foundation
+
+struct CognitoAuthTestHelper {
+    
+    /// Helper to build a JWT Token
+    static func buildToken(for payload: [String: String]) -> String {
+        
+        struct Header: Encodable {
+            let alg = "HS256"
+            let typ = "JWT"
+        }
+        
+        let secret = "your-256-bit-secret"
+        let privateKey = SymmetricKey(data: Data(secret.utf8))
+
+        let headerJSONData = try! JSONEncoder().encode(Header())
+        let headerBase64String = headerJSONData.urlSafeBase64EncodedString()
+
+        let payloadJSONData = try! JSONEncoder().encode(payload)
+        let payloadBase64String = payloadJSONData.urlSafeBase64EncodedString()
+
+        let toSign = Data((headerBase64String + "." + payloadBase64String).utf8)
+
+        let signature = HMAC<SHA256>.authenticationCode(for: toSign, using: privateKey)
+        let signatureBase64String = Data(signature).urlSafeBase64EncodedString()
+
+        let token = [headerBase64String, payloadBase64String, signatureBase64String].joined(separator: ".")
+        
+        return token
+    }
+}
+
+
+fileprivate extension Data {
+    func urlSafeBase64EncodedString() -> String {
+        return base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixing token expiring logic to use JWT tokens instead of the API response expiration date. 

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
