### PR TITLE
feat(Analytics): Adding unit tests for AnalyticsClient

### DIFF
--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Configure.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Configure.swift
@@ -38,7 +38,8 @@ extension AWSPinpointAnalyticsPlugin {
         let pinpoint = try AWSPinpointAdapter(
             appId: configuration.appId,
             region: configuration.region,
-            credentialsProvider: credentialsProvider
+            credentialsProvider: credentialsProvider,
+            shouldTrackAppSessions: configuration.trackAppSessions
         )
 
         let appSessionTracker =

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAdapter.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointAdapter.swift
@@ -17,7 +17,8 @@ class AWSPinpointAdapter: AWSPinpointBehavior {
 
     convenience init(appId: String,
                      region: String,
-                     credentialsProvider: CredentialsProvider) throws {
+                     credentialsProvider: CredentialsProvider,
+                     shouldTrackAppSessions: Bool = true) throws {
         var isDebug = false
         #if DEBUG
         isDebug = true
@@ -27,7 +28,8 @@ class AWSPinpointAdapter: AWSPinpointBehavior {
         let configuration = PinpointContextConfiguration(appId: appId,
                                                          region: region,
                                                          credentialsProvider: credentialsProvider,
-                                                         isDebug: isDebug)
+                                                         isDebug: isDebug,
+                                                         shouldTrackAppSessions: shouldTrackAppSessions)
         let pinpoint = try PinpointContext(with: configuration)
         self.init(pinpoint: pinpoint)
     }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/AnalyticsClient.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/AnalyticsClient.swift
@@ -67,7 +67,7 @@ actor AnalyticsClient: AnalyticsClientBehaviour {
 
     func addGlobalAttribute(_ attribute: String, forKey key: String, forEventType eventType: String) {
         precondition(!key.isEmpty, "Attributes and metrics must have a valid key")
-        eventTypeAttributes[eventType]?[key] = attribute
+        eventTypeAttributes[eventType, default: [:]][key] = attribute
     }
 
     func addGlobalMetric(_ metric: Double, forKey key: String) {
@@ -77,7 +77,7 @@ actor AnalyticsClient: AnalyticsClientBehaviour {
 
     func addGlobalMetric(_ metric: Double, forKey key: String, forEventType eventType: String) {
         precondition(!key.isEmpty, "Attributes and metrics must have a valid key")
-        eventTypeMetrics[eventType]?[key] = metric
+        eventTypeMetrics[eventType, default: [:]][key] = metric
     }
 
     func removeGlobalAttribute(forKey key: String) {

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/EventRecorder.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/EventRecorder.swift
@@ -21,9 +21,9 @@ protocol AnalyticsEventRecording {
 
 /// An AnalyticsEventRecording implementation that stores and submits pinpoint events
 class EventRecorder: AnalyticsEventRecording {
-    let appId: String
-    let storage: AnalyticsEventStorage
-    let pinpointClient: PinpointClientProtocol
+    private let appId: String
+    private let storage: AnalyticsEventStorage
+    private let pinpointClient: PinpointClientProtocol
     private var submittedEvents: [PinpointEvent] = []
 
     /// Initializer for Event Recorder

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/PinpointContext.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/PinpointContext.swift
@@ -306,7 +306,3 @@ extension PinpointContext {
         }
     }
 }
-
-protocol InternalPinpointClient {
-    var context: PinpointContext { get }
-}

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/PinpointContext.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/PinpointContext.swift
@@ -37,9 +37,16 @@ protocol FileManagerBehaviour {
     func urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL]
     func fileExists(atPath path: String) -> Bool
     func fileSize(for url: URL) -> Byte
+    func createDirectory(atPath path: String, withIntermediateDirectories createIntermediates: Bool) throws
 }
 
 extension FileManager: FileManagerBehaviour, DefaultLogger {
+    func createDirectory(atPath path: String, withIntermediateDirectories createIntermediates: Bool) throws {
+        try createDirectory(atPath: path,
+                        withIntermediateDirectories: createIntermediates,
+                        attributes: nil)
+    }
+
     func fileSize(for url: URL) -> Byte {
         do {
             let attributes = try self.attributesOfItem(atPath: url.path)
@@ -77,13 +84,17 @@ struct PinpointContextConfiguration {
     /// If System-level notifications for this application are disabled, this will be ignored.
     let isApplicationLevelOptOut: Bool
 
+    /// Indicates whether to track application sessions. Defaults to `true`
+    let shouldTrackAppSessions: Bool
+
     init(appId: String,
          region: String,
          credentialsProvider: CredentialsProvider,
          sessionTimeout: TimeInterval = 5,
          maxStorageSize: Byte = (1024 * 1024 * 5),
          isDebug: Bool = false,
-         isApplicationLevelOptOut: Bool = false) {
+         isApplicationLevelOptOut: Bool = false,
+         shouldTrackAppSessions: Bool = true) {
         self.appId = appId
         self.region = region
         self.credentialsProvider = credentialsProvider
@@ -91,6 +102,7 @@ struct PinpointContextConfiguration {
         self.maxStorageSize = maxStorageSize
         self.isDebug = isDebug
         self.isApplicationLevelOptOut = isApplicationLevelOptOut
+        self.shouldTrackAppSessions = shouldTrackAppSessions
     }
 }
 
@@ -106,13 +118,7 @@ class PinpointContext {
     let pinpointClient: PinpointClientProtocol
     let endpointClient: EndpointClientBehaviour
     let sessionClient: SessionClientBehaviour
-    lazy var analyticsClient: AnalyticsClientBehaviour = {
-        let client = AnalyticsClient(applicationId: configuration.appId,
-                                     context: self)
-        sessionClient.analyticsClient = client
-        sessionClient.startPinpointSession()
-        return client
-    }()
+    let analyticsClient: AnalyticsClientBehaviour
 
     private let uniqueId: String
     private let configuration: PinpointContextConfiguration
@@ -144,14 +150,28 @@ class PinpointContext {
                                         pinpointClient: pinpointClient,
                                         currentDevice: currentDevice,
                                         userDefaults: userDefaults)
-        
-        sessionClient = SessionClient(analyticsClient: nil,
-                                      archiver: archiver,
+
+        sessionClient = SessionClient(archiver: archiver,
                                       configuration: .init(appId: configuration.appId,
                                                            uniqueDeviceId: uniqueId,
                                                            sessionTimeout: configuration.sessionTimeout),
                                       endpointClient: endpointClient,
                                       userDefaults: userDefaults)
+
+        let sessionProvider: () -> PinpointSession = { [weak sessionClient] in
+            guard let sessionClient = sessionClient else {
+                fatalError("SessionClient was deallocated")
+            }
+            return sessionClient.currentSession
+        }
+
+        analyticsClient = try AnalyticsClient(applicationId: configuration.appId,
+                                              pinpointClient: pinpointClient,
+                                              sessionProvider: sessionProvider)
+        sessionClient.analyticsClient = analyticsClient
+        if configuration.shouldTrackAppSessions {
+            sessionClient.startPinpointSession()
+        }
         self.configuration = configuration
     }
 

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Session/SessionClient.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Session/SessionClient.swift
@@ -225,6 +225,6 @@ extension SessionClient {
     }
 }
 
-private extension PinpointSession {
+extension PinpointSession {
     static var invalid = PinpointSession(sessionId: "InvalidId", startTime: Date(), stopTime: nil)
 }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/LocalStorage/LocalStorageError.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/LocalStorage/LocalStorageError.swift
@@ -10,4 +10,5 @@ enum LocalStorageError: Error {
     case missingConnection
     case invalidStorage(path: String, Error? = nil)
     case invalidOperation(causedBy: Error? = nil)
+    case fileSystemError(description: String)
 }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginConfigureTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginConfigureTests.swift
@@ -23,7 +23,7 @@ class AWSPinpointAnalyticsPluginConfigureTests: AWSPinpointAnalyticsPluginTestBa
         let appId = JSONValue(stringLiteral: testAppId)
         let region = JSONValue(stringLiteral: testRegion)
         let autoFlushInterval = JSONValue(integerLiteral: testAutoFlushInterval)
-        let trackAppSession = JSONValue(booleanLiteral: testTrackAppSession)
+        let trackAppSession = JSONValue(booleanLiteral: false)
         let autoSessionTrackingInterval = JSONValue(integerLiteral: testAutoSessionTrackingInterval)
 
         let pinpointAnalyticsPluginConfiguration = JSONValue(

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AnalyticsEventStorageTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AnalyticsEventStorageTests.swift
@@ -11,16 +11,18 @@ import SQLite
 @testable import AWSPinpointAnalyticsPlugin
 
 class AnalyticsEventStorageTests: XCTestCase {
-    let databaseName = "TestDatabase"
-    var adapter: SQLStorageProtocol!
-    let eventCountStatement = "SELECT COUNT(*) FROM Event"
-    let dirtyEventCountStatement = "SELECT COUNT(*) FROM DirtyEvent"
-    var storage: AnalyticsEventStorage!
+    private let databaseName = "TestDatabase"
+    private let eventCountStatement = "SELECT COUNT(*) FROM Event"
+    private let dirtyEventCountStatement = "SELECT COUNT(*) FROM DirtyEvent"
+    private var adapter: SQLStorageProtocol!
+    private var storage: AnalyticsEventSQLStorage!
+    private var fileManager: MockFileManager!
 
     override func setUp() {
         do {
             cleanup()
-            adapter = try SQLiteLocalStorageAdapter(databaseName: databaseName)
+            fileManager = MockFileManager(fileName: databaseName)
+            adapter = try SQLiteLocalStorageAdapter(databaseName: databaseName, fileManager: fileManager)
             storage = AnalyticsEventSQLStorage(dbAdapter: adapter)
             try storage.initializeStorage()
 
@@ -66,13 +68,9 @@ class AnalyticsEventStorageTests: XCTestCase {
     }
 
     private func cleanup() {
-        let dbPath = SQLiteLocalStorageAdapter.getDbFilePath(databaseName: "TestDatabase")
-        do {
-            if FileManager.default.fileExists(atPath: dbPath.path) {
-                try FileManager.default.removeItem(atPath: dbPath.path)
-            }
-        } catch {
-        }
+        fileManager = nil
+        adapter = nil
+        storage = nil
     }
 
     /// - Given: a local storage

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/Pinpoint/MockEventRecorder.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/Pinpoint/MockEventRecorder.swift
@@ -1,0 +1,24 @@
+//
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AWSPinpointAnalyticsPlugin
+
+class MockEventRecorder: AnalyticsEventRecording {
+    var saveCount = 0
+    var lastSavedEvent: PinpointEvent?
+    func save(_ event: PinpointEvent) throws {
+        saveCount += 1
+        lastSavedEvent = event
+    }
+
+    var submitCount = 0
+    func submitAllEvents() async throws -> [PinpointEvent] {
+        submitCount += 1
+        return []
+    }
+}

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/Pinpoint/MockFileManager.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/Pinpoint/MockFileManager.swift
@@ -1,0 +1,49 @@
+//
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AWSPinpointAnalyticsPlugin
+import Foundation
+
+class MockFileManager: FileManagerBehaviour {
+    private let tempDirectory = FileManager.default.temporaryDirectory
+    private let fileName: String
+
+    init(fileName: String) {
+        self.fileName = fileName
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: tempDirectory.appendingPathComponent(fileName))
+    }
+
+    var removeItemCount = 0
+    func removeItem(atPath path: String) throws {
+        removeItemCount += 1
+    }
+
+    func urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL] {
+        return [tempDirectory]
+    }
+
+    var fileExists = false
+    func fileExists(atPath path: String) -> Bool {
+        return fileExists
+    }
+
+    var mockedFileSize = 0
+    var fileSizeCount = 0
+    func fileSize(for url: URL) -> Byte {
+        fileSizeCount += 1
+        return mockedFileSize
+    }
+
+    var createDirectoryCount = 0
+    func createDirectory(atPath path: String, withIntermediateDirectories createIntermediates: Bool) throws {
+        createDirectoryCount += 1
+    }
+}

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Pinpoint/AnalyticsClientTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Pinpoint/AnalyticsClientTests.swift
@@ -1,0 +1,205 @@
+//
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AWSPinpointAnalyticsPlugin
+import StoreKit
+import XCTest
+
+class AnalyticsClientTests: XCTestCase {
+    private var analyticsClient: AnalyticsClient!
+    private var eventRecorder: MockEventRecorder!
+    private var session: PinpointSession!
+
+    override func setUp() {
+        eventRecorder = MockEventRecorder()
+        session = PinpointSession(appId: "appId", uniqueId: "uniqueId")
+        analyticsClient = AnalyticsClient(
+            eventRecorder: eventRecorder,
+            sessionProvider: {
+                return self.session
+            }
+        )
+    }
+
+    override func tearDown() async throws {
+        analyticsClient = nil
+        session = nil
+        eventRecorder = nil
+    }
+
+    func testCreateAppleMonetizationEvent() {
+        let transaction = MockTransaction(transactionId: "transactionId", quantity: 5)
+        let product = MockProduct(productId: "producId", price: 2.5)
+        let event = analyticsClient.createAppleMonetizationEvent(with: transaction,
+                                                                 with: product)
+
+        XCTAssertEqual(event.eventType, "_monetization.purchase")
+        XCTAssertEqual(event.attributes["_store"], "Apple")
+        XCTAssertEqual(event.attributes["_product_id"], product.productIdentifier)
+        XCTAssertEqual(event.attributes["_currency"], product.priceLocale.currencyCode)
+        XCTAssertEqual(event.metrics["_item_price"], product.price.doubleValue)
+        XCTAssertEqual(event.metrics["_quantity"], Double(transaction.payment.quantity))
+        XCTAssertEqual(event.attributes["_transaction_id"], transaction.transactionIdentifier)
+    }
+
+    func testCreateVirtualMonetizationEvent() {
+        let productId = "productIt"
+        let itemPrice: Double = 5.25
+        let quantity = 2
+        let currency = "USD"
+
+        let event = analyticsClient.createVirtualMonetizationEvent(withProductId: productId,
+                                                                   withItemPrice: itemPrice,
+                                                                   withQuantity: quantity,
+                                                                   withCurrency: currency)
+
+        XCTAssertEqual(event.eventType, "_monetization.purchase")
+        XCTAssertEqual(event.attributes["_store"], "Virtual")
+        XCTAssertEqual(event.attributes["_product_id"], productId)
+        XCTAssertEqual(event.attributes["_currency"], currency)
+        XCTAssertEqual(event.metrics["_item_price"], itemPrice)
+        XCTAssertEqual(event.metrics["_quantity"], Double(quantity))
+        XCTAssertNil(event.attributes["_transaction_id"])
+    }
+
+
+    func testCreateEvent() {
+        let eventType = "mockEvent"
+        let event = analyticsClient.createEvent(withEventType: eventType)
+        XCTAssertEqual(event.eventType, eventType)
+        XCTAssertEqual(event.session, session)
+    }
+
+    func testRecord_shouldAddGlobalAttributesAndMetrics() async {
+        let event = analyticsClient.createEvent(withEventType: "mockEvent")
+        XCTAssertTrue(event.attributes.isEmpty)
+        XCTAssertTrue(event.metrics.isEmpty)
+
+        await analyticsClient.addGlobalAttribute("test_0", forKey: "attribute_0")
+        await analyticsClient.addGlobalMetric(0, forKey: "metric_0")
+        await analyticsClient.addGlobalMetric(1, forKey: "metric_1")
+
+        do {
+            try await analyticsClient.record(event)
+            XCTAssertEqual(eventRecorder.saveCount, 1)
+            guard let savedEvent = eventRecorder.lastSavedEvent else {
+                XCTFail("Expected saved event")
+                return
+            }
+
+            XCTAssertEqual(savedEvent.attributes.count, 1)
+            XCTAssertEqual(savedEvent.attributes["attribute_0"], "test_0")
+            XCTAssertEqual(savedEvent.metrics.count, 2)
+            XCTAssertEqual(savedEvent.metrics["metric_0"], 0)
+            XCTAssertEqual(savedEvent.metrics["metric_1"], 1)
+
+        } catch {
+            XCTFail("Unexpected exception while attempting to record event")
+        }
+    }
+
+    func testRecord_shouldAddGlobalAttributesAndMetrics_forProperEventType() async {
+        let eventType = "mockEvent"
+        let event = analyticsClient.createEvent(withEventType: eventType)
+        XCTAssertTrue(event.attributes.isEmpty)
+        XCTAssertTrue(event.metrics.isEmpty)
+
+        await analyticsClient.addGlobalAttribute("test_0", forKey: "attribute_0")
+        await analyticsClient.addGlobalAttribute("test_1", forKey: "attribute_1", forEventType: eventType)
+        await analyticsClient.addGlobalAttribute("test_2", forKey: "attribute_2", forEventType: "anotherEvent")
+        await analyticsClient.addGlobalMetric(0, forKey: "metric_0")
+        await analyticsClient.addGlobalMetric(1, forKey: "metric_1", forEventType: eventType)
+        await analyticsClient.addGlobalMetric(2, forKey: "metric_2", forEventType: "anotherEvent")
+        await analyticsClient.addGlobalMetric(3, forKey: "metric_3", forEventType: eventType)
+
+        do {
+            try await analyticsClient.record(event)
+            XCTAssertEqual(eventRecorder.saveCount, 1)
+            guard let savedEvent = eventRecorder.lastSavedEvent else {
+                XCTFail("Expected saved event")
+                return
+            }
+
+            XCTAssertEqual(savedEvent.attributes.count, 2) // 1 shared, 1 specific
+            XCTAssertEqual(savedEvent.attributes["attribute_0"], "test_0")
+            XCTAssertEqual(savedEvent.attributes["attribute_1"], "test_1")
+            XCTAssertNil(savedEvent.attributes["attribute_2"])
+            XCTAssertEqual(savedEvent.metrics.count, 3) // 1 shared, 2 specific
+            XCTAssertEqual(savedEvent.metrics["metric_0"], 0)
+            XCTAssertEqual(savedEvent.metrics["metric_1"], 1)
+            XCTAssertNil(savedEvent.metrics["metric_2"])
+            XCTAssertEqual(savedEvent.metrics["metric_3"], 3)
+
+        } catch {
+            XCTFail("Unexpected exception while attempting to record event")
+        }
+    }
+
+    func testSubmit() async {
+        do {
+            try await analyticsClient.submitEvents()
+            XCTAssertEqual(eventRecorder.submitCount, 1)
+        } catch {
+            XCTFail("Unexpected exception while attempting to submit events")
+        }
+    }
+}
+
+private class MockTransaction: SKPaymentTransaction {
+    private let _transactionId: String
+    private let _payment: SKPayment
+    private class MockPayment: SKPayment {
+        private let _quantity: Int
+
+        init(quantity: Int) {
+            _quantity = quantity
+        }
+
+        override var quantity: Int {
+            return _quantity
+        }
+
+    }
+
+    init(transactionId: String,
+         quantity: Int) {
+        _transactionId = transactionId
+        _payment = MockPayment(quantity: quantity)
+    }
+
+    override var transactionIdentifier: String? {
+        return _transactionId
+    }
+
+    override var payment: SKPayment {
+        return _payment
+    }
+}
+
+private class MockProduct: SKProduct {
+    private let _productId: String
+    private let _price: Double
+
+    init(productId: String,
+         price: Double) {
+        _productId = productId
+        _price = price
+    }
+
+    override var productIdentifier: String {
+        return _productId
+    }
+
+    override var price: NSDecimalNumber {
+        return NSDecimalNumber(value: _price)
+    }
+
+    override var priceLocale: Locale {
+        return Locale.current
+    }
+}

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/SQLiteLocalStorageAdapterTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/SQLiteLocalStorageAdapterTests.swift
@@ -11,12 +11,14 @@ import SQLite
 @testable import AWSPinpointAnalyticsPlugin
 
 class SQLiteLocalStorageAdapterTests: XCTestCase {
-    let databaseName = "TestDatabase"
-    var adapter: SQLStorageProtocol!
+    private let databaseName = "TestDatabase"
+    private var adapter: SQLiteLocalStorageAdapter!
+    private var fileManager: MockFileManager!
 
     override func setUp() {
+        fileManager = MockFileManager(fileName: databaseName)
         do {
-            adapter = try SQLiteLocalStorageAdapter(databaseName: databaseName)
+            adapter = try SQLiteLocalStorageAdapter(databaseName: databaseName, fileManager: fileManager)
             let analyticsEventStorage = AnalyticsEventSQLStorage(dbAdapter: adapter)
             try analyticsEventStorage.initializeStorage()
         } catch {
@@ -24,29 +26,9 @@ class SQLiteLocalStorageAdapterTests: XCTestCase {
         }
     }
 
-    override class func tearDown() {
-        let dbPath = SQLiteLocalStorageAdapter.getDbFilePath(databaseName: "TestDatabase")
-        do {
-            try FileManager.default.removeItem(atPath: dbPath.path)
-        } catch {
-            XCTFail("Failed to remove SQLite as part of teardown")
-        }
-    }
-
-    /// - Given: A database name
-    /// - When: accessing a file system
-    /// - Then: A database with the specified name exists at the specified path
-    func testLocalStorageInitialization() {
-        let dbPath = SQLiteLocalStorageAdapter.getDbFilePath(databaseName: databaseName)
-        var fileExists = FileManager.default.fileExists(atPath: dbPath.path)
-        XCTAssertTrue(fileExists)
-        do {
-            try FileManager.default.removeItem(atPath: dbPath.path)
-        } catch {
-            XCTFail("Failed to remove SQLite as part of teardown")
-        }
-        fileExists = FileManager.default.fileExists(atPath: dbPath.path)
-        XCTAssertFalse(fileExists)
+    override func tearDown() {
+        fileManager = nil
+        adapter = nil
     }
 
     /// - Given: An adapter to the SQLite local database
@@ -56,7 +38,7 @@ class SQLiteLocalStorageAdapterTests: XCTestCase {
         do {
             let countStatement = "SELECT COUNT(*) FROM Event"
             var result = try adapter.executeQuery(countStatement, []).scalar() as! Int64
-            XCTAssertTrue(result == 0)
+            XCTAssertEqual(result, 0)
 
             let insertStatement = """
                 INSERT INTO Event (
@@ -120,7 +102,7 @@ class SQLiteLocalStorageAdapterTests: XCTestCase {
 
             let countStatement = "SELECT COUNT(*) FROM Event WHERE dirty = false"
             var result = try adapter.executeQuery(countStatement, []).scalar() as! Int64
-            XCTAssertTrue(result == 1)
+            XCTAssertEqual(result, 1)
 
             let updateStatement = """
                 UPDATE Event
@@ -140,23 +122,7 @@ class SQLiteLocalStorageAdapterTests: XCTestCase {
     /// - When: Calling disk file size
     /// - Then: returns the database file size
     func testLocalStorageDiskUsage() {
-        do {
-            XCTAssertEqual(adapter.diskBytesUsed, 16384)
-            let insertStatement = """
-                INSERT INTO Event (
-                id, attributes, eventType, metrics,
-                eventTimestamp, sessionId, sessionStartTime,
-                sessionStopTime, timestamp, dirty, retryCount)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """
-            for _ in 0...100 {
-                let bindings: [Binding] = [Int.random(in: 1...1000), "attributes", "eventType", "metrics", 1654796845, 1, 1654796847, 1654796848, 1654796845, 0, 0]
-                _ = try adapter.executeQuery(insertStatement, bindings)
-            }
-
-            XCTAssertEqual(adapter.diskBytesUsed, 24576)
-        } catch {
-            XCTFail("Failed to create SQLiteLocalStorageAdapter: \(error)")
-        }
+        XCTAssertEqual(adapter.diskBytesUsed, fileManager.mockedFileSize)
+        XCTAssertEqual(fileManager.fileSizeCount, 1)
     }
 }


### PR DESCRIPTION
*Description of changes:*
- Adding unit tests for `AnalyticsClient`
- Doing some refactoring/clean up in order to facilitate testing and de-couple certain classes from each other.
- Automatically starting app session tracking if the flag is enabled in the configuration.
- Simplifying `SQLiteLocalStorageAdapterTests` and `AnalyticsEventStorageTests` with a mocked FileManager.

*Check points: (check or cross out if not relevant)*

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] ~All integration tests pass~
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
