### PR TITLE
fix(datastore): avoid creating index on foreign key fields

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
@@ -266,6 +266,20 @@ class SQLStatementTests: XCTestCase {
         XCTAssertEqual(statement, expectedStatement)
     }
 
+    /// - Given: a `Model` instance with a composite primary key and a belongsTo association.
+    /// - When:
+    ///     - the model is of type `CommentWithCompositeKeyAndIndex`
+    ///     - there's a secondary index involving on or more fields part of the foreign key
+    /// - Then:
+    ///   - ONLY an index for the fields that make up the primary key should be generated
+    func testShouldNotCreateIndexOnForeignKeyField() {
+        let statement = CommentWithCompositeKeyAndIndex.schema.createIndexStatements()
+        let expectedStatement = """
+        create index if not exists "id_content_pk" on "CommentWithCompositeKeyAndIndex" ("id", "content");
+        """
+        XCTAssertEqual(statement, expectedStatement)
+    }
+
     // MARK: - Insert Statements
 
     /// - Given: a `Model` instance

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/CommentWithCompositeKeyAndIndex+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/CommentWithCompositeKeyAndIndex+Schema.swift
@@ -1,0 +1,49 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension CommentWithCompositeKeyAndIndex {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case content
+    case post
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let commentWithCompositeKeyAndIndex = CommentWithCompositeKeyAndIndex.keys
+    
+    model.pluralName = "CommentWithCompositeKeyAndIndices"
+    
+    model.attributes(
+      .index(fields: ["id", "content"], name: nil),
+      .index(fields: ["postID", "postTitle"], name: "byPost"),
+      .primaryKey(fields: [commentWithCompositeKeyAndIndex.id, commentWithCompositeKeyAndIndex.content])
+    )
+    
+    model.fields(
+      .field(commentWithCompositeKeyAndIndex.id, is: .required, ofType: .string),
+      .field(commentWithCompositeKeyAndIndex.content, is: .required, ofType: .string),
+      .belongsTo(commentWithCompositeKeyAndIndex.post, is: .optional, ofType: PostWithCompositeKeyAndIndex.self, targetNames: ["postID", "postTitle"]),
+      .field(commentWithCompositeKeyAndIndex.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(commentWithCompositeKeyAndIndex.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension CommentWithCompositeKeyAndIndex: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension CommentWithCompositeKeyAndIndex.Identifier {
+  public static func identifier(id: String,
+      content: String) -> Self {
+    .make(fields:[(name: "id", value: id), (name: "content", value: content)])
+  }
+}

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/CommentWithCompositeKeyAndIndex.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/CommentWithCompositeKeyAndIndex.swift
@@ -1,0 +1,32 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct CommentWithCompositeKeyAndIndex: Model {
+  public let id: String
+  public let content: String
+  public var post: PostWithCompositeKeyAndIndex?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      content: String,
+      post: PostWithCompositeKeyAndIndex? = nil) {
+    self.init(id: id,
+      content: content,
+      post: post,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      content: String,
+      post: PostWithCompositeKeyAndIndex? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.content = content
+      self.post = post
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithCompositeKeyAndIndex+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithCompositeKeyAndIndex+Schema.swift
@@ -1,0 +1,48 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension PostWithCompositeKeyAndIndex {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case title
+    case comments
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let postWithCompositeKeyAndIndex = PostWithCompositeKeyAndIndex.keys
+    
+    model.pluralName = "PostWithCompositeKeyAndIndices"
+    
+    model.attributes(
+      .index(fields: ["id", "title"], name: nil),
+      .primaryKey(fields: [postWithCompositeKeyAndIndex.id, postWithCompositeKeyAndIndex.title])
+    )
+    
+    model.fields(
+      .field(postWithCompositeKeyAndIndex.id, is: .required, ofType: .string),
+      .field(postWithCompositeKeyAndIndex.title, is: .required, ofType: .string),
+      .hasMany(postWithCompositeKeyAndIndex.comments, is: .optional, ofType: CommentWithCompositeKeyAndIndex.self, associatedWith: CommentWithCompositeKeyAndIndex.keys.post),
+      .field(postWithCompositeKeyAndIndex.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(postWithCompositeKeyAndIndex.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension PostWithCompositeKeyAndIndex: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension PostWithCompositeKeyAndIndex.Identifier {
+  public static func identifier(id: String,
+      title: String) -> Self {
+    .make(fields:[(name: "id", value: id), (name: "title", value: title)])
+  }
+}

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithCompositeKeyAndIndex.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithCompositeKeyAndIndex.swift
@@ -1,0 +1,32 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct PostWithCompositeKeyAndIndex: Model {
+  public let id: String
+  public let title: String
+  public var comments: List<CommentWithCompositeKeyAndIndex>?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      title: String,
+      comments: List<CommentWithCompositeKeyAndIndex>? = []) {
+    self.init(id: id,
+      title: title,
+      comments: comments,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      title: String,
+      comments: List<CommentWithCompositeKeyAndIndex>? = [],
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.title = title
+      self.comments = comments
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/primarykey_schema.graphql
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/primarykey_schema.graphql
@@ -58,13 +58,17 @@ type TagWithCompositeKey @model {
   posts: [PostWithTagsCompositeKey] @manyToMany(relationName: "PostTagsWithCompositeKey")
 }
 
-type PostWithCompositeKeyUnidirectional @model {
+
+type PostWithCompositeKeyAndIndex @model {
   id: ID! @primaryKey(sortKeyFields: ["title"])
   title: String!
-  comments: [CommentWithCompositeKeyUnidirectional] @hasMany
+  comments: [CommentWithCompositeKeyAndIndex] @hasMany
 }
 
-type CommentWithCompositeKeyUnidirectional @model {
+type CommentWithCompositeKeyAndIndex @model {
   id: ID! @primaryKey(sortKeyFields: ["content"])
   content: String!
+  postID: ID @index(name: "byPost", sortKeyFields: ["postTitle"])
+  postTitle: String
+  post: PostWithCompositeKeyAndIndex @belongsTo(fields: ["postID", "postTitle"])
 }


### PR DESCRIPTION
*Description of changes:*
This PR introduces a change that skip SQL indexes creation when the fields involved are used to represent associations.

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
