### PR TITLE
feat(auth): Add support for authType as runtime parameter

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -49,6 +49,7 @@ extension AWSCognitoAuthPlugin {
                       userService: userService,
                       deviceService: deviceService,
                       hubEventHandler: hubEventHandler,
+                      authConfig: jsonValueConfiguration,
                       queue: operationQueue)
         } catch let authError as AuthError {
             throw authError
@@ -147,7 +148,6 @@ extension AWSCognitoAuthPlugin {
         }
 
     // MARK: Internal
-
     /// Internal configure method to set the properties of the plugin
     ///
     /// Called from the configure method which implements the Plugin protocol. Useful for testing by passing in mocks.
@@ -161,12 +161,14 @@ extension AWSCognitoAuthPlugin {
                    userService: AuthUserServiceBehavior,
                    deviceService: AuthDeviceServiceBehavior,
                    hubEventHandler: AuthHubEventBehavior,
+                   authConfig: JSONValue = JSONValue.object([:]),
                    queue: OperationQueue = OperationQueue()) {
         self.authenticationProvider = authenticationProvider
         self.authorizationProvider = authorizationProvider
         self.userService = userService
         self.deviceService = deviceService
         self.hubEventHandler = hubEventHandler
+        configuration = authConfig
         self.queue = queue
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
@@ -37,6 +37,9 @@ final public class AWSCognitoAuthPlugin: AuthCategoryPlugin {
     /// Handles different auth event send through hub
     var hubEventHandler: AuthHubEventBehavior!
 
+    /// Auth configuration used during initialization
+    var configuration: JSONValue!
+
     /// The unique key of the plugin within the auth category.
     public var key: PluginKey {
         return "awsCognitoAuthPlugin"

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
@@ -59,6 +59,7 @@ extension AWSCognitoAuthPlugin {
                                         password: password,
                                         options: options)
         let signInOperation = AWSAuthSignInOperation(request,
+                                                     configuration: configuration,
                                                      authenticationProvider: authenticationProvider,
                                                      resultListener: listener)
         queue.addOperation(signInOperation)

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -16,6 +16,8 @@ typealias SigInResultCompletion = (Result<AuthSignInResult, AuthError>) -> Void
 
 extension AuthenticationProviderAdapter {
 
+    static let cognitoClientKey = "CognitoUserPoolKey"
+
     func signIn(request: AuthSignInRequest,
                 completionHandler: @escaping SigInResultCompletion) {
 
@@ -27,6 +29,12 @@ extension AuthenticationProviderAdapter {
         let password = request.password ?? ""
 
         let clientMetaData = (request.options.pluginOptions as? AWSAuthSignInOptions)?.metadata ?? [:]
+        let authType = (request.options.pluginOptions as? AWSAuthSignInOptions)?.authFlowType
+
+        if authType != .unknown,
+           let client = AWSCognitoIdentityUserPool.init(forKey: Self.cognitoClientKey) {
+            client.isCustomAuth = (authType == .custom)
+        }
 
         awsMobileClient.signIn(username: username,
                                password: password,

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignInOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignInOptions.swift
@@ -9,12 +9,26 @@ import Foundation
 
 public struct AWSAuthSignInOptions {
 
+    public let authFlowType: AuthFlowType
+
     public let validationData: [String: String]?
 
     public let metadata: [String: String]?
 
-    public init(validationData: [String: String]? = nil, metadata: [String: String]? = nil) {
+    public init(validationData: [String: String]? = nil,
+                metadata: [String: String]? = nil,
+                authFlowType: AuthFlowType = .unknown) {
         self.validationData = validationData
         self.metadata = metadata
+        self.authFlowType = authFlowType
     }
+}
+
+public enum AuthFlowType {
+
+    case userSRP
+
+    case custom
+
+    case unknown
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignInTests/AuthUsernamePasswordSignInTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignInTests/AuthUsernamePasswordSignInTests.swift
@@ -143,6 +143,67 @@ class AuthUsernamePasswordSignInTests: AWSAuthBaseTest {
         wait(for: [operationExpectation], timeout: networkTimeout)
     }
 
+    /// Test  signIn error in invalid authflowtype
+    ///
+    /// - Given: A user registered in Cognito user pool
+    /// - When:
+    ///    - I invoke Amplify.Auth.signIn with a authflow not configured in user pool
+    /// - Then:
+    ///    - I should get a completed signIn flow with an error
+    ///
+    func testRuntimeAuthFlowSwitch() {
+
+        let username = "integTest\(UUID().uuidString)"
+        let password = "P123@\(UUID().uuidString)"
+
+        let signUpExpectation = expectation(description: "SignUp operation should complete")
+        AuthSignInHelper.signUpUser(username: username, password: password,
+                                    email: email) { didSucceed, error in
+            signUpExpectation.fulfill()
+            XCTAssertTrue(didSucceed, "Signup operation failed - \(String(describing: error))")
+        }
+        wait(for: [signUpExpectation], timeout: networkTimeout)
+
+        let operationExpectation = expectation(description: "Operation should complete")
+        let option = AWSAuthSignInOptions(authFlowType: .custom)
+        let operation = Amplify.Auth.signIn(username: username,
+                                            password: password,
+                                            options: .init(pluginOptions: option)) { result in
+            defer {
+                operationExpectation.fulfill()
+            }
+            switch result {
+            case .success:
+                XCTFail("SignIn with invalid auth flow should not succeed")
+            case .failure(let error):
+                guard case .service = error else {
+                    XCTFail("Should return service error")
+                    return
+                }
+            }
+        }
+        XCTAssertNotNil(operation, "SignIn operation should not be nil")
+        wait(for: [operationExpectation], timeout: networkTimeout)
+
+        let srpOperationExpectation = expectation(description: "Operation should complete")
+        let srpOption = AWSAuthSignInOptions(authFlowType: .userSRP)
+        let srpOperation = Amplify.Auth.signIn(username: username,
+                                            password: password,
+                                            options: .init(pluginOptions: srpOption)) { result in
+            defer {
+                srpOperationExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signInResult):
+                XCTAssertTrue(signInResult.isSignedIn, "SignIn should be complete")
+            case .failure(let error):
+                XCTFail("SignIn with a valid username/password should not fail \(error)")
+            }
+        }
+        XCTAssertNotNil(srpOperation, "SignIn operation should not be nil")
+        wait(for: [srpOperationExpectation], timeout: networkTimeout)
+    }
+
     /// Test successful signIn of a valid user
     /// Internally, Two Cognito APIs will be called, Cognito's `InitiateAuth` and `RespondToAuthChallenge` API.
     ///

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignInTests/AuthUsernamePasswordSignInTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignInTests/AuthUsernamePasswordSignInTests.swift
@@ -60,6 +60,89 @@ class AuthUsernamePasswordSignInTests: AWSAuthBaseTest {
         wait(for: [operationExpectation], timeout: networkTimeout)
     }
 
+    /// Test successful signIn of a valid user with authflowType
+    ///
+    /// - Given: A user registered in Cognito user pool
+    /// - When:
+    ///    - I invoke Amplify.Auth.signIn with the username and password
+    /// - Then:
+    ///    - I should get a completed signIn flow.
+    ///
+    func testSuccessfulSignInWithSRPFlow() {
+
+        let username = "integTest\(UUID().uuidString)"
+        let password = "P123@\(UUID().uuidString)"
+
+        let signUpExpectation = expectation(description: "SignUp operation should complete")
+        AuthSignInHelper.signUpUser(username: username, password: password,
+                                    email: email) { didSucceed, error in
+            signUpExpectation.fulfill()
+            XCTAssertTrue(didSucceed, "Signup operation failed - \(String(describing: error))")
+        }
+        wait(for: [signUpExpectation], timeout: networkTimeout)
+
+        let operationExpectation = expectation(description: "Operation should complete")
+        let option = AWSAuthSignInOptions(authFlowType: .userSRP)
+        let operation = Amplify.Auth.signIn(username: username,
+                                            password: password,
+                                            options: .init(pluginOptions: option)) { result in
+            defer {
+                operationExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signInResult):
+                XCTAssertTrue(signInResult.isSignedIn, "SignIn should be complete")
+            case .failure(let error):
+                XCTFail("SignIn with a valid username/password should not fail \(error)")
+            }
+        }
+        XCTAssertNotNil(operation, "SignIn operation should not be nil")
+        wait(for: [operationExpectation], timeout: networkTimeout)
+    }
+
+    /// Test  signIn error in invalid authflowtype
+    ///
+    /// - Given: A user registered in Cognito user pool
+    /// - When:
+    ///    - I invoke Amplify.Auth.signIn with a authflow not configured in user pool
+    /// - Then:
+    ///    - I should get a completed signIn flow with an error
+    ///
+    func testSuccessfulSignInWithCustomAuth() {
+
+        let username = "integTest\(UUID().uuidString)"
+        let password = "P123@\(UUID().uuidString)"
+
+        let signUpExpectation = expectation(description: "SignUp operation should complete")
+        AuthSignInHelper.signUpUser(username: username, password: password,
+                                    email: email) { didSucceed, error in
+            signUpExpectation.fulfill()
+            XCTAssertTrue(didSucceed, "Signup operation failed - \(String(describing: error))")
+        }
+        wait(for: [signUpExpectation], timeout: networkTimeout)
+
+        let operationExpectation = expectation(description: "Operation should complete")
+        let option = AWSAuthSignInOptions(authFlowType: .custom)
+        let operation = Amplify.Auth.signIn(username: username,
+                                            password: password,
+                                            options: .init(pluginOptions: option)) { result in
+            defer {
+                operationExpectation.fulfill()
+            }
+            switch result {
+            case .success:
+                XCTFail("SignIn with invalid auth flow should not succeed")
+            case .failure(let error):
+                guard case .service = error else {
+                    XCTFail("Should return service error")
+                    return
+                }
+            }
+        }
+        XCTAssertNotNil(operation, "SignIn operation should not be nil")
+        wait(for: [operationExpectation], timeout: networkTimeout)
+    }
+
     /// Test successful signIn of a valid user
     /// Internally, Two Cognito APIs will be called, Cognito's `InitiateAuth` and `RespondToAuthChallenge` API.
     ///

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
@@ -55,6 +55,46 @@ class AuthenticationProviderSigninTests: BaseAuthenticationProviderTest {
         wait(for: [resultExpectation], timeout: apiTimeout)
     }
 
+    /// Test a signIn with valid inputs and authflow type
+    ///
+    /// - Given: Given an auth plugin with mocked service.
+    ///
+    /// - When:
+    ///    - I invoke signIn with valid values
+    /// - Then:
+    ///    - I should get a .done response
+    ///
+    func testSuccessfulSignInWuthAuthFlow() {
+
+        let mockSigninResult = SignInResult(signInState: .signedIn)
+        mockAWSMobileClient?.signInMockResult = .success(mockSigninResult)
+
+        let pluginOptions = AWSAuthSignInOptions(validationData: ["somekey": "somevalue"],
+                                                 metadata: ["somekey": "somevalue"],
+                                                 authFlowType: .userSRP)
+        let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
+
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let signinResult):
+                guard case .done = signinResult.nextStep else {
+                    XCTFail("Result should be .done for next step")
+                    return
+                }
+                XCTAssertTrue(signinResult.isSignedIn, "Signin result should be complete")
+                XCTAssertFalse(self.mockUserDefault.isPrivateSessionPreferred(),
+                               "Prefer private session userdefaults should not be set.")
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: apiTimeout)
+    }
+
     /// Test a signIn with empty username
     ///
     /// - Given: Given an auth plugin with mocked service.

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderSigninTests.swift
@@ -64,7 +64,7 @@ class AuthenticationProviderSigninTests: BaseAuthenticationProviderTest {
     /// - Then:
     ///    - I should get a .done response
     ///
-    func testSuccessfulSignInWuthAuthFlow() {
+    func testSuccessfulSignInWithAuthFlow() {
 
         let mockSigninResult = SignInResult(signInState: .signedIn)
         mockAWSMobileClient?.signInMockResult = .success(mockSigninResult)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add runtime support for auth flow type. AWSCognitoPlugin currently supports SRP and Custom auth flow types to be changed during runtime.

Usage:

```
let options = AWSAuthSignInOptions(authFlowType: .custom)
Amplify.Auth.signIn(username: user,
                            password: password,
                            options: .init(pluginOptions: options))
```

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
