### PR TITLE
adds DEV_PREVIEW_BUILD build flag to Package.swift for all plugin targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,6 +33,7 @@ let dependencies: [Package.Dependency] = [
         url: "https://github.com/mattgallagher/CwlPreconditionTesting.git",
         .upToNextMinor(from: "2.1.0"))
 ]
+let swiftSettings: [SwiftSetting]? = [.define("DEV_PREVIEW_BUILD")]
 
 let amplifyTargets: [Target] = [
     .target(
@@ -121,7 +122,8 @@ let apiTargets: [Target] = [
         exclude: [
             "Info.plist",
             "AWSAPIPlugin.md"
-        ]
+        ],
+        swiftSettings: swiftSettings
     ),
     .testTarget(
         name: "AWSAPIPluginTests",
@@ -200,7 +202,8 @@ let authTargets: [Target] = [
             .product(name: "AWSCognitoIdentityProvider", package: "AWSSwiftSDK"),
             .product(name: "AWSCognitoIdentity", package: "AWSSwiftSDK")
         ],
-        path: "AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin"
+        path: "AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin",
+        swiftSettings: swiftSettings
     ),
     .target(
         name: "libtommathAmplify",
@@ -239,7 +242,8 @@ let dataStoreTargets: [Target] = [
         path: "AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin",
         exclude: [
             "Info.plist"
-        ]
+        ],
+        swiftSettings: swiftSettings
     ),
     .testTarget(
         name: "AWSDataStoreCategoryPluginTests",
@@ -278,7 +282,8 @@ let storageTargets: [Target] = [
         path: "AmplifyPlugins/Storage/AWSS3StoragePlugin",
         exclude: [
             "Resources/Info.plist"
-        ]
+        ],
+        swiftSettings: swiftSettings
     ),
     .testTarget(
         name: "AWSS3StoragePluginTests",


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

A build flag will be defined for builds so the following block can wrap code which should not be included in the GA release.

```swift
#if DEV_PREVIEW_BUILD
    // code which is being deprecated which will be removed before GA release
#else
#warning("Dead code, please remove before GA.")
#endif
```

Adopting Swift Concurrency with more async functions will require breaking changes and so temporary workarounds will be in place to help with migrating to the new APIs.

Defines a build flat for dev-preview.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
