### PR TITLE
fix: update plugin reset methods to use swift concurrency

### DIFF
--- a/Amplify/Categories/API/Internal/APICategory+Resettable.swift
+++ b/Amplify/Categories/API/Internal/APICategory+Resettable.swift
@@ -9,15 +9,14 @@ import Foundation
 
 extension AmplifyAPICategory: Resettable {
 
-    public func reset(onComplete: @escaping BasicClosure) {
-        let group = DispatchGroup()
-
-        for plugin in plugins.values {
-            log.verbose("Resetting \(categoryType) plugin")
-            group.enter()
-            plugin.reset {
-                self.log.verbose("Resetting \(self.categoryType) plugin: finished")
-                group.leave()
+    public func reset() async {
+        await withTaskGroup(of: Void.self) { taskGroup in
+            for plugin in plugins.values {
+                taskGroup.addTask { [weak self] in
+                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
+                    await plugin.reset()
+                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
+                }
             }
         }
 
@@ -26,10 +25,6 @@ extension AmplifyAPICategory: Resettable {
         ModelListDecoderRegistry.reset()
         log.verbose("Resetting ModelRegistry and ModelListDecoderRegistry: finished")
 
-        group.wait()
-
         isConfigured = false
-        onComplete()
     }
-
 }

--- a/Amplify/Categories/Analytics/Internal/AnalyticsCategory+Resettable.swift
+++ b/Amplify/Categories/Analytics/Internal/AnalyticsCategory+Resettable.swift
@@ -9,22 +9,18 @@ import Foundation
 
 extension AnalyticsCategory: Resettable {
 
-    public func reset(onComplete: @escaping BasicClosure) {
-        let group = DispatchGroup()
-
-        for plugin in plugins.values {
-            log.verbose("Resetting \(categoryType) plugin")
-            group.enter()
-            plugin.reset {
-                self.log.verbose("Resetting \(self.categoryType) plugin: finished")
-                group.leave()
+    public func reset() async {
+        await withTaskGroup(of: Void.self) { taskGroup in
+            for plugin in plugins.values {
+                taskGroup.addTask { [weak self] in
+                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
+                    await plugin.reset()
+                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
+                }
             }
         }
-
-        group.wait()
-
+        
         isConfigured = false
-        onComplete()
     }
 
 }

--- a/Amplify/Categories/Auth/Internal/AuthCategory+Resettable.swift
+++ b/Amplify/Categories/Auth/Internal/AuthCategory+Resettable.swift
@@ -9,22 +9,18 @@ import Foundation
 
 extension AuthCategory: Resettable {
 
-    public func reset(onComplete: @escaping BasicClosure) {
-        let group = DispatchGroup()
-
-        for plugin in plugins.values {
-            log.verbose("Resetting \(categoryType) plugin")
-            group.enter()
-            plugin.reset {
-                self.log.verbose("Resetting \(self.categoryType) plugin: finished")
-                group.leave()
+    public func reset() async {
+        await withTaskGroup(of: Void.self) { taskGroup in
+            for plugin in plugins.values {
+                taskGroup.addTask { [weak self] in
+                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
+                    await plugin.reset()
+                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
+                }
             }
         }
-
-        group.wait()
-
+        
         isConfigured = false
-        onComplete()
     }
 
 }

--- a/Amplify/Categories/DataStore/Internal/DataStoreCategory+Resettable.swift
+++ b/Amplify/Categories/DataStore/Internal/DataStoreCategory+Resettable.swift
@@ -9,15 +9,14 @@ import Foundation
 
 extension DataStoreCategory: Resettable {
 
-    public func reset(onComplete: @escaping BasicClosure) {
-        let group = DispatchGroup()
-
-        for plugin in plugins.values {
-            log.verbose("Resetting \(categoryType) plugin")
-            group.enter()
-            plugin.reset {
-                self.log.verbose("Resetting \(self.categoryType) plugin: finished")
-                group.leave()
+    public func reset() async {
+        await withTaskGroup(of: Void.self) { taskGroup in
+            for plugin in plugins.values {
+                taskGroup.addTask { [weak self] in
+                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
+                    await plugin.reset()
+                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
+                }
             }
         }
 
@@ -26,10 +25,6 @@ extension DataStoreCategory: Resettable {
         ModelListDecoderRegistry.reset()
         log.verbose("Resetting ModelRegistry and ModelListDecoderRegistry: finished")
 
-        group.wait()
-
         isConfigured = false
-        onComplete()
     }
-
 }

--- a/Amplify/Categories/Hub/Internal/HubCategory+Resettable.swift
+++ b/Amplify/Categories/Hub/Internal/HubCategory+Resettable.swift
@@ -9,22 +9,17 @@ import Foundation
 
 extension HubCategory: Resettable {
 
-    public func reset(onComplete: @escaping BasicClosure) {
-        let group = DispatchGroup()
-
-        for plugin in plugins.values {
-            log.verbose("Resetting \(categoryType) plugin")
-            group.enter()
-            plugin.reset {
-                self.log.verbose("Resetting \(self.categoryType) plugin: finished")
-                group.leave()
+    public func reset() async {
+        await withTaskGroup(of: Void.self) { taskGroup in
+            for plugin in plugins.values {
+                taskGroup.addTask { [weak self] in
+                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
+                    await plugin.reset()
+                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
+                }
             }
         }
 
-        group.wait()
-
         configurationState = .pendingConfiguration
-        onComplete()
     }
-
 }

--- a/Amplify/Categories/Logging/Internal/LoggingCategory+Resettable.swift
+++ b/Amplify/Categories/Logging/Internal/LoggingCategory+Resettable.swift
@@ -9,21 +9,12 @@ import Foundation
 
 extension LoggingCategory: Resettable {
 
-    public func reset(onComplete: @escaping BasicClosure) {
-        log.verbose("Resetting \(categoryType) plugin: no 'finish' message will be logged")
+    public func reset() async {
+        log.verbose("Resetting \(categoryType) plugin")
+        await plugin.reset()
+        log.verbose("Resetting \(categoryType) plugin: finished")
         concurrencyQueue.sync {
-            let group = DispatchGroup()
-
-            group.enter()
-            plugin.reset {
-                group.leave()
-            }
-
-            group.wait()
-
             configurationState = .default
-            onComplete()
         }
     }
-
 }

--- a/Amplify/Categories/Predictions/Internal/PredictionsCategory+Resettable.swift
+++ b/Amplify/Categories/Predictions/Internal/PredictionsCategory+Resettable.swift
@@ -8,23 +8,19 @@
 import Foundation
 
 extension PredictionsCategory: Resettable {
-
-    public func reset(onComplete: @escaping (() -> Void)) {
-        let group = DispatchGroup()
-
-        for plugin in plugins.values {
-            log.verbose("Resetting \(categoryType) plugin")
-            group.enter()
-            plugin.reset {
-                self.log.verbose("Resetting \(self.categoryType) plugin: finished")
-                group.leave()
+    
+    public func reset() async {
+        await withTaskGroup(of: Void.self) { taskGroup in
+            for plugin in plugins.values {
+                taskGroup.addTask { [weak self] in
+                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
+                    await plugin.reset()
+                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
+                }
             }
         }
-
-        group.wait()
-
+        
         isConfigured = false
-        onComplete()
     }
 
 }

--- a/Amplify/Categories/Storage/Internal/StorageCategory+Resettable.swift
+++ b/Amplify/Categories/Storage/Internal/StorageCategory+Resettable.swift
@@ -9,22 +9,18 @@ import Foundation
 
 extension StorageCategory: Resettable {
 
-    public func reset(onComplete: @escaping BasicClosure) {
-        let group = DispatchGroup()
-
-        for plugin in plugins.values {
-            log.verbose("Resetting \(categoryType) plugin")
-            group.enter()
-            plugin.reset {
-                self.log.verbose("Resetting \(self.categoryType) plugin: finished")
-                group.leave()
+    public func reset() async {
+        await withTaskGroup(of: Void.self) { taskGroup in
+            for plugin in plugins.values {
+                taskGroup.addTask { [weak self] in
+                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
+                    await plugin.reset()
+                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
+                }
             }
         }
-
-        group.wait()
-
+        
         isConfigured = false
-        onComplete()
     }
 
 }

--- a/Amplify/Core/Configuration/Internal/Amplify+Reset.swift
+++ b/Amplify/Core/Configuration/Internal/Amplify+Reset.swift
@@ -82,12 +82,8 @@ extension Amplify {
     }
 
     private static func reset(_ candidate: Any) async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) -> Void in
-            guard let resettable = candidate as? Resettable else { return }
-            
-            resettable.reset {
-                continuation.resume()
-            }
-        }
+        guard let resettable = candidate as? Resettable else { return }
+        
+        await resettable.reset()
     }
 }

--- a/Amplify/Core/Configuration/Internal/CategoryConfigurable.swift
+++ b/Amplify/Core/Configuration/Internal/CategoryConfigurable.swift
@@ -21,6 +21,6 @@ protocol CategoryConfigurable: AnyObject, CategoryTypeable {
     func configure(using amplifyConfiguration: AmplifyConfiguration) throws
 
     /// Clears the category configurations, and invokes `reset` on each added plugin
-    func reset(onComplete: @escaping BasicClosure)
+    func reset() async
 
 }

--- a/Amplify/Core/Plugin/Internal/Resettable.swift
+++ b/Amplify/Core/Plugin/Internal/Resettable.swift
@@ -14,12 +14,11 @@ public protocol Resettable {
     /// Called when the client calls `await Amplify.reset()` during testing. When invoked,
     /// the plugin must release resources and reset shared state. Shortly after calling
     /// `reset()` on the plugin, the category and its associated plugins will be
-    /// released. Plugins must invoke the `onComplete` handler when they complete their
-    /// reset. Immediately after invoking `onComplete`, the plugin's underlying system
+    /// released. Immediately after returning, the plugin's underlying system
     /// must be ready to instantiate a new plugin and configure it.
     ///
     /// This method is intended only for use by the Amplify system, and should not be
     /// invoked by host applications.
-    func reset(onComplete: @escaping BasicClosure)
+    func reset() async
 
 }

--- a/Amplify/DefaultPlugins/AWSHubPlugin/AWSHubPlugin.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/AWSHubPlugin.swift
@@ -41,9 +41,8 @@ final public class AWSHubPlugin: HubCategoryPlugin {
     }
 
     /// Removes listeners and empties the message queue
-    public func reset(onComplete: @escaping BasicClosure) {
+    public func reset() async {
         dispatcher.destroy()
-        onComplete()
     }
 
     public func dispatch(to channel: HubChannel, payload: HubPayload) {

--- a/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/AWSUnifiedLoggingPlugin.swift
+++ b/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/AWSUnifiedLoggingPlugin.swift
@@ -50,10 +50,9 @@ final public class AWSUnifiedLoggingPlugin: LoggingCategoryPlugin {
     }
 
     /// Removes listeners and empties the message queue
-    public func reset(onComplete: @escaping BasicClosure) {
+    public func reset() {
         concurrencyQueue.sync {
             registeredLogs = [:]
-            onComplete()
         }
     }
 

--- a/Amplify/DevMenu/Amplify+DevMenu.swift
+++ b/Amplify/DevMenu/Amplify+DevMenu.swift
@@ -12,6 +12,7 @@ extension Amplify {
 #if canImport(UIKit)
     static var devMenu: AmplifyDevMenu?
 
+    @MainActor
     public static func enableDevMenu(contextProvider: DevMenuPresentationContextProvider) {
 #if DEBUG
         devMenu = AmplifyDevMenu(devMenuPresentationContextProvider: contextProvider)

--- a/Amplify/DevMenu/Logging/PersistentLoggingPlugin.swift
+++ b/Amplify/DevMenu/Logging/PersistentLoggingPlugin.swift
@@ -28,9 +28,9 @@ public class PersistentLoggingPlugin: LoggingCategoryPlugin {
         return plugin.logger(forCategory: category)
     }
 
-    public func reset(onComplete: @escaping BasicClosure) {
+    public func reset() async {
         persistentLogWrapper = nil
-        plugin.reset(onComplete: onComplete)
+        await plugin.reset()
     }
 
     init(plugin: LoggingCategoryPlugin) {

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Resettable.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/AWSAPIPlugin+Resettable.swift
@@ -11,12 +11,10 @@ import AwsCommonRuntimeKit
 
 extension AWSAPIPlugin: Resettable {
 
-    public func reset(onComplete: @escaping BasicClosure) {
+    public func reset() async {
         mapper.reset()
 
-        let waitForReset = DispatchSemaphore(value: 0)
-        session.reset { waitForReset.signal() }
-        waitForReset.wait()
+        await session.cancelAndReset()
 
         session = nil
 
@@ -31,8 +29,6 @@ extension AWSAPIPlugin: Resettable {
         subscriptionConnectionFactory = nil
 
         AwsCommonRuntimeKit.cleanUp()
-
-        onComplete()
     }
 
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/URLSession+URLSessionBehavior.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/URLSession+URLSessionBehavior.swift
@@ -9,11 +9,9 @@ import Amplify
 import Foundation
 
 extension URLSession: URLSessionBehavior {
-    public func reset(onComplete: BasicClosure?) {
+    public func cancelAndReset() async {
         invalidateAndCancel()
-        reset {
-            onComplete?()
-        }
+        await reset()
     }
 
     public func dataTaskBehavior(with request: URLRequest) -> URLSessionDataTaskBehavior {
@@ -23,5 +21,4 @@ extension URLSession: URLSessionBehavior {
     public var sessionBehaviorDelegate: URLSessionBehaviorDelegate? {
         return delegate as? URLSessionBehaviorDelegate
     }
-
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/URLSessionBehavior.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/URLSessionBehavior/URLSessionBehavior.swift
@@ -14,7 +14,7 @@ import Foundation
 public protocol URLSessionBehavior {
 
     /// For testing only. Resets the state of the object in preparation for testing.
-    func reset(onComplete: BasicClosure?)
+    func cancelAndReset() async
 
     /// Returns a data task for the specified request
     /// - Parameter request: The URLRequest to fulfill

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ReachabilityTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ReachabilityTests.swift
@@ -22,10 +22,9 @@ class AWSAPICategoryPluginReachabilityTests: XCTestCase {
         apiPlugin = AWSAPIPlugin()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         if let api = apiPlugin {
-            api.reset {
-            }
+            await api.reset()
         }
     }
 

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ResetTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPlugin+ResetTests.swift
@@ -10,13 +10,9 @@ import XCTest
 
 class AWSAPICategoryPluginResetTests: AWSAPICategoryPluginTestBase {
 
-    func testReset() {
-        let completedInvoked = expectation(description: "onComplete is invoked")
-        apiPlugin.reset {
-            completedInvoked.fulfill()
-        }
+    func testReset() async {
+        await apiPlugin.reset()
 
-        waitForExpectations(timeout: 1)
         XCTAssertNotNil(apiPlugin.mapper)
         XCTAssertEqual(apiPlugin.mapper.operations.count, 0)
         XCTAssertEqual(apiPlugin.mapper.tasks.count, 0)

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPluginTestBase.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/AWSAPICategoryPluginTestBase.swift
@@ -73,10 +73,9 @@ class AWSAPICategoryPluginTestBase: XCTestCase {
         }
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         if let api = apiPlugin {
-            api.reset {
-            }
+            await api.reset()
         }
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Mocks/MockURLSession.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Mocks/MockURLSession.swift
@@ -31,7 +31,7 @@ class MockURLSession: URLSessionBehavior {
         return task
     }
 
-    func reset(onComplete: BasicClosure?) {
-        onReset?(onComplete)
+    func cancelAndReset() {
+        // do nothing
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLSubscribeCombineTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLSubscribeCombineTests.swift
@@ -40,8 +40,8 @@ class GraphQLSubscribeCombineTests: OperationTestBase {
     var connectionStateSink: AnyCancellable?
     var subscriptionDataSink: AnyCancellable?
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    override func setUp() async throws {
+        try await super.setUp()
 
         onSubscribeInvoked = expectation(description: "onSubscribeInvoked")
 

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLSubscribeTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/GraphQLSubscribeTests.swift
@@ -33,8 +33,8 @@ class GraphQLSubscribeTests: OperationTestBase {
     var subscriptionItem: SubscriptionItem!
     var subscriptionEventHandler: SubscriptionEventHandler!
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    override func setUp() async throws {
+        try await super.setUp()
 
         onSubscribeInvoked = expectation(description: "onSubscribeInvoked")
 

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/OperationTestBase.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Operation/OperationTestBase.swift
@@ -15,18 +15,9 @@ class OperationTestBase: XCTestCase {
 
     var apiPlugin: AWSAPIPlugin!
 
-    /// There are no throwing methods in this, but in order to let subclasses have a predictable way
-    /// of setting up plugins, this base class uses `setUpWithError` instead of `setUp`. (XCTest
-    /// lifecycle normally invokes `setUp` after `setUpWithError`, which means that any state config
-    /// done inside of a subclass' `setUpWithError` could be erased by this class' call to
-    /// `AWSAPIPlugin.reset` from inside `setUp`.
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         if apiPlugin != nil {
-            let waitForReset = DispatchSemaphore(value: 0)
-            apiPlugin.reset {
-                waitForReset.signal()
-            }
-            waitForReset.wait()
+            await apiPlugin.reset()
         }
         apiPlugin = nil
     }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Reset.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Reset.swift
@@ -9,7 +9,7 @@ import Amplify
 import Foundation
 extension AWSPinpointAnalyticsPlugin {
     /// Resets the state of the plugin
-    public func reset(onComplete: @escaping (() -> Void)) {
+    public func reset() {
         if pinpoint != nil {
             pinpoint = nil
         }
@@ -31,7 +31,5 @@ extension AWSPinpointAnalyticsPlugin {
         if isEnabled != nil {
             isEnabled = nil
         }
-
-        onComplete()
     }
 }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginResetTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginResetTests.swift
@@ -10,12 +10,7 @@ import XCTest
 
 class AWSPinpointAnalyticsPluginResetTests: AWSPinpointAnalyticsPluginTestBase {
     func testReset() {
-        let completedInvoked = expectation(description: "onComplete is invoked")
-        analyticsPlugin.reset {
-            completedInvoked.fulfill()
-        }
-
-        waitForExpectations(timeout: 1)
+        analyticsPlugin.reset()
         XCTAssertNil(analyticsPlugin.pinpoint)
         XCTAssertNil(analyticsPlugin.authService)
         XCTAssertNil(analyticsPlugin.autoFlushEventsTimer)

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginTestBase.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginTestBase.swift
@@ -50,6 +50,6 @@ class AWSPinpointAnalyticsPluginTestBase: XCTestCase {
 
     override func tearDown() async throws {
         await Amplify.reset()
-        analyticsPlugin.reset {}
+        analyticsPlugin.reset()
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Reset.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Reset.swift
@@ -10,8 +10,7 @@ import Amplify
 
 extension AWSCognitoAuthPlugin: Resettable {
 
-    public func reset(onComplete: @escaping BasicClosure) {
+    public func reset() {
         // TODO: Reset other parts
-        onComplete()
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -216,7 +216,7 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
         }
     }
 
-    public func reset(onComplete: @escaping (() -> Void)) {
+    public func reset() async {
         if operationQueue != nil {
             operationQueue = nil
         }
@@ -225,18 +225,11 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
             Amplify.Hub.removeListener(listener)
             hubListener = nil
         }
-        let group = DispatchGroup()
         if let resettable = storageEngine as? Resettable {
             log.verbose("Resetting storageEngine")
-            group.enter()
-            resettable.reset {
-                self.log.verbose("Resetting storageEngine: finished")
-                group.leave()
-            }
+            await resettable.reset()
+            self.log.verbose("Resetting storageEngine: finished")
         }
-
-        group.wait()
-        onComplete()
     }
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -361,20 +361,13 @@ final class StorageEngine: StorageEngineBehavior {
 }
 
 extension StorageEngine: Resettable {
-    func reset(onComplete: @escaping BasicClosure) {
+    func reset() async {
         // TOOD: Perform cleanup on StorageAdapter, including releasing its `Connection` if needed
-        let group = DispatchGroup()
         if let resettable = syncEngine as? Resettable {
             log.verbose("Resetting syncEngine")
-            group.enter()
-            resettable.reset {
-                self.log.verbose("Resetting syncEngine: finished")
-                group.leave()
-            }
+            await resettable.reset()
+            self.log.verbose("Resetting syncEngine: finished")
         }
-
-        group.wait()
-        onComplete()
     }
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
@@ -178,10 +178,9 @@ final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
 extension AWSInitialSyncOrchestrator: DefaultLogger { }
 
 extension AWSInitialSyncOrchestrator: Resettable {
-    func reset(onComplete: @escaping BasicClosure) {
+    func reset() {
         syncOperationQueue.cancelAllOperations()
         syncOperationQueue.waitUntilAllOperationsAreFinished()
-        onComplete()
     }
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter.swift
@@ -44,12 +44,11 @@ extension AWSMutationDatabaseAdapter: DefaultLogger { }
 
 extension AWSMutationDatabaseAdapter: Resettable {
 
-    func reset(onComplete: () -> Void) {
+    func reset() {
         log.verbose("Resetting AWSMutationDatabaseAdapter")
         storageAdapter = nil
         nextEventPromise.set(nil)
         log.verbose("Resetting AWSMutationDatabaseAdapter: finished")
-        onComplete()
     }
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/AWSMutationEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/MutationEvent/AWSMutationEventPublisher.swift
@@ -94,8 +94,7 @@ extension AWSMutationEventPublisher: MutationEventPublisher {
 extension AWSMutationEventPublisher: DefaultLogger { }
 
 extension AWSMutationEventPublisher: Resettable {
-    func reset(onComplete: BasicClosure) {
+    func reset() {
         eventSource = nil
-        onComplete()
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -150,20 +150,18 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
     /// - doneStopping
     private func doStop(completion: @escaping BasicClosure) {
         log.verbose(#function)
-        doStopWithoutNotifyingStateMachine {
-            self.stateMachine.notify(action: .doneStopping)
-            completion()
-        }
+        doStopWithoutNotifyingStateMachine()
+        self.stateMachine.notify(action: .doneStopping)
+        completion()
     }
 
-    private func doStopWithoutNotifyingStateMachine(completion: @escaping BasicClosure) {
+    private func doStopWithoutNotifyingStateMachine() {
         log.verbose(#function)
         subscription?.cancel()
         subscription = nil
         operationQueue.cancelAllOperations()
         operationQueue.isSuspended = true
         operationQueue.waitUntilAllOperationsAreFinished()
-        completion()
     }
 
     // MARK: - Event loop processing
@@ -411,8 +409,8 @@ extension OutgoingMutationQueue: Subscriber {
 }
 
 extension OutgoingMutationQueue: Resettable {
-    func reset(onComplete: @escaping BasicClosure) {
-        doStopWithoutNotifyingStateMachine(completion: onComplete)
+    func reset() {
+        doStopWithoutNotifyingStateMachine()
     }
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -418,9 +418,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
 extension RemoteSyncEngine: DefaultLogger { }
 
 extension RemoteSyncEngine: Resettable {
-    func reset(onComplete: @escaping BasicClosure) {
-        let group = DispatchGroup()
-
+    func reset() async {
         let mirror = Mirror(reflecting: self)
         for child in mirror.children {
             let label = child.label ?? "some RemoteSyncEngine child"
@@ -431,16 +429,10 @@ extension RemoteSyncEngine: Resettable {
             }
 
             if let resettable = child.value as? Resettable {
-                group.enter()
                 log.verbose("Resetting \(label)")
-                resettable.reset {
-                    self.log.verbose("Resetting \(label): finished")
-                    group.leave()
-                }
+                await resettable.reset()
+                self.log.verbose("Resetting \(label): finished")
             }
         }
-
-        group.wait()
-        onComplete()
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -182,18 +182,15 @@ extension AWSIncomingEventReconciliationQueue {
 // MARK: - AWSIncomingEventReconciliationQueue + Resettable
 extension AWSIncomingEventReconciliationQueue: Resettable {
 
-    func reset(onComplete: () -> Void) {
+    func reset() async {
         let group = DispatchGroup()
         for queue in reconciliationQueues.values {
             guard let queue = queue as? Resettable else {
                 continue
             }
             Amplify.log.verbose("Resetting reconciliationQueue")
-            group.enter()
-            queue.reset {
-                Amplify.log.verbose("Resetting reconciliationQueue: finished")
-                group.leave()
-            }
+            await queue.reset()
+            Amplify.log.verbose("Resetting reconciliationQueue: finished")
         }
 
         Amplify.log.verbose("Resetting reconcileAndSaveQueue")
@@ -209,7 +206,6 @@ extension AWSIncomingEventReconciliationQueue: Resettable {
         }
 
         group.wait()
-        onComplete()
     }
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -68,25 +68,14 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
 // MARK: Resettable
 extension AWSIncomingSubscriptionEventPublisher: Resettable {
 
-    func reset(onComplete: () -> Void) {
-        let group = DispatchGroup()
-
-        group.enter()
+    func reset() {
         Amplify.log.verbose("Resetting asyncEvents")
-        asyncEvents.reset {
-            Amplify.log.verbose("Resetting asyncEvents: finished")
-            group.leave()
-        }
+        asyncEvents.reset()
+        Amplify.log.verbose("Resetting asyncEvents: finished")
 
         Amplify.log.verbose("Resetting mapper")
-        group.enter()
-        mapper.reset {
-            Amplify.log.verbose("Resetting mapper: finished")
-            group.leave()
-        }
-
-        group.wait()
-        onComplete()
+        mapper.reset()
+        Amplify.log.verbose("Resetting mapper: finished")
     }
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -258,7 +258,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
         }
     }
 
-    func reset(onComplete: () -> Void) {
+    func reset() {
         consistencyQueue.sync {
             onCreateOperation?.cancel()
             onCreateOperation = nil
@@ -274,8 +274,6 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
 
             genericCompletionListenerHandler(result: .successfulVoid)
         }
-
-        onComplete()
     }
 
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
@@ -94,13 +94,12 @@ final class IncomingAsyncSubscriptionEventToAnyModelMapper: Subscriber, AmplifyC
 }
 
 extension IncomingAsyncSubscriptionEventToAnyModelMapper: Resettable {
-    func reset(onComplete: @escaping BasicClosure) {
+    func reset() {
         log.verbose("Resetting modelsFromSubscription and subscription")
         modelsFromSubscription.send(completion: .finished)
         subscription?.cancel()
         subscription = nil
         log.verbose("Resetting modelsFromSubscription and subscription: finished")
-        onComplete()
     }
 }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -217,30 +217,21 @@ extension AWSModelReconciliationQueue: DefaultLogger { }
 // MARK: Resettable
 extension AWSModelReconciliationQueue: Resettable {
 
-    func reset(onComplete: @escaping BasicClosure) {
-        let group = DispatchGroup()
-
+    func reset() async {
         log.verbose("Resetting incomingEventsSink")
         incomingEventsSink?.cancel()
         log.verbose("Resetting incomingEventsSink: finished")
 
         if let resettable = incomingSubscriptionEvents as? Resettable {
             log.verbose("Resetting incomingSubscriptionEvents")
-            group.enter()
-            resettable.reset {
-                self.log.verbose("Resetting incomingSubscriptionEvents: finished")
-                group.leave()
-            }
+            await resettable.reset()
+            self.log.verbose("Resetting incomingSubscriptionEvents: finished")
         }
 
         log.verbose("Resetting incomingSubscriptionEventQueue")
         incomingSubscriptionEventQueue.cancelAllOperations()
         incomingSubscriptionEventQueue.waitUntilAllOperationsAreFinished()
         log.verbose("Resetting incomingSubscriptionEventQueue: finished")
-
-        group.wait()
-
-        onComplete()
     }
 
 }

--- a/AmplifyPlugins/Geo/AWSLocationGeoPlugin/AWSLocationGeoPlugin+Reset.swift
+++ b/AmplifyPlugins/Geo/AWSLocationGeoPlugin/AWSLocationGeoPlugin+Reset.swift
@@ -14,11 +14,9 @@ extension AWSLocationGeoPlugin {
     ///
     /// Sets stored objects to nil to allow deallocation, then calls onComplete closure
     /// to signal the reset has completed.
-    public func reset(onComplete: @escaping (() -> Void)) {
+    public func reset() {
         locationService = nil
         authService = nil
         pluginConfig = nil
-
-        onComplete()
     }
 }

--- a/AmplifyPlugins/Geo/AWSLocationGeoPluginTests/AWSLocationGeoPluginConfigureTests.swift
+++ b/AmplifyPlugins/Geo/AWSLocationGeoPluginTests/AWSLocationGeoPluginConfigureTests.swift
@@ -20,7 +20,7 @@ class AWSLocationGeoPluginConfigureTests: AWSLocationGeoPluginTestBase {
     // MARK: - Configuration tests
 
     func testConfigureSuccess() {
-        geoPlugin.reset {}
+        geoPlugin.reset()
 
         do {
             try geoPlugin.configure(using: GeoPluginTestConfig.geoPluginConfigJSON)

--- a/AmplifyPlugins/Geo/AWSLocationGeoPluginTests/AWSLocationGeoPluginResetTests.swift
+++ b/AmplifyPlugins/Geo/AWSLocationGeoPluginTests/AWSLocationGeoPluginResetTests.swift
@@ -9,13 +9,8 @@
 import XCTest
 
 class AWSLocationGeoPluginResetTests: AWSLocationGeoPluginTestBase {
-    func testReset() {
-        let completedInvoked = expectation(description: "onComplete is invoked")
-        geoPlugin.reset {
-            completedInvoked.fulfill()
-        }
-
-        waitForExpectations(timeout: 1)
+    func testReset() async {
+        geoPlugin.reset()
         XCTAssertNil(geoPlugin.locationService)
         XCTAssertNil(geoPlugin.authService)
         XCTAssertNil(geoPlugin.pluginConfig)

--- a/AmplifyPlugins/Geo/AWSLocationGeoPluginTests/AWSLocationGeoPluginTestBase.swift
+++ b/AmplifyPlugins/Geo/AWSLocationGeoPluginTests/AWSLocationGeoPluginTestBase.swift
@@ -52,6 +52,6 @@ class AWSLocationGeoPluginTestBase: XCTestCase {
 
     override func tearDown() async throws {
         await Amplify.reset()
-        geoPlugin.reset {}
+        geoPlugin.reset()
     }
 }

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin+Reset.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin+Reset.swift
@@ -14,9 +14,8 @@ extension AWSS3StoragePlugin {
     /// Resets the state of the plugin.
     ///
     /// Calls the reset methods on the storage service and authentication service to clean up resources. Setting the
-    /// storage service, authentication service, and queue to nil to allow deallocation, then calls onComplete closure
-    /// to signal the reset has completed.
-    public func reset(onComplete: @escaping BasicClosure) {
+    /// storage service, authentication service, and queue to nil to allow deallocation.
+    public func reset() {
         if storageService != nil {
             storageService.reset()
             storageService = nil
@@ -28,7 +27,5 @@ extension AWSS3StoragePlugin {
         if queue != nil {
             queue = nil
         }
-
-        onComplete()
     }
 }

--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginResetTests.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/AWSS3StoragePluginResetTests.swift
@@ -11,12 +11,8 @@ import XCTest
 class AWSS3StoragePluginResetTests: AWSS3StoragePluginTests {
 
     func testReset() {
-        let completedInvoked = expectation(description: "onComplete is invoked")
-        storagePlugin.reset {
-            completedInvoked.fulfill()
-        }
+        storagePlugin.reset()
 
-        waitForExpectations(timeout: 1)
         XCTAssertNil(storagePlugin.authService)
         XCTAssertNil(storagePlugin.storageService)
         XCTAssertNil(storagePlugin.queue)

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -42,10 +42,9 @@ class MockAPICategoryPlugin: MessageReporter,
         notify("configure")
     }
 
-    func reset(onComplete: @escaping BasicClosure) {
+    func reset() {
         notify("reset")
         listeners.set([])
-        onComplete()
     }
 
     // MARK: - Request-based GraphQL methods

--- a/AmplifyTestCommon/Mocks/MockAnalyticsCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAnalyticsCategoryPlugin.swift
@@ -16,9 +16,8 @@ class MockAnalyticsCategoryPlugin: MessageReporter, AnalyticsCategoryPlugin {
         notify()
     }
 
-    func reset(onComplete: @escaping BasicClosure) {
+    func reset() {
         notify("reset")
-        onComplete()
     }
 
     func disable() {

--- a/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
@@ -175,9 +175,8 @@ class MockAuthCategoryPlugin: MessageReporter, AuthCategoryPlugin {
         notify()
     }
 
-    func reset(onComplete: @escaping BasicClosure) {
+    func reset() {
         notify("reset")
-        onComplete()
     }
 }
 

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -20,9 +20,8 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         notify()
     }
 
-    func reset(onComplete: @escaping BasicClosure) {
+    func reset() {
         notify("reset")
-        onComplete()
     }
 
     func save<M: Model>(_ model: M,

--- a/AmplifyTestCommon/Mocks/MockGeoCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockGeoCategoryPlugin.swift
@@ -17,9 +17,8 @@ class MockGeoCategoryPlugin: MessageReporter, GeoCategoryPlugin {
         notify()
     }
 
-    func reset(onComplete: @escaping BasicClosure) {
+    func reset() {
         notify("reset")
-        onComplete()
     }
 
     func search(for text: String, options: Geo.SearchForTextOptions?) async throws -> [Geo.Place] {

--- a/AmplifyTestCommon/Mocks/MockHubCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockHubCategoryPlugin.swift
@@ -18,9 +18,8 @@ class MockHubCategoryPlugin: MessageReporter, HubCategoryPlugin {
         notify()
     }
 
-    func reset(onComplete: @escaping BasicClosure) {
+    func reset() {
         notify("reset")
-        onComplete()
     }
 
     func dispatch(to channel: HubChannel, payload: HubPayload) {

--- a/AmplifyTestCommon/Mocks/MockLoggingCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockLoggingCategoryPlugin.swift
@@ -30,9 +30,8 @@ class MockLoggingCategoryPlugin: MessageReporter, LoggingCategoryPlugin, Logger 
         notify()
     }
 
-    func reset(onComplete: @escaping BasicClosure) {
+    func reset() {
         notify("reset")
-        onComplete()
     }
 
     func error(_ message: @autoclosure () -> String) {

--- a/AmplifyTestCommon/Mocks/MockPredictionsCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockPredictionsCategoryPlugin.swift
@@ -68,9 +68,8 @@ class MockPredictionsCategoryPlugin: MessageReporter, PredictionsCategoryPlugin 
         return MockPredictionsInterpretOperation(request: request)
     }
 
-    func reset(onComplete: @escaping BasicClosure) {
+    func reset() {
         notify("reset")
-        onComplete()
     }
 
     var key: String {

--- a/AmplifyTestCommon/Mocks/MockStorageCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockStorageCategoryPlugin.swift
@@ -91,9 +91,8 @@ class MockStorageCategoryPlugin: MessageReporter, StorageCategoryPlugin {
         notify()
     }
 
-    func reset(onComplete: @escaping BasicClosure) {
+    func reset() {
         notify("reset")
-        onComplete()
     }
 }
 

--- a/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
@@ -246,7 +246,7 @@ class APICategoryConfigurationTests: XCTestCase {
         }
     }
 
-    func testCanConfigureAfterReset() throws {
+    func testCanConfigureAfterReset() async throws {
         let plugin = MockAPICategoryPlugin()
         try Amplify.add(plugin: plugin)
         let categoryConfig = APICategoryConfiguration(
@@ -260,11 +260,7 @@ class APICategoryConfigurationTests: XCTestCase {
 
         try api.configure(using: categoryConfig)
 
-        let exp = expectation(description: #function)
-        api.reset {
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: 1.0)
+        await api.reset()
 
         XCTAssertNoThrow(try api.configure(using: categoryConfig))
     }

--- a/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryConfigurationTests.swift
@@ -240,7 +240,7 @@ class AnalyticsCategoryConfigurationTests: XCTestCase {
         }
     }
 
-    func testCanConfigureAfterReset() throws {
+    func testCanConfigureAfterReset() async throws {
         let plugin = MockAnalyticsCategoryPlugin()
         try Amplify.add(plugin: plugin)
         let categoryConfig = AnalyticsCategoryConfiguration(
@@ -249,11 +249,7 @@ class AnalyticsCategoryConfigurationTests: XCTestCase {
 
         try Amplify.Analytics.configure(using: categoryConfig)
 
-        let exp = expectation(description: #function)
-        Amplify.Analytics.reset {
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: 1.0)
+        await Amplify.Analytics.reset()
 
         XCTAssertNoThrow(try Amplify.Analytics.configure(using: categoryConfig))
     }

--- a/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
@@ -342,7 +342,7 @@ class AuthCategoryConfigurationTests: XCTestCase {
     /// - Then:
     ///    - Should not throw any error
     ///
-    func testCanConfigureAfterReset() throws {
+    func testCanConfigureAfterReset() async throws {
         let plugin = MockAuthCategoryPlugin()
         try Amplify.add(plugin: plugin)
         let config = AuthCategoryConfiguration(
@@ -351,11 +351,7 @@ class AuthCategoryConfigurationTests: XCTestCase {
 
         XCTAssertNoThrow(try Amplify.Auth.configure(using: config))
 
-        let exp = expectation(description: #function)
-        Amplify.Auth.reset {
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: 1.0)
+        await Amplify.Auth.reset()
 
         XCTAssertNoThrow(try Amplify.Auth.configure(using: config))
 

--- a/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
@@ -259,7 +259,7 @@ class DataStoreCategoryConfigurationTests: XCTestCase {
         }
     }
 
-    func testCanConfigureAfterReset() throws {
+    func testCanConfigureAfterReset() async throws {
         let plugin = MockDataStoreCategoryPlugin()
         try Amplify.add(plugin: plugin)
         let categoryConfig = DataStoreCategoryConfiguration(
@@ -268,11 +268,7 @@ class DataStoreCategoryConfigurationTests: XCTestCase {
 
         try Amplify.DataStore.configure(using: categoryConfig)
 
-        let exp = expectation(description: #function)
-        Amplify.DataStore.reset {
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: 1.0)
+        await Amplify.DataStore.reset()
 
         XCTAssertNoThrow(try Amplify.DataStore.configure(using: categoryConfig))
     }

--- a/AmplifyTests/CategoryTests/Geo/GeoCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Geo/GeoCategoryConfigurationTests.swift
@@ -237,7 +237,7 @@ class GeoCategoryConfigurationTests: XCTestCase {
         }
     }
 
-    func testCanConfigureAfterReset() throws {
+    func testCanConfigureAfterReset() async throws {
         let plugin = MockGeoCategoryPlugin()
         try Amplify.add(plugin: plugin)
         let categoryConfig = GeoCategoryConfiguration(
@@ -246,11 +246,7 @@ class GeoCategoryConfigurationTests: XCTestCase {
 
         try Amplify.Geo.configure(using: categoryConfig)
 
-        let exp = expectation(description: #function)
-        Amplify.Geo.reset {
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: 1.0)
+        await Amplify.Geo.reset()
 
         XCTAssertNoThrow(try Amplify.Geo.configure(using: categoryConfig))
     }

--- a/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
@@ -212,8 +212,8 @@ class MockDispatchingStoragePlugin: StorageCategoryPlugin {
         return operation
     }
 
-    func reset(onComplete: @escaping BasicClosure) {
-        onComplete()
+    func reset() {
+        // Do nothing
     }
 }
 

--- a/AmplifyTests/CategoryTests/Hub/HubCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubCategoryConfigurationTests.swift
@@ -242,7 +242,7 @@ class HubCategoryConfigurationTests: XCTestCase {
         }
     }
 
-    func testCanConfigureAfterReset() throws {
+    func testCanConfigureAfterReset() async throws {
         let plugin = MockHubCategoryPlugin()
         try Amplify.add(plugin: plugin)
         let categoryConfig = HubCategoryConfiguration(
@@ -251,11 +251,7 @@ class HubCategoryConfigurationTests: XCTestCase {
 
         try Amplify.Hub.configure(using: categoryConfig)
 
-        let exp = expectation(description: #function)
-        Amplify.Hub.reset {
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: 1.0)
+        await Amplify.Hub.reset()
 
         XCTAssertNoThrow(try Amplify.Hub.configure(using: categoryConfig))
     }

--- a/AmplifyTests/CategoryTests/Logging/LoggingCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Logging/LoggingCategoryClientAPITests.swift
@@ -173,8 +173,8 @@ class NonEvaluatingLoggingPlugin: LoggingCategoryPlugin, Logger {
         self
     }
 
-    func reset(onComplete: @escaping BasicClosure) {
-        onComplete()
+    func reset() {
+        // Do nothing
     }
 
     func error(_ message: @autoclosure () -> String) {

--- a/AmplifyTests/CategoryTests/Logging/LoggingCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Logging/LoggingCategoryConfigurationTests.swift
@@ -245,7 +245,7 @@ class LoggingCategoryConfigurationTests: XCTestCase {
         }
     }
 
-    func testCanConfigureAfterReset() throws {
+    func testCanConfigureAfterReset() async throws {
         let plugin = MockLoggingCategoryPlugin()
         try Amplify.add(plugin: plugin)
         let categoryConfig = LoggingCategoryConfiguration(
@@ -254,11 +254,7 @@ class LoggingCategoryConfigurationTests: XCTestCase {
 
         try Amplify.Logging.configure(using: categoryConfig)
 
-        let exp = expectation(description: #function)
-        Amplify.Logging.reset {
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: 1.0)
+        await Amplify.Logging.reset()
 
         XCTAssertNoThrow(try Amplify.Logging.configure(using: categoryConfig))
     }

--- a/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryConfigurationTests.swift
@@ -352,7 +352,7 @@ class PredictionsCategoryConfigurationTests: XCTestCase {
     /// - Then:
     ///    - Should not throw any error
     ///
-    func testCanConfigureAfterReset() throws {
+    func testCanConfigureAfterReset() async throws {
         let plugin = MockPredictionsCategoryPlugin()
         try Amplify.add(plugin: plugin)
         let config = PredictionsCategoryConfiguration(
@@ -361,11 +361,7 @@ class PredictionsCategoryConfigurationTests: XCTestCase {
 
         try Amplify.Predictions.configure(using: config)
 
-        let exp = expectation(description: #function)
-        Amplify.Predictions.reset {
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: 1.0)
+        await Amplify.Predictions.reset()
 
         XCTAssertNoThrow(try Amplify.Predictions.configure(using: config))
     }

--- a/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
@@ -245,7 +245,7 @@ class StorageCategoryConfigurationTests: XCTestCase {
         }
     }
 
-    func testCanConfigureAfterReset() throws {
+    func testCanConfigureAfterReset() async throws {
         let plugin = MockStorageCategoryPlugin()
         try Amplify.add(plugin: plugin)
         let categoryConfig = StorageCategoryConfiguration(
@@ -254,11 +254,7 @@ class StorageCategoryConfigurationTests: XCTestCase {
 
         try Amplify.Storage.configure(using: categoryConfig)
 
-        let exp = expectation(description: #function)
-        Amplify.Storage.reset {
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: 1.0)
+        await Amplify.Storage.reset()
 
         XCTAssertNoThrow(try Amplify.Storage.configure(using: categoryConfig))
     }

--- a/AmplifyTests/CoreTests/NotificationListeningAnalyticsPlugin.swift
+++ b/AmplifyTests/CoreTests/NotificationListeningAnalyticsPlugin.swift
@@ -60,8 +60,8 @@ class NotificationListeningAnalyticsPlugin: AnalyticsCategoryPlugin {
         // Do nothing
     }
 
-    func reset(onComplete: @escaping BasicClosure) {
-        onComplete()
+    func reset() {
+        // Do nothing
     }
 
 }

--- a/AmplifyTests/DevMenuTests/DevMenuExtensionTests.swift
+++ b/AmplifyTests/DevMenuTests/DevMenuExtensionTests.swift
@@ -12,9 +12,9 @@ import XCTest
 
 class DevMenuExtensionTests: XCTestCase {
     let provider = MockDevMenuContextProvider()
-    override func setUp() {
+    override func setUp() async throws {
         do {
-            Amplify.enableDevMenu(contextProvider: provider)
+            await Amplify.enableDevMenu(contextProvider: provider)
 
             /// After await Amplify.reset() is called in teardown(), Amplify.configure() doesn't
             /// initialize the plugin for LoggingCategory . This doesn't call Amplify.getLoggingCategoryPlugin()

--- a/AmplifyTests/DevMenuTests/PersistentLogWrapperTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLogWrapperTests.swift
@@ -14,9 +14,9 @@ class PersistentLogWrapperTests: XCTestCase {
 
     let provider = MockDevMenuContextProvider()
 
-    override func setUp() {
+    override func setUp() async throws {
         do {
-            Amplify.enableDevMenu(contextProvider: provider)
+            await Amplify.enableDevMenu(contextProvider: provider)
 
             /// After await Amplify.reset() is called in teardown(), Amplify.configure() doesn't
             /// initialize the plugin for LoggingCategory . This doesn't call Amplify.getLoggingCategoryPlugin()

--- a/AmplifyTests/DevMenuTests/PersistentLoggingPluginTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLoggingPluginTests.swift
@@ -14,9 +14,9 @@ class PersistentLoggingPluginTests: XCTestCase {
 
     let provider = MockDevMenuContextProvider()
 
-    override func setUp() {
+    override func setUp() async throws {
         do {
-            Amplify.enableDevMenu(contextProvider: provider)
+            await Amplify.enableDevMenu(contextProvider: provider)
 
             /// After await Amplify.reset() is called in teardown(), Amplify.configure() doesn't
             /// initialize the plugin for LoggingCategory . This doesn't call Amplify.getLoggingCategoryPlugin()


### PR DESCRIPTION
*Description of changes:*
fix: update plugin reset methods to use swift concurrency

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
