### PR TITLE
fix(datastore): resolve PK value in JSONValue models

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/Model+SQLite.swift
@@ -8,6 +8,7 @@
 import Amplify
 import Foundation
 import SQLite
+import AWSPluginsCore
 
 /// Extended types that conform to `Persistable` in order to provide conversion to SQLite's `Binding`
 /// types. This is necessary so `Model` properties' map values to a SQLite compatible types.
@@ -86,30 +87,29 @@ extension Model {
 
             // At this point, we have a value: Any. However, remember that Any could itself be an optional, so we're
             // not quite done yet.
-            // swiftlint:disable syntactic_sugar
             let value: Any
+            // swiftlint:disable syntactic_sugar
             if case Optional<Any>.some(let unwrappedValue) = anyValue {
                 value = unwrappedValue
             } else {
                 return nil
             }
-            // swiftlint:enable syntactic_sugar
 
             // Now `value` is still an Any, but we've assured ourselves that it's not an Optional, which means we can
             // safely attempt a cast to Persistable below.
 
             // if value is an associated model, get its id
             if field.isForeignKey,
-               case let .model(modelName) = field.type,
-               let modelSchema = ModelRegistry.modelSchema(from: modelName) {
+               case let .model(associatedModelName) = field.type,
+               let associatedModelSchema = ModelRegistry.modelSchema(from: associatedModelName) {
 
                 // Check if it is a Model or json object.
                 if let associatedModelValue = value as? Model {
                     return associatedModelValue.identifier
 
-                } else if let associatedModelJSON = value as? [String: JSONValue],
-                   case .string(let primaryKeyValue) = associatedModelJSON[modelSchema.primaryKey.name] {
-                    return primaryKeyValue
+                } else if let associatedModelJSON = value as? [String: JSONValue] {
+                    return associatedPrimaryKeyValue(fromJSON: associatedModelJSON,
+                                                     associatedModelSchema: associatedModelSchema)
                 }
             }
 
@@ -128,6 +128,30 @@ extension Model {
         }
 
         return values
+    }
+
+
+    /// Given a serialized JSON model, returns the serialized value of its primary key.
+    /// The returned value is either the value of the field or the serialization of multiple values in case of a composite PK.
+    /// - Parameters:
+    ///   - associatedModelJSON: model as JSON value
+    ///   - associatedModelSchema: model's schema
+    /// - Returns: serialized value of the primary key
+    private func associatedPrimaryKeyValue(fromJSON associatedModelJSON: [String: JSONValue],
+                                           associatedModelSchema: ModelSchema) -> String {
+        let associatedModelPKFields: ModelIdentifierProtocol.Fields
+
+        // get the associated model primary key fields
+        associatedModelPKFields = associatedModelSchema.primaryKey.fields.compactMap {
+            if case .string(let value) = associatedModelJSON[$0.name] {
+                return (name: $0.name, value: value)
+            }
+            return nil
+        }
+        // Since Flutter models internally use a general serialized model structure with but
+        // different model schemas, we always use an identifier with a ModelIdentifierFormat.Custom format
+        return ModelIdentifier<AnyModel, ModelIdentifierFormat.Custom>
+            .make(fields: associatedModelPKFields).stringValue
     }
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/SQLModelValueConverterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/SQLModelValueConverterTests.swift
@@ -11,6 +11,7 @@ import XCTest
 @testable import Amplify
 @testable import AWSDataStoreCategoryPlugin
 @testable import SQLite
+import AmplifyTestCommon
 
 class SQLModelValueConverterTests: BaseDataStoreTests {
 
@@ -110,6 +111,46 @@ class SQLModelValueConverterTests: BaseDataStoreTests {
                 XCTFail(error.errorDescription)
             }
         }
+    }
+
+    /// - Given: a `CommentWithCompositeKey` model as JSONValue
+    /// - When:
+    ///   - the `sqlValues()` is called
+    /// - Then:
+    ///   - the returning array of Bindings should include all the `CommentWithCompositeKey` model fields
+    ///   plus the identifier value of the associated `PostWithCompositeKey` model
+    func testJSONModelConversionToBindings() {
+        ModelRegistry.register(modelType: CommentWithCompositeKey.self)
+        ModelRegistry.register(modelType: PostWithCompositeKey.self)
+
+        let commentId = "comment-id-123"
+        let postId = "post-id-123"
+        let postTitle = "post-title"
+        let commentContent = "a comment"
+        let createdAt = Temporal.DateTime.now().iso8601String
+        let updatedAt = Temporal.DateTime.now().iso8601String
+
+        let model: [String: JSONValue] = [
+            "id": .string(commentId),
+            "content": .string(commentContent),
+            "post": .object([
+                "id": .string(postId),
+                "title": .string(postTitle),
+                "__typename": "PostWithCompositeKey"
+            ]),
+            "createdAt": .string(createdAt),
+            "updatedAt": .string(updatedAt),
+            "__typename": "CommentWithCompositeKey"
+        ]
+        let bindings = DynamicModel(id: commentId, values: model).sqlValues(modelSchema: CommentWithCompositeKey.schema)
+        let expectedPostIdentifier = PostWithCompositeKey.Identifier.identifier(id: postId, title: postTitle)
+
+        XCTAssertEqual(bindings[0] as? String, commentId)
+        XCTAssertEqual(bindings[1] as? String, commentContent)
+        XCTAssertEqual(bindings[2] as? String, createdAt)
+        XCTAssertEqual(bindings[3] as? String, updatedAt)
+        XCTAssertEqual(bindings[4] as? String, expectedPostIdentifier.stringValue)
+
     }
 
 }

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/CommentWithCompositeKeyAndIndex+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/CommentWithCompositeKeyAndIndex+Schema.swift
@@ -1,9 +1,16 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 // swiftlint:disable all
 import Amplify
 import Foundation
 
 extension CommentWithCompositeKeyAndIndex {
-  // MARK: - CodingKeys 
+  // MARK: - CodingKeys
    public enum CodingKeys: String, ModelKey {
     case id
     case content
@@ -11,21 +18,21 @@ extension CommentWithCompositeKeyAndIndex {
     case createdAt
     case updatedAt
   }
-  
+
   public static let keys = CodingKeys.self
-  //  MARK: - ModelSchema 
-  
+  //  MARK: - ModelSchema
+
   public static let schema = defineSchema { model in
     let commentWithCompositeKeyAndIndex = CommentWithCompositeKeyAndIndex.keys
-    
+
     model.pluralName = "CommentWithCompositeKeyAndIndices"
-    
+
     model.attributes(
       .index(fields: ["id", "content"], name: nil),
       .index(fields: ["postID", "postTitle"], name: "byPost"),
       .primaryKey(fields: [commentWithCompositeKeyAndIndex.id, commentWithCompositeKeyAndIndex.content])
     )
-    
+
     model.fields(
       .field(commentWithCompositeKeyAndIndex.id, is: .required, ofType: .string),
       .field(commentWithCompositeKeyAndIndex.content, is: .required, ofType: .string),
@@ -44,6 +51,6 @@ extension CommentWithCompositeKeyAndIndex: ModelIdentifiable {
 extension CommentWithCompositeKeyAndIndex.Identifier {
   public static func identifier(id: String,
       content: String) -> Self {
-    .make(fields:[(name: "id", value: id), (name: "content", value: content)])
+    .make(fields: [(name: "id", value: id), (name: "content", value: content)])
   }
 }

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/CommentWithCompositeKeyAndIndex.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/CommentWithCompositeKeyAndIndex.swift
@@ -1,3 +1,10 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 // swiftlint:disable all
 import Amplify
 import Foundation
@@ -8,7 +15,7 @@ public struct CommentWithCompositeKeyAndIndex: Model {
   public var post: PostWithCompositeKeyAndIndex?
   public var createdAt: Temporal.DateTime?
   public var updatedAt: Temporal.DateTime?
-  
+
   public init(id: String = UUID().uuidString,
       content: String,
       post: PostWithCompositeKeyAndIndex? = nil) {

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/PostTagsWithCompositeKey+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/PostTagsWithCompositeKey+Schema.swift
@@ -1,9 +1,16 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 // swiftlint:disable all
 import Amplify
 import Foundation
 
 extension PostTagsWithCompositeKey {
-  // MARK: - CodingKeys 
+  // MARK: - CodingKeys
    public enum CodingKeys: String, ModelKey {
     case id
     case postWithTagsCompositeKey
@@ -11,21 +18,21 @@ extension PostTagsWithCompositeKey {
     case createdAt
     case updatedAt
   }
-  
+
   public static let keys = CodingKeys.self
-  //  MARK: - ModelSchema 
-  
+  //  MARK: - ModelSchema
+
   public static let schema = defineSchema { model in
     let postTagsWithCompositeKey = PostTagsWithCompositeKey.keys
-    
+
     model.pluralName = "PostTagsWithCompositeKeys"
-    
+
     model.attributes(
       .index(fields: ["postWithTagsCompositeKeyID", "postWithTagsCompositeKeytitle"], name: "byPostWithTagsCompositeKey"),
       .index(fields: ["tagWithCompositeKeyID", "tagWithCompositeKeyname"], name: "byTagWithCompositeKey"),
       .primaryKey(fields: [postTagsWithCompositeKey.id])
     )
-    
+
     model.fields(
       .field(postTagsWithCompositeKey.id, is: .required, ofType: .string),
       .belongsTo(postTagsWithCompositeKey.postWithTagsCompositeKey, is: .required, ofType: PostWithTagsCompositeKey.self, targetNames: ["postWithTagsCompositeKeyID", "postWithTagsCompositeKeytitle"]),

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/PostTagsWithCompositeKey.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/PostTagsWithCompositeKey.swift
@@ -1,3 +1,10 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 // swiftlint:disable all
 import Amplify
 import Foundation
@@ -8,7 +15,7 @@ public struct PostTagsWithCompositeKey: Model {
   public var tagWithCompositeKey: TagWithCompositeKey
   public var createdAt: Temporal.DateTime?
   public var updatedAt: Temporal.DateTime?
-  
+
   public init(id: String = UUID().uuidString,
       postWithTagsCompositeKey: PostWithTagsCompositeKey,
       tagWithCompositeKey: TagWithCompositeKey) {

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithCompositeKeyAndIndex+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithCompositeKeyAndIndex+Schema.swift
@@ -1,9 +1,16 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 // swiftlint:disable all
 import Amplify
 import Foundation
 
 extension PostWithCompositeKeyAndIndex {
-  // MARK: - CodingKeys 
+  // MARK: - CodingKeys
    public enum CodingKeys: String, ModelKey {
     case id
     case title
@@ -11,20 +18,20 @@ extension PostWithCompositeKeyAndIndex {
     case createdAt
     case updatedAt
   }
-  
+
   public static let keys = CodingKeys.self
-  //  MARK: - ModelSchema 
-  
+  //  MARK: - ModelSchema
+
   public static let schema = defineSchema { model in
     let postWithCompositeKeyAndIndex = PostWithCompositeKeyAndIndex.keys
-    
+
     model.pluralName = "PostWithCompositeKeyAndIndices"
-    
+
     model.attributes(
       .index(fields: ["id", "title"], name: nil),
       .primaryKey(fields: [postWithCompositeKeyAndIndex.id, postWithCompositeKeyAndIndex.title])
     )
-    
+
     model.fields(
       .field(postWithCompositeKeyAndIndex.id, is: .required, ofType: .string),
       .field(postWithCompositeKeyAndIndex.title, is: .required, ofType: .string),
@@ -43,6 +50,6 @@ extension PostWithCompositeKeyAndIndex: ModelIdentifiable {
 extension PostWithCompositeKeyAndIndex.Identifier {
   public static func identifier(id: String,
       title: String) -> Self {
-    .make(fields:[(name: "id", value: id), (name: "title", value: title)])
+    .make(fields: [(name: "id", value: id), (name: "title", value: title)])
   }
 }

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithCompositeKeyAndIndex.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithCompositeKeyAndIndex.swift
@@ -1,3 +1,10 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 // swiftlint:disable all
 import Amplify
 import Foundation
@@ -8,7 +15,7 @@ public struct PostWithCompositeKeyAndIndex: Model {
   public var comments: List<CommentWithCompositeKeyAndIndex>?
   public var createdAt: Temporal.DateTime?
   public var updatedAt: Temporal.DateTime?
-  
+
   public init(id: String = UUID().uuidString,
       title: String,
       comments: List<CommentWithCompositeKeyAndIndex>? = []) {

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithTagsCompositeKey+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithTagsCompositeKey+Schema.swift
@@ -1,9 +1,16 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 // swiftlint:disable all
 import Amplify
 import Foundation
 
 extension PostWithTagsCompositeKey {
-  // MARK: - CodingKeys 
+  // MARK: - CodingKeys
    public enum CodingKeys: String, ModelKey {
     case postId
     case title
@@ -11,20 +18,20 @@ extension PostWithTagsCompositeKey {
     case createdAt
     case updatedAt
   }
-  
+
   public static let keys = CodingKeys.self
-  //  MARK: - ModelSchema 
-  
+  //  MARK: - ModelSchema
+
   public static let schema = defineSchema { model in
     let postWithTagsCompositeKey = PostWithTagsCompositeKey.keys
-    
+
     model.pluralName = "PostWithTagsCompositeKeys"
-    
+
     model.attributes(
       .index(fields: ["postId", "title"], name: nil),
       .primaryKey(fields: [postWithTagsCompositeKey.postId, postWithTagsCompositeKey.title])
     )
-    
+
     model.fields(
       .field(postWithTagsCompositeKey.postId, is: .required, ofType: .string),
       .field(postWithTagsCompositeKey.title, is: .required, ofType: .string),
@@ -43,6 +50,6 @@ extension PostWithTagsCompositeKey: ModelIdentifiable {
 extension PostWithTagsCompositeKey.Identifier {
   public static func identifier(postId: String,
       title: String) -> Self {
-    .make(fields:[(name: "postId", value: postId), (name: "title", value: title)])
+    .make(fields: [(name: "postId", value: postId), (name: "title", value: title)])
   }
 }

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithTagsCompositeKey.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithTagsCompositeKey.swift
@@ -1,3 +1,10 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 // swiftlint:disable all
 import Amplify
 import Foundation
@@ -8,7 +15,7 @@ public struct PostWithTagsCompositeKey: Model {
   public var tags: List<PostTagsWithCompositeKey>?
   public var createdAt: Temporal.DateTime?
   public var updatedAt: Temporal.DateTime?
-  
+
   public init(postId: String,
       title: String,
       tags: List<PostTagsWithCompositeKey>? = []) {

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/TagWithCompositeKey+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/TagWithCompositeKey+Schema.swift
@@ -1,9 +1,16 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 // swiftlint:disable all
 import Amplify
 import Foundation
 
 extension TagWithCompositeKey {
-  // MARK: - CodingKeys 
+  // MARK: - CodingKeys
    public enum CodingKeys: String, ModelKey {
     case id
     case name
@@ -11,20 +18,20 @@ extension TagWithCompositeKey {
     case createdAt
     case updatedAt
   }
-  
+
   public static let keys = CodingKeys.self
-  //  MARK: - ModelSchema 
-  
+  //  MARK: - ModelSchema
+
   public static let schema = defineSchema { model in
     let tagWithCompositeKey = TagWithCompositeKey.keys
-    
+
     model.pluralName = "TagWithCompositeKeys"
-    
+
     model.attributes(
       .index(fields: ["id", "name"], name: nil),
       .primaryKey(fields: [tagWithCompositeKey.id, tagWithCompositeKey.name])
     )
-    
+
     model.fields(
       .field(tagWithCompositeKey.id, is: .required, ofType: .string),
       .field(tagWithCompositeKey.name, is: .required, ofType: .string),
@@ -43,6 +50,6 @@ extension TagWithCompositeKey: ModelIdentifiable {
 extension TagWithCompositeKey.Identifier {
   public static func identifier(id: String,
       name: String) -> Self {
-    .make(fields:[(name: "id", value: id), (name: "name", value: name)])
+    .make(fields: [(name: "id", value: id), (name: "name", value: name)])
   }
 }

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/TagWithCompositeKey.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/TagWithCompositeKey.swift
@@ -1,3 +1,10 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 // swiftlint:disable all
 import Amplify
 import Foundation
@@ -8,7 +15,7 @@ public struct TagWithCompositeKey: Model {
   public var posts: List<PostTagsWithCompositeKey>?
   public var createdAt: Temporal.DateTime?
   public var updatedAt: Temporal.DateTime?
-  
+
   public init(id: String = UUID().uuidString,
       name: String,
       posts: List<PostTagsWithCompositeKey>? = []) {


### PR DESCRIPTION
*Description of changes:*
This PR introduces the necessary changes to produce the correct SQL values for a serialized JSON model used in an association.

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
