### PR TITLE
fix(datastore): create indexes for custom primary key

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/ModelSchema+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/ModelSchema+SQLite.swift
@@ -162,7 +162,7 @@ extension ModelSchema {
     /// Create SQLite indexes corresponding to secondary indexes in the model schema
     func createIndexStatements() -> String {
         var statement = ""
-        for case let .index(fields, name?) in indexes {
+        for case let .index(fields, name) in indexes {
             statement += CreateIndexStatement(
                 modelSchema: self,
                 fields: fields,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateIndex.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+CreateIndex.swift
@@ -19,10 +19,10 @@ struct CreateIndexStatement: SQLStatement {
     // name of the secondary index
     var indexName: String
 
-    init(modelSchema: ModelSchema, fields: [ModelFieldName], indexName: String) {
+    init(modelSchema: ModelSchema, fields: [ModelFieldName], indexName: String?) {
         self.modelSchema = modelSchema
         self.fields = fields
-        self.indexName = indexName
+        self.indexName = indexName ?? fields.joined(separator: "_") + "_pk"
     }
 
     var stringValue: String {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
@@ -232,6 +232,19 @@ class SQLStatementTests: XCTestCase {
         XCTAssertEqual(statement, expectedStatement)
     }
 
+    /// - Given: a `Model` instance with a composite primary key
+    /// - When:
+    ///     - the model is of type `ModelCompositePk`
+    /// - Then:
+    ///   - an index for the fields that make up the primary key should be generated
+    func testCreateIndexStatementFromModelWithCustomPKIndex() {
+        let statement = ModelCompositePk.schema.createIndexStatements()
+        let expectedStatement = """
+        create index if not exists "id_dob_pk" on "ModelCompositePk" ("id", "dob");
+        """
+        XCTAssertEqual(statement, expectedStatement)
+    }
+
     // MARK: - Insert Statements
 
     /// - Given: a `Model` instance


### PR DESCRIPTION
*Description of changes:*
When a model has a composite primary key, codegen generates an `.index` attribute in the model schema with a `nil` name.
This PR re-introduces the necessary changes to create local secondary indexes on the fields that make up the primary key.
Since in this scenario the index name is `nil` a default name will be used by concatenating the names of fields separated by "_" with an additional suffix of "_pk".

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
