### PR TITLE
chore: enable integ workflow and disable specific steps

### DIFF
--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -1,7 +1,7 @@
 name: Integration Tests
 on:
   push:
-    branches: [main]
+    branches: [chore/datstore-v2-test-run]
 
 permissions:
     id-token: write

--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -738,7 +738,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/
           workspace: DataStoreCategoryPlugin.xcworkspace
-          scheme: AWSDataStoreIntegrationV2Scenario1V2Tests
+          scheme: AWSDataStoreIntegrationV2Tests
   datastore-integration-observe-query-test:
     needs: [datastore-integration-test]
     runs-on: macos-latest

--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -1,7 +1,7 @@
 name: Integration Tests
 on:
   push:
-    branches: [chore/disable-most-jobs]
+    branches: [main]
 
 permissions:
     id-token: write

--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -56,7 +56,7 @@ jobs:
           scheme: AWSPinpointAnalyticsPluginIntegrationTests
 
   api-integration-test:
-    if: ${{ false }}
+    continue-on-error: true
     needs: prepare-for-test
     runs-on: macos-latest
     environment: IntegrationTest
@@ -224,7 +224,7 @@ jobs:
           scheme: GraphQLWithLambdaAuthIntegrationTests
 
   auth-integration-test:
-    if: ${{ false }}
+    continue-on-error: true
     needs: prepare-for-test
     runs-on: macos-latest
     environment: IntegrationTest
@@ -306,6 +306,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationHubTests
   datastore-integration-local-test:
+    continue-on-error: true
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -333,6 +334,7 @@ jobs:
           scheme: AWSDataStoreIntegrationLocalTests
 
   datastore-integration-V1-S1-test:
+    continue-on-error: true
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -737,6 +739,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV2Scenario8V2Tests
   datastore-integration-V2-test:
+    continue-on-error: true
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -874,7 +877,7 @@ jobs:
           scheme: AWSLocationGeoPluginIntegrationTests
 
   predictions-integration-test:
-    if: ${{ false }}
+    continue-on-error: true
     needs: prepare-for-test
     runs-on: macos-latest
     environment: IntegrationTest
@@ -912,7 +915,7 @@ jobs:
           scheme: CoreMLPredictionsPluginIntegrationTests
 
   storage-integration-test:
-    if: ${{ false }}
+    continue-on-error: true
     needs: prepare-for-test
     runs-on: macos-latest
     environment: IntegrationTest

--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -56,6 +56,7 @@ jobs:
           scheme: AWSPinpointAnalyticsPluginIntegrationTests
 
   api-integration-test:
+    if: ${{ false }}
     needs: prepare-for-test
     runs-on: macos-latest
     environment: IntegrationTest

--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -1,7 +1,7 @@
 name: Integration Tests
 on:
   push:
-    branches: [chore/datstore-v2-test-run]
+    branches: [chore/disable-most-jobs]
 
 permissions:
     id-token: write

--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -252,6 +252,7 @@ jobs:
           scheme: AWSCognitoAuthPluginIntegrationTests
 
   datastore-integration-test:
+    continue-on-error: true
     needs: prepare-for-test
     runs-on: macos-latest
     environment: IntegrationTest

--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -84,6 +84,7 @@ jobs:
           scheme: AWSAPICategoryPluginFunctionalTests
 
   api-graphqliam-integration-test:
+    if: ${{ false }}
     needs: [api-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -111,6 +112,7 @@ jobs:
           scheme: GraphQLWithIAMIntegrationTests
 
   api-graphqluserpool-integration-test:
+    if: ${{ false }}
     needs: [api-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -138,6 +140,7 @@ jobs:
           scheme: GraphQLWithUserPoolIntegrationTests
 
   api-restiam-integration-test:
+    if: ${{ false }}
     needs: [api-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -165,6 +168,7 @@ jobs:
           scheme: RESTWithIAMIntegrationTests
 
   api-restuserpool-integration-test:
+    if: ${{ false }}
     needs: [api-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -192,6 +196,7 @@ jobs:
           scheme: RESTWithUserPoolIntegrationTests
 
   api-graphqllambda-integration-test:
+    if: ${{ false }}
     needs: [api-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -219,6 +224,7 @@ jobs:
           scheme: GraphQLWithLambdaAuthIntegrationTests
 
   auth-integration-test:
+    if: ${{ false }}
     needs: prepare-for-test
     runs-on: macos-latest
     environment: IntegrationTest
@@ -272,6 +278,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreCategoryPluginIntegrationTests
   datastore-integration-hub-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -351,6 +358,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV1Scenario1Tests
   datastore-integration-V1-S2-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -377,6 +385,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV1Scenario2Tests
   datastore-integration-V1-S3-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -403,6 +412,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV1Scenario3Tests
   datastore-integration-V1-S4-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -429,6 +439,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV1Scenario4Tests
   datastore-integration-V1-S5-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -455,6 +466,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV1Scenario5Tests
   datastore-integration-V1-S6-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -481,6 +493,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV1Scenario6Tests
   datastore-integration-V2-S1-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -507,6 +520,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV2Scenario1V2Tests
   datastore-integration-V2-S2-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -533,6 +547,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV2Scenario2V2Tests
   datastore-integration-V2-S3a-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -559,6 +574,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV2Scenario3aV2Tests
   datastore-integration-V2-S3-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -585,6 +601,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV2Scenario3V2Tests
   datastore-integration-V2-S4-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -611,6 +628,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV2Scenario4V2Tests
   datastore-integration-V2-S5-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -637,6 +655,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV2Scenario5V2Tests
   datastore-integration-V2-S6-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -663,6 +682,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV2Scenario6V2Tests
   datastore-integration-V2-S7-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -689,6 +709,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV2Scenario7V2Tests
   datastore-integration-V2-S8-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -741,6 +762,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV2Tests
   datastore-integration-observe-query-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -768,6 +790,7 @@ jobs:
           scheme: AWSDataStoreIntegrationObserveQueryTests
 
   datastore-auth-integration-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -795,6 +818,7 @@ jobs:
           scheme: AWSDataStoreCategoryPluginAuthIntegrationTests
 
   datastore-flutter-integration-test:
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest
@@ -849,6 +873,7 @@ jobs:
           scheme: AWSLocationGeoPluginIntegrationTests
 
   predictions-integration-test:
+    if: ${{ false }}
     needs: prepare-for-test
     runs-on: macos-latest
     environment: IntegrationTest
@@ -886,6 +911,7 @@ jobs:
           scheme: CoreMLPredictionsPluginIntegrationTests
 
   storage-integration-test:
+    if: ${{ false }}
     needs: prepare-for-test
     runs-on: macos-latest
     environment: IntegrationTest


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/1781

*Description of changes:*
This PR adds fine grain control over the tests in the integration test workflow. Each test is a step which can be run, continue if error, or skipped:

- completely skipped: `if: ${{ false }}`
- continue on error: `continue-on-error: true`

Example workflow: https://github.com/aws-amplify/amplify-ios/actions/runs/2542707371 . This workflow passed even though storage and datastore tests failed. At this time, we'll enable most of the base integration tests of each plugin. This includes storage, auth, api and datastore's first tests, geo, analytics. For flaky base tests, set `continue-on-error` for storage, auth, api, datastore. So, geo and analytics will fail the workflow if it fails. And most of the nested tests in datastore and API are skipped

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
