### PR TITLE
feat(analytics): protect AnalyticsClient state with actor

### DIFF
--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAdapter+AnalyticsClientBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAdapter+AnalyticsClientBehavior.swift
@@ -11,35 +11,51 @@ import StoreKit
 
 extension AWSPinpointAdapter: AWSPinpointAnalyticsClientBehavior {
     func addGlobalAttribute(_ theValue: String, forKey theKey: String) {
-        pinpoint.analyticsClient.addGlobalAttribute(theValue, forKey: theKey)
+        Task {
+            await pinpoint.analyticsClient.addGlobalAttribute(theValue, forKey: theKey)
+        }
     }
 
     func addGlobalAttribute(_ theValue: String, forKey theKey: String, forEventType theEventType: String) {
-        pinpoint.analyticsClient.addGlobalAttribute(theValue, forKey: theKey, forEventType: theEventType)
+        Task {
+            await pinpoint.analyticsClient.addGlobalAttribute(theValue, forKey: theKey, forEventType: theEventType)
+        }
     }
 
     func addGlobalMetric(_ theValue: Double, forKey theKey: String) {
-        pinpoint.analyticsClient.addGlobalMetric(theValue, forKey: theKey)
+        Task {
+            await pinpoint.analyticsClient.addGlobalMetric(theValue, forKey: theKey)
+        }
     }
 
     func addGlobalMetric(_ theValue: Double, forKey theKey: String, forEventType theEventType: String) {
-        pinpoint.analyticsClient.addGlobalMetric(theValue, forKey: theKey, forEventType: theEventType)
+        Task {
+            await pinpoint.analyticsClient.addGlobalMetric(theValue, forKey: theKey, forEventType: theEventType)
+        }
     }
 
     func removeGlobalAttribute(forKey theKey: String) {
-        pinpoint.analyticsClient.removeGlobalAttribute(forKey: theKey)
+        Task {
+            await pinpoint.analyticsClient.removeGlobalAttribute(forKey: theKey)
+        }
     }
 
     func removeGlobalAttribute(forKey theKey: String, forEventType _: String) {
-        pinpoint.analyticsClient.removeGlobalAttribute(forKey: theKey)
+        Task {
+            await pinpoint.analyticsClient.removeGlobalAttribute(forKey: theKey)
+        }
     }
 
     func removeGlobalMetric(forKey theKey: String) {
-        pinpoint.analyticsClient.removeGlobalMetric(forKey: theKey)
+        Task {
+            await pinpoint.analyticsClient.removeGlobalMetric(forKey: theKey)
+        }
     }
 
     func removeGlobalMetric(forKey theKey: String, forEventType theEventType: String) {
-        pinpoint.analyticsClient.removeGlobalMetric(forKey: theKey, forEventType: theEventType)
+        Task {
+            await pinpoint.analyticsClient.removeGlobalMetric(forKey: theKey, forEventType: theEventType)
+        }
     }
 
     func record(_ theEvent: PinpointEvent) async throws {

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/AnalyticsClient.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/AnalyticsClient.swift
@@ -10,7 +10,7 @@ import StoreKit
 
 actor AnalyticsClient: InternalPinpointClient {
     private let eventRecorder: AnalyticsEventRecording
-    internal let context: PinpointContext
+    unowned let context: PinpointContext
     private lazy var globalAttributes: [String: String] = [:]
     private lazy var globalMetrics: [String: Double] = [:]
     private lazy var eventTypeAttributes: [String: [String: String]] = [:]

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/AnalyticsClient.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/AnalyticsClient.swift
@@ -8,8 +8,9 @@
 import Foundation
 import StoreKit
 
-class AnalyticsClient: InternalPinpointClient {
+actor AnalyticsClient: InternalPinpointClient {
     private let eventRecorder: AnalyticsEventRecording
+    internal let context: PinpointContext
     private lazy var globalAttributes: [String: String] = [:]
     private lazy var globalMetrics: [String: Double] = [:]
     private lazy var eventTypeAttributes: [String: [String: String]] = [:]
@@ -18,7 +19,7 @@ class AnalyticsClient: InternalPinpointClient {
     init(eventRecorder: AnalyticsEventRecording = EventRecorder(),
          context: PinpointContext) {
         self.eventRecorder = eventRecorder
-        super.init(context: context)
+        self.context = context
     }
     
     // MARK: - Attributes & Metrics
@@ -59,8 +60,8 @@ class AnalyticsClient: InternalPinpointClient {
     }
     
     // MARK: - Monetization events
-    func createAppleMonetizationEvent(with transaction: SKPaymentTransaction,
-                                      with product: SKProduct) -> PinpointEvent {
+    nonisolated func createAppleMonetizationEvent(with transaction: SKPaymentTransaction,
+                                                  with product: SKProduct) -> PinpointEvent {
         let numberFormatter = NumberFormatter()
         numberFormatter.locale = product.priceLocale
         numberFormatter.numberStyle = .currency
@@ -75,10 +76,10 @@ class AnalyticsClient: InternalPinpointClient {
                                        transactionId: transaction.transactionIdentifier)
     }
 
-    func createVirtualMonetizationEvent(withProductId productId: String,
-                                        withItemPrice itemPrice: Double,
-                                        withQuantity quantity: Int,
-                                        withCurrency currency: String) -> PinpointEvent {
+    nonisolated func createVirtualMonetizationEvent(withProductId productId: String,
+                                                    withItemPrice itemPrice: Double,
+                                                    withQuantity quantity: Int,
+                                                    withCurrency currency: String) -> PinpointEvent {
         return createMonetizationEvent(withStore: Constants.PurchaseEvent.virtual,
                                        productId: productId,
                                        quantity: quantity,
@@ -86,14 +87,14 @@ class AnalyticsClient: InternalPinpointClient {
                                        currencyCode: currency)
     }
     
-    private func createMonetizationEvent(withStore store: String,
-                                         productId: String,
-                                         quantity: Int,
-                                         itemPrice: Double,
-                                         currencyCode: String?,
-                                         formattedItemPrice: String? = nil,
-                                         priceLocale: Locale? = nil,
-                                         transactionId: String? = nil) -> PinpointEvent {
+    private nonisolated func createMonetizationEvent(withStore store: String,
+                                                     productId: String,
+                                                     quantity: Int,
+                                                     itemPrice: Double,
+                                                     currencyCode: String?,
+                                                     formattedItemPrice: String? = nil,
+                                                     priceLocale: Locale? = nil,
+                                                     transactionId: String? = nil) -> PinpointEvent {
         let monetizationEvent = PinpointEvent(eventType: Constants.PurchaseEvent.name,
                                               session: context.sessionTracker.currentSession)
         monetizationEvent.addAttribute(store,
@@ -124,7 +125,7 @@ class AnalyticsClient: InternalPinpointClient {
     }
 
     // MARK: - Event recording
-    func createEvent(withEventType eventType: String) -> PinpointEvent {
+    nonisolated func createEvent(withEventType eventType: String) -> PinpointEvent {
         precondition(!eventType.isEmpty, "Event types must be at least 1 character in length.")
         return PinpointEvent(eventType: eventType,
                              session: context.sessionTracker.currentSession)

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Endpoint/EndpointClient.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Endpoint/EndpointClient.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 class EndpointClient: InternalPinpointClient {
-    internal var context: PinpointContext
+    unowned var context: PinpointContext
     
     init(context: PinpointContext) {
         self.context = context

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Endpoint/EndpointClient.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Endpoint/EndpointClient.swift
@@ -7,7 +7,13 @@
 
 import Foundation
 
-class EndpointClient: InternalPinpointClient {    
+class EndpointClient: InternalPinpointClient {
+    internal var context: PinpointContext
+    
+    init(context: PinpointContext) {
+        self.context = context
+    }
+    
     func currentEndpointProfile() -> PinpointEndpointProfile {
         // TODO: Implement
         fatalError("Not yet implemented")

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/PinpointContext.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/PinpointContext.swift
@@ -89,9 +89,9 @@ class PinpointContext {
         self.keychainStore = keychainStore
         self.userDefaults = userDefaults
         self.fileManager = fileManager
-        let pinpointConfiguration = try PinpointClient.PinpointClientConfiguration(credentialsProvider: credentialsProvider,
-                                                                                   frameworkMetadata: AmplifyAWSServiceConfiguration.frameworkMetaData(),
-                                                                                   region: region)
+        let pinpointConfiguration = try PinpointClient.PinpointClientConfiguration(region: region,
+                                                                                   credentialsProvider: credentialsProvider,
+                                                                                   frameworkMetadata: AmplifyAWSServiceConfiguration.frameworkMetaData())
         pinpointClient = PinpointClient(config: pinpointConfiguration)
     }
     
@@ -221,10 +221,6 @@ extension PinpointContext {
     }
 }
 
-class InternalPinpointClient {
-    unowned let context: PinpointContext // ⚠️ This is known to be risky
-
-    init(context: PinpointContext) {
-        self.context = context
-    }
+protocol InternalPinpointClient {
+    var context: PinpointContext { get }
 }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Session/SessionClient.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Session/SessionClient.swift
@@ -12,14 +12,15 @@ class SessionClient: InternalPinpointClient {
     private let archiver: AmplifyArchiverBehaviour
     private let activityTracker: ActivityTracker
     private var session: PinpointSession
+    internal var context: PinpointContext
 
     init(context: PinpointContext,
          archiver: AmplifyArchiverBehaviour = AmplifyArchiver()) {
         activityTracker = ActivityTracker(timeout: context.configuration.sessionTimeout)
         self.archiver = archiver
+        self.context = context
         session = PinpointSession(appId: context.configuration.appId,
                                   uniqueId: context.uniqueId)
-        super.init(context: context)
         startSession()
     }
 
@@ -46,6 +47,7 @@ class SessionClient: InternalPinpointClient {
         activityTracker.beginActivityTracking()
 
         let startEvent = context.analyticsClient.createEvent(withEventType: Constants.Events.start)
+        
         // Update Endpoint and record Session Start event
         Task {
             try? await context.targetingClient.updateEndpointProfile()

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Session/SessionClient.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Session/SessionClient.swift
@@ -12,7 +12,7 @@ class SessionClient: InternalPinpointClient {
     private let archiver: AmplifyArchiverBehaviour
     private let activityTracker: ActivityTracker
     private var session: PinpointSession
-    internal var context: PinpointContext
+    unowned var context: PinpointContext
 
     init(context: PinpointContext,
          archiver: AmplifyArchiverBehaviour = AmplifyArchiver()) {


### PR DESCRIPTION
*Issue #, if available:*
This PR introduces the changes to make `AnalyticsClient` an actor to enforce synchronization for reads/writes to its inner state.
The `createAppleMonetizationEvent`, `createVirtualMonetizationEvent`, `createMonetizationEvent` and `createEvent` APIs are marked as `nonisolated` as they're just factories to instantiate new events and don't mutate the internal state.

*Description of changes:*

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
