### PR TITLE
Revises build to organize Package.swift and other improvements

### DIFF
--- a/Amplify/Categories/API/ClientBehavior/APICategoryReachabilityBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategoryReachabilityBehavior.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Foundation
 import Combine
 
@@ -22,3 +23,4 @@ public protocol APICategoryReachabilityBehavior {
     func reachabilityPublisher() throws -> AnyPublisher<ReachabilityUpdate, Never>?
 
 }
+#endif

--- a/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+ReachabilityBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+ReachabilityBehavior.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Foundation
 import Combine
 
@@ -20,3 +21,4 @@ extension AmplifyAPICategory: APICategoryReachabilityBehavior {
         return try plugin.reachabilityPublisher(for: nil)
     }
 }
+#endif

--- a/Amplify/Categories/API/Operation/AmplifyOperation+APIPublishers.swift
+++ b/Amplify/Categories/API/Operation/AmplifyOperation+APIPublishers.swift
@@ -5,13 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Combine
+#if canImport(Combine)
 import Foundation
+import Combine
 
 // MARK: - GraphQLOperation
-
-// The overrides require a feature and bugfix introduced in Swift 5.2
-#if swift(>=5.2)
 
 public extension GraphQLOperation {
     /// Publishes the final result of the operation

--- a/Amplify/Categories/Auth/AuthCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategory+ClientBehavior.swift
@@ -52,6 +52,7 @@ extension AuthCategory: AuthCategoryBehavior {
                              listener: listener)
     }
 
+#if canImport(AuthenticationServices)
     @discardableResult
     public func signInWithWebUI(presentationAnchor: AuthUIPresentationAnchor,
                                 options: AuthWebUISignInOperation.Request.Options? = nil,
@@ -72,6 +73,7 @@ extension AuthCategory: AuthCategoryBehavior {
                                           options: options,
                                           listener: listener)
     }
+#endif
 
     @discardableResult
     public func confirmSignIn(challengeResponse: String,

--- a/Amplify/Categories/Auth/AuthCategoryBehavior+Combine.swift
+++ b/Amplify/Categories/Auth/AuthCategoryBehavior+Combine.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(UIKit)
 import UIKit
+#endif
 
 // No-listener versions of the public APIs, to clean call sites that use Combine
 // publishers to get results
@@ -82,6 +84,7 @@ public extension AuthCategoryBehavior {
         signIn(username: username, password: password, options: options, listener: nil)
     }
 
+#if canImport(AuthenticationServices)
     /// SignIn using pre configured web UI.
     ///
     /// Calling this method will always launch the Auth plugin's default web user interface
@@ -118,6 +121,7 @@ public extension AuthCategoryBehavior {
             listener: nil
         )
     }
+#endif
 
     /// Confirms a next step in signIn flow.
     ///

--- a/Amplify/Categories/Auth/AuthCategoryBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategoryBehavior.swift
@@ -6,13 +6,15 @@
 //
 
 import Foundation
-import UIKit
+#if canImport(AuthenticationServices)
+import AuthenticationServices
 
-public typealias AuthUIPresentationAnchor = UIWindow
+public typealias AuthUIPresentationAnchor = ASPresentationAnchor
+#endif
 
 /// Behavior of the Auth category that clients will use
 public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDeviceBehavior {
-
+    
     /// SignUp a user with the authentication provider.
     ///
     /// If the signUp require multiple steps like passing a confirmation code, use the method
@@ -29,7 +31,7 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
                 password: String?,
                 options: AuthSignUpOperation.Request.Options?,
                 listener: AuthSignUpOperation.ResultListener?) -> AuthSignUpOperation
-
+    
     /// Confirms the `signUp` operation.
     ///
     /// Invoke this operation as a follow up for the signUp process if the authentication provider
@@ -45,7 +47,7 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
                        confirmationCode: String,
                        options: AuthConfirmSignUpOperation.Request.Options?,
                        listener: AuthConfirmSignUpOperation.ResultListener?) -> AuthConfirmSignUpOperation
-
+    
     /// Resends the confirmation code to confirm the signUp process
     ///
     /// - Parameters:
@@ -56,7 +58,7 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
     func resendSignUpCode(for username: String,
                           options: AuthResendSignUpCodeOperation.Request.Options?,
                           listener: AuthResendSignUpCodeOperation.ResultListener?) -> AuthResendSignUpCodeOperation
-
+    
     /// SignIn to the authentication provider
     ///
     /// Username and password are optional values, check the plugin documentation to decide on what all values need to
@@ -73,6 +75,7 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
                 options: AuthSignInOperation.Request.Options?,
                 listener: AuthSignInOperation.ResultListener?) -> AuthSignInOperation
 
+#if canImport(AuthenticationServices)
     /// SignIn using pre configured web UI.
     ///
     /// Calling this method will always launch the Auth plugin's default web user interface
@@ -85,7 +88,7 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
     func signInWithWebUI(presentationAnchor: AuthUIPresentationAnchor,
                          options: AuthWebUISignInOperation.Request.Options?,
                          listener: AuthWebUISignInOperation.ResultListener?) -> AuthWebUISignInOperation
-
+    
     /// SignIn using an auth provider on a web UI
     ///
     /// Calling this method will invoke the AuthProvider's default web user interface. Depending on the plugin
@@ -102,7 +105,8 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
                          presentationAnchor: AuthUIPresentationAnchor,
                          options: AuthSocialWebUISignInOperation.Request.Options?,
                          listener: AuthSocialWebUISignInOperation.ResultListener?) -> AuthSocialWebUISignInOperation
-
+#endif
+    
     /// Confirms a next step in signIn flow.
     ///
     /// - Parameters:
@@ -113,7 +117,7 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
     func confirmSignIn(challengeResponse: String,
                        options: AuthConfirmSignInOperation.Request.Options?,
                        listener: AuthConfirmSignInOperation.ResultListener?) -> AuthConfirmSignInOperation
-
+    
     /// Sign out the currently logged-in user.
     ///
     /// - Parameters:
@@ -123,7 +127,7 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
     @discardableResult
     func signOut(options: AuthSignOutOperation.Request.Options?,
                  listener: AuthSignOutOperation.ResultListener?) -> AuthSignOutOperation
-
+    
     /// Delete the account of the currently logged-in user.
     ///
     /// - Parameters:
@@ -131,7 +135,7 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
     /// - Returns: AuthDeleteUserOperation
     @discardableResult
     func deleteUser(listener: AuthDeleteUserOperation.ResultListener?) -> AuthDeleteUserOperation
-
+    
     /// Fetch the current authentication session.
     ///
     /// - Parameters:
@@ -140,7 +144,7 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
     @discardableResult
     func fetchAuthSession(options: AuthFetchSessionOperation.Request.Options?,
                           listener: AuthFetchSessionOperation.ResultListener?) -> AuthFetchSessionOperation
-
+    
     /// Initiate a reset password flow for the user
     ///
     /// - Parameters:
@@ -151,7 +155,7 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
     func resetPassword(for username: String,
                        options: AuthResetPasswordOperation.Request.Options?,
                        listener: AuthResetPasswordOperation.ResultListener?) -> AuthResetPasswordOperation
-
+    
     /// Confirms a reset password flow
     ///
     /// - Parameters:
@@ -166,6 +170,6 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
                               confirmationCode: String,
                               options: AuthConfirmResetPasswordOperation.Request.Options?,
                               listener: AuthConfirmResetPasswordOperation.ResultListener?)
-        -> AuthConfirmResetPasswordOperation
-
+    -> AuthConfirmResetPasswordOperation
+    
 }

--- a/Amplify/Categories/Auth/Operation/AmplifyOperation+AuthPublishers.swift
+++ b/Amplify/Categories/Auth/Operation/AmplifyOperation+AuthPublishers.swift
@@ -5,15 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Combine
+#if canImport(Combine)
 import Foundation
+import Combine
 
 // MARK: - AuthAttributeResendConfirmationCodeOperation
 
-// The overrides require a feature and bugfix introduced in Swift 5.2
-#if swift(>=5.2)
-
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthAttributeResendConfirmationCodeOperation.Request,
@@ -27,7 +24,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthChangePasswordOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthChangePasswordOperation.Request,
@@ -41,7 +37,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthConfirmResetPasswordOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthConfirmResetPasswordOperation.Request,
@@ -55,7 +50,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthConfirmSignInOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthConfirmSignInOperation.Request,
@@ -69,7 +63,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthConfirmSignUpOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthConfirmSignUpOperation.Request,
@@ -83,7 +76,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthConfirmUserAttributeOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthConfirmUserAttributeOperation.Request,
@@ -97,7 +89,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthFetchDevicesOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthFetchDevicesOperation.Request,
@@ -111,7 +102,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthFetchSessionOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthFetchSessionOperation.Request,
@@ -125,7 +115,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthFetchUserAttributeOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthFetchUserAttributeOperation.Request,
@@ -139,7 +128,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthForgetDeviceOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthForgetDeviceOperation.Request,
@@ -153,7 +141,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthRememberDeviceOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthRememberDeviceOperation.Request,
@@ -167,7 +154,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthResendSignUpCodeOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthResendSignUpCodeOperation.Request,
@@ -181,7 +167,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthResetPasswordOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthResetPasswordOperation.Request,
@@ -195,7 +180,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthSignInOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthSignInOperation.Request,
@@ -209,7 +193,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthSignOutOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthSignOutOperation.Request,
@@ -223,7 +206,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthDeleteUserOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthDeleteUserOperation.Request,
@@ -237,7 +219,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthSignUpOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthSignUpOperation.Request,
@@ -251,7 +232,7 @@ public extension AmplifyOperation
 
 // MARK: - AuthSocialWebUISignInOperation and AuthWebUISignInOperation
 
-@available(iOS 13.0, *)
+#if canImport(UIKit)
 public extension AmplifyOperation
     where
     Request == AuthSocialWebUISignInOperation.Request,
@@ -262,10 +243,10 @@ public extension AmplifyOperation
         internalResultPublisher
     }
 }
+#endif
 
 // MARK: - AuthUpdateUserAttributeOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthUpdateUserAttributeOperation.Request,
@@ -279,7 +260,6 @@ public extension AmplifyOperation
 
 // MARK: - AuthUpdateUserAttributesOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == AuthUpdateUserAttributesOperation.Request,

--- a/Amplify/Categories/Auth/Operation/AuthSocialWebUISignInOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthSocialWebUISignInOperation.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(AuthenticationServices)
 import Foundation
 
 public protocol AuthSocialWebUISignInOperation: AmplifyOperation<
