### PR TITLE
fix: Migration of legacy store with new authorization flow

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -84,8 +84,7 @@ extension AWSCognitoAuthPlugin {
         }
     }
 
-    func makeCredentialStore() -> AmplifyAuthCredentialStoreBehavior &
-    AmplifyAuthCredentialStoreProvider {
+    func makeCredentialStore() -> AmplifyAuthCredentialStoreBehavior {
         AWSCognitoAuthCredentialStore(authConfiguration: authConfiguration)
     }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AWSCognitoAuthCredentialStore.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AWSCognitoAuthCredentialStore.swift
@@ -134,14 +134,6 @@ extension AWSCognitoAuthCredentialStore: AmplifyAuthCredentialStoreBehavior {
 
 }
 
-extension AWSCognitoAuthCredentialStore: AmplifyAuthCredentialStoreProvider {
-
-    func getCredentialStore() -> CredentialStoreBehavior {
-        return keychain
-    }
-
-}
-
 /// Helpers for encode and decoding
 private extension AWSCognitoAuthCredentialStore {
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AmplifyAuthCredentialStoreBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AmplifyAuthCredentialStoreBehavior.swift
@@ -12,7 +12,3 @@ protocol AmplifyAuthCredentialStoreBehavior {
     func retrieveCredential() throws -> Codable
     func deleteCredential() throws
 }
-
-protocol AmplifyAuthCredentialStoreProvider {
-    func getCredentialStore() -> CredentialStoreBehavior
-}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/CredentialStoreEnvironment.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/CredentialStoreEnvironment.swift
@@ -11,7 +11,7 @@ struct CredentialEnvironment: Environment {
 }
 
 protocol CredentialStoreEnvironment: Environment {
-    typealias AmplifyAuthCredentialStoreFactory = () -> AmplifyAuthCredentialStoreBehavior & AmplifyAuthCredentialStoreProvider
+    typealias AmplifyAuthCredentialStoreFactory = () -> AmplifyAuthCredentialStoreBehavior
     typealias CredentialStoreFactory = (_ service: String) -> CredentialStoreBehavior
 
     var amplifyCredentialStoreFactory: AmplifyAuthCredentialStoreFactory { get }
@@ -21,7 +21,7 @@ protocol CredentialStoreEnvironment: Environment {
 
 struct BasicCredentialStoreEnvironment: CredentialStoreEnvironment {
 
-    typealias AmplifyAuthCredentialStoreFactory = () -> AmplifyAuthCredentialStoreBehavior & AmplifyAuthCredentialStoreProvider
+    typealias AmplifyAuthCredentialStoreFactory = () -> AmplifyAuthCredentialStoreBehavior
     typealias CredentialStoreFactory = (_ service: String) -> CredentialStoreBehavior
 
     // Required

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MigrateLegacyCredentialStoreTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MigrateLegacyCredentialStoreTests.swift
@@ -11,97 +11,107 @@ import XCTest
 
 class MigrateLegacyCredentialStoreTests: XCTestCase {
 
-    // TODO: FIx legacy credential store
-    
-//    /// Test is responsible to check the happy path business logic of migrating the legacy store data.
-//    ///
-//    /// - Given: A credential store with legacy data
-//    /// - When: The migration legacy store action is executed
-//    /// - Then:
-//    ///    - the new credential store should get the correct identityId, userPoolTokens and awsCredentials
-//    func testSaveLegacyCredentials() {
-//        let mockedData = "mock"
-//        let saveCredentialHandlerInvoked = expectation(description: "saveCredentialHandlerInvoked")
-//
-//        let mockLegacyCredentialStoreBehavior = MockCredentialStoreBehavior(data: mockedData)
-//        let legacyCredentialStoreFactory: BasicCredentialStoreEnvironment.CredentialStoreFactory = { _ in
-//            return mockLegacyCredentialStoreBehavior
-//        }
-//        let mockAmplifyCredentialStoreBehavior = MockAmplifyCredentialStoreBehavior(
-//            saveCredentialHandler: { codableCredentials in
-//                let credentials = codableCredentials as! AmplifyCredentials
-//                // Validate the data returned is correct and matches the mocked data.
-//                XCTAssertEqual(credentials.identityId, mockedData)
-//                XCTAssertEqual(credentials.userPoolTokens?.refreshToken, mockedData)
-//                XCTAssertEqual(credentials.userPoolTokens?.accessToken, mockedData)
-//                XCTAssertEqual(credentials.userPoolTokens?.idToken, mockedData)
-//                XCTAssertEqual(credentials.userPoolTokens?.expiration, Date.init(timeIntervalSince1970: 0))
-//                XCTAssertEqual(credentials.awsCredential?.sessionKey, mockedData)
-//                XCTAssertEqual(credentials.awsCredential?.secretKey, mockedData)
-//                XCTAssertEqual(credentials.awsCredential?.accessKey, mockedData)
-//                XCTAssertEqual(credentials.awsCredential?.expiration, Date.init(timeIntervalSince1970: 0))
-//
-//                saveCredentialHandlerInvoked.fulfill()
-//            }
-//        )
-//
-//        let amplifyCredentialStoreFactory: BasicCredentialStoreEnvironment.AmplifyAuthCredentialStoreFactory = {
-//            return mockAmplifyCredentialStoreBehavior
-//        }
-//        let authConfig = AuthConfiguration.userPoolsAndIdentityPools(
-//            Defaults.makeDefaultUserPoolConfigData(),
-//            Defaults.makeIdentityConfigData())
-//
-//        let credentialStoreEnv = BasicCredentialStoreEnvironment(
-//            amplifyCredentialStoreFactory: amplifyCredentialStoreFactory,
-//            legacyCredentialStoreFactory: legacyCredentialStoreFactory)
-//
-//        let environment = CredentialEnvironment(authConfiguration: authConfig,
-//                                                credentialStoreEnvironment: credentialStoreEnv)
-//
-//        let action = MigrateLegacyCredentialStore()
-//        action.execute(withDispatcher: MockDispatcher { _ in }, environment: environment)
-//
-//        waitForExpectations(timeout: 0.1)
-//    }
-//
-//    /// Test is responsible for making sure that the legacy credential store clearing up is getting called for user pool and identity pool
-//    ///
-//    /// - Given: A credential store with legacy data
-//    /// - When: The migration legacy store action is executed
-//    /// - Then:
-//    ///    - The remove all method gets called for both user pool and identity pool
-//    func testClearLegacyCredentialStore() {
-//        let migrationCompletionInvoked = expectation(description: "migrationCompletionInvoked")
-//        migrationCompletionInvoked.expectedFulfillmentCount = 2
-//
-//        let mockLegacyCredentialStoreBehavior = MockCredentialStoreBehavior(
-//            data: "mock",
-//            removeAllHandler: {
-//                migrationCompletionInvoked.fulfill()
-//            }
-//        )
-//        let legacyCredentialStoreFactory: BasicCredentialStoreEnvironment.CredentialStoreFactory = { _ in
-//            return mockLegacyCredentialStoreBehavior
-//        }
-//        let mockAmplifyCredentialStoreBehavior = MockAmplifyCredentialStoreBehavior()
-//
-//        let amplifyCredentialStoreFactory: BasicCredentialStoreEnvironment.AmplifyAuthCredentialStoreFactory = {
-//            return mockAmplifyCredentialStoreBehavior
-//        }
-//        let authConfig = AuthConfiguration.userPoolsAndIdentityPools(Defaults.makeDefaultUserPoolConfigData(),
-//                                                                     Defaults.makeIdentityConfigData())
-//
-//        let credentialStoreEnv = BasicCredentialStoreEnvironment(amplifyCredentialStoreFactory: amplifyCredentialStoreFactory,
-//                                                                 legacyCredentialStoreFactory: legacyCredentialStoreFactory)
-//
-//        let environment = CredentialEnvironment(authConfiguration: authConfig, credentialStoreEnvironment: credentialStoreEnv)
-//
-//        let action = MigrateLegacyCredentialStore()
-//        action.execute(withDispatcher: MockDispatcher { _ in }, environment: environment)
-//
-//        waitForExpectations(timeout: 0.1)
-//
-//    }
+    typealias AmplifyStoreFactory = BasicCredentialStoreEnvironment.AmplifyAuthCredentialStoreFactory
+
+    /// Test is responsible to check the happy path business logic of migrating the legacy store data.
+    ///
+    /// - Given: A credential store with legacy data
+    /// - When: The migration legacy store action is executed
+    /// - Then:
+    ///    - the new credential store should get the correct identityId, userPoolTokens and awsCredentials
+    func testSaveLegacyCredentials() {
+        let mockedData = "mock"
+        let saveCredentialHandlerInvoked = expectation(description: "saveCredentialHandlerInvoked")
+
+        let mockLegacyCredentialStoreBehavior = MockCredentialStoreBehavior(data: mockedData)
+        let legacyCredentialStoreFactory: BasicCredentialStoreEnvironment.CredentialStoreFactory = { _ in
+            return mockLegacyCredentialStoreBehavior
+        }
+        let mockAmplifyCredentialStoreBehavior = MockAmplifyCredentialStoreBehavior(
+            saveCredentialHandler: { codableCredentials in
+                guard let credentials = codableCredentials as? AmplifyCredentials,
+                      case .userPoolAndIdentityPool(
+                        tokens: let tokens,
+                        identityID: let identityID,
+                        credentials: let awsCredentials) = credentials else {
+                    XCTFail("The credentials saved should be of type AmplifyCredentials")
+                    return
+                }
+                // Validate the data returned is correct and matches the mocked data.
+                XCTAssertEqual(identityID, mockedData)
+                XCTAssertEqual(tokens.refreshToken, mockedData)
+                XCTAssertEqual(tokens.accessToken, mockedData)
+                XCTAssertEqual(tokens.idToken, mockedData)
+                XCTAssertEqual(tokens.expiration, Date.init(timeIntervalSince1970: 0))
+                XCTAssertEqual(awsCredentials.sessionKey, mockedData)
+                XCTAssertEqual(awsCredentials.secretKey, mockedData)
+                XCTAssertEqual(awsCredentials.accessKey, mockedData)
+                XCTAssertEqual(awsCredentials.expiration, Date.init(timeIntervalSince1970: 0))
+
+                saveCredentialHandlerInvoked.fulfill()
+            }
+        )
+
+        let amplifyCredentialStoreFactory: AmplifyStoreFactory = {
+            return mockAmplifyCredentialStoreBehavior
+        }
+        let authConfig = AuthConfiguration.userPoolsAndIdentityPools(
+            Defaults.makeDefaultUserPoolConfigData(),
+            Defaults.makeIdentityConfigData())
+
+        let credentialStoreEnv = BasicCredentialStoreEnvironment(
+            amplifyCredentialStoreFactory: amplifyCredentialStoreFactory,
+            legacyCredentialStoreFactory: legacyCredentialStoreFactory)
+
+        let environment = CredentialEnvironment(authConfiguration: authConfig,
+                                                credentialStoreEnvironment: credentialStoreEnv)
+
+        let action = MigrateLegacyCredentialStore()
+        action.execute(withDispatcher: MockDispatcher { _ in }, environment: environment)
+
+        waitForExpectations(timeout: 0.1)
+    }
+
+    /// Test is responsible for making sure that the legacy credential store clearing up is getting called for user pool and identity pool
+    ///
+    /// - Given: A credential store with legacy data
+    /// - When: The migration legacy store action is executed
+    /// - Then:
+    ///    - The remove all method gets called for both user pool and identity pool
+    func testClearLegacyCredentialStore() {
+        let migrationCompletionInvoked = expectation(description: "migrationCompletionInvoked")
+        migrationCompletionInvoked.expectedFulfillmentCount = 2
+
+        let mockLegacyCredentialStoreBehavior = MockCredentialStoreBehavior(
+            data: "mock",
+            removeAllHandler: {
+                migrationCompletionInvoked.fulfill()
+            }
+        )
+        let legacyCredentialStoreFactory: BasicCredentialStoreEnvironment.CredentialStoreFactory = { _ in
+            return mockLegacyCredentialStoreBehavior
+        }
+        let mockAmplifyCredentialStoreBehavior = MockAmplifyCredentialStoreBehavior()
+
+        let amplifyCredentialStoreFactory: AmplifyStoreFactory = {
+            return mockAmplifyCredentialStoreBehavior
+        }
+        let authConfig = AuthConfiguration.userPoolsAndIdentityPools(
+            Defaults.makeDefaultUserPoolConfigData(),
+            Defaults.makeIdentityConfigData())
+
+        let credentialStoreEnv = BasicCredentialStoreEnvironment(
+            amplifyCredentialStoreFactory: amplifyCredentialStoreFactory,
+            legacyCredentialStoreFactory: legacyCredentialStoreFactory)
+
+        let environment = CredentialEnvironment(authConfiguration: authConfig,
+                                                credentialStoreEnvironment: credentialStoreEnv)
+
+        let action = MigrateLegacyCredentialStore()
+        action.execute(withDispatcher: MockDispatcher { _ in }, environment: environment)
+
+        waitForExpectations(timeout: 0.1)
+
+    }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MockAmplifyCredentialStoreBehavior.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MockAmplifyCredentialStoreBehavior.swift
@@ -9,7 +9,7 @@ import Foundation
 
 @testable import AWSCognitoAuthPlugin
 
-class MockAmplifyCredentialStoreBehavior: AmplifyAuthCredentialStoreBehavior, AmplifyAuthCredentialStoreProvider {
+class MockAmplifyCredentialStoreBehavior: AmplifyAuthCredentialStoreBehavior {
 
     typealias Migrationhandler = () -> Void
     typealias SaveCredentialHandler = (Codable) throws -> Void

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/DefaultConfig.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/DefaultConfig.swift
@@ -79,8 +79,7 @@ enum Defaults {
         return .userPoolsAndIdentityPools(userPoolConfigData, identityConfigDate)
     }
 
-    static func makeAmplifyStore() -> AmplifyAuthCredentialStoreBehavior &
-    AmplifyAuthCredentialStoreProvider {
+    static func makeAmplifyStore() -> AmplifyAuthCredentialStoreBehavior {
         return MockAmplifyStore()
     }
 
@@ -89,8 +88,7 @@ enum Defaults {
     }
 
     static func makeDefaultCredentialStoreEnvironment(
-        amplifyStoreFactory: @escaping () -> AmplifyAuthCredentialStoreBehavior &
-        AmplifyAuthCredentialStoreProvider = makeAmplifyStore,
+        amplifyStoreFactory: @escaping () -> AmplifyAuthCredentialStoreBehavior = makeAmplifyStore,
         legacyStoreFactory: @escaping (String) -> CredentialStoreBehavior = makeLegacyStore(service: )
     ) -> CredentialEnvironment {
         CredentialEnvironment(
@@ -154,7 +152,7 @@ enum Defaults {
 
 }
 
-struct MockAmplifyStore: AmplifyAuthCredentialStoreBehavior, AmplifyAuthCredentialStoreProvider {
+struct MockAmplifyStore: AmplifyAuthCredentialStoreBehavior {
     func saveCredential(_ credential: Codable) throws {
 
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Enable migration flow, after refactoring authorization flow.

This is the continuation of the PRs from: 
https://github.com/aws-amplify/amplify-ios/pull/1919 fix: SignIn, signOut and confirmsignIn with new authorizationflow
https://github.com/aws-amplify/amplify-ios/pull/1916 chore: Fix fetchauthsession helper
https://github.com/aws-amplify/amplify-ios/pull/1914 test(auth): Fix unit test errors for authorization statemachine refctor
https://github.com/aws-amplify/amplify-ios/pull/1897 chore: Refactor authorization flow, adds refresh flow
https://github.com/aws-amplify/amplify-ios/pull/1872 chore: Change credential state machine and authorization flow

Pending work:

- [x] Finalize Refresh flow
- [x] Fixing test
- [x] Use session in the operations
- [x] Fix signIn and confirm signIn flow
- [x] Fix signout flow
- [x] Fix migration of credentials
- [ ] Error handling


*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
