### PR TITLE
fix(datastore): stop sync engine on non-retryable errors to allow restart

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -202,6 +202,15 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
         case .finished:
             break
         }
+        stop { result in
+            switch result {
+            case .success:
+                self.log.info("Stopping DataStore successful.")
+                return
+            case .failure(let error):
+                self.log.error("Failed to stop StorageEngine with error: \(error)")
+            }
+        }
     }
 
     @available(iOS 13.0, *)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
@@ -39,12 +39,15 @@ extension RemoteSyncEngine {
             remoteSyncTopicPublisher.send(.subscriptionsInitialized)
             stateMachine.notify(action: .initializedSubscriptions)
         case .started:
-            remoteSyncTopicPublisher.send(.subscriptionsActivated)
-            if let api = self.api {
-                stateMachine.notify(action: .activatedCloudSubscriptions(api,
-                                                                         mutationEventPublisher,
-                                                                         reconciliationQueue))
+            guard let api = self.api else {
+                let error = DataStoreError.internalOperation("api is unexpectedly `nil`", "", nil)
+                stateMachine.notify(action: .errored(error))
+                return
             }
+            remoteSyncTopicPublisher.send(.subscriptionsActivated)
+            stateMachine.notify(action: .activatedCloudSubscriptions(api,
+                                                                     mutationEventPublisher,
+                                                                     reconciliationQueue))
         case .paused:
             remoteSyncTopicPublisher.send(.subscriptionsPaused)
         case .mutationEventDropped, .mutationEventApplied:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -356,7 +356,13 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
 
     private func activateCloudSubscriptions() {
         log.debug(#function)
-        reconciliationQueue?.start()
+        guard let reconciliationQueue = reconciliationQueue else {
+            let error = DataStoreError.internalOperation("reconciliationQueue is unexpectedly `nil`", "", nil)
+            stateMachine.notify(action: .errored(error))
+            return
+        }
+
+        reconciliationQueue.start()
     }
 
     private func startMutationQueue(api: APICategoryGraphQLBehavior,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSDataStorePluginTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/AWSDataStorePluginTests.swift
@@ -11,7 +11,8 @@ import AmplifyTestCommon
 @testable import Amplify
 @testable import AWSDataStoreCategoryPlugin
 
-class AWSAPICategoryPluginTests: XCTestCase {
+// swiftlint:disable type_body_length
+class AWSDataStorePluginTests: XCTestCase {
     func testStorageEngineDoesNotStartsOnConfigure() throws {
         let startExpectation = expectation(description: "Start Sync should not be called")
         startExpectation.isInverted = true
@@ -487,6 +488,66 @@ class AWSAPICategoryPluginTests: XCTestCase {
                 pluginClearExpectation.fulfill()
             }
         }
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testStopStorageEngineOnTerminalEvent() {
+        let storageEngine = MockStorageEngineBehavior()
+        let stopExpectation = expectation(description: "stop should be called")
+        var count = 0
+        storageEngine.responders[.stopSync] = StopSyncResponder { _ in
+            count = self.expect(stopExpectation, count, 1)
+        }
+        let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+            return storageEngine
+        }
+        let dataStorePublisher = DataStorePublisher()
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        storageEngineBehaviorFactory: storageEngineBehaviorFactory,
+                                        dataStorePublisher: dataStorePublisher,
+                                        validAPIPluginKey: "MockAPICategoryPlugin",
+                                        validAuthPluginKey: "MockAuthCategoryPlugin")
+
+        let semaphore = DispatchSemaphore(value: 0)
+        plugin.start(completion: {_ in
+            XCTAssertNotNil(plugin.storageEngine)
+            XCTAssertNotNil(plugin.dataStorePublisher)
+            semaphore.signal()
+        })
+        semaphore.wait()
+
+        storageEngine.mockPublisher.send(completion: .finished)
+
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testStopStorageEngineOnTerminalFailureEvent() {
+        let storageEngine = MockStorageEngineBehavior()
+        let stopExpectation = expectation(description: "stop should be called")
+        var count = 0
+        storageEngine.responders[.stopSync] = StopSyncResponder { _ in
+            count = self.expect(stopExpectation, count, 1)
+        }
+        let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
+            return storageEngine
+        }
+        let dataStorePublisher = DataStorePublisher()
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        storageEngineBehaviorFactory: storageEngineBehaviorFactory,
+                                        dataStorePublisher: dataStorePublisher,
+                                        validAPIPluginKey: "MockAPICategoryPlugin",
+                                        validAuthPluginKey: "MockAuthCategoryPlugin")
+
+        let semaphore = DispatchSemaphore(value: 0)
+        plugin.start(completion: {_ in
+            XCTAssertNotNil(plugin.storageEngine)
+            XCTAssertNotNil(plugin.dataStorePublisher)
+            semaphore.signal()
+        })
+        semaphore.wait()
+
+        storageEngine.mockPublisher.send(completion: .failure(.internalOperation("", "", nil)))
+
         waitForExpectations(timeout: 1.0)
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -287,8 +287,9 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
 
     }
 
+    var mockPublisher = PassthroughSubject<StorageEngineEvent, DataStoreError>()
     var publisher: AnyPublisher<StorageEngineEvent, DataStoreError> {
-        return PassthroughSubject<StorageEngineEvent, DataStoreError>().eraseToAnyPublisher()
+        mockPublisher.eraseToAnyPublisher()
     }
 
     func startSync(completion: @escaping DataStoreCallback<Void>) {

--- a/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/DataStoreCategoryPlugin.xcodeproj/project.pbxproj
@@ -138,7 +138,7 @@
 		6BC4FDAA23A899680027D20C /* MockRequestRetryablePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */; };
 		6BDC224023E21A4E007C8410 /* RemoteSyncEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */; };
 		6BDC224223E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */; };
-		6BE7431C2575B8B000009FCB /* AWSAPICategoryPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE7431B2575B8B000009FCB /* AWSAPICategoryPluginTests.swift */; };
+		6BE7431C2575B8B000009FCB /* AWSDataStorePluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE7431B2575B8B000009FCB /* AWSDataStorePluginTests.swift */; };
 		6BE9D6F125A6643100AB5C9A /* StorageEngineTestsHasOne.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D6F025A6643100AB5C9A /* StorageEngineTestsHasOne.swift */; };
 		6BE9D6F325A665EA00AB5C9A /* StorageEngineTestsBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D6F225A665EA00AB5C9A /* StorageEngineTestsBase.swift */; };
 		6BE9D73E25A6800100AB5C9A /* StorageEngineTestsManyToMany.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D73D25A6800100AB5C9A /* StorageEngineTestsManyToMany.swift */; };