@@ -18,3 +19,4 @@ public extension HubPayload.EventName.Auth {
     /// eventName for HubPayloads emitted by this operation
     static let socialWebUISignInAPI = "Auth.socialWebUISignInAPI"
 }
+#endif

--- a/Amplify/Categories/Auth/Operation/AuthWebUISignInOperation.swift
+++ b/Amplify/Categories/Auth/Operation/AuthWebUISignInOperation.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(AuthenticationServices)
 import Foundation
 
 public protocol AuthWebUISignInOperation: AmplifyOperation<
@@ -18,3 +19,4 @@ public extension HubPayload.EventName.Auth {
     /// eventName for HubPayloads emitted by this operation
     static let webUISignInAPI = "Auth.webUISignInAPI"
 }
+#endif

--- a/Amplify/Categories/Auth/Request/AuthWebUISignInRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthWebUISignInRequest.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(AuthenticationServices)
 import Foundation
-import UIKit
 
 /// Request to initiate sign in using a web UI.
 ///
@@ -65,3 +65,4 @@ public extension AuthWebUISignInRequest {
         }
     }
 }
+#endif

--- a/Amplify/Categories/DataStore/Model/Collection/ArrayLiteralListProvider.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/ArrayLiteralListProvider.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Combine
+//import Combine
 
 public struct ArrayLiteralListProvider<Element: Model>: ModelListProvider {
     let elements: [Element]

--- a/Amplify/Categories/DataStore/Model/Collection/ArrayLiteralListProvider.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/ArrayLiteralListProvider.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-//import Combine
 
 public struct ArrayLiteralListProvider<Element: Model>: ModelListProvider {
     let elements: [Element]

--- a/Amplify/Categories/DataStore/Model/Collection/List+Combine.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+Combine.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
 
 extension List {
@@ -12,3 +13,4 @@ extension List {
     public typealias LazyListPublisher = AnyPublisher<[Element], DataStoreError>
     
 }
+#endif

--- a/Amplify/Categories/Hub/HubCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Hub/HubCategory+ClientBehavior.swift
@@ -5,13 +5,16 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import Foundation
+#if canImport(Combine)
 import Combine
+#endif
 
 extension HubCategory: HubCategoryBehavior {
     public func dispatch(to channel: HubChannel, payload: HubPayload) {
-        if #available(iOS 13.0, *) {
-            Amplify.Hub.subject(for: channel).send(payload)
-        }
+#if canImport(Combine)
+        Amplify.Hub.subject(for: channel).send(payload)
+#endif
         plugin.dispatch(to: channel, payload: payload)
     }
 

--- a/Amplify/Categories/Hub/HubCategoryBehavior+Combine.swift
+++ b/Amplify/Categories/Hub/HubCategoryBehavior+Combine.swift
@@ -5,23 +5,20 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
 
-@available(iOS 13.0, *)
 public typealias HubPublisher = AnyPublisher<HubPayload, Never>
 
-@available(iOS 13.0, *)
 typealias HubSubject = PassthroughSubject<HubPayload, Never>
 
 /// Maintains a map of Subjects by Hub Channel. All downstream subscribers will
 /// attach to the same Subject.
-@available(iOS 13.0, *)
 private struct HubSubjectMap {
     static var `default` = HubSubjectMap()
     var subjectsByChannel = AtomicValue<[HubChannel: HubSubject]>(initialValue: [:])
 }
 
-@available(iOS 13.0, *)
 extension HubCategoryBehavior {
     /// Returns a publisher for all Hub messages sent to `channel`
     ///
@@ -52,3 +49,4 @@ extension HubCategoryBehavior {
     }
 
 }
+#endif

--- a/Amplify/Categories/Predictions/Operation/AmplifyOperation+PredictionsPublishers.swift
+++ b/Amplify/Categories/Predictions/Operation/AmplifyOperation+PredictionsPublishers.swift
@@ -5,15 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Combine
+#if canImport(Combine)
 import Foundation
+import Combine
 
 // MARK: - PredictionsIdentifyOperation
 
-// The overrides require a feature and bugfix introduced in Swift 5.2
-#if swift(>=5.2)
-
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == PredictionsIdentifyOperation.Request,
@@ -27,7 +24,6 @@ public extension AmplifyOperation
 
 // MARK: - PredictionsInterpretOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == PredictionsInterpretOperation.Request,
@@ -41,7 +37,6 @@ public extension AmplifyOperation
 
 // MARK: - PredictionsSpeechToTextOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == PredictionsSpeechToTextOperation.Request,
@@ -55,7 +50,6 @@ public extension AmplifyOperation
 
 // MARK: - PredictionsTextToSpeechOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == PredictionsTextToSpeechOperation.Request,
@@ -69,7 +63,6 @@ public extension AmplifyOperation
 
 // MARK: - PredictionsTranslateTextOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == PredictionsTranslateTextOperation.Request,
@@ -80,5 +73,4 @@ public extension AmplifyOperation
         internalResultPublisher
     }
 }
-
 #endif

--- a/Amplify/Categories/Predictions/Request/PredictionsIdentifyRequest.swift
+++ b/Amplify/Categories/Predictions/Request/PredictionsIdentifyRequest.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import UIKit
 
 public struct PredictionsIdentifyRequest: AmplifyOperationRequest {
 

--- a/Amplify/Categories/Storage/Operation/Operation+StoragePublishers.swift
+++ b/Amplify/Categories/Storage/Operation/Operation+StoragePublishers.swift
@@ -5,15 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Combine
+#if canImport(Combine)
 import Foundation
+import Combine
 
 // MARK: - StorageDownloadDataOperation
 
-// The overrides require a feature and bugfix introduced in Swift 5.2
-#if swift(>=5.2)
-
-@available(iOS 13.0, *)
 public extension AmplifyInProcessReportingOperation
     where
     Request == StorageDownloadDataOperation.Request,
@@ -37,7 +34,6 @@ public extension AmplifyInProcessReportingOperation
 
 // MARK: - StorageDownloadFileOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyInProcessReportingOperation
     where
     Request == StorageDownloadFileOperation.Request,
@@ -61,7 +57,6 @@ public extension AmplifyInProcessReportingOperation
 
 // MARK: - StorageGetURLOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == StorageGetURLOperation.Request,
@@ -75,7 +70,6 @@ public extension AmplifyOperation
 
 // MARK: - StorageListOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == StorageListOperation.Request,
@@ -89,7 +83,6 @@ public extension AmplifyOperation
 
 // MARK: - StorageRemoveOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyOperation
     where
     Request == StorageRemoveOperation.Request,
@@ -103,7 +96,6 @@ public extension AmplifyOperation
 
 // MARK: - StorageUploadDataOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyInProcessReportingOperation
     where
     Request == StorageUploadDataOperation.Request,
@@ -127,7 +119,6 @@ public extension AmplifyInProcessReportingOperation
 
 // MARK: - StorageUploadFileOperation
 
-@available(iOS 13.0, *)
 public extension AmplifyInProcessReportingOperation
     where
     Request == StorageUploadFileOperation.Request,
@@ -148,5 +139,4 @@ public extension AmplifyInProcessReportingOperation
         internalInProcessPublisher
     }
 }
-
 #endif

--- a/Amplify/Core/Configuration/Internal/Amplify+Reset.swift
+++ b/Amplify/Core/Configuration/Internal/Amplify+Reset.swift
@@ -57,9 +57,9 @@ extension Amplify {
             }
         }
 
-        if #available(iOS 13.0.0, *) {
-            devMenu = nil
-        }
+#if canImport(UIKit)
+        devMenu = nil
+#endif
 
         group.wait()
 

--- a/Amplify/Core/Support/AmplifyInProcessReportingOperation+Combine.swift
+++ b/Amplify/Core/Support/AmplifyInProcessReportingOperation+Combine.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Combine
+#if canImport(Combine)
 import Foundation
+import Combine
 
-@available(iOS 13.0, *)
 extension AmplifyInProcessReportingOperation {
     /// A Publisher that emits in-process values for an operation, or the associated
     /// failure. Cancelled operations will emit a completion without a value as long as
@@ -48,3 +48,4 @@ extension AmplifyInProcessReportingOperation {
     }
 
 }
+#endif

--- a/Amplify/Core/Support/AmplifyInProcessReportingOperation.swift
+++ b/Amplify/Core/Support/AmplifyInProcessReportingOperation.swift
@@ -5,8 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Combine
 import Foundation
+#if canImport(Combine)
+import Combine
+#endif
 
 /// An AmplifyOperation that emits InProcess values intermittently during the operation.
 ///
@@ -41,9 +43,9 @@ open class AmplifyInProcessReportingOperation<
 
         super.init(categoryType: categoryType, eventName: eventName, request: request, resultListener: resultListener)
 
-        if #available(iOS 13.0, *) {
-            inProcessSubject = PassthroughSubject<InProcess, Never>()
-        }
+#if canImport(Combine)
+        inProcessSubject = PassthroughSubject<InProcess, Never>()
+#endif
 
         // If the inProcessListener is present, we need to register a hub event listener for it, and ensure we
         // automatically unsubscribe when we receive a completion event for the operation
@@ -83,9 +85,9 @@ open class AmplifyInProcessReportingOperation<
     /// Classes that override this method must emit a completion to the `inProcessPublisher` upon cancellation
     open override func cancel() {
         super.cancel()
-        if #available(iOS 13.0, *) {
-            publish(completion: .finished)
-        }
+#if canImport(Combine)
+        publish(completion: .finished)
+#endif
     }
 
     /// Invokes `super.dispatch()`. On iOS 13+, this method first publishes a
@@ -94,9 +96,9 @@ open class AmplifyInProcessReportingOperation<
     /// - Parameter result: The OperationResult to dispatch to the hub as part of the
     ///   HubPayload
     public override func dispatch(result: OperationResult) {
-        if #available(iOS 13.0, *) {
-            publish(completion: .finished)
-        }
+#if canImport(Combine)
+        publish(completion: .finished)
+#endif
         super.dispatch(result: result)
     }
 
