### PR TITLE
fix: update Amplify.reset() to work with Swift Concurrency

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/AWSAPIPlugin.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AWSAPIPlugin.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      enableThreadSanitizer = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
@@ -495,6 +495,13 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "LIBDISPATCH_COOPERATIVE_POOL_STRICT"
+            value = "1"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
@@ -477,6 +477,16 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AWSPinpointAnalyticsPluginIntegrationTests"
+               BuildableName = "AWSPinpointAnalyticsPluginIntegrationTests"
+               BlueprintName = "AWSPinpointAnalyticsPluginIntegrationTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "AWSPinpointAnalyticsPluginTests"
                BuildableName = "AWSPinpointAnalyticsPluginTests"
                BlueprintName = "AWSPinpointAnalyticsPluginTests"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
@@ -432,6 +432,11 @@
                BlueprintName = "AWSS3StoragePluginTests"
                ReferencedContainer = "container:">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "AWSS3StoragePluginConfigureTests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
@@ -483,6 +483,16 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AWSPinpointAnalyticsPluginIntegrationTests"
+               BuildableName = "AWSPinpointAnalyticsPluginIntegrationTests"
+               BlueprintName = "AWSPinpointAnalyticsPluginIntegrationTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
@@ -482,16 +482,6 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AWSPinpointAnalyticsPluginIntegrationTests"
-               BuildableName = "AWSPinpointAnalyticsPluginIntegrationTests"
-               BlueprintName = "AWSPinpointAnalyticsPluginIntegrationTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "AWSPinpointAnalyticsPluginTests"
                BuildableName = "AWSPinpointAnalyticsPluginTests"
                BlueprintName = "AWSPinpointAnalyticsPluginTests"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
@@ -432,11 +432,6 @@
                BlueprintName = "AWSS3StoragePluginTests"
                ReferencedContainer = "container:">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "AWSS3StoragePluginConfigureTests">