@@ -562,7 +562,7 @@
 		6BC4FDA923A899680027D20C /* MockRequestRetryablePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRequestRetryablePolicy.swift; sourceTree = "<group>"; };
 		6BDC223F23E21A4E007C8410 /* RemoteSyncEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSyncEngineTests.swift; sourceTree = "<group>"; };
 		6BDC224123E27324007C8410 /* MockAWSInitialSyncOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSInitialSyncOrchestrator.swift; sourceTree = "<group>"; };
-		6BE7431B2575B8B000009FCB /* AWSAPICategoryPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAPICategoryPluginTests.swift; sourceTree = "<group>"; };
+		6BE7431B2575B8B000009FCB /* AWSDataStorePluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStorePluginTests.swift; sourceTree = "<group>"; };
 		6BE9D6F025A6643100AB5C9A /* StorageEngineTestsHasOne.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageEngineTestsHasOne.swift; sourceTree = "<group>"; };
 		6BE9D6F225A665EA00AB5C9A /* StorageEngineTestsBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageEngineTestsBase.swift; sourceTree = "<group>"; };
 		6BE9D73D25A6800100AB5C9A /* StorageEngineTestsManyToMany.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageEngineTestsManyToMany.swift; sourceTree = "<group>"; };
@@ -1563,7 +1563,7 @@
 		FAD2BDF423957F35006EB065 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				6BE7431B2575B8B000009FCB /* AWSAPICategoryPluginTests.swift */,
+				6BE7431B2575B8B000009FCB /* AWSDataStorePluginTests.swift */,
 				FA1C819E25868D17006160E9 /* AWSDataStorePluginAmplifyVersionableTests.swift */,
 				B40EF02724BF68C900F2264C /* ConfigurationTests.swift */,
 				21A4EE5B259D50C700E1047D /* DataStoreListDecoderTests.swift */,
@@ -2578,7 +2578,7 @@
 				211FFEDD26CD621400F0DB75 /* DataStoreObserveQueryOperationTests.swift in Sources */,
 				FA4B8E942391C2CD009FC10F /* MutationIngesterConflictResolutionTests.swift in Sources */,
 				FA4A9557239ACAD7008E876E /* ModelReconciliationQueueBehaviorTests.swift in Sources */,