@@ -110,9 +112,9 @@ public extension AmplifyInProcessReportingOperation {
     /// `AmplifyOperationContext` object from the operation's `id`, and `request`
     /// - Parameter result: The OperationResult to dispatch to the hub as part of the HubPayload
     func dispatchInProcess(data: InProcess) {
-        if #available(iOS 13.0, *) {
-            publish(inProcessValue: data)
-        }
+#if canImport(Combine)
+        publish(inProcessValue: data)
+#endif
 
         let channel = HubChannel(from: categoryType)
         let context = AmplifyOperationContext(operationId: id, request: request)

--- a/Amplify/Core/Support/AmplifyOperation+Combine.swift
+++ b/Amplify/Core/Support/AmplifyOperation+Combine.swift
@@ -5,8 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Combine
+#if canImport(Combine)
 import Foundation
+import Combine
 
 // Most APIs will return an operation that exposes a `resultPublisher`. The
 // Storage and API category methods that expose both a result and an in-process
@@ -28,7 +29,6 @@ import Foundation
 // isn't as meaningful at the call site of a Storage file operation as a
 // `progressPublisher`.
 
-@available(iOS 13.0, *)
 extension AmplifyOperation {
     /// A Publisher that emits the result of the operation, or the associated failure.
     /// Cancelled operations will emit a completion without a value as long as the
@@ -68,3 +68,4 @@ extension AmplifyOperation {
     }
 
 }
+#endif

--- a/Amplify/Core/Support/AmplifyOperation.swift
+++ b/Amplify/Core/Support/AmplifyOperation.swift
@@ -109,9 +109,9 @@ open class AmplifyOperation<Request: AmplifyOperationRequest, Success, Failure: 
 
         super.init()
 
-        if #available(iOS 13.0, *) {
-            resultFuture = Future<Success, Failure> { self.resultPromise = $0 }
-        }
+#if canImport(Combine)
+        resultFuture = Future<Success, Failure> { self.resultPromise = $0 }
+#endif
 
         if let resultListener = resultListener {
             self.resultListenerUnsubscribeToken = subscribe(resultListener: resultListener)
@@ -146,14 +146,14 @@ open class AmplifyOperation<Request: AmplifyOperationRequest, Success, Failure: 
     /// Classes that override this method must emit a completion to the `resultPublisher` upon cancellation
     open override func cancel() {
         super.cancel()
-        if #available(iOS 13.0, *) {
-            let cancellationError = Failure(
-                errorDescription: "Operation cancelled",
-                recoverySuggestion: "The operation was cancelled before it completed",
-                error: OperationCancelledError()
-            )
-            publish(result: .failure(cancellationError))
-        }
+#if canImport(Combine)
+        let cancellationError = Failure(
+            errorDescription: "Operation cancelled",
+            recoverySuggestion: "The operation was cancelled before it completed",
+            error: OperationCancelledError()
+        )
+        publish(result: .failure(cancellationError))
+#endif
     }
 
     /// Dispatches an event to the hub. Internally, creates an
@@ -163,9 +163,9 @@ open class AmplifyOperation<Request: AmplifyOperationRequest, Success, Failure: 
     /// - Parameter result: The OperationResult to dispatch to the hub as part of the
     ///   HubPayload
     public func dispatch(result: OperationResult) {
-        if #available(iOS 13.0, *) {
-            publish(result: result)
-        }
+#if canImport(Combine)
+        publish(result: result)
+#endif
 
         let channel = HubChannel(from: categoryType)
         let context = AmplifyOperationContext(operationId: id, request: request)

--- a/Amplify/DevMenu/Amplify+DevMenu.swift
+++ b/Amplify/DevMenu/Amplify+DevMenu.swift
@@ -9,40 +9,38 @@ import Foundation
 
 /// Extension of `Amplify` for supporting Developer Menu feature
 extension Amplify {
-
-    @available(iOS 13.0.0, *)
+#if canImport(UIKit)
     static var devMenu: AmplifyDevMenu?
 
-    @available(iOS 13.0.0, *)
     public static func enableDevMenu(contextProvider: DevMenuPresentationContextProvider) {
-        #if DEBUG
-            devMenu = AmplifyDevMenu(devMenuPresentationContextProvider: contextProvider)
-        #else
-            Logging.warn(DevMenuStringConstants.logTag + "Developer Menu is available only in debug mode")
-        #endif
+#if DEBUG
+        devMenu = AmplifyDevMenu(devMenuPresentationContextProvider: contextProvider)
+#else
+        Logging.warn(DevMenuStringConstants.logTag + "Developer Menu is available only in debug mode")
+#endif
 
     }
 
     /// Checks whether developer menu is enabled by developer
-    @available(iOS 13.0.0, *)
     static func isDevMenuEnabled() -> Bool {
         return devMenu != nil
     }
+#endif
 
     /// Returns a `PersistentLoggingPlugin` if developer menu feature is enabled in debug mode
     static func getLoggingCategoryPlugin(loggingPlugin: LoggingCategoryPlugin) -> LoggingCategoryPlugin {
-        if #available(iOS 13.0.0, *) {
-            #if DEBUG
-                if isDevMenuEnabled() {
-                    return PersistentLoggingPlugin(plugin: loggingPlugin)
-                } else {
-                    return loggingPlugin
-                }
-            #else
-                return loggingPlugin
-            #endif
+#if canImport(UIKit)
+#if DEBUG
+        if isDevMenuEnabled() {
+            return PersistentLoggingPlugin(plugin: loggingPlugin)
         } else {
             return loggingPlugin
         }
+#else
+        return loggingPlugin
+#endif
+#else
+        return loggingPlugin
+#endif
     }
 }

--- a/Amplify/DevMenu/AmplifyDevMenu.swift
+++ b/Amplify/DevMenu/AmplifyDevMenu.swift
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
-import UIKit
 import SwiftUI
+import UIKit
 
 /// Presents a developer menu using the provided `DevMenuPresentationContextProvider`
 /// upon notification from a `TriggerRecognizer`. Default recognizer is a `LongPressGestureRecognizer`
-@available(iOS 13.0.0, *)
 public final class AmplifyDevMenu: DevMenuBehavior, TriggerDelegate {
 
     weak var devMenuPresentationContextProvider: DevMenuPresentationContextProvider?
@@ -39,3 +39,4 @@ public final class AmplifyDevMenu: DevMenuBehavior, TriggerDelegate {
         rootViewController.present(viewController, animated: true)
     }
 }
+#endif

--- a/Amplify/DevMenu/Data/DevMenuItem.swift
+++ b/Amplify/DevMenu/Data/DevMenuItem.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// Data class for a row shown in the Developer Menu
-@available(iOS 13.0.0, *)
 struct DevMenuItem: Identifiable {
     let id = UUID()
     let type: DevMenuItemType
@@ -17,3 +17,4 @@ struct DevMenuItem: Identifiable {
         self.type = type
     }
 }
+#endif

--- a/Amplify/DevMenu/Data/DevMenuItemType.swift
+++ b/Amplify/DevMenu/Data/DevMenuItemType.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// Item types for each row in the Developer Menu
@@ -41,3 +42,4 @@ enum DevMenuItemType {
         }
     }
 }
+#endif

--- a/Amplify/DevMenu/Data/DeviceInfoHelper.swift
+++ b/Amplify/DevMenu/Data/DeviceInfoHelper.swift
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 import UIKit
 
 /// Helper class to fetch information for Device Information Screen
-@available(iOS 13.0.0, *)
 struct DeviceInfoHelper {
 
     static func getDeviceInformation() -> [DeviceInfoItem] {
@@ -27,3 +27,4 @@ struct DeviceInfoHelper {
             ]
     }
 }
+#endif

--- a/Amplify/DevMenu/Data/DeviceInfoItem.swift
+++ b/Amplify/DevMenu/Data/DeviceInfoItem.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// Data class for each item shown in the Device Info screen
-@available(iOS 13.0.0, *)
 struct DeviceInfoItem: Identifiable, InfoItemProvider {
     let id = UUID()
     let type: DeviceInfoItemType
@@ -50,3 +50,4 @@ struct DeviceInfoItem: Identifiable, InfoItemProvider {
         }
     }
 }
+#endif

--- a/Amplify/DevMenu/Data/DeviceInfoItemType.swift
+++ b/Amplify/DevMenu/Data/DeviceInfoItemType.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// Item types for a row in the Device Info screen
@@ -26,3 +27,4 @@ enum DeviceInfoItemType {
 
     case isSimulator(Bool?)
 }
+#endif

--- a/Amplify/DevMenu/Data/EnvironmentInfoHelper.swift
+++ b/Amplify/DevMenu/Data/EnvironmentInfoHelper.swift
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 import UIKit
 
 /// Helper class to fetch Developer Environment Information
-@available(iOS 13.0.0, *)
 struct EnvironmentInfoHelper {
 
     static let environmentInfoSourceFileName = "local-env-info"
@@ -42,3 +42,4 @@ struct EnvironmentInfoHelper {
         ]
     }
 }
+#endif

--- a/Amplify/DevMenu/Data/EnvironmentInfoItem.swift
+++ b/Amplify/DevMenu/Data/EnvironmentInfoItem.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// Data class for  each item showing Developer Environment Information
-@available(iOS 13.0.0, *)
 struct EnvironmentInfoItem: Identifiable, InfoItemProvider {
 
     let id = UUID()
@@ -48,3 +48,4 @@ struct EnvironmentInfoItem: Identifiable, InfoItemProvider {
         }
     }
 }
+#endif

--- a/Amplify/DevMenu/Data/EnvironmentInfoItemType.swift
+++ b/Amplify/DevMenu/Data/EnvironmentInfoItemType.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// Item types for each row displaying Developer Environment Information
@@ -16,3 +17,4 @@ enum EnvironmentInfoItemType {
     case xcodeVersion(String?)
     case osVersion(String?)
 }
+#endif

--- a/Amplify/DevMenu/Data/InfoItemProvider.swift
+++ b/Amplify/DevMenu/Data/InfoItemProvider.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// Implement this protocol to display information for each row in Device / Environment Information screen
@@ -12,3 +13,4 @@ protocol InfoItemProvider {
     var displayName: String { get }
     var information: String { get }
 }
+#endif

--- a/Amplify/DevMenu/Data/IssueInfo.swift
+++ b/Amplify/DevMenu/Data/IssueInfo.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// Struct consisting of information required to report an issue
-@available(iOS 13.0.0, *)
 struct IssueInfo {
 
     private var includeEnvironmentInfo: Bool
@@ -80,3 +80,4 @@ struct IssueInfo {
         }
     }
 }
+#endif

--- a/Amplify/DevMenu/Data/IssueInfoHelper.swift
+++ b/Amplify/DevMenu/Data/IssueInfoHelper.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// Helper class to generate markdown text for issue reporting
-@available(iOS 13.0.0, *)
 struct IssueInfoHelper {
 
     private static let issueDescTitle = "Issue Description"
@@ -35,3 +35,4 @@ struct IssueInfoHelper {
     }
 
 }
