### PR TITLE
chore: add action to post message for maintainer opened issues

### DIFF
--- a/.github/workflows/new_issue_maintainer.yml
+++ b/.github/workflows/new_issue_maintainer.yml
@@ -1,0 +1,22 @@
+name: New Issue by Maintainer
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  maintainer-opened:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.issue.pull_request && contains(fromJSON('["palpatim", "brennanMKE", "diegocstn", "lawmicha", "harsh62", "thisisabhash", "ameter", "royjit", "atierian", "ukhan-amazon", "ruisebas", "phantumcode"]'), github.event.issue.user.login) }}
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: add message if maintainer opened
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh issue comment $ISSUE_NUMBER -b "This issue was opened by a maintainer of this repository; updates will be posted here. If you are also experiencing this issue, please comment here with any relevant information so that we're aware and can prioritize accordingly."

--- a/.github/workflows/new_issue_maintainer.yml
+++ b/.github/workflows/new_issue_maintainer.yml
@@ -12,11 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.issue.pull_request && contains(fromJSON('["palpatim", "brennanMKE", "diegocstn", "lawmicha", "harsh62", "thisisabhash", "ameter", "royjit", "atierian", "ukhan-amazon", "ruisebas", "phantumcode"]'), github.event.issue.user.login) }}
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: add message if maintainer opened
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          gh issue comment $ISSUE_NUMBER -b "This issue was opened by a maintainer of this repository; updates will be posted here. If you are also experiencing this issue, please comment here with any relevant information so that we're aware and can prioritize accordingly."
+          gh issue comment $ISSUE_NUMBER --repo aws-amplify/amplify-ios -b "This issue was opened by a maintainer of this repository; updates will be posted here. If you are also experiencing this issue, please comment here with any relevant information so that we're aware and can prioritize accordingly."


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adds a GitHub Action to comment the following on issues opened by maintainers.
> This issue was opened by a maintainer of this repository; updates will be posted here. If you are also experiencing this issue, please comment here with any relevant information so that we're aware and can prioritize accordingly.

*We should look accessing the list of maintainers from the GitHub API or through a txt file. We're now maintaining this list here and in `notify_new_issue_comment`, which isn't great.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [ ] ~Build succeeds with all target using Swift Package Manager~
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
