### PR TITLE
chore: Removed outdated TODO

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -12,8 +12,6 @@ public class AmplifyAWSServiceConfiguration: AWSServiceConfiguration {
     static let version = "1.23.1"
 
     override public class func baseUserAgent() -> String! {
-        //TODO: Retrieve this version from a centralized location:
-        //https://github.com/aws-amplify/amplify-ios/issues/276
         let platformInfo = AmplifyAWSServiceConfiguration.platformInformation()
         let systemName = UIDevice.current.systemName.replacingOccurrences(of: " ", with: "-")
         let systemVersion = UIDevice.current.systemVersion


### PR DESCRIPTION
Removed an outdated TODO about retrieving configs from a centralized location. That TODO was closed wontfix in 2021.

*Issue #, if available:*

*Description of changes:*

*Check points: (check or cross out if not relevant)*

- [ ] ~~Added new tests to cover change, if needed~~
- [ ] ~~Build succeeds with all target using Swift Package Manager~~
- [ ] ~~All unit tests pass~~
- [ ] ~~All integration tests pass~~
- [ ] ~~Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
- [ ] ~~Documentation update for the change if required~~
- [X] PR title conforms to conventional commit style
- [ ] ~~If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
