### PR TITLE
fix(DataStore): retry initial sync network failures from RemoteSyncEngine

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
@@ -160,7 +160,7 @@ final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
 
         var underlyingError: Error?
         if let error = syncErrors.first(where: isNetworkError(_:)) {
-            underlyingError = getFirstUnderlyingNetworkError(error)
+            underlyingError = getUnderlyingNetworkError(error)
         }
 
         let allMessages = syncErrors.map { String(describing: $0) }
@@ -242,7 +242,7 @@ extension AWSInitialSyncOrchestrator {
         return false
     }
 
-    private func getFirstUnderlyingNetworkError(_ error: DataStoreError) -> Error? {
+    private func getUnderlyingNetworkError(_ error: DataStoreError) -> Error? {
         guard case let .sync(_, _, underlyingError) = error,
               let datastoreError = underlyingError as? DataStoreError
               else {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Retryable.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+Retryable.swift
@@ -30,10 +30,15 @@ extension RemoteSyncEngine {
     }
 
     private func getRetryAdvice(error: Error) -> RequestRetryAdvice {
-        //TODO: Parse error from the receive completion to use as an input into getting retry advice.
-        //      For now, specifying not connected to internet to force a retry up to our maximum
-        let urlError = URLError(.notConnectedToInternet)
-        let advice = requestRetryablePolicy.retryRequestAdvice(urlError: urlError,
+        var urlErrorOptional: URLError?
+        if let dataStoreError = error as? DataStoreError,
+            let underlyingError = dataStoreError.underlyingError as? URLError {
+            urlErrorOptional = underlyingError
+        } else if let urlError = error as? URLError {
+            urlErrorOptional = urlError
+        }
+
+        let advice = requestRetryablePolicy.retryRequestAdvice(urlError: urlErrorOptional,
                                                                httpURLResponse: nil,
                                                                attemptNumber: currentAttemptNumber)
         return advice

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSyncEngineTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSyncEngineTests.swift
@@ -72,11 +72,15 @@ class RemoteSyncEngineTests: XCTestCase {
         let subscriptionsEstablishedReceived = expectation(description: "subscriptionsEstablished received")
         let cleanedup = expectation(description: "cleanedup")
         let failureOnInitialSync = expectation(description: "failureOnInitialSync")
-
+        let retryAdviceReceivedNetworkError = expectation(description: "retry advice received network error")
         var currCount = 1
 
         let advice = RequestRetryAdvice.init(shouldRetry: false)
         mockRequestRetryablePolicy.pushOnRetryRequestAdvice(response: advice)
+        mockRequestRetryablePolicy.setOnRetryRequestAdvice { urlError, httpURLResponse, attemptNumber in
+            XCTAssertNotNil(urlError)
+            retryAdviceReceivedNetworkError.fulfill()
+        }
 
         let filter = HubFilters.forEventName(HubPayload.EventName.DataStore.subscriptionsEstablished)
         let hubListener = Amplify.Hub.listen(to: .dataStore, isIncluded: filter) { payload in
@@ -116,8 +120,8 @@ class RemoteSyncEngineTests: XCTestCase {
                     XCTFail("Unexpected case gets hit")
                 }
             })
-        MockAWSInitialSyncOrchestrator.setResponseOnSync(result:
-            .failure(DataStoreError.internalOperation("forceError", "none", nil)))
+        MockAWSInitialSyncOrchestrator.setResponseOnSync(result: .failure(
+            DataStoreError.internalOperation("forceError", "none", URLError(.notConnectedToInternet))))
 
         remoteSyncEngine.start(api: apiPlugin)
 
@@ -128,7 +132,8 @@ class RemoteSyncEngineTests: XCTestCase {
                    subscriptionsInitialized,
                    subscriptionsEstablishedReceived,
                    cleanedup,
-                   failureOnInitialSync], timeout: defaultAsyncWaitTimeout)
+                   failureOnInitialSync,
+                   retryAdviceReceivedNetworkError], timeout: defaultAsyncWaitTimeout)
         remoteSyncEngineSink.cancel()
         Amplify.Hub.removeListener(hubListener)
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockRequestRetryablePolicy.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/Mocks/MockRequestRetryablePolicy.swift
@@ -15,15 +15,21 @@ import Foundation
 class MockRequestRetryablePolicy: RequestRetryablePolicy {
 
     var responseQueue: [RequestRetryAdvice] = []
+    var onRetryRequestAdvice: ((URLError?, HTTPURLResponse?, Int) -> Void)?
 
     func pushOnRetryRequestAdvice(response: RequestRetryAdvice) {
         responseQueue.append(response)
     }
 
+    func setOnRetryRequestAdvice(onRetryRequestAdvice: @escaping (URLError?, HTTPURLResponse?, Int) -> Void) {
+        self.onRetryRequestAdvice = onRetryRequestAdvice
+    }
+
     override func retryRequestAdvice(urlError: URLError?,
                                      httpURLResponse: HTTPURLResponse?,
                                      attemptNumber: Int) -> RequestRetryAdvice {
+        onRetryRequestAdvice?(urlError, httpURLResponse, attemptNumber)
         // If this breaks, you didn't push anything onto the queue
-        responseQueue.removeFirst()
+        return responseQueue.removeFirst()
     }
 }


### PR DESCRIPTION

### Description:

This PR fixes **RemoteSyncEngine** to accurately determine whether it should retry based on the URLError. Previously, when errors were handled, they were ignored and a hardcoded `URLError.notConnected` is passed to the `retryRequestAdvice` method to get the advice to retry. This is a bug when the error is a non-retryable error, since the RemoteSyncEngine's retry attempt will immediately fall into the same errored state. For example, data decoding issues which should be non-retryable but the bug caused the sync engine to restart a number of times up to the limit determine by the algorithm in **RequestRetryablePolicy**.

### Changes made
- RemoteSyncEngine's error handling path to stop using the hardcoded `URLError` and start checking against a real URLError, retrieved from the underlying error. All components, specifically the sync and subscription components, are responsible for populating the underlying error that it receives from `Amplify.API`. 
- AWSInitialSyncOrchestrator: If any of the syncQuery requests fail with a network error, pick the first one to be the underlying error. This is returned as a `DataStoreError.sync` error with the URLError as the underlying error.

### Testing Initial Sync - AWSInitialSyncOrchestrator
An end-to-end flow is when the component propagates the URLError back up to RemoteSyncEngine and RemoteSyncEngine accurately determines that it should retry. 
1. network on, DataStore.start(), then breakpoint into InitialSyncOperation's `query(lastSyncTime:, nextToken:)`
2. network off, See that API returns a failure and AWSInitialSyncOrchestrator pulls it out and into the DataStoreError.sync error.

### Testing data decoding issue
1. A schema with a model containing enum cases like
```
type Todo @model {
  id: ID!
  name: String!
  description: String
  status: Status!
}

enum Status {
  notStarted
  inProgress
  completed
  blocked
}
```
2. save some data, and then update the Status enum to remove one of the cases

```swift
public enum Status: String, EnumPersistable {
  case notStarted
  case inProgress
  case completed
  //case blocked
}
```
3. DataStore.start() should sync the data and receive the error
```
dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "items", intValue: nil), _JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "status", intValue: nil)], debugDescription: "Cannot initialize Status from invalid String value blocked", underlyingError: nil))
```
4. Observe that no retries are made.

### Subscriptions

Amplify.API.subscription API will use the AppSyncRealTimeClient library for subscriptions. When there is a network status changes, it will internally disconnect and reconnect with exponential back-ff. From Amplify.API's perspective, it doesn't receive an error until all retry attempts have been exhausted, and the error is an `.operationError`, not a URLError. See https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/58 for more details

### Sync to Cloud Mutations
OutgoingMutationQueue will create a SyncMutationtoCloudOperation for the mutation event, which contains retry logic for network failures. See https://github.com/aws-amplify/amplify-ios/pull/1722 for more details

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
