### PR TITLE
chore: Add IDETemplateMacros.plist for file header generation with spm [skip ci]

### DIFF
--- a/.swiftpm/xcode/xcshareddata/IDETemplateMacros.plist
+++ b/.swiftpm/xcode/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>FILEHEADER</key>
+  <string>
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//</string>
+</dict>
+</plist>


### PR DESCRIPTION
*Issue #, if available:*
Adding files in the xcodeproj generated by opening Package.swift doesn't produce the typical file header.
```
//
// Copyright Amazon.com Inc. or its affiliates.
// All Rights Reserved.
//
// SPDX-License-Identifier: Apache-2.0
//
```
*Description of changes:*
This change adds an IDETemplateMacros.plist to the xcshareddata directory to autogenerate the correct file header when using Package.swift.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [ ] ~Build succeeds with all target using Swift Package Manager~
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [ ] ~Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~
- [ ] ~Documentation update for the change if required~
- [ ] ~PR title conforms to conventional commit style~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
