### PR TITLE
chore(auth): Change the configuration and add configure to the op-queue

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
@@ -10,10 +10,11 @@ import Amplify
 
 public final class AWSCognitoAuthPlugin: AuthCategoryPlugin {
 
-    var authStateMachine: StateMachine<AuthState, AuthEnvironment>!
-    var authStateListenerToken: StateMachine<AuthState, AuthEnvironment>.StateChangeListenerToken!
+    var authStateMachine: AuthStateMachine!
 
-    var credentialStoreStateMachine: StateMachine<CredentialStoreState, CredentialEnvironment>!
+    var credentialStoreStateMachine: CredentialStoreStateMachine!
+
+    var authStateListenerToken: AuthStateMachine.StateChangeListenerToken!
 
     /// A queue that regulates the execution of operations.
     var queue: OperationQueue!

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/AuthConfigureOperation.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/AuthConfigureOperation.swift
@@ -1,8 +1,8 @@
 //
-//  File.swift
-//  
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
-//  Created by Roy, Jithin on 5/25/22.
+// SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/AuthConfigureOperation.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/AuthConfigureOperation.swift
@@ -1,0 +1,130 @@
+//
+//  File.swift
+//  
+//
+//  Created by Roy, Jithin on 5/25/22.
+//
+
+import Foundation
+import Amplify
+
+import ClientRuntime
+import AWSCognitoIdentityProvider
+
+typealias ConfigureOperation = AmplifyOperation<
+    AuthConfigureRequest,
+    Void,
+    AuthError>
+
+class AuthConfigureOperation: ConfigureOperation {
+
+    let authConfiguration: AuthConfiguration
+    let authStateMachine: AuthStateMachine
+    let credentialStoreStateMachine: CredentialStoreStateMachine
+
+    var authToken: AuthStateMachine.StateChangeListenerToken?
+    var credentialStoreToken: CredentialStoreStateMachine.StateChangeListenerToken?
+
+    init(request: AuthConfigureRequest,
+         authStateMachine: AuthStateMachine,
+         credentialStoreStateMachine: CredentialStoreStateMachine) {
+
+        self.authConfiguration = request.authConfiguration
+        self.authStateMachine = authStateMachine
+        self.credentialStoreStateMachine = credentialStoreStateMachine
+        super.init(categoryType: .auth,
+                   eventName: "InternalConfigureAuth",
+                   request: request)
+    }
+
+    deinit {
+        authToken = nil
+        credentialStoreToken = nil
+    }
+
+    override public func main() {
+        if isCancelled {
+            finish()
+            return
+        }
+
+        /// Auth needs the Credential Store to be configured first.
+        sendConfigureCredentialEvent() { result in
+            self.credentialStoreToken = nil
+            do {
+                /// If Credential store is successfully configured send event to configure auth statemachine.
+                /// Auth state change listener should finish this operation after that.
+                let credentials = try result.get()
+                self.sendConfigureAuthEvent(with: credentials)
+            } catch {
+                // TODO: Fix failure, should we move auth state to an error state?
+                self.finish()
+            }
+        }
+    }
+
+    func sendConfigureCredentialEvent(
+        completion: @escaping (Result<AmplifyCredentials?, Error>) -> Void) {
+        credentialStoreToken = credentialStoreStateMachine.listen {
+
+            switch $0 {
+            case .success(let storedCredentials):
+                completion(.success(storedCredentials))
+
+            case .error(let credentialStoreError):
+
+                guard case .itemNotFound = credentialStoreError else {
+                    let error = AuthError.service(
+                        "An exception occurred when configuring credential store",
+                        AmplifyErrorMessages.reportBugToAWS(),
+                        credentialStoreError)
+                    completion(.failure(error))
+                    return
+                }
+
+                completion(.success(nil))
+            default:
+                break
+            }
+        } onSubscribe: { [weak self] in
+            let event = CredentialStoreEvent(eventType: .migrateLegacyCredentialStore)
+            self?.credentialStoreStateMachine.send(event)
+        }
+    }
+
+    func sendConfigureAuthEvent(with storedCredentials: AmplifyCredentials?) {
+        authToken = authStateMachine.listen({ [weak self] state in
+            switch state {
+            case .configured(_, _):
+                self?.finish()
+            default: break
+            }
+        }, onSubscribe: {[weak self] in
+            guard let self = self else {
+                return
+            }
+
+            let event = AuthEvent(eventType: .configureAuth(self.authConfiguration, storedCredentials))
+            self.authStateMachine.send(event)
+        })
+    }
+}
+
+
+struct AuthConfigureRequest: AmplifyOperationRequest {
+
+    let authConfiguration: AuthConfiguration
+
+    var options: Options
+
+    init(authConfiguration: AuthConfiguration, options: Options = Options()) {
+        self.authConfiguration = authConfiguration
+        self.options = options
+    }
+}
+
+
+extension AuthConfigureRequest {
+
+    struct Options {}
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/IdentityPoolConfigurationData.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/IdentityPoolConfigurationData.swift
@@ -26,7 +26,7 @@ extension IdentityPoolConfigurationData: CustomDebugDictionaryConvertible {
     var debugDictionary: [String: Any] {
         [
             "poolId": poolId.masked(interiorCount: 4, retainingCount: 4),
-            "region": region.masked(interiorCount: 4, retainingCount: 4)
+            "region": region.redacted()
         ]
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/UserPoolConfigurationData.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/UserPoolConfigurationData.swift
@@ -44,7 +44,7 @@ extension UserPoolConfigurationData: CustomDebugDictionaryConvertible {
         [
             "poolId": poolId.masked(interiorCount: 4, retainingCount: 4),
             "clientId": clientId.masked(interiorCount: 4, retainingCount: 4),
-            "region": region.masked(interiorCount: 4, retainingCount: 4),
+            "region": region.redacted(),
             "clientSecret": clientSecret.masked(interiorCount: 4),
             "pinpointAppId": pinpointAppId.masked(interiorCount: 4, retainingCount: 4),
             "hostedUI": hostedUIConfig?.debugDescription ?? "NA"

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/AuthState.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/AuthState.swift
@@ -19,8 +19,6 @@ enum AuthState: State {
 
     case configured(AuthenticationState, AuthorizationState)
 
-   // case configurationError(Error)
-
 }
 
 extension AuthState {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/AuthState.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/AuthState.swift
@@ -19,6 +19,8 @@ enum AuthState: State {
 
     case configured(AuthenticationState, AuthorizationState)
 
+   // case configurationError(Error)
+
 }
 
 extension AuthState {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ConfigurationHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ConfigurationHelper.swift
@@ -1,0 +1,70 @@
+//
+//  File.swift
+//  
+//
+//  Created by Roy, Jithin on 5/26/22.
+//
+
+import Foundation
+import Amplify
+
+struct ConfigurationHelper {
+
+    static func parseUserPoolData(_ config: JSONValue) -> UserPoolConfigurationData? {
+        // TODO: Use JSON serialization here to convert.
+        guard let cognitoUserPoolJSON = config.value(at: "CognitoUserPool.Default") else {
+            Amplify.Logging.info("Could not find Cognito User Pool configuration")
+            return nil
+        }
+        guard case .string(let poolId)  = cognitoUserPoolJSON.value(at: "PoolId"),
+              case .string(let appClientId) = cognitoUserPoolJSON.value(at: "AppClientId"),
+              case .string(let region) = cognitoUserPoolJSON.value(at: "Region")
+        else {
+            return nil
+        }
+
+        var clientSecret: String?
+        if case .string(let clientSecretFromConfig) = cognitoUserPoolJSON.value(at: "AppClientSecret") {
+            clientSecret = clientSecretFromConfig
+        }
+        return UserPoolConfigurationData(poolId: poolId,
+                                         clientId: appClientId,
+                                         region: region,
+                                         clientSecret: clientSecret)
+    }
+
+    static func parseIdentityPoolData(_ config: JSONValue) -> IdentityPoolConfigurationData? {
+
+        guard let cognitoIdentityPoolJSON = config.value(at: "CredentialsProvider.CognitoIdentity.Default") else {
+            Amplify.Logging.info("Could not find Cognito Identity Pool configuration")
+            return nil
+        }
+        guard case .string(let poolId) = cognitoIdentityPoolJSON.value(at: "PoolId"),
+              case .string(let region) = cognitoIdentityPoolJSON.value(at: "Region")
+        else {
+            return nil
+        }
+        return IdentityPoolConfigurationData(poolId: poolId, region: region)
+    }
+
+    static func authConfiguration(_ config: JSONValue) throws -> AuthConfiguration {
+        let userPoolConfig = parseUserPoolData(config)
+        let identityPoolConfig = parseIdentityPoolData(config)
+
+        if let userPoolConfigNonNil = userPoolConfig, let identityPoolConfigNonNil = identityPoolConfig {
+            return .userPoolsAndIdentityPools(userPoolConfigNonNil, identityPoolConfigNonNil)
+        }
+        if  let userPoolConfigNonNil = userPoolConfig {
+            return .userPools(userPoolConfigNonNil)
+        }
+        if  let identityPoolConfigNonNil = identityPoolConfig {
+            return .identityPools(identityPoolConfigNonNil)
+        }
+        // Could not get either Userpool or Identitypool configuration
+        // Throw an error to stop the configure flow.
+        throw AuthError.configuration(
+            "Error configuring \(String(describing: self))",
+            AuthPluginErrorConstants.configurationMissingError
+        )
+    }
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ConfigurationHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ConfigurationHelper.swift
@@ -1,8 +1,8 @@
 //
-//  File.swift
-//  
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
 //
-//  Created by Roy, Jithin on 5/26/22.
+// SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation


### PR DESCRIPTION
*Description of changes:*

Moving the task of configuring the credential store and auth state machine to the operation queue. This way we can make sure that the statemachine are always configured before starting any operation. 

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
