### PR TITLE
fix(DataStore): retry on URLError.dataNotAllowed

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RequestRetryablePolicy.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RequestRetryablePolicy.swift
@@ -37,7 +37,8 @@ class RequestRetryablePolicy: RequestRetryable {
              .dnsLookupFailed,
              .cannotConnectToHost,
              .cannotFindHost,
-             .timedOut:
+             .timedOut,
+             .dataNotAllowed:
             let waitMillis = retryDelayInMillseconds(for: attemptNumber)
             return RequestRetryAdvice(shouldRetry: true, retryInterval: .milliseconds(waitMillis))
         default:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/1718#issuecomment-1122536571

*Description of changes:*
We know from trial and error that when running on a device, the URLError returned after toggling the network state will return `.dataNotAllowed`. This is a quick fix to make sure the library handles this error by retrying. By not retrying, we are essentally classifying a retryable error as non retryable.

As a longer term follow-up, we should do more extensive testing on possible URLErrors returned, and essentially map the URLError codes https://developer.apple.com/documentation/foundation/urlerror/code to retryable and non-retryable. That exercise should result in either adding more to the list to retry, or we can invert the list to always retry except for a few non-retryable URLErrors. Or result in retrying for any URLError.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