-               </Test>
-            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      enableThreadSanitizer = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Amplify/Core/Configuration/Internal/Amplify+Reset.swift
+++ b/Amplify/Core/Configuration/Internal/Amplify+Reset.swift
@@ -17,51 +17,36 @@ extension Amplify {
     /// - Releases each configured category, and replaces the instances referred to by the static accessor properties
     ///   (e.g., `Amplify.Hub`) with new instances. These instances must subsequently have providers added, and be
     ///   configured prior to use.
-    static func reset() {
+    static func reset() async {
         // Looping through all categories to ensure we don't accidentally forget a category at some point in the future
-
-        let group = DispatchGroup()
-
         for categoryType in CategoryType.allCases {
             switch categoryType {
             case .analytics:
-                reset(Analytics, in: group) { group.leave() }
+                await reset(Analytics)
             case .api:
-                reset(API, in: group) { group.leave() }
+                await reset(API)
             case .auth:
-                reset(Auth, in: group) { group.leave() }
+                await reset(Auth)
             case .dataStore:
-                reset(DataStore, in: group) { group.leave() }
+                await reset(DataStore)
             case .geo:
-                reset(Geo, in: group) { group.leave() }
+                await reset(Geo)
             case .storage:
-                reset(Storage, in: group) { group.leave() }
+                await reset(Storage)
             case .predictions:
-                reset(Predictions, in: group) { group.leave() }
+                await reset(Predictions)
             case .hub, .logging:
                 // Hub and Logging should be reset after all other categories
                 break
             }
         }
-
-        group.wait()
-
-        for categoryType in CategoryType.allCases {
-            switch categoryType {
-            case .hub:
-                reset(Hub, in: group) { group.leave() }
-            case .logging:
-                reset(Logging, in: group) { group.leave() }
-            default:
-                break
-            }
-        }
+        
+        await reset(Hub)
+        await reset(Logging)
 
 #if canImport(UIKit)
         devMenu = nil
 #endif
-
-        group.wait()
 
         // Initialize Logging and Hub first, to ensure their default plugins are registered and available to other
         // categories during their initialization and configuration phases.
@@ -94,15 +79,13 @@ extension Amplify {
         isConfigured = false
     }
 
-    /// If `candidate` is `Resettable`, `enter()`s `group`, then invokes `candidate.reset(onComplete)` on a background
-    /// queue. If `candidate` is not resettable, exits without invoking `onComplete`.
-    private static func reset(_ candidate: Any, in group: DispatchGroup, onComplete: @escaping BasicClosure) {
-        guard let resettable = candidate as? Resettable else {
-            return
+    private static func reset(_ candidate: Any) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) -> Void in
+            guard let resettable = candidate as? Resettable else { return }
+            
+            resettable.reset {
+                continuation.resume()
+            }
         }
-
-        group.enter()
-        resettable.reset(onComplete: onComplete)
     }
-
 }

--- a/Amplify/Core/Configuration/Internal/Amplify+Reset.swift
+++ b/Amplify/Core/Configuration/Internal/Amplify+Reset.swift
@@ -45,7 +45,9 @@ extension Amplify {
         await reset(Logging)
 
 #if canImport(UIKit)
-        devMenu = nil
+        await MainActor.run {
+            devMenu = nil
+        }
 #endif
 
         // Initialize Logging and Hub first, to ensure their default plugins are registered and available to other

--- a/Amplify/Core/Plugin/Internal/Resettable.swift
+++ b/Amplify/Core/Plugin/Internal/Resettable.swift
@@ -11,7 +11,7 @@ import Foundation
 /// for internal use, and should not be invoked by host applications.
 public protocol Resettable {
 
-    /// Called when the client calls `Amplify.reset()` during testing. When invoked,
+    /// Called when the client calls `await Amplify.reset()` during testing. When invoked,
     /// the plugin must release resources and reset shared state. Shortly after calling
     /// `reset()` on the plugin, the category and its associated plugins will be
     /// released. Plugins must invoke the `onComplete` handler when they complete their

--- a/Amplify/DefaultPlugins/AWSHubPlugin/Internal/HubChannelDispatcher.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/Internal/HubChannelDispatcher.swift
@@ -61,8 +61,8 @@ final class HubChannelDispatcher {
     /// cancels in-process operations and waits for them to complete, it does not attempt to assert anything about
     /// whether a given listener closure has completed. To mitigate this, the method sleeps for 1 second before
     /// returning, which should give common test cases time to execute their listeners. However, it's still not a
-    /// guarantee, so if your test encounters errors like "Hub is not configured" after you issue an `Amplify.reset()`,
-    /// you may wish to add additional sleep around your code that calls `Amplify.reset()`.
+    /// guarantee, so if your test encounters errors like "Hub is not configured" after you issue an `await Amplify.reset()`,
+    /// you may wish to add additional sleep around your code that calls `await Amplify.reset()`.
     func destroy() {
         listenersById.removeAll()
         messageQueue.cancelAllOperations()

--- a/AmplifyFunctionalTests/AmplifyConfigurationInitFromFileTests.swift
+++ b/AmplifyFunctionalTests/AmplifyConfigurationInitFromFileTests.swift
@@ -9,9 +9,9 @@ import XCTest
 import Amplify
 
 /// Test the public AmplifyConfiguration initializer. Note that this means we must not import
-/// Amplify as `@testable`. That means we cannot `Amplify.reset()`, which means we can only have
+/// Amplify as `@testable`. That means we cannot `await Amplify.reset()`, which means we can only have
 /// one test in this file. Further, this means we need to ensure that other tests do call
-/// `Amplify.reset()` in their static `setUp()` and `tearDown()` methods.
+/// `await Amplify.reset()` in their static `setUp()` and `tearDown()` methods.
 class AmplifyConfigurationInitFromFileTests: XCTestCase {
 
     func testInitFromFile() throws {

--- a/AmplifyFunctionalTests/AmplifyConfigurationTests.swift
+++ b/AmplifyFunctionalTests/AmplifyConfigurationTests.swift
@@ -12,15 +12,15 @@ import XCTest
 
 class AmplifyConfigurationTests: XCTestCase {
 
-    override static func setUp() {
+    override static func setUp() async throws {
         await Amplify.reset()
     }
 
-    override static func tearDown() {
+    override static func tearDown() async throws {
         await Amplify.reset()
     }
 
-    override func setUp() {
+    override func setUp() async throws {
         await Amplify.reset()
     }
 

--- a/AmplifyFunctionalTests/AmplifyConfigurationTests.swift
+++ b/AmplifyFunctionalTests/AmplifyConfigurationTests.swift
@@ -13,15 +13,15 @@ import XCTest
 class AmplifyConfigurationTests: XCTestCase {
 
     override static func setUp() {
-        Amplify.reset()
+        await Amplify.reset()
     }
 
     override static func tearDown() {
-        Amplify.reset()
+        await Amplify.reset()
     }
 
     override func setUp() {
-        Amplify.reset()
+        await Amplify.reset()
     }
 
     /// Given: An app with an `amplifyconfiguration.json` file in the main bundle

--- a/AmplifyFunctionalTests/Hub/ConcurrentDispatcherPerformanceTests.swift
+++ b/AmplifyFunctionalTests/Hub/ConcurrentDispatcherPerformanceTests.swift
@@ -15,7 +15,7 @@ import XCTest
 //
 //    let dispatcherTypeUnderTest = ConcurrentDispatcher.self
 //
-//    override func setUp() {
+//    override func setUp() async throws {
 //        await Amplify.reset()
 //        let config = AmplifyConfiguration()
 //        do {
@@ -25,7 +25,7 @@ import XCTest
 //        }
 //    }
 //
-//    override func tearDown() {
+//    override func tearDown() async throws {
 //        await Amplify.reset()
 //    }
 //

--- a/AmplifyFunctionalTests/Hub/ConcurrentDispatcherPerformanceTests.swift
+++ b/AmplifyFunctionalTests/Hub/ConcurrentDispatcherPerformanceTests.swift
@@ -16,7 +16,7 @@ import XCTest
 //    let dispatcherTypeUnderTest = ConcurrentDispatcher.self
 //
 //    override func setUp() {
-//        Amplify.reset()
+//        await Amplify.reset()
 //        let config = AmplifyConfiguration()
 //        do {
 //            try Amplify.configure(config)
@@ -26,7 +26,7 @@ import XCTest
 //    }
 //
 //    override func tearDown() {
-//        Amplify.reset()
+//        await Amplify.reset()
 //    }
 //
 //    // MARK: - Performance of single channel, multiple listeners

--- a/AmplifyFunctionalTests/Hub/SerialDispatcherPerformanceTests.swift
+++ b/AmplifyFunctionalTests/Hub/SerialDispatcherPerformanceTests.swift
@@ -13,15 +13,15 @@ class SerialDispatcherPerformanceTests: XCTestCase {
     let dispatcherTypeUnderTest = SerialDispatcher.self
 
     override static func setUp() {
-        Amplify.reset()
+        await Amplify.reset()
     }
 
     override static func tearDown() {
-        Amplify.reset()
+        await Amplify.reset()
     }
 
     override func setUp() {
-        Amplify.reset()
+        await Amplify.reset()
         let config = AmplifyConfiguration()
         do {
             try Amplify.configure(config)
@@ -31,7 +31,7 @@ class SerialDispatcherPerformanceTests: XCTestCase {
     }
 
     override func tearDown() {
-        Amplify.reset()
+        await Amplify.reset()
     }
 
     // MARK: - Performance of single channel, multiple listeners

--- a/AmplifyFunctionalTests/Hub/SerialDispatcherPerformanceTests.swift
+++ b/AmplifyFunctionalTests/Hub/SerialDispatcherPerformanceTests.swift
@@ -12,15 +12,15 @@ class SerialDispatcherPerformanceTests: XCTestCase {
 
     let dispatcherTypeUnderTest = SerialDispatcher.self
 
-    override static func setUp() {
+    override static func setUp() async throws {
         await Amplify.reset()
     }
 
-    override static func tearDown() {
+    override static func tearDown() async throws {
         await Amplify.reset()
     }
 
-    override func setUp() {
+    override func setUp() async throws {
         await Amplify.reset()
         let config = AmplifyConfiguration()
         do {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/AnyModelIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/AnyModelIntegrationTests.swift
@@ -16,8 +16,8 @@ import AWSPluginsCore
 class AnyModelIntegrationTests: XCTestCase {
     let networkTimeout: TimeInterval = 180.0
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
         Amplify.Logging.logLevel = .verbose
 
         let plugin = AWSAPIPlugin(modelRegistration: PostCommentModelRegistration())
@@ -37,8 +37,8 @@ class AnyModelIntegrationTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     func testCreateAsAnyModel() throws {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario1Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario1Tests.swift
@@ -46,8 +46,8 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     func testCreateAndGetProject() throws {
@@ -59,7 +59,7 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
         let project = Project1(team: team)
         Amplify.API.mutate(request: .create(project)) { result in
             switch result {
-            case .success(let result):
+            case .success(_):
                 createProjectSuccessful.fulfill()
             case .failure(let error):
                 XCTFail("\(error)")

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario2Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario2Tests.swift
@@ -47,8 +47,8 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     // Create Project2 in different ways, then retrieve it
@@ -63,7 +63,7 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
         let project2a = Project2(teamID: team2.id, team: team2)
         Amplify.API.mutate(request: .create(project2a)) { result in
             switch result {
-            case .success(let result):
+            case .success(_):
                 createProject2aSuccessful.fulfill()
             case .failure(let error):
                 XCTFail("\(error)")

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario3Tests.swift
@@ -47,8 +47,8 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     func testQuerySinglePost() {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario4Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario4Tests.swift
@@ -48,8 +48,8 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     func testCreateCommentAndGetCommentWithPost() {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario5Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario5Tests.swift
@@ -60,8 +60,8 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     func testListPostEditorByPost() {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLConnectionScenario6Tests.swift
@@ -55,8 +55,8 @@ class GraphQLConnectionScenario6Tests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     func testGetBlogThenFetchPostsThenFetchComments() {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLModelBasedTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLModelBasedTests.swift
@@ -15,8 +15,8 @@ class GraphQLModelBasedTests: XCTestCase {
 
     static let amplifyConfiguration = "GraphQLModelBasedTests-amplifyconfiguration"
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
         Amplify.Logging.logLevel = .verbose
         let plugin = AWSAPIPlugin(modelRegistration: PostCommentModelRegistration())
 
@@ -35,8 +35,8 @@ class GraphQLModelBasedTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     func testQuerySinglePostWithModel() {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLScalarTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLModelBased/GraphQLScalarTests.swift
@@ -32,8 +32,8 @@ class GraphQLScalarTests: GraphQLTestBase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     func testScalarContainer() throws {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncBasedTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncBasedTests.swift
@@ -16,8 +16,8 @@ class GraphQLSyncBasedTests: XCTestCase {
 
     static let amplifyConfiguration = "testconfiguration/GraphQLSyncBasedTests-amplifyconfiguration"
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
         let plugin = AWSAPIPlugin(modelRegistration: PostCommentModelRegistration())
 
         do {
@@ -35,8 +35,8 @@ class GraphQLSyncBasedTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     // Given: No post created

--- a/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncCustomPrimaryKeyTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncCustomPrimaryKeyTests.swift
@@ -15,8 +15,8 @@ class GraphQLSyncCustomPrimaryKeyTests: XCTestCase {
 
     static let amplifyConfiguration = "testconfiguration/GraphQLSyncBasedTests-amplifyconfiguration"
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
         let plugin = AWSAPIPlugin()
 
         do {
@@ -33,8 +33,8 @@ class GraphQLSyncCustomPrimaryKeyTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     /// Test for deletion of model with custom primary keys

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithIAMIntegrationTests/GraphQLWithIAMIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithIAMIntegrationTests/GraphQLWithIAMIntegrationTests.swift
@@ -39,8 +39,8 @@ class GraphQLWithIAMIntegrationTests: XCTestCase {
 //        }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     /// Test create mutation with a custom GraphQL Document

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithLambdaAuthIntegrationTests/GraphQLWithLambdaAuthIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithLambdaAuthIntegrationTests/GraphQLWithLambdaAuthIntegrationTests.swift
@@ -27,7 +27,7 @@ class GraphQLWithLambdaAuthIntegrationTests: XCTestCase {
     }
 
     override func tearDown() {
-        Amplify.reset()
+        await Amplify.reset()
     }
 
     /// Test create mutation with a custom GraphQL Document

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/GraphQLAuthDirectiveIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/AuthDirective/GraphQLAuthDirectiveIntegrationTests.swift
@@ -49,7 +49,7 @@ class GraphQLAuthDirectiveIntegrationTests: XCTestCase {
 
     override func tearDown() {
         signOut()
-        Amplify.reset()
+        await Amplify.reset()
     }
 
     /// Models created with:

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/GraphQLWithUserPoolIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/GraphQLWithUserPoolIntegrationTests.swift
@@ -45,7 +45,7 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
 
     override func tearDown() {
         signOut()
-        Amplify.reset()
+        await Amplify.reset()
     }
 
     /// Given: A CreateTodo mutation request, and user signed in, graphql has userpools as auth mode.

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithIAMIntegrationTests/RESTWithIAMIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithIAMIntegrationTests/RESTWithIAMIntegrationTests.swift
@@ -29,8 +29,8 @@ class RESTWithIAMIntegrationTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     func testSetUp() {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/RESTWithUserPoolIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/REST/RESTWithUserPoolIntegrationTests/RESTWithUserPoolIntegrationTests.swift
@@ -33,7 +33,7 @@ class RESTWithUserPoolIntegrationTests: XCTestCase {
 
     override func tearDown() {
         signOut()
-        Amplify.reset()
+        await Amplify.reset()
     }
 
     func testGetAPISuccess() {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPluginTestBase.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPluginTestBase.swift
@@ -30,7 +30,7 @@ class AWSAPICategoryPluginTestBase: XCTestCase {
     let testBody = Data()
     let testPath = "testPath"
 
-    override func setUp() {
+    override func setUp() async throws {
         apiPlugin = AWSAPIPlugin()
 
         let authService = MockAWSAuthService()
@@ -63,8 +63,8 @@ class AWSAPICategoryPluginTestBase: XCTestCase {
             XCTFail("Failed to create endpoint config")
         }
 
-        Amplify.reset()
-        // Amplify.reset() doesn't immediately stop all in-progress tasks, so we sleep here to
+        await Amplify.reset()
+        // await Amplify.reset() doesn't immediately stop all in-progress tasks, so we sleep here to
         // give everything a chance to complete. This prevents sporadic failures when running many tests.
         sleep(2)
         let config = AmplifyConfiguration()

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -34,8 +34,8 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
                                                    authService: MockAWSAuthService())
     }
 
-    func testThrowsOnMissingConfig() throws {
-        Amplify.reset()
+    func testThrowsOnMissingConfig() async throws {
+        await Amplify.reset()
         let plugin = AWSAPIPlugin()
         try Amplify.add(plugin: plugin)
 

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListProviderTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListProviderTests.swift
@@ -14,8 +14,8 @@ import XCTest
 class AppSyncListProviderTests: XCTestCase {
     var mockAPIPlugin: MockAPICategoryPlugin!
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
         ModelRegistry.register(modelType: Post4.self)
         ModelRegistry.register(modelType: Comment4.self)
         ModelListDecoderRegistry.registerDecoder(AppSyncListDecoder.self)

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
@@ -30,7 +30,7 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
     let testBody = Data()
     let testPath = "testPath"
 
-    func setUp(subscriptionConnectionFactory: SubscriptionConnectionFactory) {
+    func setUp(subscriptionConnectionFactory: SubscriptionConnectionFactory) async {
         apiPlugin = AWSAPIPlugin()
 
         let authService = MockAWSAuthService()
@@ -58,7 +58,7 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
             XCTFail("Failed to create endpoint config")
         }
 
-        Amplify.reset()
+        await Amplify.reset()
         let config = AmplifyConfiguration()
         do {
             try Amplify.configure(config)
@@ -67,7 +67,7 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
         }
     }
 
-    func testCancelSendsCompletion() {
+    func testCancelSendsCompletion() async {
         let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _ in
             return MockSubscriptionConnection(onSubscribe: { (_, _, eventHandler) -> SubscriptionItem in
                 let item = SubscriptionItem(requestString: "", variables: nil, eventHandler: { _, _ in
@@ -77,7 +77,7 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
             }, onUnsubscribe: {_ in
             })
         })
-        setUp(subscriptionConnectionFactory: mockSubscriptionConnectionFactory)
+        await setUp(subscriptionConnectionFactory: mockSubscriptionConnectionFactory)
 
         let request = GraphQLRequest(apiName: apiName,
                                      document: testDocument,
@@ -123,15 +123,15 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
         wait(for: [receivedValueConnecting], timeout: 0.3)
         operation.cancel()
         XCTAssert(operation.isCancelled)
-        waitForExpectations(timeout: 0.3)
+        await waitForExpectations(timeout: 0.3)
     }
 
-    func testFailureOnConnection() {
+    func testFailureOnConnection() async {
         let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _ in
             throw APIError.invalidConfiguration("something went wrong", "", nil)
         })
 
-        setUp(subscriptionConnectionFactory: mockSubscriptionConnectionFactory)
+        await setUp(subscriptionConnectionFactory: mockSubscriptionConnectionFactory)
 
         let request = GraphQLRequest(apiName: apiName,
                                      document: testDocument,
@@ -164,10 +164,10 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
         )
         wait(for: [receivedFailure], timeout: 0.3)
         XCTAssert(operation.isFinished)
-        waitForExpectations(timeout: 0.3)
+        await waitForExpectations(timeout: 0.3)
     }
 
-    func testCallingCancelWhileCreatingConnectionShouldCallCompletionListener() {
+    func testCallingCancelWhileCreatingConnectionShouldCallCompletionListener() async {
         let connectionCreation = expectation(description: "connection factory called")
         let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _ in
             connectionCreation.fulfill()
@@ -180,7 +180,7 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
             })
         })
 
-        setUp(subscriptionConnectionFactory: mockSubscriptionConnectionFactory)
+        await setUp(subscriptionConnectionFactory: mockSubscriptionConnectionFactory)
 
         let request = GraphQLRequest(apiName: apiName,
                                      document: testDocument,
@@ -213,6 +213,6 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
         wait(for: [connectionCreation], timeout: 0.3)
         operation.cancel()
         XCTAssert(operation.isCancelled)
-        waitForExpectations(timeout: 0.3)
+        await waitForExpectations(timeout: 0.3)
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Decode/GraphQLResponseDecoder+DecodeDataTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Decode/GraphQLResponseDecoder+DecodeDataTests.swift
@@ -129,8 +129,8 @@ extension GraphQLResponseDecoderTests {
                                            myDateTime: .now(),
                                            myTime: .now())
 
-        let data = try GraphQLResponseDecoderTests.encoder.encode(expectedObject)
-        let objectJSON = try GraphQLResponseDecoderTests.decoder.decode(JSONValue.self, from: data)
+        let data = try encoder.encode(expectedObject)
+        let objectJSON = try decoder.decode(JSONValue.self, from: data)
         let graphQLData: [String: JSONValue] = [
             "getSimpleCodable": objectJSON
         ]

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Decode/GraphQLResponseDecoderTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Decode/GraphQLResponseDecoderTests.swift
@@ -15,8 +15,8 @@ class GraphQLResponseDecoderTests: XCTestCase {
     static let decoder = JSONDecoder()
     static let encoder = JSONEncoder()
 
-    override class func setUp() {
-        Amplify.reset()
+    override class func setUp() async {
+        await Amplify.reset()
         ModelRegistry.register(modelType: SimpleModel.self)
         ModelRegistry.register(modelType: Post4.self)
         ModelRegistry.register(modelType: Comment4.self)

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Decode/GraphQLResponseDecoderTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Support/Decode/GraphQLResponseDecoderTests.swift
@@ -12,10 +12,10 @@ import AWSPluginsCore
 @testable import AWSAPIPlugin
 
 class GraphQLResponseDecoderTests: XCTestCase {
-    static let decoder = JSONDecoder()
-    static let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    let encoder = JSONEncoder()
 
-    override class func setUp() async {
+    override func setUp() async throws {
         await Amplify.reset()
         ModelRegistry.register(modelType: SimpleModel.self)
         ModelRegistry.register(modelType: Post4.self)
@@ -71,7 +71,7 @@ class GraphQLResponseDecoderTests: XCTestCase {
                 ]
             ]
         ]
-        let data = try GraphQLResponseDecoderTests.encoder.encode(graphQLData)
+        let data = try encoder.encode(graphQLData)
         decoder.appendResponse(data)
 
         let result = try decoder.decodeToGraphQLResponse()
@@ -94,7 +94,7 @@ class GraphQLResponseDecoderTests: XCTestCase {
                 ["message": "message2"]
             ]
         ]
-        let data = try GraphQLResponseDecoderTests.encoder.encode(graphQLData)
+        let data = try encoder.encode(graphQLData)
         decoder.appendResponse(data)
 
         let result = try decoder.decodeToGraphQLResponse()
@@ -122,7 +122,7 @@ class GraphQLResponseDecoderTests: XCTestCase {
                 ["message": "message2"]
             ]
         ]
-        let data = try GraphQLResponseDecoderTests.encoder.encode(graphQLData)
+        let data = try encoder.encode(graphQLData)
         decoder.appendResponse(data)
 
         let result = try decoder.decodeToGraphQLResponse()
@@ -150,7 +150,7 @@ class GraphQLResponseDecoderTests: XCTestCase {
                 ["message": "message2"]
             ]
         ]
-        let data = try GraphQLResponseDecoderTests.encoder.encode(graphQLData)
+        let data = try encoder.encode(graphQLData)
         decoder.appendResponse(data)
 
         do {
@@ -180,7 +180,7 @@ class GraphQLResponseDecoderTests: XCTestCase {
                 ["message": "message2"]
             ]
         ]
-        let data = try GraphQLResponseDecoderTests.encoder.encode(graphQLData)
+        let data = try encoder.encode(graphQLData)
         decoder.appendResponse(data)
 
         let result = try decoder.decodeToGraphQLResponse()

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginIntegrationTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginIntegrationTests.swift
@@ -32,7 +32,7 @@ class AWSPinpointAnalyticsPluginIntergrationTests: XCTestCase {
     }
 
     override func tearDown() {
-        Amplify.reset()
+        await Amplify.reset()
     }
 
     func testIdentifyUser() {

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginIntegrationTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginIntegrationTests.swift
@@ -31,7 +31,7 @@ class AWSPinpointAnalyticsPluginIntergrationTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         await Amplify.reset()
     }
 

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginTestBase.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginTestBase.swift
@@ -30,7 +30,7 @@ class AWSPinpointAnalyticsPluginTestBase: XCTestCase {
         return plugin
     }
 
-    override func setUp() {
+    override func setUp() async throws {
         analyticsPlugin = AWSPinpointAnalyticsPlugin()
 
         mockPinpoint = MockAWSPinpoint()
@@ -54,7 +54,7 @@ class AWSPinpointAnalyticsPluginTestBase: XCTestCase {
         }
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         await Amplify.reset()
         analyticsPlugin.reset {}
     }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginTestBase.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginTestBase.swift
@@ -45,7 +45,7 @@ class AWSPinpointAnalyticsPluginTestBase: XCTestCase {
                                   autoFlushEventsTimer: nil,
                                   appSessionTracker: appSessionTracker)
 
-        Amplify.reset()
+        await Amplify.reset()
         let config = AmplifyConfiguration()
         do {
             try Amplify.configure(config)
@@ -55,7 +55,7 @@ class AWSPinpointAnalyticsPluginTestBase: XCTestCase {
     }
 
     override func tearDown() {
-        Amplify.reset()
+        await Amplify.reset()
         analyticsPlugin.reset {}
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
@@ -11,8 +11,8 @@ import XCTest
 
 class AWSCognitoAuthPluginConfigTests: XCTestCase {
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     /// Test Auth configuration with invalid config for auth

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/EscapeHatchTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/EscapeHatchTests.swift
@@ -11,8 +11,8 @@ import XCTest
 
 class EscapeHatchTests: XCTestCase {
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     /// Test escape hatch with valid config for user pool and identity pool

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/HubEventTests/AuthHubEventHandlerTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/HubEventTests/AuthHubEventHandlerTests.swift
@@ -17,8 +17,8 @@ class AuthHubEventHandlerTests: XCTestCase {
         authHandler = AuthHubEventHandler()
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
         authHandler = nil
     }
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/AWSAuthConfirmSignUpOperationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/AWSAuthConfirmSignUpOperationTests.swift
@@ -30,9 +30,9 @@ class AWSAuthConfirmSignUpOperationTests: XCTestCase {
         queue = OperationQueue()
         queue?.maxConcurrentOperationCount = 1
     }
-    override func tearDown() {
-        super.tearDown()
-        Amplify.reset()
+    override func tearDown() async throws {
+        try await super.tearDown()
+        await Amplify.reset()
         sleep(2)
     }
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/AWSAuthSignInOperationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/AWSAuthSignInOperationTests.swift
@@ -25,9 +25,9 @@ class AWSAuthSignInOperationTests: XCTestCase {
         queue?.maxConcurrentOperationCount = 1
     }
 
-    override func tearDown() {
-        super.tearDown()
-        Amplify.reset()
+    override func tearDown() async throws {
+        try await super.tearDown()
+        await Amplify.reset()
         sleep(2)
     }
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/AWSAuthSignUpOperationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/AWSAuthSignUpOperationTests.swift
@@ -24,9 +24,9 @@ class AWSAuthSignUpOperationTests: XCTestCase {
         queue = OperationQueue()
         queue?.maxConcurrentOperationCount = 1
     }
-    override func tearDown() {
-        super.tearDown()
-        Amplify.reset()
+    override func tearDown() async throws {
+        try await super.tearDown()
+        await Amplify.reset()
         sleep(2)
     }
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/UserBehaviourTests/BaseUserBehaviorTest.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/UserBehaviourTests/BaseUserBehaviorTest.swift
@@ -73,8 +73,8 @@ class BaseUserBehaviorTest: XCTestCase {
             hubEventHandler: MockAuthHubEventBehavior())
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         plugin = nil
-        Amplify.reset()
+        await Amplify.reset()
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AuthEventTests/AuthEventIntegrationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AuthEventTests/AuthEventIntegrationTests.swift
@@ -19,8 +19,8 @@ class AuthEventIntegrationTests: AWSAuthBaseTest {
         AuthSessionHelper.clearSession()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
         await Amplify.reset()
         AuthSessionHelper.clearSession()
         sleep(2)

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AuthEventTests/AuthEventIntegrationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AuthEventTests/AuthEventIntegrationTests.swift
@@ -21,7 +21,7 @@ class AuthEventIntegrationTests: AWSAuthBaseTest {
 
     override func tearDown() {
         super.tearDown()
-        Amplify.reset()
+        await Amplify.reset()
         AuthSessionHelper.clearSession()
         sleep(2)
     }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AuthUserAttributesTests/AuthUserAttributesTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AuthUserAttributesTests/AuthUserAttributesTests.swift
@@ -20,7 +20,7 @@ class AuthUserAttributesTests: AWSAuthBaseTest {
     override func tearDown() {
         super.tearDown()
         AuthSessionHelper.clearSession()
-        Amplify.reset()
+        await Amplify.reset()
     }
 
     /// Test fetching the user's email attribute.

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AuthUserAttributesTests/AuthUserAttributesTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AuthUserAttributesTests/AuthUserAttributesTests.swift
@@ -17,8 +17,8 @@ class AuthUserAttributesTests: AWSAuthBaseTest {
         AuthSessionHelper.clearSession()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
         AuthSessionHelper.clearSession()
         await Amplify.reset()
     }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SessionTests/SignedInAuthSessionTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SessionTests/SignedInAuthSessionTests.swift
@@ -18,8 +18,8 @@ class SignedInAuthSessionTests: AWSAuthBaseTest {
         AuthSessionHelper.clearSession()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
         AuthSessionHelper.clearSession()
         await Amplify.reset()
     }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SessionTests/SignedInAuthSessionTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SessionTests/SignedInAuthSessionTests.swift
@@ -21,7 +21,7 @@ class SignedInAuthSessionTests: AWSAuthBaseTest {
     override func tearDown() {
         super.tearDown()
         AuthSessionHelper.clearSession()
-        Amplify.reset()
+        await Amplify.reset()
     }
 
     /// Test if successful session is retreived after a user signin

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SessionTests/SignedOutAuthSessionTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SessionTests/SignedOutAuthSessionTests.swift
@@ -18,8 +18,8 @@ class SignedOutAuthSessionTests: AWSAuthBaseTest {
         AuthSessionHelper.clearSession()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
         AuthSessionHelper.clearSession()
         await Amplify.reset()
     }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SessionTests/SignedOutAuthSessionTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SessionTests/SignedOutAuthSessionTests.swift
@@ -21,7 +21,7 @@ class SignedOutAuthSessionTests: AWSAuthBaseTest {
     override func tearDown() {
         super.tearDown()
         AuthSessionHelper.clearSession()
-        Amplify.reset()
+        await Amplify.reset()
     }
 
     /// Test if we can fetch auth session in signedOut state

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignInTests/AuthSRPSignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignInTests/AuthSRPSignInTests.swift
@@ -17,8 +17,8 @@ class AuthSRPSignInTests: AWSAuthBaseTest {
         AuthSessionHelper.clearSession()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
         await Amplify.reset()
         AuthSessionHelper.clearSession()
         sleep(2)

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignInTests/AuthSRPSignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignInTests/AuthSRPSignInTests.swift
@@ -19,7 +19,7 @@ class AuthSRPSignInTests: AWSAuthBaseTest {
 
     override func tearDown() {
         super.tearDown()
-        Amplify.reset()
+        await Amplify.reset()
         AuthSessionHelper.clearSession()
         sleep(2)
     }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignOutTests/AuthSignOutTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignOutTests/AuthSignOutTests.swift
@@ -26,7 +26,7 @@ class AuthSignOutTests: AWSAuthBaseTest {
 
     override func tearDown() {
         super.tearDown()
-        Amplify.reset()
+        await Amplify.reset()
         AuthSessionHelper.clearSession()
         sleep(2)
     }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignOutTests/AuthSignOutTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignOutTests/AuthSignOutTests.swift
@@ -24,8 +24,8 @@ class AuthSignOutTests: AWSAuthBaseTest {
         }
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
         await Amplify.reset()
         AuthSessionHelper.clearSession()
         sleep(2)

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignUpTests/AuthConfirmSignUpTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignUpTests/AuthConfirmSignUpTests.swift
@@ -19,7 +19,7 @@ class AuthConfirmSignUpTests: AWSAuthBaseTest {
 
     override func tearDown() {
         super.tearDown()
-        Amplify.reset()
+        await Amplify.reset()
         sleep(2)
     }
 

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignUpTests/AuthConfirmSignUpTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignUpTests/AuthConfirmSignUpTests.swift
@@ -17,8 +17,8 @@ class AuthConfirmSignUpTests: AWSAuthBaseTest {
         Amplify.Auth.signOut { _ in }
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
         await Amplify.reset()
         sleep(2)
     }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignUpTests/AuthResendSignUpCodeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignUpTests/AuthResendSignUpCodeTests.swift
@@ -18,7 +18,7 @@ class AuthResendSignUpCodeTests: AWSAuthBaseTest {
 //
 //    override func tearDown() {
 //        super.tearDown()
-//        Amplify.reset()
+//        await Amplify.reset()
 //        sleep(2)
 //    }
 //

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignUpTests/AuthSignUpTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignUpTests/AuthSignUpTests.swift
@@ -19,7 +19,7 @@ class AuthSignUpTests: AWSAuthBaseTest {
 
     override func tearDown() {
         super.tearDown()
-        Amplify.reset()
+        await Amplify.reset()
         sleep(2)
     }
 

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignUpTests/AuthSignUpTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignUpTests/AuthSignUpTests.swift
@@ -17,8 +17,8 @@ class AuthSignUpTests: AWSAuthBaseTest {
         Amplify.Auth.signOut { _ in }
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
         await Amplify.reset()
         sleep(2)
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/Common/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginAuthIntegrationTests/Common/AWSDataStoreAuthBaseTest.swift
@@ -30,7 +30,7 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
         clearDataStore()
         requests = []
         signOut()
-        Amplify.reset()
+        await Amplify.reset()
     }
 
     // MARK: - Test Helpers

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginFlutterIntegrationTests/TestSupport/SyncEngineFlutterIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginFlutterIntegrationTests/TestSupport/SyncEngineFlutterIntegrationTestBase.swift
@@ -33,7 +33,7 @@ class SyncEngineFlutterIntegrationTestBase: XCTestCase {
         super.setUp()
         continueAfterFailure = false
 
-        Amplify.reset()
+        await Amplify.reset()
         Amplify.Logging.logLevel = .verbose
 
         do {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario1Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario1Tests.swift
@@ -40,8 +40,8 @@ class DataStoreConnectionScenario1Tests: SyncEngineIntegrationTestBase {
         let version: String = "1"
     }
 
-    func testSaveTeamAndProjectSyncToCloud() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveTeamAndProjectSyncToCloud() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let team = Team1(name: "name1")
         let project = Project1(team: team)
@@ -107,8 +107,8 @@ class DataStoreConnectionScenario1Tests: SyncEngineIntegrationTestBase {
         wait(for: [queriedProjectCompleted], timeout: networkTimeout)
     }
 
-    func testUpdateProjectWithAnotherTeam() throws {
-        setUp(withModels: TestModelRegistration())
+    func testUpdateProjectWithAnotherTeam() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let team = Team1(name: "name1")
         let anotherTeam = Team1(name: "name1")
@@ -194,8 +194,8 @@ class DataStoreConnectionScenario1Tests: SyncEngineIntegrationTestBase {
         wait(for: [queriedProjectCompleted, syncUpdatedProjectReceived], timeout: networkTimeout)
     }
 
-    func testDeleteAndGetProjectReturnsNilWithSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteAndGetProjectReturnsNilWithSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name"),
               let project = saveProject(teamID: team.id, team: team) else {
@@ -275,8 +275,8 @@ class DataStoreConnectionScenario1Tests: SyncEngineIntegrationTestBase {
         wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteWithValidCondition() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteWithValidCondition() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name"),
               let project = saveProject(teamID: team.id, team: team) else {
@@ -307,8 +307,8 @@ class DataStoreConnectionScenario1Tests: SyncEngineIntegrationTestBase {
         wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteWithInvalidCondition() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteWithInvalidCondition() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name"),
               let project = saveProject(teamID: team.id, team: team) else {
@@ -343,8 +343,8 @@ class DataStoreConnectionScenario1Tests: SyncEngineIntegrationTestBase {
         wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testListProjectsByTeamID() throws {
-        setUp(withModels: TestModelRegistration())
+    func testListProjectsByTeamID() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name") else {
             XCTFail("Could not save team")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario2Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario2Tests.swift
@@ -41,8 +41,8 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
         let version: String = "1"
     }
 
-    func testSaveTeamAndProjectSyncToCloud() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveTeamAndProjectSyncToCloud() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let team = Team2(name: "name1")
         let project = Project2(teamID: team.id, team: team)
@@ -104,8 +104,8 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
         wait(for: [queriedProjectCompleted], timeout: networkTimeout)
     }
 
-    func testUpdateProjectWithAnotherTeam() throws {
-        setUp(withModels: TestModelRegistration())
+    func testUpdateProjectWithAnotherTeam() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let team = Team2(name: "name1")
         let anotherTeam = Team2(name: "name1")
@@ -192,8 +192,8 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
         wait(for: [queriedProjectCompleted, syncUpdatedProjectReceived], timeout: networkTimeout)
     }
 
-    func testDeleteAndGetProjectReturnsNilWithSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteAndGetProjectReturnsNilWithSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name"),
               let project = saveProject(teamID: team.id, team: team) else {
@@ -273,8 +273,8 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
         wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteWithValidCondition() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteWithValidCondition() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name"),
               let project = saveProject(teamID: team.id, team: team) else {
@@ -305,8 +305,8 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
         wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteWithInvalidCondition() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteWithInvalidCondition() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name"),
               let project = saveProject(teamID: team.id, team: team) else {
@@ -341,8 +341,8 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
         wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteAlreadyDeletedItemWithCondition() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteAlreadyDeletedItemWithCondition() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name"),
               let project = saveProject(teamID: team.id, team: team) else {
@@ -383,8 +383,8 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
         wait(for: [deleteProjectSuccessful2], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testListProjectsByTeamID() throws {
-        setUp(withModels: TestModelRegistration())
+    func testListProjectsByTeamID() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name") else {
             XCTFail("Could not save team")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario3Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario3Tests.swift
@@ -41,8 +41,8 @@ class DataStoreConnectionScenario3Tests: SyncEngineIntegrationTestBase {
         let version: String = "1"
     }
 
-    func testSavePostAndCommentSyncToCloud() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSavePostAndCommentSyncToCloud() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let post = Post3(title: "title")
         let comment = Comment3(postID: post.id, content: "content")
@@ -100,8 +100,8 @@ class DataStoreConnectionScenario3Tests: SyncEngineIntegrationTestBase {
         wait(for: [queriedCommentCompleted], timeout: networkTimeout)
     }
 
-    func testSaveCommentAndGetPostWithComments() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveCommentAndGetPostWithComments() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {
@@ -144,8 +144,8 @@ class DataStoreConnectionScenario3Tests: SyncEngineIntegrationTestBase {
         wait(for: [getPostCompleted, getCommentsCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testUpdateComment() throws {
-        setUp(withModels: TestModelRegistration())
+    func testUpdateComment() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {
@@ -174,8 +174,8 @@ class DataStoreConnectionScenario3Tests: SyncEngineIntegrationTestBase {
         wait(for: [updateCommentSuccessful], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteAndGetComment() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteAndGetComment() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -211,8 +211,8 @@ class DataStoreConnectionScenario3Tests: SyncEngineIntegrationTestBase {
         wait(for: [getCommentAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testListCommentsByPostID() throws {
-        setUp(withModels: TestModelRegistration())
+    func testListCommentsByPostID() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario4Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario4Tests.swift
@@ -42,8 +42,8 @@ class DataStoreConnectionScenario4Tests: SyncEngineIntegrationTestBase {
         let version: String = "1"
     }
 
-    func testCreateCommentAndGetCommentWithPost() throws {
-        setUp(withModels: TestModelRegistration())
+    func testCreateCommentAndGetCommentWithPost() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -73,14 +73,14 @@ class DataStoreConnectionScenario4Tests: SyncEngineIntegrationTestBase {
         wait(for: [getCommentCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testCreateCommentAndGetPostWithComments() throws {
-        setUp(withModels: TestModelRegistration())
+    func testCreateCommentAndGetPostWithComments() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
             return
         }
-        guard let comment = saveComment(content: "content", post: post) else {
+        guard saveComment(content: "content", post: post) != nil else {
             XCTFail("Could not create comment")
             return
         }
@@ -116,8 +116,8 @@ class DataStoreConnectionScenario4Tests: SyncEngineIntegrationTestBase {
         wait(for: [getPostCompleted, getCommentsCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testUpdateComment() throws {
-        setUp(withModels: TestModelRegistration())
+    func testUpdateComment() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -145,8 +145,8 @@ class DataStoreConnectionScenario4Tests: SyncEngineIntegrationTestBase {
         wait(for: [updateCommentSuccessful], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteAndGetComment() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteAndGetComment() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -183,8 +183,8 @@ class DataStoreConnectionScenario4Tests: SyncEngineIntegrationTestBase {
         wait(for: [getCommentAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testListCommentsByPostID() throws {
-        setUp(withModels: TestModelRegistration())
+    func testListCommentsByPostID() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario5Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario5Tests.swift
@@ -101,7 +101,7 @@ class DataStoreConnectionScenario5Tests: SyncEngineIntegrationTestBase {
         let predicateByUserId = PostEditor5.keys.editor.eq(user.id)
         Amplify.DataStore.query(PostEditor5.self, where: predicateByUserId) { result in
             switch result {
-            case .success(_):
+            case .success(let projects):
                 listPostEditorByEditorIdCompleted.fulfill()
             case .failure(let error):
                 XCTFail("\(error)")
@@ -121,7 +121,7 @@ class DataStoreConnectionScenario5Tests: SyncEngineIntegrationTestBase {
             XCTFail("Could not create user")
             return
         }
-        guard savePostEditor(post: post, editor: user) != nil else {
+        guard let postEditor = savePostEditor(post: post, editor: user) else {
             XCTFail("Could not create user")
             return
         }
@@ -168,7 +168,7 @@ class DataStoreConnectionScenario5Tests: SyncEngineIntegrationTestBase {
             XCTFail("Could not create user")
             return
         }
-        guard savePostEditor(post: post, editor: user) != nil else {
+        guard let postEditor = savePostEditor(post: post, editor: user) else {
             XCTFail("Could not create user")
             return
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario5Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario5Tests.swift
@@ -54,8 +54,8 @@ class DataStoreConnectionScenario5Tests: SyncEngineIntegrationTestBase {
         let version: String = "1"
     }
 
-    func testListPostEditorByPost() throws {
-        setUp(withModels: TestModelRegistration())
+    func testListPostEditorByPost() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -82,8 +82,8 @@ class DataStoreConnectionScenario5Tests: SyncEngineIntegrationTestBase {
         wait(for: [listPostEditorByPostIDCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testListPostEditorByUser() throws {
-        setUp(withModels: TestModelRegistration())
+    func testListPostEditorByUser() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -101,7 +101,7 @@ class DataStoreConnectionScenario5Tests: SyncEngineIntegrationTestBase {
         let predicateByUserId = PostEditor5.keys.editor.eq(user.id)
         Amplify.DataStore.query(PostEditor5.self, where: predicateByUserId) { result in
             switch result {
-            case .success(let projects):
+            case .success(_):
                 listPostEditorByEditorIdCompleted.fulfill()
             case .failure(let error):
                 XCTFail("\(error)")
@@ -110,8 +110,8 @@ class DataStoreConnectionScenario5Tests: SyncEngineIntegrationTestBase {
         wait(for: [listPostEditorByEditorIdCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testGetPostThenLoadPostEditors() throws {
-        setUp(withModels: TestModelRegistration())
+    func testGetPostThenLoadPostEditors() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -121,7 +121,7 @@ class DataStoreConnectionScenario5Tests: SyncEngineIntegrationTestBase {
             XCTFail("Could not create user")
             return
         }
-        guard let postEditor = savePostEditor(post: post, editor: user) else {
+        guard savePostEditor(post: post, editor: user) != nil else {
             XCTFail("Could not create user")
             return
         }
@@ -157,8 +157,8 @@ class DataStoreConnectionScenario5Tests: SyncEngineIntegrationTestBase {
         wait(for: [getPostCompleted, getPostEditorsCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testGetUserThenLoadPostEditors() throws {
-        setUp(withModels: TestModelRegistration())
+    func testGetUserThenLoadPostEditors() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -168,7 +168,7 @@ class DataStoreConnectionScenario5Tests: SyncEngineIntegrationTestBase {
             XCTFail("Could not create user")
             return
         }
-        guard let postEditor = savePostEditor(post: post, editor: user) else {
+        guard savePostEditor(post: post, editor: user) != nil else {
             XCTFail("Could not create user")
             return
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario6Tests.swift
@@ -50,12 +50,12 @@ class DataStoreConnectionScenario6Tests: SyncEngineIntegrationTestBase {
         let version: String = "1"
     }
 
-    func testGetBlogThenFetchPostsThenFetchComments() throws {
-        setUp(withModels: TestModelRegistration())
+    func testGetBlogThenFetchPostsThenFetchComments() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post1 = savePost(title: "title", blog: blog),
-              let post2 = savePost(title: "title", blog: blog),
+              let _ = savePost(title: "title", blog: blog),
               let comment1post1 = saveComment(post: post1, content: "content"),
               let comment2post1 = saveComment(post: post1, content: "content") else {
             XCTFail("Could not create blog, posts, and comments")
@@ -100,8 +100,8 @@ class DataStoreConnectionScenario6Tests: SyncEngineIntegrationTestBase {
         }
     }
 
-    func testGetCommentThenFetchPostThenFetchBlog() throws {
-        setUp(withModels: TestModelRegistration())
+    func testGetCommentThenFetchPostThenFetchBlog() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post = savePost(title: "title", blog: blog),
@@ -150,8 +150,8 @@ class DataStoreConnectionScenario6Tests: SyncEngineIntegrationTestBase {
         XCTAssertEqual(fetchedBlog.name, blog.name)
     }
 
-    func testGetPostThenFetchBlogAndComment() throws {
-        setUp(withModels: TestModelRegistration())
+    func testGetPostThenFetchBlogAndComment() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post = savePost(title: "title", blog: blog),
@@ -215,8 +215,8 @@ class DataStoreConnectionScenario6Tests: SyncEngineIntegrationTestBase {
         }
     }
 
-    func testDeleteAll() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteAll() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForReady()
         var cancellables = Set<AnyCancellable>()
         let remoteEventReceived = expectation(description: "received mutation event with version 1")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/Connection/DataStoreConnectionScenario6Tests.swift
@@ -55,7 +55,7 @@ class DataStoreConnectionScenario6Tests: SyncEngineIntegrationTestBase {
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post1 = savePost(title: "title", blog: blog),
-              let _ = savePost(title: "title", blog: blog),
+              let post2 = savePost(title: "title", blog: blog),
               let comment1post1 = saveComment(post: post1, content: "content"),
               let comment2post1 = saveComment(post: post1, content: "content") else {
             XCTFail("Could not create blog, posts, and comments")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreConfigurationTests.swift
@@ -15,15 +15,15 @@ import AWSPluginsCore
 
 class DataStoreConfigurationTests: XCTestCase {
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
     }
 
     override func tearDown() {
         Amplify.DataStore.clear(completion: { _ in })
     }
 
-    func testConfigureWithSameSchemaDoesNotDeleteDatabase() throws {
+    func testConfigureWithSameSchemaDoesNotDeleteDatabase() async throws {
 
         let previousVersion = "previousVersion"
         let saveSuccess = expectation(description: "Save was successful")
@@ -49,7 +49,7 @@ class DataStoreConfigurationTests: XCTestCase {
 
         wait(for: [saveSuccess], timeout: TestCommonConstants.networkTimeout)
 
-        Amplify.reset()
+        await Amplify.reset()
 
         let querySuccess = expectation(description: "query was successful")
 
@@ -82,7 +82,7 @@ class DataStoreConfigurationTests: XCTestCase {
         wait(for: [querySuccess], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testConfigureWithDifferentSchemaClearsDatabase() throws {
+    func testConfigureWithDifferentSchemaClearsDatabase() async throws {
 
         let prevoisVersion = "previousVersion"
         let saveSuccess = expectation(description: "Save was successful")
@@ -108,7 +108,7 @@ class DataStoreConfigurationTests: XCTestCase {
 
         wait(for: [saveSuccess], timeout: TestCommonConstants.networkTimeout)
 
-        Amplify.reset()
+        await Amplify.reset()
 
         let querySuccess = expectation(description: "query was successful")
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreConsecutiveUpdatesTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreConsecutiveUpdatesTests.swift
@@ -28,8 +28,8 @@ class DataStoreConsecutiveUpdatesTests: SyncEngineIntegrationTestBase {
     /// - Given: API has been setup with `Post` model registered
     /// - When: A Post is saved and then immediately updated
     /// - Then: The post should be updated with new fields immediately and in the eventual consistent state
-    func testSaveAndImmediatelyUpdate() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveAndImmediatelyUpdate() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         let newPost = Post(title: "MyPost",
@@ -144,8 +144,8 @@ class DataStoreConsecutiveUpdatesTests: SyncEngineIntegrationTestBase {
     /// - Given: API has been setup with `Post` model registered
     /// - When: A Post is saved and deleted immediately
     /// - Then: The Post should not be returned when queried for immediately and in the eventual consistent state
-    func testSaveAndImmediatelyDelete() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveAndImmediatelyDelete() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         let newPost = Post(title: "MyPost",
@@ -249,8 +249,8 @@ class DataStoreConsecutiveUpdatesTests: SyncEngineIntegrationTestBase {
     /// - Given: API has been setup with `Post` model registered
     /// - When: A Post is saved with sync complete, updated and deleted immediately
     /// - Then: The Post should not be returned when queried for
-    func testSaveThenUpdateAndImmediatelyDelete() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveThenUpdateAndImmediatelyDelete() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         let newPost = Post(title: "MyPost",
@@ -382,8 +382,8 @@ class DataStoreConsecutiveUpdatesTests: SyncEngineIntegrationTestBase {
     /// - Given: API has been setup with `Post` model registered
     /// - When: A Post is saved with sync complete, then it is updated 10 times
     /// - Then: The Post should be updated with new fields
-    func testSaveThenMultipleUpdate() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveThenMultipleUpdate() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         let newPost = Post(title: "MyPost",

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreCustomPrimaryKeyTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreCustomPrimaryKeyTests.swift
@@ -30,8 +30,8 @@ class DataStoreCustomPrimaryKeyTests: SyncEngineIntegrationTestBase {
     ///     - deleted
     ///     - queried
     /// - Then: The model should be deleted finally and the sync events should be received in order
-    func testDeleteModelWithCustomPrimaryKey() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteModelWithCustomPrimaryKey() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let customerOrder = CustomerOrder(orderId: UUID().uuidString, email: "test@abc.com")
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -25,8 +25,8 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
         let version: String = "1"
     }
 
-    func testCreate() throws {
-        setUp(withModels: TestModelRegistration())
+    func testCreate() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         var cancellables = Set<AnyCancellable>()
         let date = Temporal.DateTime.now()
@@ -108,8 +108,8 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
                    remoteEventReceived], timeout: 10.0)
     }
 
-    func testCreateMutateDelete() throws {
-        setUp(withModels: TestModelRegistration())
+    func testCreateMutateDelete() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         let date = Temporal.DateTime.now()
@@ -185,8 +185,8 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
     ///    - attempt to update the existing post with a condition that matches existing data
     /// - Then:
     ///    - the update with condition that matches existing data will be applied and returned.
-    func testCreateThenMutateWithCondition() throws {
-        setUp(withModels: TestModelRegistration())
+    func testCreateThenMutateWithCondition() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         let post = Post.keys
@@ -254,8 +254,8 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
     /// - Then:
     ///    - the post is first only updated on local store is not sync to the remote
     ///    - the save with condition reaches the remote and fails with conditional save failed
-    func testCreateThenMutateWithConditionFailOnSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testCreateThenMutateWithConditionFailOnSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         let post = Post.keys
@@ -341,8 +341,8 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
     /// - Then:
     ///    - Saving a post should be successful
     ///
-    func testStopStart() throws {
-        setUp(withModels: TestModelRegistration())
+    func testStopStart() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let stopStartSuccess = expectation(description: "stop then start successful")
         Amplify.DataStore.stop { result in
@@ -372,8 +372,8 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
     ///   - I call DataStore.query()
     /// - Then:
     ///   - DataStore is automatically started
-    func testQueryImplicitlyStarts() throws {
-        setUp(withModels: TestModelRegistration())
+    func testQueryImplicitlyStarts() async throws {
+        await setUp(withModels: TestModelRegistration())
         let dataStoreStarted = expectation(description: "dataStoreStarted")
         let sink = Amplify
             .Hub
@@ -400,8 +400,8 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
     /// - Then:
     ///    - Saving a post should be successful
     ///
-    func testClearStart() throws {
-        setUp(withModels: TestModelRegistration())
+    func testClearStart() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let clearStartSuccess = expectation(description: "clear then start successful")
         Amplify.DataStore.clear { result in
@@ -434,8 +434,8 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
     ///    - Clean up: Concurrently perform Delete's
     ///    - Ensure the expected mutation event with version 2 (synced from cloud) is received
     ///
-    func testConcurrentSave() throws {
-        setUp(withModels: TestModelRegistration())
+    func testConcurrentSave() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         var posts = [Post]()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -477,15 +477,17 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
                 }
             }
         }
+        
+        let capturedPosts = posts
 
         DispatchQueue.concurrentPerform(iterations: count) { index in
-            _ = Amplify.DataStore.save(posts[index])
+            _ = Amplify.DataStore.save(capturedPosts[index])
         }
 
         wait(for: [postsSyncedToCloud], timeout: 100)
 
         DispatchQueue.concurrentPerform(iterations: count) { index in
-            _ = Amplify.DataStore.delete(posts[index])
+            _ = Amplify.DataStore.delete(capturedPosts[index])
         }
         wait(for: [postsDeletedFromCloud], timeout: 100)
         sink.cancel()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreObserveQueryTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreObserveQueryTests.swift
@@ -35,8 +35,8 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     ///    - The first snapshot should have `isSynced` false
     ///    - Eventually one of the query snapshots will be returned with `isSynced` true
     ///
-    func testObserveQueryInitialSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testObserveQueryInitialSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplify()
         clearDataStore()
         var snapshots = [DataStoreQuerySnapshot<Post>]()
@@ -72,8 +72,8 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     /// - Then:
     ///    - The models only contain models based on the predicate
     ///
-    func testInitialSyncWithPredicate() throws {
-        setUp(withModels: TestModelRegistration(), logLevel: .info)
+    func testInitialSyncWithPredicate() async throws {
+        await setUp(withModels: TestModelRegistration(), logLevel: .info)
         try startAmplify()
         savePostAndWaitForSync(Post(title: "xyz 1", content: "content", createdAt: .now()))
         savePostAndWaitForSync(Post(title: "xyz 2", content: "content", createdAt: .now()))
@@ -119,8 +119,8 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     /// - Then:
     ///    - Each snapshot should have items sorted according to the sort order
     ///
-    func testObserveQueryWithSort() throws {
-        setUp(withModels: TestModelRegistration())
+    func testObserveQueryWithSort() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplify()
         clearDataStore()
         let post1 = Post(title: "title", content: "content", createdAt: .now())
@@ -164,8 +164,8 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     ///    - The first snapshot should have the old data and `isSynced` false
     ///    - The final snapshot should have all the models with `isSynced` true
     ///
-    func testObserveQueryWithDataStoreDeltaSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testObserveQueryWithDataStoreDeltaSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForReady()
         savePostAndWaitForSync(Post(title: "title", content: "content", createdAt: .now()))
         let numberOfPosts = queryNumberOfPosts()
@@ -209,8 +209,8 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     ///         Model is added to the snapshot
     ///     - Delete a model that matches the predicate. Model is removed from the snapshot
     ///     - Delete a model that does NOT match the predicate. No snapshot is emitted
-    func testPredicateWithCreateUpdateDelete() throws {
-        setUp(withModels: TestModelRegistration(), logLevel: .info)
+    func testPredicateWithCreateUpdateDelete() async throws {
+        await setUp(withModels: TestModelRegistration(), logLevel: .info)
         try startAmplify()
 
         let testId = UUID().uuidString
@@ -303,8 +303,8 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     ///      The snasphot sould have the models in the correct sorted order
     ///    - Delete models. The snapshot should have the models removed
     ///
-    func testSortWithCreateUpdateDelete() throws {
-        setUp(withModels: TestModelRegistration(), logLevel: .info)
+    func testSortWithCreateUpdateDelete() async throws {
+        await setUp(withModels: TestModelRegistration(), logLevel: .info)
         try startAmplify()
 
         let testId = UUID().uuidString
@@ -402,8 +402,8 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     /// - Then:
     ///    -  ObserveQuery is not completed.
     ///
-    func testObserveQueryShouldResetOnDataStoreStop() throws {
-        setUp(withModels: TestModelRegistration())
+    func testObserveQueryShouldResetOnDataStoreStop() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForReady()
         let firstSnapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
         let observeQueryReceivedCompleted = expectation(description: "observeQuery received completed")
@@ -442,8 +442,8 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     /// - Then:
     ///    -  ObserveQuery is not completed.
     ///
-    func testObserveQueryShouldResetOnDataStoreClear() throws {
-        setUp(withModels: TestModelRegistration())
+    func testObserveQueryShouldResetOnDataStoreClear() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForReady()
         let firstSnapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
         let observeQueryReceivedCompleted = expectation(description: "observeQuery received completed")
@@ -474,8 +474,8 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         sink.cancel()
     }
 
-    func testObserveQueryShouldStartOnDataStoreStart() throws {
-        setUp(withModels: TestModelRegistration())
+    func testObserveQueryShouldStartOnDataStoreStart() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForReady()
         let firstSnapshot = expectation(description: "first query snapshot")
         let secondSnapshot = expectation(description: "second query snapshot")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreScalarTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreScalarTests.swift
@@ -25,8 +25,8 @@ class DataStoreScalarTests: SyncEngineIntegrationTestBase {
         let version: String = "1"
     }
 
-    func testScalarContainer() throws {
-        setUp(withModels: TestModelRegistration())
+    func testScalarContainer() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let container = ScalarContainer(myString: "myString",
                                         myInt: 1,
@@ -71,8 +71,8 @@ class DataStoreScalarTests: SyncEngineIntegrationTestBase {
         XCTAssertNil(emptyModel)
     }
 
-    func testListIntContainer() throws {
-        setUp(withModels: TestModelRegistration())
+    func testListIntContainer() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let container = ListIntContainer(
             test: 1,
@@ -118,8 +118,8 @@ class DataStoreScalarTests: SyncEngineIntegrationTestBase {
         XCTAssertNil(emptyModel)
     }
 
-    func testListStringContainer() throws {
-        setUp(withModels: TestModelRegistration())
+    func testListStringContainer() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let container = ListStringContainer(
             test: "test",
@@ -165,8 +165,8 @@ class DataStoreScalarTests: SyncEngineIntegrationTestBase {
         XCTAssertNil(emptyModel)
     }
 
-    func testListContainerWithNil() throws {
-        setUp(withModels: TestModelRegistration())
+    func testListContainerWithNil() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let container = ListStringContainer(
             test: "test",
@@ -212,8 +212,8 @@ class DataStoreScalarTests: SyncEngineIntegrationTestBase {
         XCTAssertNil(emptyModel)
     }
 
-    func testEnumTestModel() throws {
-        setUp(withModels: TestModelRegistration())
+    func testEnumTestModel() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let container = EnumTestModel(enumVal: .valueOne,
                                       nullableEnumVal: .valueTwo,
@@ -257,8 +257,8 @@ class DataStoreScalarTests: SyncEngineIntegrationTestBase {
         XCTAssertNil(emptyModel)
     }
 
-    func testNestedEnumTestModel() throws {
-        setUp(withModels: TestModelRegistration())
+    func testNestedEnumTestModel() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let container = NestedTypeTestModel(nestedVal: .init(valueOne: 1),
                                             nullableNestedVal: .init(),

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/SubscriptionEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/SubscriptionEndToEndTests.swift
@@ -29,8 +29,8 @@ class SubscriptionEndToEndTests: SyncEngineIntegrationTestBase {
     ///    - I start Amplify
     /// - Then:
     ///    - I receive subscriptions from other systems for syncable models
-    func testSubscribeReceivesCreateMutateDelete() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSubscribeReceivesCreateMutateDelete() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         // Filter all events to ensure they have this ID. This prevents us from overfulfilling on

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
@@ -57,11 +57,11 @@ class HubEventsIntegrationTestBase: XCTestCase {
         }
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         sleep(1)
         print("Amplify reset")
         storageAdapter.delete(untypedModelType: ModelSyncMetadata.self, withId: "Post") { _ in }
         storageAdapter.delete(untypedModelType: ModelSyncMetadata.self, withId: "Comment") { _ in }
-        Amplify.reset()
+        await Amplify.reset()
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/LocalStoreIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/LocalStoreIntegrationTestBase.swift
@@ -26,13 +26,13 @@ class LocalStoreIntegrationTestBase: XCTestCase {
         }
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         let semaphore = DispatchSemaphore(value: 0)
         Amplify.DataStore.clear { _ in
             semaphore.signal()
         }
         semaphore.wait()
-        Amplify.reset()
+        await Amplify.reset()
     }
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
@@ -32,11 +32,11 @@ class SyncEngineIntegrationTestBase: DataStoreTestBase {
     // swiftlint:enable force_try
     // swiftlint:enable force_cast
 
-    func setUp(withModels models: AmplifyModelRegistration, logLevel: LogLevel = .error) {
+    func setUp(withModels models: AmplifyModelRegistration, logLevel: LogLevel = .error) async {
 
         continueAfterFailure = false
 
-        Amplify.reset()
+        await Amplify.reset()
         sleep(2)
         Amplify.Logging.logLevel = logLevel
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/SyncEngineIntegrationV2TestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/SyncEngineIntegrationV2TestBase.swift
@@ -31,11 +31,11 @@ class SyncEngineIntegrationV2TestBase: DataStoreTestBase {
     // swiftlint:enable force_try
     // swiftlint:enable force_cast
 
-    func setUp(withModels models: AmplifyModelRegistration, logLevel: LogLevel = .error) {
+    func setUp(withModels models: AmplifyModelRegistration, logLevel: LogLevel = .error) async {
 
         continueAfterFailure = false
 
-        Amplify.reset()
+        await Amplify.reset()
         sleep(2)
         Amplify.Logging.logLevel = logLevel
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario1V2Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario1V2Tests.swift
@@ -39,8 +39,8 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         let version: String = "1"
     }
 
-    func testSaveTeamAndProjectSyncToCloud() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveTeamAndProjectSyncToCloud() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let team = Team1V2(name: "name1")
         // TODO: No need to add the `team` into the project, it is using explicit field `project1V2TeamId`
@@ -113,8 +113,8 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [queriedProjectCompleted], timeout: networkTimeout)
     }
 
-    func testUpdateProjectWithAnotherTeam() throws {
-        setUp(withModels: TestModelRegistration())
+    func testUpdateProjectWithAnotherTeam() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let team = Team1V2(name: "name1")
         let anotherTeam = Team1V2(name: "name1")
@@ -209,8 +209,8 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [queriedProjectCompleted, syncUpdatedProjectReceived], timeout: networkTimeout)
     }
 
-    func testCreateUpdateDeleteAndGetProjectReturnsNil() throws {
-        setUp(withModels: TestModelRegistration())
+    func testCreateUpdateDeleteAndGetProjectReturnsNil() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name"),
               var project = saveProject(project1V2TeamId: team.id) else {
@@ -282,8 +282,8 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteAndGetProjectReturnsNilWithSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteAndGetProjectReturnsNilWithSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name"),
               let project = saveProject(project1V2TeamId: team.id) else {
@@ -375,8 +375,8 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getTeamIsEmptySuccess], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteWithValidCondition() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteWithValidCondition() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name"),
               let project = saveProject(project1V2TeamId: team.id) else {
@@ -407,8 +407,8 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteWithInvalidCondition() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteWithInvalidCondition() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name"),
               let project = saveProject(project1V2TeamId: team.id) else {
@@ -443,8 +443,8 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testListProjectsByTeamID() throws {
-        setUp(withModels: TestModelRegistration())
+    func testListProjectsByTeamID() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name") else {
             XCTFail("Could not save team")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario2V2Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario2V2Tests.swift
@@ -41,8 +41,8 @@ class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
         let version: String = "1"
     }
 
-    func testSaveTeamAndProjectSyncToCloud() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveTeamAndProjectSyncToCloud() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let team = Team2V2(name: "name1")
         let project = Project2V2(teamID: team.id, team: team)
@@ -105,8 +105,8 @@ class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [queriedProjectCompleted], timeout: networkTimeout)
     }
 
-    func testUpdateProjectWithAnotherTeam() throws {
-        setUp(withModels: TestModelRegistration())
+    func testUpdateProjectWithAnotherTeam() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let team = Team2V2(name: "name1")
         let anotherTeam = Team2V2(name: "name1")
@@ -193,8 +193,8 @@ class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [queriedProjectCompleted, syncUpdatedProjectReceived], timeout: networkTimeout)
     }
 
-    func testCreateUpdateDeleteAndGetProjectReturnsNil() throws {
-        setUp(withModels: TestModelRegistration())
+    func testCreateUpdateDeleteAndGetProjectReturnsNil() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name"),
               var project = saveProject(teamID: team.id, team: team) else {
@@ -265,8 +265,8 @@ class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteAndGetProjectReturnsNilWithSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteAndGetProjectReturnsNilWithSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name"),
               let project = saveProject(teamID: team.id, team: team) else {
@@ -358,8 +358,8 @@ class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getTeamIsEmptySuccess], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteWithValidCondition() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteWithValidCondition() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name"),
               let project = saveProject(teamID: team.id, team: team) else {
@@ -390,8 +390,8 @@ class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteWithInvalidCondition() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteWithInvalidCondition() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name"),
               let project = saveProject(teamID: team.id, team: team) else {
@@ -426,8 +426,8 @@ class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteAlreadyDeletedItemWithCondition() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteAlreadyDeletedItemWithCondition() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name"),
               let project = saveProject(teamID: team.id, team: team) else {
@@ -468,8 +468,8 @@ class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [deleteProjectSuccessful2], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testListProjectsByTeamID() throws {
-        setUp(withModels: TestModelRegistration())
+    func testListProjectsByTeamID() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let team = saveTeam(name: "name") else {
             XCTFail("Could not save team")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario3V2Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario3V2Tests.swift
@@ -39,8 +39,8 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
         let version: String = "1"
     }
 
-    func testSavePostAndCommentSyncToCloud() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSavePostAndCommentSyncToCloud() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let post = Post3V2(title: "title")
         let comment = Comment3V2(postID: post.id, content: "content")
@@ -98,8 +98,8 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [queriedCommentCompleted], timeout: networkTimeout)
     }
 
-    func testSaveCommentAndGetPostWithComments() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveCommentAndGetPostWithComments() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {
@@ -142,8 +142,8 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getPostCompleted, getCommentsCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testUpdateComment() throws {
-        setUp(withModels: TestModelRegistration())
+    func testUpdateComment() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {
@@ -172,8 +172,8 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [updateCommentSuccessful], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteAndGetComment() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteAndGetComment() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -209,8 +209,8 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getCommentAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testListCommentsByPostID() throws {
-        setUp(withModels: TestModelRegistration())
+    func testListCommentsByPostID() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {
@@ -235,8 +235,8 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [listCommentByPostIDCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testSavePostWithSyncAndReadPost() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSavePostWithSyncAndReadPost() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {
@@ -275,8 +275,8 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [queriedPostCompleted], timeout: networkTimeout)
     }
 
-    func testUpdatePostWithSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testUpdatePostWithSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard var post = savePost(title: "title") else {
@@ -325,8 +325,8 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [updatePostCompleted, updateReceived], timeout: networkTimeout)
     }
 
-    func testDeletePostWithSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeletePostWithSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {
@@ -372,8 +372,8 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [deletePostSuccess, deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeletePostCascadeToComments() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeletePostCascadeToComments() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario3aV2Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario3aV2Tests.swift
@@ -38,8 +38,8 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
         let version: String = "1"
     }
 
-    func testSavePostAndCommentSyncToCloud() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSavePostAndCommentSyncToCloud() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         let post = Post3aV2(title: "title")
         let comment = Comment3aV2(content: "content", post3aV2CommentsId: post.id)
@@ -97,8 +97,8 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [queriedCommentCompleted], timeout: networkTimeout)
     }
 
-    func testSaveCommentAndGetPostWithComments() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveCommentAndGetPostWithComments() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {
@@ -141,8 +141,8 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getPostCompleted, getCommentsCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testUpdateComment() throws {
-        setUp(withModels: TestModelRegistration())
+    func testUpdateComment() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {
@@ -171,8 +171,8 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [updateCommentSuccessful], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteAndGetComment() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteAndGetComment() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -208,8 +208,8 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getCommentAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testListCommentsByPostID() throws {
-        setUp(withModels: TestModelRegistration())
+    func testListCommentsByPostID() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {
@@ -234,8 +234,8 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [listCommentByPostIDCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testSavePostWithSyncAndReadPost() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSavePostWithSyncAndReadPost() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {
@@ -274,8 +274,8 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [queriedPostCompleted], timeout: networkTimeout)
     }
 
-    func testUpdatePostWithSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testUpdatePostWithSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard var post = savePost(title: "title") else {
@@ -324,8 +324,8 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [updatePostCompleted, updateReceived], timeout: networkTimeout)
     }
 
-    func testDeletePostWithSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeletePostWithSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {
@@ -371,8 +371,8 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [deletePostSuccess, deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeletePostCascadeToComments() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeletePostCascadeToComments() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario4V2Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario4V2Tests.swift
@@ -40,8 +40,8 @@ class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
         let version: String = "1"
     }
 
-    func testCreateCommentAndGetCommentWithPost() throws {
-        setUp(withModels: TestModelRegistration())
+    func testCreateCommentAndGetCommentWithPost() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -71,14 +71,14 @@ class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getCommentCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testCreateCommentAndGetPostWithComments() throws {
-        setUp(withModels: TestModelRegistration())
+    func testCreateCommentAndGetPostWithComments() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
             return
         }
-        guard let comment = saveComment(content: "content", post: post) else {
+        guard saveComment(content: "content", post: post) != nil else {
             XCTFail("Could not create comment")
             return
         }
@@ -114,8 +114,8 @@ class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getPostCompleted, getCommentsCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testUpdateComment() throws {
-        setUp(withModels: TestModelRegistration())
+    func testUpdateComment() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -143,8 +143,8 @@ class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [updateCommentSuccessful], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteAndGetComment() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteAndGetComment() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -181,8 +181,8 @@ class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getCommentAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testListCommentsByPostID() throws {
-        setUp(withModels: TestModelRegistration())
+    func testListCommentsByPostID() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -206,8 +206,8 @@ class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [listCommentByPostIDCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testSavePostWithSyncAndReadPost() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSavePostWithSyncAndReadPost() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {
@@ -246,8 +246,8 @@ class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [queriedPostCompleted], timeout: networkTimeout)
     }
 
-    func testUpdatePostWithSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testUpdatePostWithSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard var post = savePost(title: "title") else {
@@ -296,8 +296,8 @@ class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [updatePostCompleted, updateReceived], timeout: networkTimeout)
     }
 
-    func testDeletePostWithSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeletePostWithSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {
@@ -343,8 +343,8 @@ class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [deletePostSuccess, deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeletePostCascadeToComments() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeletePostCascadeToComments() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario5V2Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario5V2Tests.swift
@@ -40,8 +40,8 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
         let version: String = "1"
     }
 
-    func testListPostEditorByPost() throws {
-        setUp(withModels: TestModelRegistration())
+    func testListPostEditorByPost() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -68,8 +68,8 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [listPostEditorByPostIDCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testListPostEditorByUser() throws {
-        setUp(withModels: TestModelRegistration())
+    func testListPostEditorByUser() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -87,7 +87,7 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
         let predicateByUserId = PostEditor5V2.keys.user5V2.eq(user.id)
         Amplify.DataStore.query(PostEditor5V2.self, where: predicateByUserId) { result in
             switch result {
-            case .success(let projects):
+            case .success(_):
                 listPostEditorByEditorIdCompleted.fulfill()
             case .failure(let error):
                 XCTFail("\(error)")
@@ -96,8 +96,8 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [listPostEditorByEditorIdCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testGetPostThenLoadPostEditors() throws {
-        setUp(withModels: TestModelRegistration())
+    func testGetPostThenLoadPostEditors() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -107,7 +107,7 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
             XCTFail("Could not create user")
             return
         }
-        guard let postEditor = savePostEditor(post5V2: post, user5V2: user) else {
+        guard savePostEditor(post5V2: post, user5V2: user) != nil else {
             XCTFail("Could not create user")
             return
         }
@@ -143,8 +143,8 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getPostCompleted, getPostEditorsCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testGetUserThenLoadPostEditors() throws {
-        setUp(withModels: TestModelRegistration())
+    func testGetUserThenLoadPostEditors() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let post = savePost(title: "title") else {
             XCTFail("Could not create post")
@@ -154,7 +154,7 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
             XCTFail("Could not create user")
             return
         }
-        guard let postEditor = savePostEditor(post5V2: post, user5V2: user) else {
+        guard savePostEditor(post5V2: post, user5V2: user) != nil else {
             XCTFail("Could not create user")
             return
         }
@@ -189,8 +189,8 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getUserCompleted, getPostsCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testSavePostWithSyncAndReadPost() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSavePostWithSyncAndReadPost() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {
@@ -229,8 +229,8 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [queriedPostCompleted], timeout: networkTimeout)
     }
 
-    func testUpdatePostWithSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testUpdatePostWithSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard var post = savePost(title: "title") else {
@@ -278,8 +278,8 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [updatePostCompleted, updateReceived], timeout: networkTimeout)
     }
 
-    func testDeletePostWithSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeletePostWithSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {
@@ -325,8 +325,8 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [deletePostSuccess, deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeletePostCascadeToPostEditor() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeletePostCascadeToPostEditor() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario6V2Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario6V2Tests.swift
@@ -54,7 +54,7 @@ class DataStoreConnectionScenario6V2Tests: SyncEngineIntegrationV2TestBase {
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post1 = savePost(title: "title", blog: blog),
-              let _ = savePost(title: "title", blog: blog),
+              let post2 = savePost(title: "title", blog: blog),
               let comment1post1 = saveComment(post: post1, content: "content"),
               let comment2post1 = saveComment(post: post1, content: "content") else {
             XCTFail("Could not create blog, posts, and comments")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario6V2Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario6V2Tests.swift
@@ -49,12 +49,12 @@ class DataStoreConnectionScenario6V2Tests: SyncEngineIntegrationV2TestBase {
         let version: String = "1"
     }
 
-    func testGetBlogThenFetchPostsThenFetchComments() throws {
-        setUp(withModels: TestModelRegistration())
+    func testGetBlogThenFetchPostsThenFetchComments() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post1 = savePost(title: "title", blog: blog),
-              let post2 = savePost(title: "title", blog: blog),
+              let _ = savePost(title: "title", blog: blog),
               let comment1post1 = saveComment(post: post1, content: "content"),
               let comment2post1 = saveComment(post: post1, content: "content") else {
             XCTFail("Could not create blog, posts, and comments")
@@ -99,8 +99,8 @@ class DataStoreConnectionScenario6V2Tests: SyncEngineIntegrationV2TestBase {
         }
     }
 
-    func testGetCommentThenFetchPostThenFetchBlog() throws {
-        setUp(withModels: TestModelRegistration())
+    func testGetCommentThenFetchPostThenFetchBlog() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post = savePost(title: "title", blog: blog),
@@ -149,8 +149,8 @@ class DataStoreConnectionScenario6V2Tests: SyncEngineIntegrationV2TestBase {
         XCTAssertEqual(fetchedBlog.name, blog.name)
     }
 
-    func testGetPostThenFetchBlogAndComment() throws {
-        setUp(withModels: TestModelRegistration())
+    func testGetPostThenFetchBlogAndComment() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post = savePost(title: "title", blog: blog),
@@ -214,8 +214,8 @@ class DataStoreConnectionScenario6V2Tests: SyncEngineIntegrationV2TestBase {
         }
     }
 
-    func testSaveBlog() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveBlog() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name") else {
             XCTFail("Could not create blog")
@@ -262,8 +262,8 @@ class DataStoreConnectionScenario6V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getBlogCompleted, createReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testSaveBlogPost() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveBlogPost() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post1 = savePost(title: "title", blog: blog),
@@ -335,8 +335,8 @@ class DataStoreConnectionScenario6V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [createReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testSaveBlogPostComment() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveBlogPostComment() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post = savePost(title: "title", blog: blog),
@@ -417,8 +417,8 @@ class DataStoreConnectionScenario6V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [createReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testCascadeDeleteBlogDeletesPostAndComments() throws {
-        setUp(withModels: TestModelRegistration())
+    func testCascadeDeleteBlogDeletesPostAndComments() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post = savePost(title: "title", blog: blog),

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario7V2Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario7V2Tests.swift
@@ -44,12 +44,12 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
         let version: String = "1"
     }
 
-    func testGetBlogThenFetchPostsThenFetchComments() throws {
-        setUp(withModels: TestModelRegistration())
+    func testGetBlogThenFetchPostsThenFetchComments() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post1 = savePost(title: "title", blog: blog),
-              let post2 = savePost(title: "title", blog: blog),
+              let _ = savePost(title: "title", blog: blog),
               let comment1post1 = saveComment(post: post1, content: "content"),
               let comment2post1 = saveComment(post: post1, content: "content") else {
             XCTFail("Could not create blog, posts, and comments")
@@ -94,8 +94,8 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
         }
     }
 
-    func testGetCommentThenFetchPostThenFetchBlog() throws {
-        setUp(withModels: TestModelRegistration())
+    func testGetCommentThenFetchPostThenFetchBlog() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post = savePost(title: "title", blog: blog),
@@ -144,8 +144,8 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
         XCTAssertEqual(fetchedBlog.name, blog.name)
     }
 
-    func testGetPostThenFetchBlogAndComment() throws {
-        setUp(withModels: TestModelRegistration())
+    func testGetPostThenFetchBlogAndComment() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post = savePost(title: "title", blog: blog),
@@ -209,8 +209,8 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
         }
     }
 
-    func testSaveBlog() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveBlog() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name") else {
             XCTFail("Could not create blog")
@@ -257,8 +257,8 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getBlogCompleted, createReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testSaveBlogPost() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveBlogPost() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post1 = savePost(title: "title", blog: blog),
@@ -330,8 +330,8 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [createReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testSaveBlogPostComment() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveBlogPostComment() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post = savePost(title: "title", blog: blog),
@@ -412,8 +412,8 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [createReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testUpdatePostWithSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testUpdatePostWithSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let blog = saveBlog(name: "name"),
@@ -463,8 +463,8 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [updatePostCompleted, updateReceived], timeout: networkTimeout)
     }
 
-    func testDeletePostWithSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeletePostWithSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post = savePost(title: "title", blog: blog) else {
@@ -510,8 +510,8 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [deletePostSuccess, deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteBlogCascadeToPostAndComments() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteBlogCascadeToPostAndComments() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post = savePost(title: "title", blog: blog),

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario7V2Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario7V2Tests.swift
@@ -49,7 +49,7 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post1 = savePost(title: "title", blog: blog),
-              let _ = savePost(title: "title", blog: blog),
+              let post2 = savePost(title: "title", blog: blog),
               let comment1post1 = saveComment(post: post1, content: "content"),
               let comment2post1 = saveComment(post: post1, content: "content") else {
             XCTFail("Could not create blog, posts, and comments")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario8V2Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario8V2Tests.swift
@@ -48,8 +48,8 @@ class DataStoreConnectionScenario8V2Tests: SyncEngineIntegrationV2TestBase {
         let version: String = "1"
     }
 
-    func testSaveRegistration() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveRegistration() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let attendee = saveAttendee(),
               let meeting = saveMeeting(),
@@ -127,8 +127,8 @@ class DataStoreConnectionScenario8V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getMeetingCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testUpdateRegistrationToAnotherAttendee() throws {
-        setUp(withModels: TestModelRegistration())
+    func testUpdateRegistrationToAnotherAttendee() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let attendee = saveAttendee(),
               let attendee2 = saveAttendee(),
@@ -227,8 +227,8 @@ class DataStoreConnectionScenario8V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getAttendeesCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteRegistration() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteRegistration() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let attendee = saveAttendee(),
               let meeting = saveMeeting(),
@@ -319,8 +319,8 @@ class DataStoreConnectionScenario8V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getMeetingCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteAttendeeShouldCascadeDeleteRegistration() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteAttendeeShouldCascadeDeleteRegistration() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let attendee = saveAttendee(),
               let meeting = saveMeeting(),
@@ -412,8 +412,8 @@ class DataStoreConnectionScenario8V2Tests: SyncEngineIntegrationV2TestBase {
         wait(for: [getMeetingCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testDeleteMeetingShouldCascadeDeleteRegistration() throws {
-        setUp(withModels: TestModelRegistration())
+    func testDeleteMeetingShouldCascadeDeleteRegistration() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let attendee = saveAttendee(),
               let meeting = saveMeeting(),

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreModelWithCustomTimestampTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreModelWithCustomTimestampTests.swift
@@ -35,11 +35,11 @@ class DataStoreModelWithCustomTimestampTests: SyncEngineIntegrationV2TestBase {
         await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
-        guard let todo = saveTodo(content: "content") else {
+        guard var todo = saveTodo(content: "content") else {
             XCTFail("Could not create blog, posts, and comments")
             return
         }
-        _ = "updatedContent"
+        let updatedContent = "updatedContent"
         let createReceived = expectation(description: "Create notification received")
         // let updateReceived = expectation(description: "Update notification received")
         var receivedTodoResult: TodoCustomTimestampV2?

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreModelWithCustomTimestampTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreModelWithCustomTimestampTests.swift
@@ -31,15 +31,15 @@ class DataStoreModelWithCustomTimestampTests: SyncEngineIntegrationV2TestBase {
 
     // TODO: Upates are not working due to CLI provisioning issue. the Update mutation is missing the `id`
     // https://github.com/aws-amplify/amplify-cli/issues/9136
-    func testSaveModelAndSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveModelAndSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
-        guard var todo = saveTodo(content: "content") else {
+        guard let todo = saveTodo(content: "content") else {
             XCTFail("Could not create blog, posts, and comments")
             return
         }
-        let updatedContent = "updatedContent"
+        _ = "updatedContent"
         let createReceived = expectation(description: "Create notification received")
         // let updateReceived = expectation(description: "Update notification received")
         var receivedTodoResult: TodoCustomTimestampV2?

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreModelWithDefaultValueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreModelWithDefaultValueTests.swift
@@ -28,8 +28,8 @@ class DataStoreModelWithDefaultValueTests: SyncEngineIntegrationV2TestBase {
         let version: String = "1"
     }
 
-    func testSaveModelWithExplicitContentAndSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveModelWithExplicitContentAndSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let todo = saveTodo(content: "content") else {
@@ -79,8 +79,8 @@ class DataStoreModelWithDefaultValueTests: SyncEngineIntegrationV2TestBase {
         wait(for: [getTodoCompleted, createReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testSaveModelWithoutExplicitContentAndSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveModelWithoutExplicitContentAndSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard let todo = saveTodo(content: nil) else {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreModelWithSecondaryIndexTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreModelWithSecondaryIndexTests.swift
@@ -31,8 +31,8 @@ class DataStoreModelWithSecondaryIndexTests: SyncEngineIntegrationV2TestBase {
         let version: String = "1"
     }
 
-    func testSaveModelAndSync() throws {
-        setUp(withModels: TestModelRegistration())
+    func testSaveModelAndSync() async throws {
+        await setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
 
         guard var customer = saveCustomer(name: "name", accountRepresentativeID: "accountId") else {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/DataStoreCategoryConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/DataStoreCategoryConfigurationTests.swift
@@ -11,8 +11,8 @@ import AWSDataStorePlugin
 
 class AWSDataStorePluginConfigurationTests: XCTestCase {
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
     }
 
     func testDoesNotThrowOnMissingConfig() throws {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/DataStoreListProviderTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/DataStoreListProviderTests.swift
@@ -14,8 +14,8 @@ class DataStoreListProviderTests: XCTestCase {
 
     var mockDataStorePlugin: MockDataStoreCategoryPlugin!
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
         ModelRegistry.register(modelType: Post4.self)
         ModelRegistry.register(modelType: Comment4.self)
         ModelListDecoderRegistry.registerDecoder(DataStoreListDecoder.self)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
@@ -23,10 +23,10 @@ class SQLiteStorageEngineAdapterJsonTests: XCTestCase {
 
     // MARK: - Lifecycle
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         sleep(2)
-        Amplify.reset()
+        await Amplify.reset()
         Amplify.Logging.logLevel = .warn
 
         let validAPIPluginKey = "MockAPICategoryPlugin"

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/APICategoryDependencyTests.swift
@@ -23,8 +23,8 @@ class APICategoryDependencyTests: XCTestCase {
     ///    - I invoke `save` on a non-syncable model
     /// - Then:
     ///    - The operation succeeds
-    func testNonSyncableWithoutAPICategorySucceeds() throws {
-        try setUpWithAPI()
+    func testNonSyncableWithoutAPICategorySucceeds() async throws {
+        try await setUpWithAPI()
 
         let model = MockUnsynced()
 
@@ -59,8 +59,8 @@ class APICategoryDependencyTests: XCTestCase {
 // MARK: - Setup
 
 extension APICategoryDependencyTests {
-    private func setUpCore() throws -> AmplifyConfiguration {
-        Amplify.reset()
+    private func setUpCore() async throws -> AmplifyConfiguration {
+        await Amplify.reset()
 
         let connection = try Connection(.inMemory)
         storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
@@ -109,14 +109,14 @@ extension APICategoryDependencyTests {
         return amplifyConfig
     }
 
-    private func setUpWithAPI() throws {
-        let configWithoutAPI = try setUpCore()
+    private func setUpWithAPI() async throws {
+        let configWithoutAPI = try await setUpCore()
         let configWithAPI = try setUpAPICategory(config: configWithoutAPI)
         try Amplify.configure(configWithAPI)
     }
 
-    private func setUpWithoutAPI() throws {
-        let configWithoutAPI = try setUpCore()
+    private func setUpWithoutAPI() async throws {
+        let configWithoutAPI = try await setUpCore()
         try Amplify.configure(configWithoutAPI)
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionTests.swift
@@ -17,10 +17,10 @@ import Combine
 /// Tests behavior of local DataStore subscriptions (as opposed to remote API subscription behaviors)
 class LocalSubscriptionTests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
 
-        Amplify.reset()
+        await Amplify.reset()
         Amplify.Logging.logLevel = .warn
 
         let storageAdapter: SQLiteStorageEngineAdapter

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionWithJSONModelTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/LocalSubscriptionWithJSONModelTests.swift
@@ -19,10 +19,10 @@ import Combine
 class LocalSubscriptionWithJSONModelTests: XCTestCase {
     var dataStorePlugin: AWSDataStorePlugin!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
 
-        Amplify.reset()
+        await Amplify.reset()
         Amplify.Logging.logLevel = .warn
 
         let storageAdapter: SQLiteStorageEngineAdapter

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
@@ -16,8 +16,8 @@ class AWSMutationEventIngesterTests: XCTestCase {
     // Used by tests to assert that the MutationEvent table is being updated
     var storageAdapter: SQLiteStorageEngineAdapter!
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
 
         let apiConfig = APICategoryConfiguration(plugins: [
             "MockAPICategoryPlugin": true

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
@@ -35,7 +35,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                         content: "content",
                         createdAt: .now())
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try saveMutationEvent(of: .create, for: post)
             try setUpDataStore()
@@ -84,7 +84,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                         content: "content",
                         createdAt: .now())
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try saveMutationEvent(of: .create, for: post)
             try savePost(post)
@@ -140,7 +140,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                         content: "content",
                         createdAt: .now())
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try saveMutationEvent(of: .create, for: post)
             try savePost(post)
@@ -192,7 +192,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                         content: "content",
                         createdAt: .now())
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try saveMutationEvent(of: .update, for: post)
             try setUpDataStore()
@@ -243,7 +243,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                         content: "content",
                         createdAt: .now())
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try saveMutationEvent(of: .update, for: post)
             try savePost(post)
@@ -299,7 +299,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                         content: "content",
                         createdAt: .now())
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try saveMutationEvent(of: .update, for: post)
             try savePost(post)
@@ -355,7 +355,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                         content: "content",
                         createdAt: .now())
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try saveMutationEvent(of: .delete, for: post)
             try setUpDataStore()
@@ -408,7 +408,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                         content: "content",
                         createdAt: .now())
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try saveMutationEvent(of: .delete, for: post)
             try savePost(post)
@@ -465,7 +465,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                         content: "content",
                         createdAt: .now())
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try setUpDataStore()
             try startAmplifyAndWaitForSync()
@@ -515,7 +515,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                         content: "content",
                         createdAt: .now())
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try savePost(post)
             try setUpDataStore()
@@ -566,7 +566,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                         content: "content",
                         createdAt: .now())
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try savePost(post)
             try setUpDataStore()
@@ -620,7 +620,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                         content: "content",
                         createdAt: .now())
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try setUpDataStore()
             try startAmplifyAndWaitForSync()
@@ -669,7 +669,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                         content: "content",
                         createdAt: .now())
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try setUpDataStore()
             try startAmplifyAndWaitForSync()
@@ -723,7 +723,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                         content: "content",
                         createdAt: .now())
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try setUpDataStore()
             try startAmplifyAndWaitForSync()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
@@ -29,7 +29,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
     /// - Then:
     ///    - I receive an error
     ///    - The mutation queue retains the original event
-    func test_create_create() {
+    func test_create_create() async {
         let post = Post(id: "post-1",
                         title: "title",
                         content: "content",
@@ -78,7 +78,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
     /// - Then:
     ///    - The update is saved to DataStore
     ///    - The mutation event is updated with the new values
-    func test_create_update() {
+    func test_create_update() async {
         let post = Post(id: "post-1",
                         title: "title",
                         content: "content",
@@ -134,7 +134,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
     /// - Then:
     ///    - The delete is saved to DataStore
     ///    - The mutation event is removed from the mutation queue
-    func test_create_delete() {
+    func test_create_delete() async {
         let post = Post(id: "post-1",
                         title: "title",
                         content: "content",
@@ -186,7 +186,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
     /// - Then:
     ///    - I receive an error
     ///    - The mutation queue retains the original event
-    func test_update_create() {
+    func test_update_create() async {
         let post = Post(id: "post-1",
                         title: "title",
                         content: "content",
@@ -237,7 +237,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
     /// - Then:
     ///    - The update is saved to DataStore
     ///    - The mutation event is updated with the new values
-    func test_update_update() {
+    func test_update_update() async {
         let post = Post(id: "post-1",
                         title: "title",
                         content: "content",
@@ -293,7 +293,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
     /// - Then:
     ///    - The delete is saved to DataStore
     ///    - The mutation event is updated to a .delete type
-    func test_update_delete() {
+    func test_update_delete() async {
         let post = Post(id: "post-1",
                         title: "title",
                         content: "content",
@@ -349,7 +349,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
     /// - Then:
     ///    - I receive an error
     ///    - The mutation queue retains the original event
-    func test_delete_create() {
+    func test_delete_create() async {
         let post = Post(id: "post-1",
                         title: "title",
                         content: "content",
@@ -402,7 +402,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
     /// - Then:
     ///    - I receive an error
     ///    - The mutation queue retains the original event
-    func test_delete_update() {
+    func test_delete_update() async {
         let post = Post(id: "post-1",
                         title: "title",
                         content: "content",
@@ -459,7 +459,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
     /// - Then:
     ///    - The update is saved to DataStore
     ///    - The mutation event is appended to the queue
-    func testCreateMutationAppendedToEmptyQueue() {
+    func testCreateMutationAppendedToEmptyQueue() async {
         let post = Post(id: "post-1",
                         title: "title",
                         content: "content",
@@ -509,7 +509,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
     /// - Then:
     ///    - The update is saved to DataStore
     ///    - The mutation event is appended to the queue
-    func testUpdateMutationAppendedToEmptyQueue() {
+    func testUpdateMutationAppendedToEmptyQueue() async {
         let post = Post(id: "post-1",
                         title: "title",
                         content: "content",
@@ -560,7 +560,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
     /// - Then:
     ///    - The update is saved to DataStore
     ///    - The mutation event is appended to the queue
-    func testDeleteMutationAppendedToEmptyQueue() {
+    func testDeleteMutationAppendedToEmptyQueue() async {
         let post = Post(id: "post-1",
                         title: "title",
                         content: "content",
@@ -614,7 +614,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
     /// - Then:
     ///    - The update is saved to DataStore
     ///    - The mutation event is appended to the queue, even though it would normally have thrown an error
-    func testCreateMutationAppendedToInProcessQueue() {
+    func testCreateMutationAppendedToInProcessQueue() async {
         let post = Post(id: "post-1",
                         title: "title",
                         content: "content",
@@ -663,7 +663,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
     ///    - The update is saved to DataStore
     ///    - The mutation event is appended to the queue, even though it would normally have overwritten the existing
     ///      create
-    func testUpdateMutationAppendedToInProcessQueue() {
+    func testUpdateMutationAppendedToInProcessQueue() async {
         let post = Post(id: "post-1",
                         title: "title",
                         content: "content",
@@ -717,7 +717,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
     /// - Then:
     ///    - The update is saved to DataStore
     ///    - The mutation event is appended to the queue, even though it would normally have thrown an error
-    func testDeleteMutationAppendedToInProcessQueue() {
+    func testDeleteMutationAppendedToInProcessQueue() async {
         let post = Post(id: "post-1",
                         title: "title",
                         content: "content",

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
@@ -22,7 +22,7 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
     ///    - The outgoing mutation queue sends a create mutation
     func testMutationQueueCreateSendsSync() async throws {
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter()
             try setUpDataStore(mutationQueue: OutgoingMutationQueue(storageAdapter: storageAdapter,
                                                                     dataStoreConfiguration: .default,
@@ -82,7 +82,7 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
         try startAmplifyAndWaitForSync()
 
         Amplify.DataStore.save(post) { _ in }
-        waitForExpectations(timeout: 5.0, handler: nil)
+        await waitForExpectations(timeout: 5.0, handler: nil)
         Amplify.Hub.removeListener(hubListener)
     }
 
@@ -100,9 +100,9 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
     ///    - I start syncing with mutation events already in the database
     /// - Then:
     ///    - The mutation queue delivers the first previously loaded event
-    func testMutationQueueLoadsPendingMutations() async throwsasync throws {
+    func testMutationQueueLoadsPendingMutations() async throws {
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter()
         }
 
@@ -174,14 +174,14 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
             }
         }
 
-        tryOrFail {
+        await tryOrFail {
             try setUpDataStore(mutationQueue: OutgoingMutationQueue(storageAdapter: storageAdapter,
                                                                     dataStoreConfiguration: .default,
                                                                     authModeStrategy: AWSDefaultAuthModeStrategy()))
             try startAmplify()
         }
 
-        waitForExpectations(timeout: 5.0, handler: nil)
+        await waitForExpectations(timeout: 5.0, handler: nil)
         Amplify.Hub.removeListener(hubListener)
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
@@ -20,7 +20,7 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
     ///    - I invoke DataStore.save() for a new model
     /// - Then:
     ///    - The outgoing mutation queue sends a create mutation
-    func testMutationQueueCreateSendsSync() throws {
+    func testMutationQueueCreateSendsSync() async throws {
 
         tryOrFail {
             try setUpStorageAdapter()
@@ -100,7 +100,7 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
     ///    - I start syncing with mutation events already in the database
     /// - Then:
     ///    - The mutation queue delivers the first previously loaded event
-    func testMutationQueueLoadsPendingMutations() throws {
+    func testMutationQueueLoadsPendingMutations() async throwsasync throws {
 
         tryOrFail {
             try setUpStorageAdapter()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
@@ -22,9 +22,9 @@ class OutgoingMutationQueueMockStateTest: XCTestCase {
     var apiBehavior: MockAPICategoryPlugin!
     var storageAdapter: StorageEngineAdapter!
     var eventSource: MockMutationEventSource!
-    override func setUp() {
+    override func setUp() async throws {
         do {
-            try setUpWithAPI()
+            try await setUpWithAPI()
         } catch {
             XCTFail(String(describing: "Unable to setup API category for unit tests"))
         }
@@ -282,8 +282,8 @@ class MockMutationEventSource: MutationEventSource {
 
 extension OutgoingMutationQueueMockStateTest {
 
-    private func setUpCore() throws -> AmplifyConfiguration {
-        Amplify.reset()
+    private func setUpCore() async throws -> AmplifyConfiguration {
+        await Amplify.reset()
 
         let dataStorePublisher = DataStorePublisher()
         let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
@@ -310,8 +310,8 @@ extension OutgoingMutationQueueMockStateTest {
         return amplifyConfig
     }
 
-    private func setUpWithAPI() throws {
-        let configWithoutAPI = try setUpCore()
+    private func setUpWithAPI() async throws {
+        let configWithoutAPI = try await setUpCore()
         let configWithAPI = try setUpAPICategory(config: configWithoutAPI)
         try Amplify.configure(configWithAPI)
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -23,9 +23,9 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     var mockAPIPlugin: MockAPICategoryPlugin!
     var storageAdapter: StorageEngineAdapter!
 
-    override func setUp() {
-        tryOrFail {
-            try setUpWithAPI()
+    override func setUp() async throws {
+        await tryOrFail {
+            try await setUpWithAPI()
         }
         storageAdapter = MockSQLiteStorageEngineAdapter()
 
@@ -951,8 +951,8 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
 }
 
 extension ProcessMutationErrorFromCloudOperationTests {
-    private func setUpCore() throws -> AmplifyConfiguration {
-        Amplify.reset()
+    private func setUpCore() async throws -> AmplifyConfiguration {
+        await Amplify.reset()
 
         let dataStorePublisher = DataStorePublisher()
         let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
@@ -981,8 +981,8 @@ extension ProcessMutationErrorFromCloudOperationTests {
         return amplifyConfig
     }
 
-    private func setUpWithAPI() throws {
-        let configWithoutAPI = try setUpCore()
+    private func setUpWithAPI() async throws {
+        let configWithoutAPI = try await setUpCore()
         let configWithAPI = try setUpAPICategory(config: configWithoutAPI)
         try Amplify.configure(configWithAPI)
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
@@ -24,10 +24,10 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         return reachabilityPublisher.eraseToAnyPublisher()
     }
 
-    override func setUp() {
+    override func setUp() async {
         reachabilityPublisher = CurrentValueSubject<ReachabilityUpdate, Never>(ReachabilityUpdate(isOnline: false))
-        tryOrFail {
-            try setUpWithAPI()
+        await tryOrFail {
+            try await setUpWithAPI()
         }
         ModelRegistry.register(modelType: Post.self)
         ModelRegistry.register(modelType: Comment.self)
@@ -237,8 +237,8 @@ class SyncMutationToCloudOperationTests: XCTestCase {
 }
 
 extension SyncMutationToCloudOperationTests {
-    private func setUpCore() throws -> AmplifyConfiguration {
-        Amplify.reset()
+    private func setUpCore() async throws -> AmplifyConfiguration {
+        await Amplify.reset()
 
         let dataStorePublisher = DataStorePublisher()
         let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
@@ -268,8 +268,8 @@ extension SyncMutationToCloudOperationTests {
         return amplifyConfig
     }
 
-    private func setUpWithAPI() throws {
-        let configWithoutAPI = try setUpCore()
+    private func setUpWithAPI() async throws {
+        let configWithoutAPI = try await setUpCore()
         let configWithAPI = try setUpAPICategory(config: configWithoutAPI)
         try Amplify.configure(configWithAPI)
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
@@ -24,7 +24,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         return reachabilityPublisher.eraseToAnyPublisher()
     }
 
-    override func setUp() async {
+    override func setUp() async throws {
         reachabilityPublisher = CurrentValueSubject<ReachabilityUpdate, Never>(ReachabilityUpdate(isOnline: false))
         await tryOrFail {
             try await setUpWithAPI()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
@@ -23,12 +23,12 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
     /// and so we need to wait to configure during the actual test.
     var amplifyConfig: AmplifyConfiguration!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
 
         // Allows any previously-running API calls to finish up before unconfiguring the category
         sleep(2)
-        Amplify.reset()
+        await Amplify.reset()
         Amplify.Logging.logLevel = .warn
 
         apiPlugin = MockAPICategoryPlugin()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
@@ -125,7 +125,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
     ///    - The sync engine receives a delete mutation
     /// - Then:
     ///    - The delete metadata record is written but no model record is written
-    func testDeleteWithNoLocalModel() async; throwsasync throws {
+    func testDeleteWithNoLocalModel() async throws {
         let expectationListener = expectation(description: "listener")
 
         tryOrFail {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
@@ -25,9 +25,9 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
     ///    - The sync engine receives an update mutation
     /// - Then:
     ///    - The update is not applied
-    func testUpdateAfterDelete() throws {
+    func testUpdateAfterDelete() async throws {
         let expectationListener = expectation(description: "listener")
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter(preCreating: [MockSynced.self])
         }
 
@@ -53,7 +53,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
 
         apiPlugin.responders[.subscribeRequestListener] = responder
 
-        tryOrFail {
+        await tryOrFail {
             try setUpDataStore(modelRegistration: MockModelRegistration())
             mockRemoteSyncEngineFor_testUpdateAfterDelete()
             try startAmplifyAndWaitForSync()
@@ -125,7 +125,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
     ///    - The sync engine receives a delete mutation
     /// - Then:
     ///    - The delete metadata record is written but no model record is written
-    func testDeleteWithNoLocalModel() throws {
+    func testDeleteWithNoLocalModel() async; throwsasync throws {
         let expectationListener = expectation(description: "listener")
 
         tryOrFail {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
@@ -128,7 +128,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
     func testDeleteWithNoLocalModel() async throws {
         let expectationListener = expectation(description: "listener")
 
-        tryOrFail {
+        await tryOrFail {
             try setUpStorageAdapter()
         }
 
@@ -145,7 +145,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
 
         apiPlugin.responders[.subscribeRequestListener] = responder
 
-        tryOrFail {
+        await tryOrFail {
             try setUpDataStore(modelRegistration: MockModelRegistration())
             mockRemoteSyncEngineFor_testDeleteWithNoLocalModel()
             try startAmplifyAndWaitForSync()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -26,7 +26,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
     var stateMachine: MockStateMachine<ReconcileAndLocalSaveOperation.State, ReconcileAndLocalSaveOperation.Action>!
     var cancellables: Set<AnyCancellable>!
     override func setUp() async throws {
-        tryOrFail {
+        await tryOrFail {
             try await setUpWithAPI()
         }
         ModelRegistry.register(modelType: Post.self)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -715,7 +715,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
             completion(.success(model))
         }
         storageAdapter.responders[.saveModelCompletion] = saveMetadataResponder
-        _ = Amplify.Hub.listen(to: .dataStore) { payload in
+        let hubListener = Amplify.Hub.listen(to: .dataStore) { payload in
             if payload.eventName == "DataStore.syncReceived" {
                 hubExpect.fulfill()
             }
@@ -791,7 +791,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
             completion(.success(model))
         }
         storageAdapter.responders[.saveModelCompletion] = saveMetadataResponder
-        _ = Amplify.Hub.listen(to: .dataStore) { payload in
+        let hubListener = Amplify.Hub.listen(to: .dataStore) { payload in
             if payload.eventName == "DataStore.syncReceived" {
                 hubExpect.fulfill()
             }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -25,9 +25,9 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
     var operation: ReconcileAndLocalSaveOperation!
     var stateMachine: MockStateMachine<ReconcileAndLocalSaveOperation.State, ReconcileAndLocalSaveOperation.Action>!
     var cancellables: Set<AnyCancellable>!
-    override func setUp() {
+    override func setUp() async throws {
         tryOrFail {
-            try setUpWithAPI()
+            try await setUpWithAPI()
         }
         ModelRegistry.register(modelType: Post.self)
 
@@ -659,7 +659,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
             completion(.success(model))
         }
         storageAdapter.responders[.saveModelCompletion] = saveMetadataResponder
-        let hubListener = Amplify.Hub.listen(to: .dataStore) { payload in
+        _ = Amplify.Hub.listen(to: .dataStore) { payload in
             if payload.eventName == "DataStore.syncReceived" {
                 hubExpect.fulfill()
             }
@@ -715,7 +715,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
             completion(.success(model))
         }
         storageAdapter.responders[.saveModelCompletion] = saveMetadataResponder
-        let hubListener = Amplify.Hub.listen(to: .dataStore) { payload in
+        _ = Amplify.Hub.listen(to: .dataStore) { payload in
             if payload.eventName == "DataStore.syncReceived" {
                 hubExpect.fulfill()
             }
@@ -791,7 +791,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
             completion(.success(model))
         }
         storageAdapter.responders[.saveModelCompletion] = saveMetadataResponder
-        let hubListener = Amplify.Hub.listen(to: .dataStore) { payload in
+        _ = Amplify.Hub.listen(to: .dataStore) { payload in
             if payload.eventName == "DataStore.syncReceived" {
                 hubExpect.fulfill()
             }
@@ -1052,8 +1052,8 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
 }
 
 extension ReconcileAndLocalSaveOperationTests {
-    private func setUpCore() throws -> AmplifyConfiguration {
-        Amplify.reset()
+    private func setUpCore() async throws -> AmplifyConfiguration {
+        await Amplify.reset()
 
         let dataStorePublisher = DataStorePublisher()
         let dataStorePlugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
@@ -1082,8 +1082,8 @@ extension ReconcileAndLocalSaveOperationTests {
         return amplifyConfig
     }
 
-    private func setUpWithAPI() throws {
-        let configWithoutAPI = try setUpCore()
+    private func setUpWithAPI() async throws {
+        let configWithoutAPI = try await setUpCore()
         let configWithAPI = try setUpAPICategory(config: configWithoutAPI)
         try Amplify.configure(configWithAPI)
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/BaseDataStoreTests.swift
@@ -23,10 +23,10 @@ class BaseDataStoreTests: XCTestCase {
 
     // MARK: - Lifecycle
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         sleep(2)
-        Amplify.reset()
+        await Amplify.reset()
         Amplify.Logging.logLevel = .warn
 
         let validAPIPluginKey = "MockAPICategoryPlugin"

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -41,7 +41,7 @@ class SyncEngineTestBase: XCTestCase {
 
     // MARK: - Setup
 
-    override func setUpWithError() async throws {
+    override func setUp() async throws {
         continueAfterFailure = false
 
         await Amplify.reset()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/SyncEngineTestBase.swift
@@ -41,10 +41,10 @@ class SyncEngineTestBase: XCTestCase {
 
     // MARK: - Setup
 
-    override func setUpWithError() throws {
+    override func setUpWithError() async throws {
         continueAfterFailure = false
 
-        Amplify.reset()
+        await Amplify.reset()
 
         let apiConfig = APICategoryConfiguration(plugins: [
             "MockAPICategoryPlugin": true

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/XCTest+AmplifyExtensions.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/TestSupport/XCTest+AmplifyExtensions.swift
@@ -11,9 +11,9 @@ import XCTest
 // extension file, presumably because AmplifyTestCommon isn't a test target?
 extension XCTestCase {
     /// Execute `block` inside a do/catch block, and fail the test with an XCTFail if the block throws an error
-    func tryOrFail(block: () throws -> Void) {
+    func tryOrFail(block: () async throws -> Void) async {
         do {
-            try block()
+            try await block()
         } catch {
             XCTFail(String(describing: error))
         }

--- a/AmplifyPlugins/Geo/AWSLocationGeoPluginTests/AWSLocationGeoPluginTestBase.swift
+++ b/AmplifyPlugins/Geo/AWSLocationGeoPluginTests/AWSLocationGeoPluginTestBase.swift
@@ -41,7 +41,7 @@ class AWSLocationGeoPluginTestBase: XCTestCase {
         geoPlugin.authService = MockAWSAuthService()
         geoPlugin.pluginConfig = pluginConfig
 
-        Amplify.reset()
+        await Amplify.reset()
         let config = AmplifyConfiguration()
         do {
             try Amplify.configure(config)
@@ -51,7 +51,7 @@ class AWSLocationGeoPluginTestBase: XCTestCase {
     }
 
     override func tearDown() {
-        Amplify.reset()
+        await Amplify.reset()
         geoPlugin.reset {}
     }
 }

--- a/AmplifyPlugins/Geo/AWSLocationGeoPluginTests/AWSLocationGeoPluginTestBase.swift
+++ b/AmplifyPlugins/Geo/AWSLocationGeoPluginTests/AWSLocationGeoPluginTestBase.swift
@@ -17,7 +17,7 @@ class AWSLocationGeoPluginTestBase: XCTestCase {
     var pluginConfig: AWSLocationGeoPluginConfiguration!
     var emptyPluginConfig: AWSLocationGeoPluginConfiguration!
 
-    override func setUp() {
+    override func setUp() async throws {
         pluginConfig = AWSLocationGeoPluginConfiguration(regionName: GeoPluginTestConfig.regionName,
                                                          defaultMap: GeoPluginTestConfig.map,
                                                          maps: GeoPluginTestConfig.maps,
@@ -50,7 +50,7 @@ class AWSLocationGeoPluginTestBase: XCTestCase {
         }
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         await Amplify.reset()
         geoPlugin.reset {}
     }

--- a/AmplifyPlugins/Geo/GeoHostApp/AWSLocationGeoPluginIntegrationTests/AWSLocationGeoPluginIntegrationTests.swift
+++ b/AmplifyPlugins/Geo/GeoHostApp/AWSLocationGeoPluginIntegrationTests/AWSLocationGeoPluginIntegrationTests.swift
@@ -32,7 +32,7 @@ class AWSLocationGeoPluginIntergrationTests: XCTestCase {
     }
 
     override func tearDown() {
-        Amplify.reset()
+        await Amplify.reset()
     }
 
     func testGetEscapeHatch() throws {

--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/AWSPredictionsPluginTestBase.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/AWSPredictionsPluginTestBase.swift
@@ -37,6 +37,6 @@ class AWSPredictionsPluginTestBase: XCTestCase {
     override func tearDown() {
         sleep(1)
         print("Amplify reset")
-        Amplify.reset()
+        await Amplify.reset()
     }
 }

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPluginIntegrationTests/CoreMLPredictionsPluginTestBase.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPluginIntegrationTests/CoreMLPredictionsPluginTestBase.swift
@@ -21,7 +21,7 @@ class AWSPredictionsPluginTestBase: XCTestCase {
 
     override func tearDown() {
         print("Amplify reset")
-        Amplify.reset()
+        await Amplify.reset()
         sleep(5)
     }
 

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginConfigurationTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginConfigurationTests.swift
@@ -14,8 +14,8 @@ class AWSS3StoragePluginConfigurationTests: XCTestCase {
     /// Given: awss3StoragePlugin configuration with incorrect DefaultAccessLevel value
     /// When: Configure Amplify
     /// Then: The call throws a PluginError.pluginConfigurationError
-    func testConfigureWithIncorrectDefaultAccessLevelValueShouldThrow() {
-        Amplify.reset()
+    func testConfigureWithIncorrectDefaultAccessLevelValueShouldThrow() async {
+        await Amplify.reset()
 
         let storageConfig = StorageCategoryConfiguration(
             plugins: [

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginPrefixKeyResolverTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginPrefixKeyResolverTests.swift
@@ -16,8 +16,8 @@ class AWSS3StoragePluginKeyResolverTests: XCTestCase {
 
     static let amplifyConfiguration = "AWSS3StoragePluginTests-amplifyconfiguration"
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
         do {
             try Amplify.add(plugin: AWSCognitoAuthPlugin())
             try Amplify.add(plugin: AWSS3StoragePlugin(
@@ -30,8 +30,8 @@ class AWSS3StoragePluginKeyResolverTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
         // Unforunately, `sleep` has been added here to get more consistent test runs. The SDK will be used with
         // same key to create a URLSession. The `sleep` helps avoid the error:
         // ```

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginTestBase.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/AWSS3StoragePluginTestBase.swift
@@ -27,9 +27,9 @@ class AWSS3StoragePluginTestBase: XCTestCase {
     static var isFirstUserSignedUp = false
     static var isSecondUserSignedUp = false
 
-    override func setUp() {
+    override func setUp() async throws {
         do {
-            Amplify.reset()
+            await Amplify.reset()
             try Amplify.add(plugin: AWSCognitoAuthPlugin())
             try Amplify.add(plugin: AWSS3StoragePlugin())
             let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(
@@ -41,8 +41,8 @@ class AWSS3StoragePluginTestBase: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
         // Unforunately, `sleep` has been added here to get more consistent test runs. The SDK will be used with
         // same key to create a URLSession. The `sleep` helps avoid the error:
         // ```

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/ResumabilityTests/AWSS3StoragePluginPutDataResumabilityTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginFunctionalTests/ResumabilityTests/AWSS3StoragePluginPutDataResumabilityTests.swift
@@ -57,8 +57,8 @@ class AWSS3StoragePluginUploadDataResumabilityTests: AWSS3StoragePluginTestBase 
         wait(for: [completeInvoked, failedInvoked, noProgressAfterPause], timeout: 30)
         operation.cancel()
         // A 5 second sleep has been added because, the cancelling runs async task to cancel anything existing that is still running, 
-        // This gives ample time for operation to cancel, and then Amplify.reset(), Amplify.configure works as expected.
-        // If the sleep is not added, Amplify.reset() will be trigerred in the tear down method which will remove all the plugins, 
+        // This gives ample time for operation to cancel, and then await Amplify.reset(), Amplify.configure works as expected.
+        // If the sleep is not added, await Amplify.reset() will be trigerred in the tear down method which will remove all the plugins, 
         // Removing all the plugins when operation is still cancelling, results in undesired behavior from the storage/auth plugin 
         sleep(5)
     }

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginBaseConfigTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginBaseConfigTests.swift
@@ -28,9 +28,9 @@ class AWSS3StoragePluginBaseConfigTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         // Need this to avoid plugin already configured exception in the subsequent tests
-        Amplify.reset()
+        await Amplify.reset()
     }
 
 }

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageOperationTestBase.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageOperationTestBase.swift
@@ -43,8 +43,8 @@ class AWSS3StorageOperationTestBase: XCTestCase {
         mockAuthService = MockAWSAuthService()
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
 }

--- a/AmplifyTests/CategoryTests/API/APICategoryClientGraphQLTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryClientGraphQLTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-// Only @testable so we can get access to `Amplify.reset()`
+// Only @testable so we can get access to `await Amplify.reset()`
 @testable import Amplify
 
 @testable import AmplifyTestCommon
@@ -15,8 +15,8 @@ import XCTest
 class APICategoryClientGraphQLTests: XCTestCase {
     var mockAmplifyConfig: AmplifyConfiguration!
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
 
         let apiConfig = APICategoryConfiguration(
             plugins: ["MockAPICategoryPlugin": true]

--- a/AmplifyTests/CategoryTests/API/APICategoryClientInterceptorTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryClientInterceptorTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-// Only @testable so we can get access to `Amplify.reset()`
+// Only @testable so we can get access to `await Amplify.reset()`
 @testable import Amplify
 
 @testable import AmplifyTestCommon
@@ -15,8 +15,8 @@ import XCTest
 class APICategoryClientInterceptorTests: XCTestCase {
     var mockAmplifyConfig: AmplifyConfiguration!
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
 
         let apiConfig = APICategoryConfiguration(
             plugins: ["MockAPICategoryPlugin": true]

--- a/AmplifyTests/CategoryTests/API/APICategoryClientRESTTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryClientRESTTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-// Only @testable so we can get access to `Amplify.reset()`
+// Only @testable so we can get access to `await Amplify.reset()`
 @testable import Amplify
 
 @testable import AmplifyTestCommon
@@ -15,8 +15,8 @@ import XCTest
 class APICategoryClientRESTTests: XCTestCase {
     var mockAmplifyConfig: AmplifyConfiguration!
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
 
         let apiConfig = APICategoryConfiguration(
             plugins: ["MockAPICategoryPlugin": true]

--- a/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
@@ -11,8 +11,8 @@ import XCTest
 @testable import AmplifyTestCommon
 
 class APICategoryConfigurationTests: XCTestCase {
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
     }
 
     func testCanAddAPIPlugin() throws {
@@ -36,7 +36,7 @@ class APICategoryConfigurationTests: XCTestCase {
         XCTAssertNotNil(try Amplify.API.getPlugin(for: "MockAPICategoryPlugin"))
     }
 
-    func testCanResetAPIPlugin() throws {
+    func testCanResetAPIPlugin() async throws {
         let plugin = MockAPICategoryPlugin()
         let resetWasInvoked = expectation(description: "reset() was invoked")
         plugin.listeners.append { message in
@@ -53,11 +53,11 @@ class APICategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(api: apiConfig)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
-        waitForExpectations(timeout: 1.0)
+        await Amplify.reset()
+        await waitForExpectations(timeout: 1.0)
     }
 
-    func testResetRemovesAddedPlugin() throws {
+    func testResetRemovesAddedPlugin() async throws {
         let plugin = MockAPICategoryPlugin()
         try Amplify.add(plugin: plugin)
 
@@ -68,7 +68,7 @@ class APICategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(api: apiConfig)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
+        await Amplify.reset()
         XCTAssertThrowsError(try Amplify.API.getPlugin(for: "MockAPICategoryPlugin"),
                              "Getting a plugin after reset() should throw") { error in
                                 guard case APIError.invalidConfiguration = error else {
@@ -295,7 +295,7 @@ class APICategoryConfigurationTests: XCTestCase {
         XCTAssertTrue(category.isConfigured)
     }
 
-    func testIsConfiguredIsFalseAfterReset() throws {
+    func testIsConfiguredIsFalseAfterReset() async throws {
         let plugin = MockAPICategoryPlugin()
         try Amplify.add(plugin: plugin)
         let categoryConfig = APICategoryConfiguration(
@@ -305,7 +305,7 @@ class APICategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(api: categoryConfig)
         try Amplify.configure(amplifyConfig)
 
-        Amplify.reset()
+        await Amplify.reset()
 
         guard let category = Amplify.API as? AmplifyAPICategory else {
             XCTFail("Could not cast Amplify.API as AmplifyAPICategory")

--- a/AmplifyTests/CategoryTests/API/APIPluginSelectorFactoryTests.swift
+++ b/AmplifyTests/CategoryTests/API/APIPluginSelectorFactoryTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class APIPluginSelectorFactoryTests: XCTestCase {
 
 //    override func setUp() {
-//        Amplify.reset()
+//        await Amplify.reset()
 //    }
 //
 //    func testAddingSelectorFactoryBeforeFirstPluginWorks() throws {

--- a/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryClientAPITests.swift
@@ -14,8 +14,8 @@ class AnalyticsCategoryClientAPITests: XCTestCase {
     var analytics: AnalyticsCategory!
     var plugin: MockAnalyticsCategoryPlugin!
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
         plugin = MockAnalyticsCategoryPlugin()
         analytics = Amplify.Analytics
         let categoryConfiguration = AnalyticsCategoryConfiguration(

--- a/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryConfigurationTests.swift
@@ -11,8 +11,8 @@ import XCTest
 @testable import AmplifyTestCommon
 
 class AnalyticsCategoryConfigurationTests: XCTestCase {
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
     }
 
     func testCanAddAnalyticsPlugin() throws {
@@ -36,7 +36,7 @@ class AnalyticsCategoryConfigurationTests: XCTestCase {
         XCTAssertNotNil(try Amplify.Analytics.getPlugin(for: "MockAnalyticsCategoryPlugin"))
     }
 
-    func testCanResetAnalyticsPlugin() throws {
+    func testCanResetAnalyticsPlugin() async throws {
         let plugin = MockAnalyticsCategoryPlugin()
         let resetWasInvoked = expectation(description: "reset() was invoked")
         plugin.listeners.append { message in
@@ -53,11 +53,11 @@ class AnalyticsCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(analytics: analyticsConfig)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
-        waitForExpectations(timeout: 1.0)
+        await Amplify.reset()
+        await waitForExpectations(timeout: 1.0)
     }
 
-    func testResetRemovesAddedPlugin() throws {
+    func testResetRemovesAddedPlugin() async throws {
         let plugin = MockAnalyticsCategoryPlugin()
         try Amplify.add(plugin: plugin)
 
@@ -68,7 +68,7 @@ class AnalyticsCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(analytics: analyticsConfig)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
+        await Amplify.reset()
         XCTAssertThrowsError(try Amplify.Analytics.getPlugin(for: "MockAnalyticsCategoryPlugin"),
                              "Getting a plugin after reset() should throw") { error in
                                 guard case AnalyticsError.configuration = error else {

--- a/AmplifyTests/CategoryTests/Analytics/AnalyticsPluginSelectorFactoryTests.swift
+++ b/AmplifyTests/CategoryTests/Analytics/AnalyticsPluginSelectorFactoryTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class AnalyticsPluginSelectorFactoryTests: XCTestCase {
 
 //    override func setUp() {
-//        Amplify.reset()
+//        await Amplify.reset()
 //    }
 //
 //    func testAddingSelectorFactoryBeforeFirstPluginWorks() throws {

--- a/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
@@ -12,8 +12,8 @@ import XCTest
 
 class AuthCategoryConfigurationTests: XCTestCase {
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
     }
 
     /// Test if we can add a new auth plugin
@@ -57,11 +57,11 @@ class AuthCategoryConfigurationTests: XCTestCase {
     ///
     /// - Given: Amplify framework configured with Auth plugin
     /// - When:
-    ///    - I call Amplify.reset()
+    ///    - I call await Amplify.reset()
     /// - Then:
     ///    - The plugin should invoke the reset method.
     ///
-    func testCanResetCategory() throws {
+    func testCanResetCategory() async throws {
         let plugin = MockAuthCategoryPlugin()
         let resetWasInvoked = expectation(description: "reset() was invoked")
         plugin.listeners.append { message in
@@ -78,8 +78,8 @@ class AuthCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(auth: config)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
-        waitForExpectations(timeout: 1.0)
+        await Amplify.reset()
+        await waitForExpectations(timeout: 1.0)
     }
 
     /// Test whether calling reset removes the plugin added
@@ -90,7 +90,7 @@ class AuthCategoryConfigurationTests: XCTestCase {
     /// - Then:
     ///    - Auth plugin should no longer work
     ///
-    func testResetRemovesAddedPlugin() throws {
+    func testResetRemovesAddedPlugin() async throws {
         let plugin = MockAuthCategoryPlugin()
         try Amplify.add(plugin: plugin)
 
@@ -101,7 +101,7 @@ class AuthCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(auth: config)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
+        await Amplify.reset()
         XCTAssertThrowsError(try Amplify.Auth.getPlugin(for: "MockAuthCategoryPlugin"),
                              "Getting a plugin after reset() should throw") { error in
                                 guard case AuthError.configuration = error else {

--- a/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryClientAPITests.swift
@@ -12,8 +12,8 @@ import XCTest
 class DataStoreCategoryClientAPITests: XCTestCase {
     var mockAmplifyConfig: AmplifyConfiguration!
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
 
         let dataStoreConfig = DataStoreCategoryConfiguration(
             plugins: ["MockDataStoreCategoryPlugin": true]

--- a/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
@@ -11,8 +11,8 @@ import XCTest
 @testable import AmplifyTestCommon
 
 class DataStoreCategoryConfigurationTests: XCTestCase {
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
     }
 
     func testCanAddDataStorePlugin() throws {
@@ -55,7 +55,7 @@ class DataStoreCategoryConfigurationTests: XCTestCase {
         XCTAssertNotNil(try Amplify.DataStore.getPlugin(for: "MockDataStoreCategoryPlugin"))
     }
 
-    func testCanResetDataStorePlugin() throws {
+    func testCanResetDataStorePlugin() async throws {
         let plugin = MockDataStoreCategoryPlugin()
         let resetWasInvoked = expectation(description: "reset() was invoked")
         plugin.listeners.append { message in
@@ -72,11 +72,11 @@ class DataStoreCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(dataStore: dataStoreConfig)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
-        waitForExpectations(timeout: 1.0)
+        await Amplify.reset()
+        await waitForExpectations(timeout: 1.0)
     }
 
-    func testResetRemovesAddedPlugin() throws {
+    func testResetRemovesAddedPlugin() async throws {
         let plugin = MockDataStoreCategoryPlugin()
         try Amplify.add(plugin: plugin)
 
@@ -87,7 +87,7 @@ class DataStoreCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(dataStore: dataStoreConfig)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
+        await Amplify.reset()
         XCTAssertThrowsError(try Amplify.DataStore.getPlugin(for: "MockDataStoreCategoryPlugin"),
                              "Getting a plugin after reset() should throw") { error in
                                 guard case DataStoreError.configuration = error else {

--- a/AmplifyTests/CategoryTests/Geo/GeoCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Geo/GeoCategoryClientAPITests.swift
@@ -14,8 +14,8 @@ class GeoCategoryClientAPITests: XCTestCase {
     var geo: GeoCategory!
     var plugin: MockGeoCategoryPlugin!
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
         plugin = MockGeoCategoryPlugin()
         geo = Amplify.Geo
         let categoryConfiguration = GeoCategoryConfiguration(

--- a/AmplifyTests/CategoryTests/Geo/GeoCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Geo/GeoCategoryConfigurationTests.swift
@@ -11,8 +11,8 @@ import XCTest
 @testable import AmplifyTestCommon
 
 class GeoCategoryConfigurationTests: XCTestCase {
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
     }
 
     func testCanAddGeoPlugin() throws {
@@ -36,7 +36,7 @@ class GeoCategoryConfigurationTests: XCTestCase {
         XCTAssertNotNil(try Amplify.Geo.getPlugin(for: "MockGeoCategoryPlugin"))
     }
 
-    func testCanResetGeoPlugin() throws {
+    func testCanResetGeoPlugin() async throws {
         let plugin = MockGeoCategoryPlugin()
         let resetWasInvoked = expectation(description: "reset() was invoked")
         plugin.listeners.append { message in
@@ -53,11 +53,11 @@ class GeoCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(geo: geoConfig)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
-        waitForExpectations(timeout: 1.0)
+        await Amplify.reset()
+        await waitForExpectations(timeout: 1.0)
     }
 
-    func testResetRemovesAddedPlugin() throws {
+    func testResetRemovesAddedPlugin() async throws {
         let plugin = MockGeoCategoryPlugin()
         try Amplify.add(plugin: plugin)
 
@@ -68,7 +68,7 @@ class GeoCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(geo: geoConfig)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
+        await Amplify.reset()
         XCTAssertThrowsError(try Amplify.Geo.getPlugin(for: "MockGeoCategoryPlugin"),
                              "Getting a plugin after reset() should throw") { error in
             guard case Geo.Error.invalidConfiguration = error else {

--- a/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
@@ -11,8 +11,8 @@ import XCTest
 
 class AmplifyOperationHubTests: XCTestCase {
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
 
         let storageConfiguration =
             StorageCategoryConfiguration(plugins: ["MockDispatchingStoragePlugin": nil])
@@ -25,8 +25,8 @@ class AmplifyOperationHubTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     /// Given: An AmplifyOperation

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeHubListenToOperationTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeHubListenToOperationTests.swift
@@ -11,8 +11,8 @@ import XCTest
 
 class AutoUnsubscribeHubListenToOperationTests: XCTestCase {
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
 
         let storageConfiguration =
             StorageCategoryConfiguration(plugins: ["MockDispatchingStoragePlugin": nil])
@@ -25,8 +25,8 @@ class AutoUnsubscribeHubListenToOperationTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     /// - Given: An Amplify operation class

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeOperationTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeOperationTests.swift
@@ -11,8 +11,8 @@ import XCTest
 
 class AutoUnsubscribeOperationTests: XCTestCase {
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
 
         let storageConfiguration =
             StorageCategoryConfiguration(plugins: ["MockDispatchingStoragePlugin": nil])
@@ -25,8 +25,8 @@ class AutoUnsubscribeOperationTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     /// - Given: An Amplify operation class

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginConcurrencyTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginConcurrencyTests.swift
@@ -18,8 +18,8 @@ class DefaultHubPluginConcurrencyTests: XCTestCase {
         return plugin
     }
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
         let config = AmplifyConfiguration()
         do {
             try Amplify.configure(config)
@@ -28,8 +28,8 @@ class DefaultHubPluginConcurrencyTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     /// Given: The default configuration

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginCustomChannelTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginCustomChannelTests.swift
@@ -20,8 +20,8 @@ class DefaultHubPluginCustomChannelTests: XCTestCase {
         return plugin
     }
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
         let config = AmplifyConfiguration()
         do {
             try Amplify.configure(config)
@@ -30,8 +30,8 @@ class DefaultHubPluginCustomChannelTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     /// Given: A listener to a custom channel

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginTests.swift
@@ -20,8 +20,8 @@ class DefaultHubPluginTests: XCTestCase {
         return plugin
     }
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
         // This test suite will have a lot of in-flight messages at the time of the `reset`. Give them time to finis
         // being delivered before moving to the next step.
         Thread.sleep(forTimeInterval: 1.0)
@@ -33,8 +33,8 @@ class DefaultHubPluginTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     /// Given: An Amplify system configured with default values
@@ -78,7 +78,7 @@ class DefaultHubPluginTests: XCTestCase {
     func testDefaultPluginDispatches() throws {
         let messageReceived = expectation(description: "Message was received")
 
-        // We have other tests for multiple message delivery, and since Amplify.reset() is known to leave in-process
+        // We have other tests for multiple message delivery, and since await Amplify.reset() is known to leave in-process
         // messages going, we'll let this test's expectation pass as long as it fulfills at least once
         messageReceived.assertForOverFulfill = false
 

--- a/AmplifyTests/CategoryTests/Hub/HubCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubCategoryConfigurationTests.swift
@@ -11,8 +11,8 @@ import XCTest
 @testable import AmplifyTestCommon
 
 class HubCategoryConfigurationTests: XCTestCase {
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
     }
 
     func testCanAddHubPlugin() throws {
@@ -36,7 +36,7 @@ class HubCategoryConfigurationTests: XCTestCase {
         XCTAssertNotNil(try Amplify.Hub.getPlugin(for: "MockHubCategoryPlugin"))
     }
 
-    func testCanResetHubPlugin() throws {
+    func testCanResetHubPlugin() async throws {
         let plugin = MockHubCategoryPlugin()
         let resetWasInvoked = expectation(description: "reset() was invoked")
         plugin.listeners.append { message in
@@ -53,11 +53,11 @@ class HubCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(hub: hubConfig)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
-        waitForExpectations(timeout: 1.0)
+        await Amplify.reset()
+        await waitForExpectations(timeout: 1.0)
     }
 
-    func testResetRemovesAddedPlugin() throws {
+    func testResetRemovesAddedPlugin() async throws {
         let plugin = MockHubCategoryPlugin()
         try Amplify.add(plugin: plugin)
 
@@ -68,7 +68,7 @@ class HubCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(hub: hubConfig)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
+        await Amplify.reset()
         XCTAssertThrowsError(try Amplify.Hub.getPlugin(for: "MockHubCategoryPlugin"),
                              "Getting a plugin after reset() should throw") { error in
                                 guard case HubError.configuration = error else {

--- a/AmplifyTests/CategoryTests/Hub/HubClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubClientAPITests.swift
@@ -13,8 +13,8 @@ import XCTest
 class HubClientAPITests: XCTestCase {
     var mockAmplifyConfig: AmplifyConfiguration!
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
 
         let hubConfig = HubCategoryConfiguration(
             plugins: ["MockHubCategoryPlugin": true]

--- a/AmplifyTests/CategoryTests/Hub/HubPluginSelectorFactoryTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubPluginSelectorFactoryTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class HubPluginSelectorFactoryTests: XCTestCase {
 
 //    override func setUp() {
-//        Amplify.reset()
+//        await Amplify.reset()
 //    }
 //
 //    func testAddingSelectorFactoryBeforeFirstPluginWorks() throws {

--- a/AmplifyTests/CategoryTests/Logging/DefaultLoggingPluginTests.swift
+++ b/AmplifyTests/CategoryTests/Logging/DefaultLoggingPluginTests.swift
@@ -18,8 +18,8 @@ import XCTest
 /// method.
 class DefaultLoggingPluginTests: XCTestCase {
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
         let config = AmplifyConfiguration()
         do {
             try Amplify.configure(config)
@@ -28,8 +28,8 @@ class DefaultLoggingPluginTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
-        Amplify.reset()
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
 
     /// Given: An Amplify system configured with default values

--- a/AmplifyTests/CategoryTests/Logging/LoggingCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Logging/LoggingCategoryClientAPITests.swift
@@ -12,8 +12,8 @@ import XCTest
 class LoggingCategoryClientAPITests: XCTestCase {
     var mockAmplifyConfig: AmplifyConfiguration!
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
 
         let loggingConfig = LoggingCategoryConfiguration(
             plugins: ["MockLoggingCategoryPlugin": true]

--- a/AmplifyTests/CategoryTests/Logging/LoggingCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Logging/LoggingCategoryConfigurationTests.swift
@@ -11,8 +11,8 @@ import XCTest
 @testable import AmplifyTestCommon
 
 class LoggingCategoryConfigurationTests: XCTestCase {
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
     }
 
     func testCanAddLoggingPlugin() throws {
@@ -36,7 +36,7 @@ class LoggingCategoryConfigurationTests: XCTestCase {
         XCTAssertNotNil(try Amplify.Logging.getPlugin(for: "MockLoggingCategoryPlugin"))
     }
 
-    func testCanResetLoggingPlugin() throws {
+    func testCanResetLoggingPlugin() async throws {
         let plugin = MockLoggingCategoryPlugin()
         let resetWasInvoked = expectation(description: "reset() was invoked")
         plugin.listeners.append { message in
@@ -53,11 +53,11 @@ class LoggingCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(logging: loggingConfig)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
-        waitForExpectations(timeout: 1.0)
+        await Amplify.reset()
+        await waitForExpectations(timeout: 1.0)
     }
 
-    func testResetRemovesAddedPlugin() throws {
+    func testResetRemovesAddedPlugin() async throws {
         let plugin = MockLoggingCategoryPlugin()
         try Amplify.add(plugin: plugin)
 
@@ -68,7 +68,7 @@ class LoggingCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(logging: loggingConfig)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
+        await Amplify.reset()
         XCTAssertThrowsError(try Amplify.Logging.getPlugin(for: "MockLoggingCategoryPlugin"),
                              "Getting a plugin after reset() should throw") { error in
                                 guard case LoggingError.configuration = error else {

--- a/AmplifyTests/CategoryTests/Logging/LoggingPluginSelectorFactoryTests.swift
+++ b/AmplifyTests/CategoryTests/Logging/LoggingPluginSelectorFactoryTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class LoggingPluginSelectorFactoryTests: XCTestCase {
 //
 //    override func setUp() {
-//        Amplify.reset()
+//        await Amplify.reset()
 //    }
 //
 //    func testAddingSelectorFactoryBeforeFirstPluginWorks() throws {

--- a/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryClientAPITests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import Amplify
 
 class PredictionsCategoryClientAPITests: XCTestCase {
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
     }
 }

--- a/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryConfigurationTests.swift
@@ -12,8 +12,8 @@ import XCTest
 
 class PredictionsCategoryConfigurationTests: XCTestCase {
 
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
     }
 
     /// Test if we can add a new prediction plugin
@@ -57,11 +57,11 @@ class PredictionsCategoryConfigurationTests: XCTestCase {
     ///
     /// - Given: Amplify framework configured with Prediction plugin
     /// - When:
-    ///    - I call Amplify.reset()
+    ///    - I call await Amplify.reset()
     /// - Then:
     ///    - The plugin should invoke the reset method.
     ///
-    func testCanResetPlugin() throws {
+    func testCanResetPlugin() async throws {
         let plugin = MockPredictionsCategoryPlugin()
         let resetWasInvoked = expectation(description: "reset() was invoked")
         plugin.listeners.append { message in
@@ -78,8 +78,8 @@ class PredictionsCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(predictions: config)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
-        waitForExpectations(timeout: 1.0)
+        await Amplify.reset()
+        await waitForExpectations(timeout: 1.0)
     }
 
     /// Test whether calling reset removes the plugin added
@@ -90,7 +90,7 @@ class PredictionsCategoryConfigurationTests: XCTestCase {
     /// - Then:
     ///    - Predicitons plugin should no longer work
     ///
-    func testResetRemovesAddedPlugin() throws {
+    func testResetRemovesAddedPlugin() async throws {
         let plugin = MockPredictionsCategoryPlugin()
         try Amplify.add(plugin: plugin)
 
@@ -101,7 +101,7 @@ class PredictionsCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(predictions: config)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
+        await Amplify.reset()
         XCTAssertThrowsError(try Amplify.Predictions.getPlugin(for: "MockPredictionsCategoryPlugin"),
                              "Getting a plugin after reset() should throw") { error in
                                 guard case PredictionsError.configuration = error else {

--- a/AmplifyTests/CategoryTests/Storage/StorageCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StorageCategoryClientAPITests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import Amplify
 
 class StorageCategoryClientAPITests: XCTestCase {
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
     }
 }

--- a/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
@@ -11,8 +11,8 @@ import XCTest
 @testable import AmplifyTestCommon
 
 class StorageCategoryConfigurationTests: XCTestCase {
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
     }
 
     func testCanAddStoragePlugin() throws {
@@ -36,7 +36,7 @@ class StorageCategoryConfigurationTests: XCTestCase {
         XCTAssertNotNil(try Amplify.Storage.getPlugin(for: "MockStorageCategoryPlugin"))
     }
 
-    func testCanResetStoragePlugin() throws {
+    func testCanResetStoragePlugin() async throws {
         let plugin = MockStorageCategoryPlugin()
         let resetWasInvoked = expectation(description: "reset() was invoked")
         plugin.listeners.append { message in
@@ -53,11 +53,11 @@ class StorageCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(storage: storageConfig)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
-        waitForExpectations(timeout: 1.0)
+        await Amplify.reset()
+        await waitForExpectations(timeout: 1.0)
     }
 
-    func testResetRemovesAddedPlugin() throws {
+    func testResetRemovesAddedPlugin() async throws {
         let plugin = MockStorageCategoryPlugin()
         try Amplify.add(plugin: plugin)
 
@@ -68,7 +68,7 @@ class StorageCategoryConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(storage: storageConfig)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
+        await Amplify.reset()
         XCTAssertThrowsError(try Amplify.Storage.getPlugin(for: "MockStorageCategoryPlugin"),
                              "Getting a plugin after reset() should throw") { error in
                                 guard case StorageError.configuration = error else {

--- a/AmplifyTests/CategoryTests/Storage/StoragePluginSelectorFactoryTests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StoragePluginSelectorFactoryTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class StoragePluginSelectorFactoryTests: XCTestCase {
 
 //    override func setUp() {
-//        Amplify.reset()
+//        await Amplify.reset()
 //    }
 //
 //    func testAddingSelectorFactoryBeforeFirstPluginWorks() throws {

--- a/AmplifyTests/CoreTests/AmplifyConfigurationInitializationTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyConfigurationInitializationTests.swift
@@ -153,10 +153,10 @@ class AmplifyConfigurationInitializationTests: XCTestCase {
     ///    - Amplify is finished configuring its plugins
     /// - Then:
     ///    - I receive a Hub event
-    func testConfigurationNotification() throws {
+    func testConfigurationNotification() async throws {
         let notificationReceived = expectation(description: "Configured notification received")
         let listeningPlugin = NotificationListeningAnalyticsPlugin(notificationReceived: notificationReceived)
-        Amplify.reset()
+        await Amplify.reset()
         try Amplify.add(plugin: listeningPlugin)
 
         let analyticsConfiguration = AnalyticsCategoryConfiguration(plugins: [

--- a/AmplifyTests/CoreTests/ConfigurationTests.swift
+++ b/AmplifyTests/CoreTests/ConfigurationTests.swift
@@ -11,8 +11,8 @@ import XCTest
 @testable import AmplifyTestCommon
 
 class ConfigurationTests: XCTestCase {
-    override func setUp() {
-        Amplify.reset()
+    override func setUp() async throws {
+        await Amplify.reset()
     }
 
     // Remember, this test must be invoked with a category that doesn't include an Amplify-supplied default plugin
@@ -69,7 +69,7 @@ class ConfigurationTests: XCTestCase {
         }
     }
 
-    func testResetClearsPreviouslyAddedPlugins() throws {
+    func testResetClearsPreviouslyAddedPlugins() async throws {
         let plugin = MockLoggingCategoryPlugin()
         try Amplify.add(plugin: plugin)
 
@@ -81,7 +81,7 @@ class ConfigurationTests: XCTestCase {
 
         try Amplify.configure(amplifyConfig)
         XCTAssertNotNil(try Amplify.Logging.getPlugin(for: "MockLoggingCategoryPlugin"))
-        Amplify.reset()
+        await Amplify.reset()
         XCTAssertThrowsError(try Amplify.Logging.getPlugin(for: "MockLoggingCategoryPlugin"),
                              "Plugins should be reset") { error in
                                 guard case LoggingError.configuration = error else {
@@ -91,7 +91,7 @@ class ConfigurationTests: XCTestCase {
         }
     }
 
-    func testResetDelegatesToPlugins() throws {
+    func testResetDelegatesToPlugins() async throws {
         let plugin = MockLoggingCategoryPlugin()
 
         let resetWasInvoked = expectation(description: "Reset was invoked")
@@ -110,14 +110,14 @@ class ConfigurationTests: XCTestCase {
         let amplifyConfig = AmplifyConfiguration(logging: loggingConfig)
 
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
+        await Amplify.reset()
         wait(for: [resetWasInvoked], timeout: 1.0)
     }
 
-    func testResetAllowsReconfiguration() throws {
+    func testResetAllowsReconfiguration() async throws {
         let amplifyConfig = AmplifyConfiguration()
         try Amplify.configure(amplifyConfig)
-        Amplify.reset()
+        await Amplify.reset()
         XCTAssertNoThrow(try Amplify.configure(amplifyConfig))
     }
 

--- a/AmplifyTests/DevMenuTests/DevMenuExtensionTests.swift
+++ b/AmplifyTests/DevMenuTests/DevMenuExtensionTests.swift
@@ -50,7 +50,7 @@ class DevMenuExtensionTests: XCTestCase {
         let devMenuPlugin = try Amplify.Logging.getPlugin(for: DevMenuStringConstants.persistentLoggingPluginKey)
         XCTAssertTrue(devMenuPlugin is PersistentLoggingPlugin)
     }
-    override func tearDown() {
+    override func tearDown() async throws {
         await Amplify.reset()
     }
 }

--- a/AmplifyTests/DevMenuTests/DevMenuExtensionTests.swift
+++ b/AmplifyTests/DevMenuTests/DevMenuExtensionTests.swift
@@ -16,7 +16,7 @@ class DevMenuExtensionTests: XCTestCase {
         do {
             Amplify.enableDevMenu(contextProvider: provider)
 
-            /// After Amplify.reset() is called in teardown(), Amplify.configure() doesn't
+            /// After await Amplify.reset() is called in teardown(), Amplify.configure() doesn't
             /// initialize the plugin for LoggingCategory . This doesn't call Amplify.getLoggingCategoryPlugin()
             /// and the plugin is not updated to PersistentLoggingPlugin. Making a call to
             /// add() so that configure() updates the plugin
@@ -51,7 +51,7 @@ class DevMenuExtensionTests: XCTestCase {
         XCTAssertTrue(devMenuPlugin is PersistentLoggingPlugin)
     }
     override func tearDown() {
-        Amplify.reset()
+        await Amplify.reset()
     }
 }
 #endif

--- a/AmplifyTests/DevMenuTests/PersistentLogWrapperTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLogWrapperTests.swift
@@ -18,7 +18,7 @@ class PersistentLogWrapperTests: XCTestCase {
         do {
             Amplify.enableDevMenu(contextProvider: provider)
 
-            /// After Amplify.reset() is called in teardown(), Amplify.configure() doesn't
+            /// After await Amplify.reset() is called in teardown(), Amplify.configure() doesn't
             /// initialize the plugin for LoggingCategory . This doesn't call Amplify.getLoggingCategoryPlugin()
             /// and the plugin is not updated to PersistentLoggingPlugin. Making a call to
             /// add() so that configure() updates the plugin
@@ -134,7 +134,7 @@ class PersistentLogWrapperTests: XCTestCase {
     }
 
     override func tearDown() {
-        Amplify.reset()
+        await Amplify.reset()
     }
 }
 #endif

--- a/AmplifyTests/DevMenuTests/PersistentLogWrapperTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLogWrapperTests.swift
@@ -133,7 +133,7 @@ class PersistentLogWrapperTests: XCTestCase {
         XCTAssertTrue(logHistory[0].message == "Message 2")
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         await Amplify.reset()
     }
 }

--- a/AmplifyTests/DevMenuTests/PersistentLoggingPluginTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLoggingPluginTests.swift
@@ -43,7 +43,7 @@ class PersistentLoggingPluginTests: XCTestCase {
         XCTAssertTrue(devMenuPlugin.default is PersistentLogWrapper)
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         await Amplify.reset()
     }
 }

--- a/AmplifyTests/DevMenuTests/PersistentLoggingPluginTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLoggingPluginTests.swift
@@ -18,7 +18,7 @@ class PersistentLoggingPluginTests: XCTestCase {
         do {
             Amplify.enableDevMenu(contextProvider: provider)
 
-            /// After Amplify.reset() is called in teardown(), Amplify.configure() doesn't
+            /// After await Amplify.reset() is called in teardown(), Amplify.configure() doesn't
             /// initialize the plugin for LoggingCategory . This doesn't call Amplify.getLoggingCategoryPlugin()
             /// and the plugin is not updated to PersistentLoggingPlugin. Making a call to
             /// add() so that configure() updates the plugin
@@ -44,7 +44,7 @@ class PersistentLoggingPluginTests: XCTestCase {
     }
 
     override func tearDown() {
-        Amplify.reset()
+        await Amplify.reset()
     }
 }
 #endif

--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,10 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
-let platforms: [SupportedPlatform] = [.iOS(.v13)]
+let platforms: [SupportedPlatform] = [
+    .iOS(.v13),
+    .macOS(.v10_15)
+]
 let dependencies: [Package.Dependency] = [
     .package(
         url: "https://github.com/stephencelis/SQLite.swift.git",

--- a/Package.swift
+++ b/Package.swift
@@ -2,10 +2,7 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
-let platforms: [SupportedPlatform] = [
-    .iOS(.v13),
-    .macOS(.v10_15)
-]
+let platforms: [SupportedPlatform] = [.iOS(.v13)]
 let dependencies: [Package.Dependency] = [
     .package(
         url: "https://github.com/stephencelis/SQLite.swift.git",


### PR DESCRIPTION
*Description of changes:*
Update Amplify.reset to use Swift Concurrency and update all tests to work with it.

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