-				6BE7431C2575B8B000009FCB /* AWSAPICategoryPluginTests.swift in Sources */,
+				6BE7431C2575B8B000009FCB /* AWSDataStorePluginTests.swift in Sources */,
 				FA4A955D239AD810008E876E /* MockSQLiteStorageEngineAdapterResponders.swift in Sources */,
 				D80064F62499297800935DA3 /* MockFileManager.swift in Sources */,
 				21A4EE5C259D50C700E1047D /* DataStoreListDecoderTests.swift in Sources */,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/1839

*Description of changes:*
When the app is placed in the background for an extended period of time, the subscriptions get severed. This causes the sync engine to transition its state to cleanUp(error), and then scheduleRestartOrTerminate. Since the subscription error isn't handled as a retryable network error, the sync engine transitions to a terminal state. If the sync engine can accurately check the error from its downstream components as a retryable network error, then it can also perform the restart of the sync process. For this fix, we aren't addressing whether the subscription error should be handled as a retryable or non-retryable error at the moment, and generalize this problem to handling non-retryble errors and provide a fix for these scenarios as it could happen in various places of the sync process:


```mermaid
stateDiagram-v2
notStarted --> pausingSubscriptions: if receivedStart
pausingSubscriptions --> pausingMutationQueue: if pausedSubscriptions
pausingMutationQueue --> clearingStateOutgoingMutations: if pausedMutationQueue
clearingStateOutgoingMutations --> initializingSubscriptions: if clearedStateOutgoingMutations
initializingSubscriptions --> performingInitialSync: initializedSubscriptions
initializingSubscriptions --> cleaningUp: if errored
performingInitialSync --> activatingCloudSubscriptions: if performedInitialSync
performingInitialSync --> cleaningUp: if errored
activatingCloudSubscriptions --> activatingMutationQueue: if activatedCloudSubscriptions
activatingCloudSubscriptions --> cleaningUp: if errored
activatingMutationQueue --> notifyingSyncStarted: if activatedMutationQueue
activatingMutationQueue --> cleaningUp: if errored
notifyingSyncStarted --> syncEngineActive: if notifiedSyncStarted
syncEngineActive --> cleaningUp: if errored
[*] --> cleaningUpForTermination: if finished
cleaningUp --> schedulingRestart: if cleanedUp
cleaningUpForTermination --> terminate: if cleanedUpForTermination
schedulingRestart --> pausingSubscriptions: if scheduledRestartTriggered
```
Above is a snapshot of the state transitions in RemoteSyncEngine. In the happy case, the sync engine sites in `syncEngineActive` state, and when an error occurs with the subscriptions, it's returned from reconciliationQueue's publisher, and the state machine transitions it from `syncEngineActive` + if errorred -> cleaningUp.

One of the problems we fixed recently had to do with treating all non-retryable errors as retryable, and sync engine would restart continuously, causing a retry storm on AppSync, getting limit exceeded / throttled (https://github.com/aws-amplify/amplify-ios/pull/1773). From this experience, we do not want to immediately restart the sync engine for non-retryable errors. Non-retryable errors will put the sync engine through a clean up step that stops the outgoing mutation queue and deinits the reconciliation queue, decides not to reschedule a restart, followed by sending the publisher's terminating completion event, putting the sync engine in a terminal state.

The completion event is handled by the storage engine, which then also sends a terminating completion event back up to the DataStorePlugin. DataStorePlugin logs the error. DataStorePlugin's operates on the storage engine by creating a new instance when it's started, and deinits it when it's stopped/cleared. This means that all subsequent operations will think that the storage engine is available despite it being in terminal state.  models and outgoing mutation event continue to be saved to local store with the storage adapter and mutation events injester. but none of the mutation events get synced to the cloud.

The fix here is for DataStorePlugin to stop the storage engine (in turn stops the sync engine and dereferences storage engine) when it receives a terminating event from the storage engine. This way, the non-retryable errors are not immediately retried. When a DataStore operation is performed at a later time, such as a save or a query, it will check if storage engine is there, if not it will create the storage engine and start the sync process. This avoids immediately/continuous retry when it encounters non-retrable errors, and allows the app to recover (for example, sync process goes through steps such as delta sync to get the latest data), without having the end-user or developer intervene by restarting the app or making calls to stop/clear/start on app lifecycle events like foregrounding. 

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
