### PR TITLE
fix(Auth): Fixing a typo in the Auth error message (#1782)

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Constants/AuthPluginErrorConstants.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Constants/AuthPluginErrorConstants.swift
@@ -146,7 +146,7 @@ extension AuthPluginErrorConstants {
     static let signInUsernameError: AuthPluginValidationErrorString = (
         "username",
         "Username is required to signIn",
-        "Make sure that a valid username is passed during sigIn"
+        "Make sure that a valid username is passed during signIn"
     )
 
     static let signUpUsernameError: AuthPluginValidationErrorString = (


### PR DESCRIPTION
*Issue #, if available:*
[#1782 ](https://github.com/aws-amplify/amplify-ios/issues/1782)

*Description of changes:*
Fixing a typo

*Check points: (check or cross out if not relevant)*

- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