+#endif

--- a/Amplify/DevMenu/Data/LogEntryHelper.swift
+++ b/Amplify/DevMenu/Data/LogEntryHelper.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// Helper class to fetch log entry related information
-@available(iOS 13.0, *)
 struct LogEntryHelper {
 
     /// Date formatter instance for date formatting
@@ -34,3 +34,4 @@ struct LogEntryHelper {
         return [LogEntryItem]()
     }
 }
+#endif

--- a/Amplify/DevMenu/Data/LogEntryItem.swift
+++ b/Amplify/DevMenu/Data/LogEntryItem.swift
@@ -5,11 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 import SwiftUI
 
 /// Data class for each log item in Log Viewer Screen
-@available(iOS 13.0, *)
+
 struct LogEntryItem: Identifiable, Hashable {
     var id = UUID()
 
@@ -54,3 +55,4 @@ struct LogEntryItem: Identifiable, Hashable {
         }
     }
 }
+#endif

--- a/Amplify/DevMenu/Data/PluginInfoHelper.swift
+++ b/Amplify/DevMenu/Data/PluginInfoHelper.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// Helper class to fetch Amplify plugin information
-@available(iOS 13.0.0, *)
 struct PluginInfoHelper {
 
     static func getPluginInformation() -> [PluginInfoItem] {
@@ -70,3 +70,4 @@ struct PluginInfoHelper {
     }
 
 }
+#endif

--- a/Amplify/DevMenu/Data/PluginInfoItem.swift
+++ b/Amplify/DevMenu/Data/PluginInfoItem.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
-@available(iOS 13.0.0, *)
 struct PluginInfoItem: Identifiable, InfoItemProvider {
 
     let id = UUID()
@@ -19,3 +19,4 @@ struct PluginInfoItem: Identifiable, InfoItemProvider {
         self.information = information.isEmpty ? DevMenuStringConstants.notAvailable : information
     }
 }
+#endif

--- a/Amplify/DevMenu/DevEnvironmentInfo.swift
+++ b/Amplify/DevMenu/DevEnvironmentInfo.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 // struct to decode/encode information about developer environment in json format
@@ -25,3 +26,4 @@ struct DevEnvironmentInfo: Codable {
         case osVersion
     }
 }
+#endif

--- a/Amplify/DevMenu/DevMenuBehavior.swift
+++ b/Amplify/DevMenu/DevMenuBehavior.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// A protocol describing the behaviors of a Developer Menu
@@ -12,3 +13,4 @@ public protocol DevMenuBehavior {
     /// Display the menu
     func showMenu()
 }
+#endif

--- a/Amplify/DevMenu/DevMenuPresentationContextProvider.swift
+++ b/Amplify/DevMenu/DevMenuPresentationContextProvider.swift
@@ -5,11 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 import UIKit
 
 /// A protocol which provides a UI context over which views can be presented
-@available(iOS 13.0, *)
 public protocol DevMenuPresentationContextProvider: AnyObject {
     func devMenuPresentationContext() -> UIWindow
 }
+#endif

--- a/Amplify/DevMenu/DevMenuStringConstants.swift
+++ b/Amplify/DevMenu/DevMenuStringConstants.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// String constants used in the developer menu
@@ -15,3 +16,4 @@ struct DevMenuStringConstants {
     static let logTag = "DevMenu"
     static let persistentLoggingPluginKey = "PersistentLoggingPlugin"
 }
+#endif

--- a/Amplify/DevMenu/Logging/PersistentLogWrapper.swift
+++ b/Amplify/DevMenu/Logging/PersistentLogWrapper.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// Class that wraps another `Logger` and saves the logs in memory
-@available(iOS 13.0, *)
 class PersistentLogWrapper: Logger {
     var logLevel: LogLevel
 
@@ -68,3 +68,4 @@ class PersistentLogWrapper: Logger {
     }
 
 }
+#endif

--- a/Amplify/DevMenu/Logging/PersistentLoggingPlugin.swift
+++ b/Amplify/DevMenu/Logging/PersistentLoggingPlugin.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// `LoggingCategoryPlugin` that wraps another`LoggingCategoryPlugin` and saves the logs in memory
-@available(iOS 13.0, *)
 public class PersistentLoggingPlugin: LoggingCategoryPlugin {
 
     var plugin: LoggingCategoryPlugin
@@ -46,5 +46,5 @@ public class PersistentLoggingPlugin: LoggingCategoryPlugin {
     }
 }
 
-@available(iOS 13.0, *)
 extension PersistentLoggingPlugin: AmplifyVersionable { }
+#endif

--- a/Amplify/DevMenu/Trigger/LongPressGestureRecognizer.swift
+++ b/Amplify/DevMenu/Trigger/LongPressGestureRecognizer.swift
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 import UIKit
 
 /// A class for recognizing long press gesture which notifies a `TriggerDelegate` of the event
-@available(iOS 13.0.0, *)
 class LongPressGestureRecognizer: NSObject, TriggerRecognizer, UIGestureRecognizerDelegate {
 
     weak var triggerDelegate: TriggerDelegate?
@@ -56,3 +56,4 @@ class LongPressGestureRecognizer: NSObject, TriggerRecognizer, UIGestureRecogniz
         triggerDelegate = nil
     }
 }
+#endif

--- a/Amplify/DevMenu/Trigger/TriggerDelegate.swift
+++ b/Amplify/DevMenu/Trigger/TriggerDelegate.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// Implement this protocol to get notified of the trigger events recognized by
@@ -12,3 +13,4 @@ import Foundation
 public protocol TriggerDelegate: AnyObject {
     func onTrigger(triggerRecognizer: TriggerRecognizer)
 }
+#endif

--- a/Amplify/DevMenu/Trigger/TriggerRecognizer.swift
+++ b/Amplify/DevMenu/Trigger/TriggerRecognizer.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Foundation
 
 /// A protocol to be implemented for recognizing user interaction events
@@ -13,3 +14,4 @@ public protocol TriggerRecognizer {
     /// Update trigger delegate so that it can be notified in case a trigger happens
     func updateTriggerDelegate(delegate: TriggerDelegate)
 }
+#endif

--- a/Amplify/DevMenu/View/DetailViewFactory.swift
+++ b/Amplify/DevMenu/View/DetailViewFactory.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import SwiftUI
 
 /// A factory to create detail views based on `DevMenuItemType`
