### PR TITLE
test: increase network timeout for integration tests

### DIFF
--- a/AmplifyTestCommon/TestCommonConstants.swift
+++ b/AmplifyTestCommon/TestCommonConstants.swift
@@ -7,5 +7,5 @@
 
 import Foundation
 class TestCommonConstants {
-    static let networkTimeout = TimeInterval(5)
+    static let networkTimeout = TimeInterval(10)
 }


### PR DESCRIPTION
*Issue #, if available:*
#1781
*Description of changes:*
* Integration tests are passing when running locally and failing as part of Github Actions.  Updating the network timeout to see if this fixes integration tests running as part of GitHub Actions.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [ ] ~Build succeeds with all target using Swift Package Manager~
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] ~Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
