### PR TITLE
chore: fix unit tests workflow

### DIFF
--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -14,5 +14,5 @@ runs:
   steps:
     - name: Test ${{ inputs.scheme }}
       run: |
-        xcodebuild test -scheme AWSCognitoAuthPlugin -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13' | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}        
+        xcodebuild test -scheme ${{ inputs.scheme }} -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13' | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}        
       shell: bash 

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -13,6 +13,8 @@ runs:
   using: "composite"
   steps:
     - name: Test ${{ inputs.scheme }}
+      env:
+        SCHEME: ${{ inputs.scheme }}
       run: |
-        xcodebuild test -scheme ${{ inputs.scheme }} -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13' | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}        
+        xcodebuild test -scheme $SCHEME -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13' | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}        
       shell: bash 

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AmplifyTests"
+               BuildableName = "AmplifyTests"
+               BlueprintName = "AmplifyTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
*Description of changes:*
- Fixing `.github/composite_actions/run_xcodebuild_test/action.yml` to actually run the scheme passed in the input
- Adding `AmplifyTests` to the `Amplify` scheme

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