-@available(iOS 13.0, *)
 class DetailViewFactory {
 
     static func getDetailView(type: DevMenuItemType) -> AnyView {
@@ -25,3 +25,4 @@ class DetailViewFactory {
     }
 
 }
+#endif

--- a/Amplify/DevMenu/View/DevMenuList.swift
+++ b/Amplify/DevMenu/View/DevMenuList.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import SwiftUI
 
 /// View containing a list of developer menu items
-@available(iOS 13.0.0, *)
 struct DevMenuList: View {
 
     private let screenTitle = "Amplify Developer Menu"
@@ -40,3 +40,4 @@ struct AmplifyDevMenuList_Previews: PreviewProvider {
         DevMenuList()
     }
 }
+#endif

--- a/Amplify/DevMenu/View/DevMenuRow.swift
+++ b/Amplify/DevMenu/View/DevMenuRow.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import SwiftUI
 
 /// View corresponding to each row in Developer Menu
-@available(iOS 13.0.0, *)
 struct DevMenuRow: View {
     var rowItem: DevMenuItem
 
@@ -23,9 +23,9 @@ struct DevMenuRow: View {
     }
 }
 
-@available(iOS 13.0.0, *)
 struct DevMenuRow_Previews: PreviewProvider {
     static var previews: some View {
         DevMenuRow(rowItem: DevMenuItem(type: .environmentInformation))
     }
 }
+#endif

--- a/Amplify/DevMenu/View/DeviceInfoDetailView.swift
+++ b/Amplify/DevMenu/View/DeviceInfoDetailView.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import SwiftUI
 
 /// Detail view containing device information
-@available(iOS 13.0.0, *)
 struct DeviceInfoDetailView: View {
 
     private let screenTitle = "Device Information"
@@ -21,9 +21,9 @@ struct DeviceInfoDetailView: View {
     }
 }
 
-@available(iOS 13.0.0, *)
 struct DeviceInfoDetailView_Previews: PreviewProvider {
     static var previews: some View {
         DeviceInfoDetailView()
     }
 }
+#endif

--- a/Amplify/DevMenu/View/EnvironmentInfoDetailView.swift
+++ b/Amplify/DevMenu/View/EnvironmentInfoDetailView.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import SwiftUI
 
 /// Detail view showing environment information
-@available(iOS 13.0.0, *)
 struct EnvironmentInfoDetailView: View {
     private let screenTitle  = "Environment Information"
     private let amplifyPluginSectionTitle  = "Amplify Plugins Information"
@@ -50,14 +50,12 @@ struct EnvironmentInfoDetailView: View {
     }
 }
 
-@available(iOS 13.0.0, *)
 struct EnvironmentInfoDetailView_Previews: PreviewProvider {
     static var previews: some View {
         EnvironmentInfoDetailView()
     }
 }
 
-@available(iOS 13.0, *)
 struct NoItemView: View {
     var body: some View {
         HStack {
@@ -66,3 +64,4 @@ struct NoItemView: View {
         }
     }
 }
+#endif

--- a/Amplify/DevMenu/View/InfoRow.swift
+++ b/Amplify/DevMenu/View/InfoRow.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import SwiftUI
 
 /// View corresponding to each row in Device Information Screen / Environment Information Screen
-@available(iOS 13.0.0, *)
 struct InfoRow: View {
     var infoItem: InfoItemProvider
 
@@ -20,9 +20,9 @@ struct InfoRow: View {
     }
 }
 
-@available(iOS 13.0.0, *)
 struct DeviceInfoRow_Previews: PreviewProvider {
     static var previews: some View {
         InfoRow(infoItem: DeviceInfoItem(type: .deviceName("iPhone")))
     }
 }
+#endif

--- a/Amplify/DevMenu/View/IssueReporter.swift
+++ b/Amplify/DevMenu/View/IssueReporter.swift
@@ -6,10 +6,14 @@
 //
 
 import SwiftUI
+#if canImport(UIKit)
 import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 /// Issue report screen in developer menu
-@available(iOS 13.0, *)
+#if canImport(UIKit)
 struct IssueReporter: View {
     @State var issueDescription: String = ""
     @State var includeLogs = true
@@ -112,16 +116,18 @@ struct IssueReporter: View {
 
     /// Copy issue as a markdown string to clipboard
     private func copyToClipboard() {
-        UIPasteboard.general.string =
-            IssueInfoHelper.generateMarkdownForIssue(
-                issue: IssueInfo(issueDescription: issueDescription,
-                                 includeEnvInfo: includeEnvInfo,
-                                 includeDeviceInfo: includeDeviceInfo)
-            )
+        let issue = IssueInfo(issueDescription: issueDescription,
+                              includeEnvInfo: includeEnvInfo,
+                              includeDeviceInfo: includeDeviceInfo)
+        let value = IssueInfoHelper.generateMarkdownForIssue(issue: issue)
+#if canImport(UIKit)
+        UIPasteboard.general.string = value
+#elseif canImport(AppKit)
+        NSPasteboard.general.setString(value, forType: .string)
+#endif
     }
 }
 
-@available(iOS 13.0.0, *)
 final class IssueReporter_Previews: PreviewProvider {
     static var previews: some View {
         IssueReporter()
@@ -129,7 +135,6 @@ final class IssueReporter_Previews: PreviewProvider {
 }
 
 /// Custom defined view for multi line text field
-@available(iOS 13.0, *)
 final class MultilineTextField: UIViewRepresentable {
     @Binding var text: String
     var placeHolderText: String = ""
@@ -192,3 +197,4 @@ final class MultilineTextField: UIViewRepresentable {
         }
     }
 }
+#endif

--- a/Amplify/DevMenu/View/LogEntryRow.swift
+++ b/Amplify/DevMenu/View/LogEntryRow.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import SwiftUI
 
 /// View for each row in Log Viewer screen
-@available(iOS 13.0.0, *)
 struct LogEntryRow: View {
     var logEntryItem: LogEntryItem
 
@@ -26,3 +26,4 @@ struct LogEntryRow: View {
         }.padding(5)
     }
 }
+#endif

--- a/Amplify/DevMenu/View/LogViewer.swift
+++ b/Amplify/DevMenu/View/LogViewer.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import SwiftUI
 
-@available(iOS 13.0.0, *)
 struct LogViewer: View {
 
     @State private var searchText: String = ""
@@ -69,7 +69,6 @@ struct LogViewer: View {
     }
 }
 
-@available(iOS 13.0.0, *)
 struct LogViewer_Previews: PreviewProvider {
     static var previews: some View {
         LogViewer()
@@ -77,7 +76,6 @@ struct LogViewer_Previews: PreviewProvider {
 }
 
 /// Search bar view
-@available(iOS 13.0, *)
 struct SearchBar: UIViewRepresentable {
 
     @Binding var text: String
@@ -113,3 +111,4 @@ struct SearchBar: UIViewRepresentable {
         uiView.text = text
     }
 }
+#endif

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPluginsCore.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPluginsCore.swift
@@ -5,7 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import UIKit
+#endif
+import Foundation
 import Amplify
 import ClientRuntime
 import AWSClientRuntime
@@ -16,13 +19,28 @@ struct AWSAPIPluginsCore {
     static let version = "1.16.1"
     
     static var platformMapping: [Platform: String] = [:]
+
+    static var systemName: String {
+#if canImport(UIKit)
+        UIDevice.current.systemName.replacingOccurrences(of: " ", with: "-")
+#else
+        "macOS"
+#endif
+    }
+    static var systemVersion: String {
+#if canImport(UIKit)
+        UIDevice.current.systemVersion
+#else
+        ProcessInfo.processInfo.operatingSystemVersionString
+#endif
+    }
     
     static func baseUserAgent() -> String! {
         //TODO: Retrieve this version from a centralized location:
         //https://github.com/aws-amplify/amplify-ios/issues/276
         let platformInfo = AWSAPIPluginsCore.platformInformation()
-        let systemName = UIDevice.current.systemName.replacingOccurrences(of: " ", with: "-")
-        let systemVersion = UIDevice.current.systemVersion
+        let systemName = Self.systemName
+        let systemVersion = Self.systemVersion
         let localeIdentifier = Locale.current.identifier
         return "\(platformInfo) \(systemName)/\(systemVersion) \(localeIdentifier)"
     }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSRESTOperationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSRESTOperationTests.swift
@@ -12,24 +12,24 @@ import XCTest
 
 class AWSRESTOperationTests: OperationTestBase {
 
-    func testRESTOperationSuccess() {
-        XCTFail("Not yet implemented.")
+    func testRESTOperationSuccess() throws {
+        throw XCTSkip("Not yet implemented")
     }
 
-    func testRESTOperationValidationError() {
-        XCTFail("Not yet implemented.")
+    func testRESTOperationValidationError() throws {
+        throw XCTSkip("Not yet implemented")
     }
 
-    func testRESTOperationEndpointConfigurationError() {
-        XCTFail("Not yet implemented.")
+    func testRESTOperationEndpointConfigurationError() throws {
+        throw XCTSkip("Not yet implemented")
     }
 
-    func testRESTOperationConstructURLFailure() {
-        XCTFail("Not yet implemented.")
+    func testRESTOperationConstructURLFailure() throws {
+        throw XCTSkip("Not yet implemented")
     }
 
-    func testRESTOperationInterceptorError() {
-        XCTFail("Not yet implemented.")
+    func testRESTOperationInterceptorError() throws {
+        throw XCTSkip("Not yet implemented")
     }
 
     func testGetReturnsOperation() throws {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Reachability/NetworkReachabilityNotifierTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Reachability/NetworkReachabilityNotifierTests.swift
@@ -8,6 +8,7 @@
 import Foundation
 import XCTest
 import Combine
+@testable import Amplify
 @testable import AWSAPIPlugin
 
 class NetworkReachabilityNotifierTests: XCTestCase {
@@ -33,7 +34,7 @@ class NetworkReachabilityNotifierTests: XCTestCase {
         var values = [Bool]()
         let cancellable = notifier.publisher.sink(receiveCompletion: { _ in
             XCTFail("Not expecting any error")
-        }, receiveValue: { value in
+        }, receiveValue: { (value: ReachabilityUpdate) -> Void in
             values.append(value.isOnline)
             if values.count == 2 {
                 XCTAssertFalse(values[0])
@@ -54,7 +55,7 @@ class NetworkReachabilityNotifierTests: XCTestCase {
         var values = [Bool]()
         let cancellable = notifier.publisher.sink(receiveCompletion: { _ in
             XCTFail("Not expecting any error")
-        }, receiveValue: { value in
+        }, receiveValue: { (value: ReachabilityUpdate) -> Void in
             values.append(value.isOnline)
             if values.count == 2 {
                 XCTAssertFalse(values[0])
@@ -76,7 +77,7 @@ class NetworkReachabilityNotifierTests: XCTestCase {
         var values = [Bool]()
         let cancellable = notifier.publisher.sink(receiveCompletion: { _ in
             XCTFail("Not expecting any error")
-        }, receiveValue: { value in
+        }, receiveValue: { (value: ReachabilityUpdate) -> Void in
             values.append(value.isOnline)
             if values.count == 2 {
                 XCTAssertFalse(values[0])
@@ -98,7 +99,7 @@ class NetworkReachabilityNotifierTests: XCTestCase {
         let completeExpect = expectation(description: ".sink receives completion")
         let cancellable = notifier.publisher.sink(receiveCompletion: { _ in
             completeExpect.fulfill()
-        }, receiveValue: { value in
+        }, receiveValue: { (value: ReachabilityUpdate) -> Void in
             XCTAssertFalse(value.isOnline)
             defaultValueExpect.fulfill()
         })

--- a/AmplifyPlugins/API/HostApp/Source/AppDelegate.swift
+++ b/AmplifyPlugins/API/HostApp/Source/AppDelegate.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import UIKit
 
-@available(iOS 13.0, *)
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -35,3 +35,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
 }
+#endif

--- a/AmplifyPlugins/API/HostApp/Source/SceneDelegate.swift
+++ b/AmplifyPlugins/API/HostApp/Source/SceneDelegate.swift
@@ -5,14 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
-    @available(iOS 13.0, *)
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
@@ -22,4 +21,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 
 }
-
+#endif

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
@@ -62,6 +62,7 @@ extension AWSCognitoAuthPlugin: AuthCategoryBehavior {
         return signInOperation
     }
 
+#if canImport(AuthenticationServices)
     public func signInWithWebUI(presentationAnchor: AuthUIPresentationAnchor,
                                 options: AuthWebUISignInOperation.Request.Options?,
                                 listener: AuthWebUISignInOperation.ResultListener?) -> AuthWebUISignInOperation
@@ -76,6 +77,7 @@ extension AWSCognitoAuthPlugin: AuthCategoryBehavior {
     {
         fatalError("Not implemented")
     }
+#endif
 
     public func confirmSignIn(challengeResponse: String,
                               options: AuthConfirmSignInOperation.Request.Options?,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/CredentialStore.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/CredentialStore.swift
@@ -115,8 +115,9 @@ struct CredentialStore: CredentialStoreBehavior {
 
     func removeAll() throws {
         var query = attributes.query()
+        // TODO: determine proper behavior for macOS
 #if !os(iOS) && !os(watchOS) && !os(tvOS)
-        query[MatchLimit] = MatchLimitAll
+        query[CredentialStoreConstant.MatchLimit] = CredentialStoreConstant.MatchLimitAll
 #endif
 
         let status = SecItemDelete(query as CFDictionary)

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import UIKit
 import AWSClientRuntime
 
 public class AmplifyAWSServiceConfiguration {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/StorageEnginePublisherTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/StorageEnginePublisherTests.swift
@@ -52,7 +52,7 @@ class StorageEnginePublisherTests: StorageEngineTestsBase {
         let receivedSyncQueriesReadyEvent = expectation(description: "Received syncQueries event")
         let receivedReadyEvent = expectation(description: "Received ready event")
         let sink = storageEngine.publisher.sink { _ in
-        } receiveValue: { event in
+        } receiveValue: { (event: StorageEngineEvent) in
             switch event {
             case .mutationEvent(let mutationEventPayload):
                 XCTAssertEqual(mutationEventPayload, mutationEvent)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/DataStoreHubTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/DataStoreHubTests.swift
@@ -15,8 +15,8 @@ class DataStoreHubTests: XCTestCase {
     /// - Then:
     ///    - Hub is notified
     ///    - Hub payload accurately represents the incoming sync
-    func testDataStoreDispatchesCreateToHub() {
-        XCTFail("Not yet implemented")
+    func testDataStoreDispatchesCreateToHub() throws {
+        throw XCTSkip("Not yet implemented")
     }
 
     /// - Given: An API-enabled DataStore
@@ -25,8 +25,8 @@ class DataStoreHubTests: XCTestCase {
     /// - Then:
     ///    - Hub is notified
     ///    - Hub payload accurately represents the incoming sync
-    func testDataStoreDispatchesUpdateToHub() {
-        XCTFail("Not yet implemented")
+    func testDataStoreDispatchesUpdateToHub() throws {
+        throw XCTSkip("Not yet implemented")
     }
 
     /// - Given: An API-enabled DataStore
@@ -35,8 +35,8 @@ class DataStoreHubTests: XCTestCase {
     /// - Then:
     ///    - Hub is notified
     ///    - Hub payload accurately represents the incoming sync
-    func testDataStoreDispatchesDeleteToHub() {
-        XCTFail("Not yet implemented")
+    func testDataStoreDispatchesDeleteToHub() throws {
+        throw XCTSkip("Not yet implemented")
     }
 
     /// - Given: An API-enabled DataStore
@@ -45,9 +45,9 @@ class DataStoreHubTests: XCTestCase {
     /// - Then:
     ///    - Hub is notified
     ///    - Hub payload accurately represents the incoming sync
-    func testDataStoreDispatchesConflictToHub() {
+    func testDataStoreDispatchesConflictToHub() throws {
         // TODO: Can this actually happen on an incoming sync?
-        XCTFail("Not yet implemented")
+        throw XCTSkip("Not yet implemented")
     }
 
     /// - Given: An API-enabled DataStore
@@ -55,8 +55,8 @@ class DataStoreHubTests: XCTestCase {
     ///    - DataStore encounters a sync error
     /// - Then:
     ///    - Hub is notified
-    func testDataStoreDispatchesErrorToHub() {
-        XCTFail("Not yet implemented")
+    func testDataStoreDispatchesErrorToHub() throws {
+        throw XCTSkip("Not yet implemented")
     }
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/SyncEngineStartupTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/InitialSync/SyncEngineStartupTests.swift
@@ -14,47 +14,47 @@ import XCTest
 class SyncEngineStartupTests: SyncEngineTestBase {
 
     func testShouldPauseSubscriptions() throws {
-        XCTFail("Not yet implemented")
+        throw XCTSkip("Not yet implemented")
     }
 
     func testShouldBufferSubscriptions() throws {
-        XCTFail("Not yet implemented")
+        throw XCTSkip("Not yet implemented")
     }
 
     func testShouldBufferOutgoingMutations() throws {
-        XCTFail("Not yet implemented")
+        throw XCTSkip("Not yet implemented")
     }
 
     func testShouldSetUpSubscriptions() throws {
-        XCTFail("Not yet implemented")
+        throw XCTSkip("Not yet implemented")
     }
 
     func testShouldPerformInitialQueries() throws {
-        XCTFail("Not yet implemented")
+        throw XCTSkip("Not yet implemented")
     }
 
     func testShouldActivateSubscriptions() throws {
-        XCTFail("Not yet implemented")
+        throw XCTSkip("Not yet implemented")
     }
 
     func testShouldStartMutations() throws {
-        XCTFail("Not yet implemented")
+        throw XCTSkip("Not yet implemented")
     }
 
     func testDispatchesToHub() throws {
-        XCTFail("Not yet implemented")
+        throw XCTSkip("Not yet implemented")
     }
 
     func testOrderOfOperations() throws {
-        XCTFail("Not yet implemented")
+        throw XCTSkip("Not yet implemented")
     }
 
     func testInvokesGlobalErrorHandler() throws {
-        XCTFail("Not yet implemented")
+        throw XCTSkip("Not yet implemented")
     }
 
     func testDispatchesToHubOnError() throws {
-        XCTFail("Not yet implemented")
+        throw XCTSkip("Not yet implemented")
     }
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionWithJSONModelTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionWithJSONModelTests.swift
@@ -150,7 +150,7 @@ class LocalSubscriptionWithJSONModelTests: XCTestCase {
                 case .finished:
                     break
                 }
-            }, receiveValue: { event in
+            }, receiveValue: { (event: MutationEvent) in
                 switch event.modelName {
                 case "Post":
                     receivedPostMutationEvent.fulfill()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
@@ -117,7 +117,7 @@ class AWSMutationEventIngesterTests: XCTestCase {
     ///    - The MutationIngester encounters an error
     /// - Then:
     ///    - The entire `save()` operation fails
-    func testMutationQueueFailureCausesSaveFailure() {
-        XCTFail("Not yet implemented")
+    func testMutationQueueFailureCausesSaveFailure() throws {
+        throw XCTSkip("Not yet implemented")
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
@@ -91,8 +91,8 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
     ///    - I invoke DataStore.delete()
     /// - Then:
     ///    - The mutation queue writes events
-    func testMutationQueueStoresDeleteEvents() {
-        XCTFail("Not yet implemented")
+    func testMutationQueueStoresDeleteEvents() throws {
+        throw XCTSkip("Not yet implemented")
     }
 
     /// - Given: A sync-configured DataStore
@@ -191,8 +191,8 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
     ///    - I add mutations before the pending mutations have been processed
     /// - Then:
     ///    - The mutation queue delivers events in FIFO order
-    func testMutationQueueDeliversPendingMutationsFirst() {
-        XCTFail("Not yet implemented")
+    func testMutationQueueDeliversPendingMutationsFirst() throws {
+        throw XCTSkip("Not yet implemented")
     }
 
     /// - Given: A sync-configured DataStore
@@ -200,8 +200,8 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
     ///    - I successfully process a mutation
     /// - Then:
     ///    - The mutation queue deletes the event from its persistent store
-    func testMutationQueueDequeuesSavedEvents() {
-        XCTFail("Not yet implemented")
+    func testMutationQueueDequeuesSavedEvents() throws {
+        throw XCTSkip("Not yet implemented")
     }
 
     /// - Given: A sync-configured DataStore
@@ -209,8 +209,8 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
     ///    - I successfully process a mutation
     /// - Then:
     ///    - The mutation listener is unsubscribed from Hub
-    func testLocalMutationUnsubcsribesFromCloud() {
-        XCTFail("Not yet implemented")
+    func testLocalMutationUnsubcsribesFromCloud() throws {
+        throw XCTSkip("Not yet implemented")
     }
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
@@ -117,7 +117,7 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
     /// - Then:
     ///    - The listener is notified
     func testOnCreateNotifiesListener() throws {
-        //XCTFail("Not yet implemented")
+        //throw XCTSkip("Not yet implemented")
     }
 
     /// - Given: Amplify configured with an API
@@ -126,7 +126,7 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
     /// - Then:
     ///    - The listener is notified
     func testOnCreateUpdatesLocalStore() throws {
-        //XCTFail("Not yet implemented")
+        //throw XCTSkip("Not yet implemented")
     }
 
     /// - Given: Amplify configured with an API
@@ -135,7 +135,7 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
     /// - Then:
     ///    - The listener is notified
     func testOnUpdateNotifiesListener() throws {
-        //XCTFail("Not yet implemented")
+        //throw XCTSkip("Not yet implemented")
     }
 
     /// - Given: Amplify configured with an API
@@ -144,7 +144,7 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
     /// - Then:
     ///    - The listener is notified
     func testOnUpdateUpdatesLocalStore() throws {
-        //XCTFail("Not yet implemented")
+        //throw XCTSkip("Not yet implemented")
     }
 
     /// - Given: Amplify configured with an API
@@ -153,7 +153,7 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
     /// - Then:
     ///    - The listener is notified
     func testOnDeleteNotifiesListener() throws {
-        //XCTFail("Not yet implemented")
+        //throw XCTSkip("Not yet implemented")
     }
 
     /// - Given: Amplify configured with an API
@@ -162,7 +162,7 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
     /// - Then:
     ///    - The listener is notified
     func testOnDeleteUpdatesLocalStore() throws {
-       // XCTFail("Not yet implemented")
+       // throw XCTSkip("Not yet implemented")
     }
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSyncEngineTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSyncEngineTests.swift
@@ -93,7 +93,7 @@ class RemoteSyncEngineTests: XCTestCase {
             .publisher
             .sink(receiveCompletion: { _ in
                 currCount = self.checkAndFulfill(currCount, 7, expectation: failureOnInitialSync)
-            }, receiveValue: { event in
+            }, receiveValue: { (event: RemoteSyncEngineEvent) in
                 switch event {
                 case .storageAdapterAvailable:
                     currCount = self.checkAndFulfill(currCount, 1, expectation: storageAdapterAvailable)
@@ -150,7 +150,7 @@ class RemoteSyncEngineTests: XCTestCase {
             .publisher
             .sink(receiveCompletion: { _ in
                 XCTFail("Completion should never happen")
-            }, receiveValue: { event in
+            }, receiveValue: { (event: RemoteSyncEngineEvent) in
                 switch event {
                 case .storageAdapterAvailable:
                     currCount = self.checkAndFulfill(currCount, 1, expectation: storageAdapterAvailable)
@@ -215,7 +215,7 @@ class RemoteSyncEngineTests: XCTestCase {
             .publisher
             .sink(receiveCompletion: { _ in
                 currCount = self.checkAndFulfill(currCount, 11, expectation: forceFailToNotRestartSyncEngine)
-            }, receiveValue: { event in
+            }, receiveValue: { (event: RemoteSyncEngineEvent) in
                 switch event {
                 case .storageAdapterAvailable:
                     currCount = self.checkAndFulfill(currCount, 1, expectation: storageAdapterAvailable)
@@ -289,7 +289,7 @@ class RemoteSyncEngineTests: XCTestCase {
             .publisher
             .sink(receiveCompletion: { _ in
                 currCount = self.checkAndFulfill(currCount, 11, expectation: forceFailToNotRestartSyncEngine)
-            }, receiveValue: { event in
+            }, receiveValue: { (event: RemoteSyncEngineEvent) in
                 switch event {
                 case .storageAdapterAvailable:
                     currCount = self.checkAndFulfill(currCount, 1, expectation: storageAdapterAvailable)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
@@ -97,7 +97,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
         remoteSyncEngineSink = syncEngine
             .publisher
             .sink(receiveCompletion: {_ in },
-                  receiveValue: { event in
+                  receiveValue: { (event: RemoteSyncEngineEvent) in
                     switch event {
                     case .mutationsPaused:
                         //Assume AWSIncomingEventReconciliationQueue succeeds in establishing connections
@@ -200,7 +200,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
         remoteSyncEngineSink = syncEngine
             .publisher
             .sink(receiveCompletion: {_ in },
-                  receiveValue: { event in
+                  receiveValue: { (event: RemoteSyncEngineEvent) in
                     switch event {
                     case .mutationsPaused:
                         //Assume AWSIncomingEventReconciliationQueue succeeds in establishing connections

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -337,7 +337,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
                 case .failure(let error):
                     XCTFail("Unexpected error \(error)")
                 }
-            } receiveValue: { event in
+            } receiveValue: { (event: ReconcileAndLocalSaveOperationEvent) in
                 switch event {
                 case .mutationEventDropped(let name):
                     XCTAssertEqual(name, Post.modelName)
@@ -481,7 +481,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
                 case .failure(let error):
                     XCTFail("Unexpected error \(error)")
                 }
-            } receiveValue: { event in
+            } receiveValue: { (event: ReconcileAndLocalSaveOperationEvent) in
                 switch event {
                 case .mutationEventDropped(let name):
                     XCTAssertEqual(name, Post.modelName)
@@ -571,7 +571,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
                 case .failure(let error):
                     XCTFail("Unexpected error \(error)")
                 }
-            } receiveValue: { event in
+            } receiveValue: { (event: ReconcileAndLocalSaveOperationEvent) in
                 switch event {
                 case .mutationEvent(let mutationEvent):
                     XCTAssertEqual(mutationEvent.modelId, self.anyPostMutationSync.model.id)
@@ -627,7 +627,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
                 case .failure(let error):
                     XCTFail("Unexpected error \(error)")
                 }
-            } receiveValue: { event in
+            } receiveValue: { (event: ReconcileAndLocalSaveOperationEvent) in
                 switch event {
                 case .mutationEvent(let mutationEvent):
                     XCTAssertEqual(mutationEvent.modelId, self.anyPostMutationSync.model.id)
@@ -683,7 +683,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
                 case .failure(let error):
                     XCTFail("Unexpected error \(error)")
                 }
-            } receiveValue: { event in
+            } receiveValue: { (event: ReconcileAndLocalSaveOperationEvent) in
                 switch event {
                 case .mutationEvent(let mutationEvent):
                     XCTAssertEqual(mutationEvent.modelId, self.anyPostMutationSync.model.id)
@@ -759,7 +759,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
                 case .failure(let error):
                     XCTFail("Unexpected error \(error)")
                 }
-            } receiveValue: { event in
+            } receiveValue: { (event: ReconcileAndLocalSaveOperationEvent) in
                 switch event {
                 case .mutationEvent(let mutationEvent):
                     XCTAssertEqual(mutationEvent.modelId, self.anyPostMutationSync.model.id)
@@ -846,9 +846,9 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
                 case .failure(let error):
                     XCTFail("Unexpected error \(error)")
                 }
-            } receiveValue: { event in
+            } receiveValue: { (event: ReconcileAndLocalSaveOperationEvent) in
                 switch event {
-                case .mutationEventDropped(let name):
+                case .mutationEventDropped:
                     expectDropped.fulfill()
                 default:
                     break

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -124,7 +124,7 @@ class SyncEngineTestBase: XCTestCase {
         remoteSyncEngineSink = syncEngine
             .publisher
             .sink(receiveCompletion: {_ in },
-                  receiveValue: { event in
+                  receiveValue: { (event: RemoteSyncEngineEvent) in
                     switch event {
                     case .mutationsPaused:
                         //Assume AWSIncomingEventReconciliationQueue succeeds in establishing connections

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Internal/FileSystem.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/Support/Internal/FileSystem.swift
@@ -197,17 +197,9 @@ class FileSystem {
             do {
                 let fileHandle = try FileHandle(forReadingFrom: fileURL)
                 defer {
-                    if #available(iOS 13.0, *) {
-                        try? fileHandle.close()
-                    } else {
-                        fileHandle.closeFile()
-                    }
+                    try? fileHandle.close()
                 }
-                if #available(iOS 13.0, *) {
-                    try fileHandle.seek(toOffset: UInt64(offset))
-                } else {
-                    fileHandle.seek(toFileOffset: UInt64(offset))
-                }
+                try fileHandle.seek(toOffset: UInt64(offset))
                 let data = fileHandle.readData(ofLength: length)
                 let fileURL = try self.createTemporaryFile(data: data)
                 completionHandler(.success(fileURL))

--- a/AmplifyPlugins/Storage/HostApp/Source/AppDelegate.swift
+++ b/AmplifyPlugins/Storage/HostApp/Source/AppDelegate.swift
@@ -5,12 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -19,20 +18,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // MARK: UISceneSession Lifecycle
 
-    @available(iOS 13.0, *)
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
-    @available(iOS 13.0, *)
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
-
 }
-
+#endif

--- a/AmplifyPlugins/Storage/HostApp/Source/SceneDelegate.swift
+++ b/AmplifyPlugins/Storage/HostApp/Source/SceneDelegate.swift
@@ -5,14 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
-    @available(iOS 13.0, *)
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
@@ -20,6 +19,5 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let _ = (scene as? UIWindowScene) else { return }
     }
 
-
 }
-
+#endif

--- a/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
@@ -45,6 +45,7 @@ class MockAuthCategoryPlugin: MessageReporter, AuthCategoryPlugin {
         fatalError()
     }
 
+#if canImport(AuthenticationServices)
     public func signInWithWebUI(presentationAnchor: AuthUIPresentationAnchor,
                                 options: AuthWebUISignInOperation.Request.Options? = nil,
                                 listener: AuthWebUISignInOperation.ResultListener?) -> AuthWebUISignInOperation {
@@ -58,6 +59,7 @@ class MockAuthCategoryPlugin: MessageReporter, AuthCategoryPlugin {
         -> AuthSocialWebUISignInOperation {
             fatalError()
     }
+#endif
 
     public func confirmSignIn(challengeResponse: String,
                               options: AuthConfirmSignInOperation.Request.Options? = nil,

--- a/AmplifyTestCommon/Mocks/MockDevMenuContextProvider.swift
+++ b/AmplifyTestCommon/Mocks/MockDevMenuContextProvider.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import Amplify
 import UIKit
 
@@ -17,3 +18,4 @@ class MockDevMenuContextProvider: DevMenuPresentationContextProvider {
         return uiWindow
     }
 }
+#endif

--- a/AmplifyTestCommon/Mocks/MockPredictionsCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockPredictionsCategoryPlugin.swift
@@ -6,7 +6,6 @@
 //
 
 import Amplify
-import UIKit
 import Foundation
 
 class MockPredictionsCategoryPlugin: MessageReporter, PredictionsCategoryPlugin {

--- a/AmplifyTests/CategoryTests/Hub/HubCombineTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubCombineTests.swift
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import XCTest
 import Combine
 
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-@available(iOS 13.0, *)
 class HubCombineTests: XCTestCase {
 
     func testValue() {
@@ -68,3 +68,4 @@ class HubCombineTests: XCTestCase {
     }
 
 }
+#endif

--- a/AmplifyTests/CoreTests/AmplifyInProcessReportingOperationChainedTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyInProcessReportingOperationChainedTests.swift
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Combine
+#if canImport(Combine)
 import XCTest
+import Combine
 
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-@available(iOS 13.0, *)
 // swiftlint:disable:next type_name
 class AmplifyInProcessReportingOperationChainedTests: XCTestCase {
 
@@ -161,3 +161,4 @@ class AmplifyInProcessReportingOperationChainedTests: XCTestCase {
     }
 
 }
+#endif

--- a/AmplifyTests/CoreTests/AmplifyInProcessReportingOperationCombineTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyInProcessReportingOperationCombineTests.swift
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Combine
+#if canImport(Combine)
 import XCTest
+import Combine
 
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-@available(iOS 13.0, *)
 // swiftlint:disable:next type_name
 class AmplifyInProcessReportingOperationCombineTests: XCTestCase {
 
@@ -155,3 +155,4 @@ class MockPublisherInProcessOperation: AmplifyInProcessReportingOperation<
     }
 
 }
+#endif

--- a/AmplifyTests/CoreTests/AmplifyOperationCombineTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyOperationCombineTests.swift
@@ -5,8 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Combine
+#if canImport(Combine)
 import XCTest
+import Combine
 
 @testable import Amplify
 @testable import AmplifyTestCommon
@@ -286,3 +287,4 @@ class MockPublisherOperation: AmplifyOperation<MockPublisherRequest, Int, APIErr
     }
 
 }
+#endif

--- a/AmplifyTests/DevMenuTests/DevMenuExtensionTests.swift
+++ b/AmplifyTests/DevMenuTests/DevMenuExtensionTests.swift
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-@available(iOS 13.0.0, *)
 class DevMenuExtensionTests: XCTestCase {
     let provider = MockDevMenuContextProvider()
     override func setUp() {
@@ -54,3 +54,4 @@ class DevMenuExtensionTests: XCTestCase {
         Amplify.reset()
     }
 }
+#endif

--- a/AmplifyTests/DevMenuTests/GestureRecognizerTests.swift
+++ b/AmplifyTests/DevMenuTests/GestureRecognizerTests.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
@@ -33,3 +34,4 @@ class GestureRecognizerTests: XCTestCase {
     }
 
 }
+#endif

--- a/AmplifyTests/DevMenuTests/PersistentLogWrapperTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLogWrapperTests.swift
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-@available(iOS 13.0.0, *)
 class PersistentLogWrapperTests: XCTestCase {
 
     let provider = MockDevMenuContextProvider()
@@ -137,3 +137,4 @@ class PersistentLogWrapperTests: XCTestCase {
         Amplify.reset()
     }
 }
+#endif

--- a/AmplifyTests/DevMenuTests/PersistentLoggingPluginAmplifyVersionableTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLoggingPluginAmplifyVersionableTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import Amplify
 
-@available(iOS 13.0, *)
+#if canImport(UIKit)
 // swiftlint:disable:next type_name
 class PersistentLoggingPluginAmplifyVersionableTests: XCTestCase {
 
@@ -18,3 +18,4 @@ class PersistentLoggingPluginAmplifyVersionableTests: XCTestCase {
     }
 
 }
+#endif

--- a/AmplifyTests/DevMenuTests/PersistentLoggingPluginTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLoggingPluginTests.swift
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(UIKit)
 import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-@available(iOS 13.0.0, *)
 class PersistentLoggingPluginTests: XCTestCase {
 
     let provider = MockDevMenuContextProvider()
@@ -47,3 +47,4 @@ class PersistentLoggingPluginTests: XCTestCase {
         Amplify.reset()
     }
 }
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,17 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
+
+let platforms: [SupportedPlatform] = [.iOS(.v13)]
+let dependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/stephencelis/SQLite.swift.git", exact: "0.12.2"),
+    .package(url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git", exact: "1.9.0"),
+    // We can remove AwsCrt and ClientRuntime once we move to the latest AWS SDK for Swift
+    .package(url: "https://github.com/awslabs/aws-crt-swift.git", exact: "0.1.1"),
+    .package(url: "https://github.com/awslabs/smithy-swift.git", exact: "0.1.4"),
+    .package(url: "https://github.com/awslabs/aws-sdk-swift.git", exact: "0.1.4"),
+    .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting", .upToNextMinor(from: "2.1.0"))
+]
 
 let amplifyTargets: [Target] = [
     .target(
@@ -15,7 +26,7 @@ let amplifyTargets: [Target] = [
         name: "AWSPluginsCore",
         dependencies: [
             "Amplify",
-            .product(name: "AWSClientRuntime", package: "AWSSwiftSDK")
+            .product(name: "AWSClientRuntime", package: "aws-sdk-swift")
         ],
         path: "AmplifyPlugins/Core/AWSPluginsCore",
         exclude: [
@@ -57,7 +68,7 @@ let amplifyTargets: [Target] = [
         dependencies: [
             "Amplify",
             "AWSPluginsCore",
-            .product(name: "AWSClientRuntime", package: "AWSSwiftSDK")
+            .product(name: "AWSClientRuntime", package: "aws-sdk-swift")
         ],
         path: "AmplifyPlugins/Core/AWSPluginsTestCommon",
         exclude: [
@@ -69,7 +80,7 @@ let amplifyTargets: [Target] = [
         dependencies: [
             "AWSPluginsCore",
             "AmplifyTestCommon",
-            .product(name: "AWSClientRuntime", package: "AWSSwiftSDK")
+            .product(name: "AWSClientRuntime", package: "aws-sdk-swift")
         ],
         path: "AmplifyPlugins/Core/AWSPluginsCoreTests",
         exclude: [
@@ -84,7 +95,7 @@ let apiTargets: [Target] = [
         dependencies: [
             .target(name: "Amplify"),
             .target(name: "AWSPluginsCore"),
-            .product(name: "AppSyncRealTimeClient", package: "AppSyncRealTimeClient")],
+            .product(name: "AppSyncRealTimeClient", package: "aws-appsync-realtime-client-ios")],
         path: "AmplifyPlugins/API/AWSAPICategoryPlugin",
         exclude: [
             "Info.plist",
@@ -164,9 +175,9 @@ let authTargets: [Target] = [
             .target(name: "Amplify"),
             .target(name: "AmplifySRP"),
             .target(name: "AWSPluginsCore"),
-            .product(name: "AWSClientRuntime", package: "AWSSwiftSDK"),
-            .product(name: "AWSCognitoIdentityProvider", package: "AWSSwiftSDK"),
-            .product(name: "AWSCognitoIdentity", package: "AWSSwiftSDK")
+            .product(name: "AWSClientRuntime", package: "aws-sdk-swift"),
+            .product(name: "AWSCognitoIdentityProvider", package: "aws-sdk-swift"),
+            .product(name: "AWSCognitoIdentity", package: "aws-sdk-swift")
         ],
         path: "AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin"
     ),
@@ -242,7 +253,7 @@ let storageTargets: [Target] = [
         dependencies: [
             .target(name: "Amplify"),
             .target(name: "AWSPluginsCore"),
-            .product(name: "AWSS3", package: "AWSSwiftSDK")],
+            .product(name: "AWSS3", package: "aws-sdk-swift")],
         path: "AmplifyPlugins/Storage/AWSS3StoragePlugin",
         exclude: [
             "Resources/Info.plist"
@@ -274,7 +285,7 @@ let targets: [Target] = amplifyTargets + apiTargets + authTargets + dataStoreTar
 
 let package = Package(
     name: "Amplify",
-    platforms: [.iOS(.v13)],
+    platforms: platforms,
     products: [
         .library(
             name: "Amplify",
@@ -298,35 +309,6 @@ let package = Package(
         ),
         
     ],
-    dependencies: [
-        .package(
-            url: "https://github.com/stephencelis/SQLite.swift.git",
-            .exact("0.12.2")
-        ),
-        .package(
-            name: "AppSyncRealTimeClient",
-            url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
-            from: "1.9.0"
-        ),// We can remove AwsCrt and ClientRuntime once we move to the latest AWS SDK for Swift
-        .package(
-            name: "AwsCrt",
-            url: "https://github.com/awslabs/aws-crt-swift.git",
-            .exact("0.1.1")
-        ),
-        .package(
-            name: "ClientRuntime",
-            url: "https://github.com/awslabs/smithy-swift.git",
-            .exact("0.1.4")
-        ),
-        .package(
-            name: "AWSSwiftSDK",
-            url: "https://github.com/awslabs/aws-sdk-swift",
-            .exact("0.1.4")
-        ),
-        .package(
-            name: "CwlPreconditionTesting",
-            url: "https://github.com/mattgallagher/CwlPreconditionTesting",
-            .upToNextMinor(from: "2.1.0"))
-    ],
+    dependencies: dependencies,
     targets: targets
 )

--- a/Package.swift
+++ b/Package.swift
@@ -4,13 +4,34 @@ import PackageDescription
 
 let platforms: [SupportedPlatform] = [.iOS(.v13)]
 let dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/stephencelis/SQLite.swift.git", exact: "0.12.2"),
-    .package(url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git", exact: "1.9.0"),
-    // We can remove AwsCrt and ClientRuntime once we move to the latest AWS SDK for Swift
-    .package(url: "https://github.com/awslabs/aws-crt-swift.git", exact: "0.1.1"),
-    .package(url: "https://github.com/awslabs/smithy-swift.git", exact: "0.1.4"),
-    .package(url: "https://github.com/awslabs/aws-sdk-swift.git", exact: "0.1.4"),
-    .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting", .upToNextMinor(from: "2.1.0"))
+    .package(
+        url: "https://github.com/stephencelis/SQLite.swift.git",
+        .exact("0.12.2")
+    ),
+    .package(
+        name: "AppSyncRealTimeClient",
+        url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
+        from: "1.9.0"
+    ),// We can remove AwsCrt and ClientRuntime once we move to the latest AWS SDK for Swift
+    .package(
+        name: "AwsCrt",
+        url: "https://github.com/awslabs/aws-crt-swift.git",
+        .exact("0.1.1")
+    ),
+    .package(
+        name: "ClientRuntime",
+        url: "https://github.com/awslabs/smithy-swift.git",
+        .exact("0.1.4")
+    ),
+    .package(
+        name: "AWSSwiftSDK",
+        url: "https://github.com/awslabs/aws-sdk-swift.git",
+        .exact("0.1.4")
+    ),
+    .package(
+        name: "CwlPreconditionTesting",
+        url: "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        .upToNextMinor(from: "2.1.0"))
 ]
 
 let amplifyTargets: [Target] = [
@@ -26,7 +47,7 @@ let amplifyTargets: [Target] = [
         name: "AWSPluginsCore",
         dependencies: [
             "Amplify",
-            .product(name: "AWSClientRuntime", package: "aws-sdk-swift")
+            .product(name: "AWSClientRuntime", package: "AWSSwiftSDK")
         ],
         path: "AmplifyPlugins/Core/AWSPluginsCore",
         exclude: [
@@ -68,7 +89,7 @@ let amplifyTargets: [Target] = [
         dependencies: [
             "Amplify",
             "AWSPluginsCore",
-            .product(name: "AWSClientRuntime", package: "aws-sdk-swift")
+            .product(name: "AWSClientRuntime", package: "AWSSwiftSDK")
         ],
         path: "AmplifyPlugins/Core/AWSPluginsTestCommon",
         exclude: [
@@ -80,7 +101,7 @@ let amplifyTargets: [Target] = [
         dependencies: [
             "AWSPluginsCore",
             "AmplifyTestCommon",
-            .product(name: "AWSClientRuntime", package: "aws-sdk-swift")
+            .product(name: "AWSClientRuntime", package: "AWSSwiftSDK")
         ],
         path: "AmplifyPlugins/Core/AWSPluginsCoreTests",
         exclude: [
@@ -95,7 +116,7 @@ let apiTargets: [Target] = [
         dependencies: [
             .target(name: "Amplify"),
             .target(name: "AWSPluginsCore"),
-            .product(name: "AppSyncRealTimeClient", package: "aws-appsync-realtime-client-ios")],
+            .product(name: "AppSyncRealTimeClient", package: "AppSyncRealTimeClient")],
         path: "AmplifyPlugins/API/AWSAPICategoryPlugin",
         exclude: [
             "Info.plist",
@@ -175,9 +196,9 @@ let authTargets: [Target] = [
             .target(name: "Amplify"),
             .target(name: "AmplifySRP"),
             .target(name: "AWSPluginsCore"),
-            .product(name: "AWSClientRuntime", package: "aws-sdk-swift"),
-            .product(name: "AWSCognitoIdentityProvider", package: "aws-sdk-swift"),
-            .product(name: "AWSCognitoIdentity", package: "aws-sdk-swift")
+            .product(name: "AWSClientRuntime", package: "AWSSwiftSDK"),
+            .product(name: "AWSCognitoIdentityProvider", package: "AWSSwiftSDK"),
+            .product(name: "AWSCognitoIdentity", package: "AWSSwiftSDK")
         ],
         path: "AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin"
     ),
@@ -253,7 +274,7 @@ let storageTargets: [Target] = [
         dependencies: [
             .target(name: "Amplify"),
             .target(name: "AWSPluginsCore"),
-            .product(name: "AWSS3", package: "aws-sdk-swift")],
+            .product(name: "AWSS3", package: "AWSSwiftSDK")],
         path: "AmplifyPlugins/Storage/AWSS3StoragePlugin",
         exclude: [
             "Resources/Info.plist"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ let task = awsS3.headBucket(input: input) { result in
 
 ## Platform Support
 
-Amplify supports iOS 13 and above. There are currently no plans to support Amplify on WatchOS, tvOS, or MacOS.
+Amplify supports iOS 13 and above. There are currently no plans to support Amplify on watchOS, tvOS, or macOS.
 
 ## License
 


### PR DESCRIPTION
*Issue #, if available:*

#1809 

*Description of changes:*

* replaces deprecated API in Package.swift
* replaces `@available` statements with `canImport` statements to simplify build
* uses XCTSkip in tests which are not yet implemented
* explicitly declares types in closures which could not handle type inference

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
