### PR TITLE
fix: SignIn, signOut and confirmsignIn with new authorizationflow

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/AuthorizationState.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/AuthorizationState.swift
@@ -15,6 +15,8 @@ enum AuthorizationState: State {
 
     case signingIn
 
+    case signingOut
+
     case fetchingUnAuthSession(FetchAuthSessionState)
 
     case fetchingAuthSessionWithUserPool(FetchAuthSessionState,
@@ -38,6 +40,8 @@ extension AuthorizationState {
             return "AuthorizationState.configured"
         case .signingIn:
             return "AuthorizationState.signingIn"
+        case .signingOut:
+            return "AuthorizationState.signingOut"
         case .fetchingUnAuthSession:
             return "AuthorizationState.fetchingUnAuthSession"
         case .sessionEstablished:

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/DebugInfo/AuthorizationState+Debug.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/DebugInfo/AuthorizationState+Debug.swift
@@ -14,7 +14,9 @@ extension AuthorizationState: CustomDebugDictionaryConvertible {
         switch self {
         case .notConfigured,
                 .configured,
-                .signingIn:
+                .signingIn,
+                .signingOut,
+                .refreshingSession:
             additionalMetadataDictionary = [:]
         case .refreshingSession(existingCredentials: let credentials, let state):
             additionalMetadataDictionary = ["existing": credentials.debugDescription,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/StateMachineSupport/StateMachineEvent+Type.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/StateMachineSupport/StateMachineEvent+Type.swift
@@ -23,6 +23,13 @@ extension StateMachineEvent {
         return authZEvent
     }
 
+    var isAuthenticationEvent: AuthenticationEvent.EventType? {
+        guard let authNEvent = (self as? AuthenticationEvent)?.eventType else {
+            return nil
+        }
+        return authNEvent
+    }
+
     var isRefreshSessionEvent: RefreshSessionEvent.EventType? {
         guard let refreshSessionEvent = (self as? RefreshSessionEvent)?.eventType else {
             return nil
@@ -35,6 +42,13 @@ extension StateMachineEvent {
             return nil
         }
         return fetchSessionEvent
+    }
+
+    var isSignOutEvent: SignOutEvent.EventType? {
+        guard let event = (self as? SignOutEvent)?.eventType else {
+            return nil
+        }
+        return event
     }
     
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignOutState/SignOutStateResolverTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignOutState/SignOutStateResolverTests.swift
@@ -49,14 +49,6 @@ class SignOutStateResolverTests: XCTestCase {
             SignOutStateSequence(
                 oldState: .revokingToken,
                 event: SignOutEvent(eventType: .signedOutFailure(.testData)),
-                expected: .error(.testData)),
-            SignOutStateSequence(
-                oldState: .signingOutLocally(.testData),
-                event: SignOutEvent(eventType: .signedOutSuccess),
-                expected: .signedOut(.testData)),
-            SignOutStateSequence(
-                oldState: .signingOutLocally(.testData),
-                event: SignOutEvent(eventType: .signedOutFailure(.testData)),
                 expected: .error(.testData))
         ]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Updates signIn, signOut and confirmSignIn to use the refactored flow.

This is the continuation of the PRs from: 
https://github.com/aws-amplify/amplify-ios/pull/1916 chore: Fix fetchauthsession helper
https://github.com/aws-amplify/amplify-ios/pull/1914 test(auth): Fix unit test errors for authorization statemachine refctor
https://github.com/aws-amplify/amplify-ios/pull/1897 chore: Refactor authorization flow, adds refresh flow
https://github.com/aws-amplify/amplify-ios/pull/1872 chore: Change credential state machine and authorization flow

Pending work:

- [x] Finalize Refresh flow
- [x] Fixing test
- [x] Use session in the operations
- [x] Fix signIn and confirm signIn flow
- [x] Fix signout flow
- [ ] Error handling
- [ ] Fix migration of credentials

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
