### PR TITLE
feat(auth): Add Reset Password API implementation

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
@@ -122,7 +122,14 @@ extension AWSCognitoAuthPlugin: AuthCategoryBehavior {
     public func resetPassword(for username: String,
                               options: AuthResetPasswordOperation.Request.Options?,
                               listener: AuthResetPasswordOperation.ResultListener?) -> AuthResetPasswordOperation {
-        fatalError("Not implemented")
+        let options = options ?? AuthResetPasswordRequest.Options()
+        let request = AuthResetPasswordRequest(username: username, options: options)
+        let resetPasswordOperation = AWSAuthResetPasswordOperation(request,
+                                                                         userPoolFactory: authEnvironment.cognitoUserPoolFactory,
+                                                                         authConfiguration: authConfiguration,
+                                                                         resultListener: listener)
+        queue.addOperation(resetPasswordOperation)
+        return resetPasswordOperation
     }
 
     public func confirmResetPassword(for username: String,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthResendSignUpCodeOperation.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthResendSignUpCodeOperation.swift
@@ -93,10 +93,7 @@ public class AWSAuthResendSignUpCodeOperation:
             self.dispatch(error)
         }
         catch let error {
-            let error = AuthError.configuration(
-                "Unable to create a Swift SDK user pool service",
-                AuthPluginErrorConstants.configurationError,
-                error)
+            let error = AuthError.unknown("Unable to create a Swift SDK user pool service", error)
             self.dispatch(error)
         }
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthResetPasswordOperation.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthResetPasswordOperation.swift
@@ -1,0 +1,118 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import AWSPluginsCore
+import ClientRuntime
+import AWSCognitoIdentityProvider
+
+public class AWSAuthResetPasswordOperation:
+    AmplifyOperation< AuthResetPasswordRequest, AuthResetPasswordResult, AuthError>, AuthResetPasswordOperation {
+    
+    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+    private let userPoolFactory: CognitoUserPoolFactory
+    private var authConfiguration: AuthConfiguration
+    
+    init(_ request: AuthResetPasswordRequest,
+         userPoolFactory: @escaping CognitoUserPoolFactory,
+         authConfiguration: AuthConfiguration,
+         resultListener: ResultListener?)
+    {
+        self.userPoolFactory = userPoolFactory
+        self.authConfiguration = authConfiguration
+        super.init(categoryType: .auth,
+                   eventName: HubPayload.EventName.Auth.resetPasswordAPI,
+                   request: request,
+                   resultListener: resultListener)
+    }
+    
+    override public func main() {
+        if isCancelled {
+            finish()
+            return
+        }
+        
+        if let validationError = request.hasError() {
+            dispatch(validationError)
+            finish()
+            return
+        }
+        
+        Task.init { [weak self] in
+            await self?.resetPassword()
+        }
+    }
+    
+    func resetPassword() async {
+        do {
+            let userPoolService = try userPoolFactory()
+            let clientMetaData = (request.options.pluginOptions
+                                  as? AWSResendSignUpCodeOptions)?.metadata ?? [:]
+            
+            let userPoolConfigurationData : UserPoolConfigurationData
+            switch authConfiguration {
+            case .userPools(let data):
+                userPoolConfigurationData = data
+            case .userPoolsAndIdentityPools(let data, _):
+                userPoolConfigurationData = data
+            case .identityPools:
+                let error = AuthError.configuration("UserPool configuration is missing", AuthPluginErrorConstants.configurationError)
+                throw error
+            }
+            
+            let input = ForgotPasswordInput(clientId: userPoolConfigurationData.clientId,
+                                                    clientMetadata: clientMetaData,
+                                                    username: request.username)
+            
+            let result = try await userPoolService.forgotPassword(input: input)
+            
+            if self.isCancelled {
+                finish()
+                return
+            }
+            
+            guard let deliveryDetails = result.codeDeliveryDetails?.toAuthCodeDeliveryDetails() else {
+                let authError = AuthError.unknown("Unable to get Auth code delivery details",
+                                                  nil)
+                self.dispatch(authError)
+                return
+            }
+            let nextStep = AuthResetPasswordStep.confirmResetPasswordWithCode(deliveryDetails, nil)
+            let authResetPasswordResult = AuthResetPasswordResult(isPasswordReset: false, nextStep: nextStep)
+            self.dispatch(authResetPasswordResult)
+        }
+        catch let error as ForgotPasswordOutputError {
+            self.dispatch(error.authError)
+        }
+        catch let error as SdkError<ForgotPasswordOutputError> {
+            self.dispatch(error.authError)
+        }
+        catch let error as AuthError {
+            self.dispatch(error)
+        }
+        catch let error {
+            let error = AuthError.configuration(
+                "Unable to create a Swift SDK user pool service",
+                AuthPluginErrorConstants.configurationError,
+                error)
+            self.dispatch(error)
+        }
+    }
+    
+    private func dispatch(_ result: AuthResetPasswordResult) {
+        let result = OperationResult.success(result)
+        dispatch(result: result)
+        finish()
+    }
+    
+    private func dispatch(_ error: AuthError) {
+        let result = OperationResult.failure(error)
+        dispatch(result: result)
+        Amplify.log.error(error: error)
+        finish()
+    }
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthResetPasswordOperation.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthResetPasswordOperation.swift
@@ -95,10 +95,7 @@ public class AWSAuthResetPasswordOperation:
             self.dispatch(error)
         }
         catch let error {
-            let error = AuthError.configuration(
-                "Unable to create a Swift SDK user pool service",
-                AuthPluginErrorConstants.configurationError,
-                error)
+            let error = AuthError.unknown("Unable to create a Swift SDK user pool service", error)
             self.dispatch(error)
         }
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/CognitoUserPoolBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/CognitoUserPoolBehavior.swift
@@ -51,4 +51,8 @@ protocol CognitoUserPoolBehavior {
     /// Resends sign up code
     /// Throws ResendConfirmationCodeOutputError
     func resendConfirmationCode(input: ResendConfirmationCodeInput) async throws -> ResendConfirmationCodeOutputResponse
+    
+    /// Resets password
+    /// Throws ForgotPasswordOutputError
+    func forgotPassword(input: ForgotPasswordInput) async throws -> ForgotPasswordOutputResponse
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ForgotPasswordOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ForgotPasswordOutputError+AuthError.swift
@@ -1,0 +1,90 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import AWSCognitoIdentityProvider
+import Amplify
+
+extension ForgotPasswordOutputError: AuthErrorConvertible {
+    var authError: AuthError {
+        switch self {
+        case .codeDeliveryFailureException(let exception):
+            return .service(
+                exception.message ?? "Code Delivery Failure error",
+                AuthPluginErrorConstants.codeDeliveryError,
+                AWSCognitoAuthError.codeDelivery
+            )
+        case .internalErrorException(let exception):
+            return .unknown(exception.message ?? "Internal exception occurred")
+        case .invalidEmailRoleAccessPolicyException(let exception):
+            return .service(
+                exception.message ?? "Invalid email role access policy error",
+                AuthPluginErrorConstants.invalidEmailRoleError,
+                AWSCognitoAuthError.emailRole
+            )
+        case .invalidLambdaResponseException(let exception):
+            return .service(
+                exception.message ?? "Invalid lambda response error",
+                AuthPluginErrorConstants.lambdaError,
+                AWSCognitoAuthError.lambda
+            )
+        case .invalidParameterException(let exception):
+            return AuthError.service(exception.message ?? "Invalid parameter error",
+                                     AuthPluginErrorConstants.invalidParameterError,
+                                     AWSCognitoAuthError.invalidParameter)
+        case .invalidSmsRoleAccessPolicyException(let exception):
+            return AuthError.service(exception.message ?? "Invalid SMS Role Access Policy error",
+                                     AuthPluginErrorConstants.invalidSMSRoleError,
+                                     AWSCognitoAuthError.smsRole)
+        case .invalidSmsRoleTrustRelationshipException(let exception):
+            return AuthError.service(exception.message ?? "Invalid SMS Role Trust Relationship error",
+                                     AuthPluginErrorConstants.invalidSMSRoleError,
+                                     AWSCognitoAuthError.smsRole)
+        case .limitExceededException(let exception):
+            return .service(
+                exception.message ?? "Limit exceeded error",
+                AuthPluginErrorConstants.limitExceededError,
+                AWSCognitoAuthError.limitExceeded
+            )
+        case .notAuthorizedException(let exception):
+            return AuthError.notAuthorized(exception.message ?? "Not authorized error",
+                                           AuthPluginErrorConstants.notAuthorizedError)
+        case .resourceNotFoundException(let exception):
+            return AuthError.service(exception.message ?? "Resource not found error",
+                                     AuthPluginErrorConstants.resourceNotFoundError,
+                                     AWSCognitoAuthError.resourceNotFound)
+        case .tooManyRequestsException(let exception):
+            return AuthError.service(exception.message ?? "Too many requests error",
+                               AuthPluginErrorConstants.tooManyRequestError,
+                               AWSCognitoAuthError.requestLimitExceeded)
+        case .unexpectedLambdaException(let exception):
+            return .service(
+                exception.message ?? "Unexpected lambda error",
+                AuthPluginErrorConstants.lambdaError,
+                AWSCognitoAuthError.lambda
+            )
+        case .userLambdaValidationException(let exception):
+            return .service(
+                exception.message ?? "User lambda validation error",
+                AuthPluginErrorConstants.lambdaError,
+                AWSCognitoAuthError.lambda
+            )
+        case .userNotConfirmedException(let userNotConfirmedException):
+            return .service(userNotConfirmedException.message ?? "User not confirmed error",
+                            AuthPluginErrorConstants.userNotConfirmedError,
+                            AWSCognitoAuthError.userNotConfirmed)
+        case .userNotFoundException(let exception):
+            return AuthError.service(exception.message ?? "User not found error",
+                                     AuthPluginErrorConstants.userNotFoundError,
+                                     AWSCognitoAuthError.userNotFound)
+        case .unknown(let serviceError):
+            let statusCode = serviceError._statusCode?.rawValue ?? -1
+            let message = serviceError._message ?? ""
+            return .unknown("Unknown service error occurred with status \(statusCode) \(message)")
+        }
+    }
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Request/AuthResetPasswordRequest+Validation.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Request/AuthResetPasswordRequest+Validation.swift
@@ -1,0 +1,20 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+import Amplify
+
+extension AuthResetPasswordRequest {
+    
+    func hasError() -> AuthError? {
+        guard !username.isEmpty else {
+            return AuthError.validation(
+                AuthPluginErrorConstants.resetPasswordUsernameError.field,
+                AuthPluginErrorConstants.resetPasswordUsernameError.errorDescription,
+                AuthPluginErrorConstants.resetPasswordUsernameError.recoverySuggestion)
+        }
+        return nil
+    }
+}

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/ClientBehaviorTests/AWSCognitoAuthClientBehaviorTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/ClientBehaviorTests/AWSCognitoAuthClientBehaviorTests.swift
@@ -26,12 +26,6 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
     }
     
     override func setUp() {
-        mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
-                ResendConfirmationCodeOutputResponse(codeDeliveryDetails: .init())
-            }
-        )
-        
         plugin = AWSCognitoAuthPlugin()
         
         let getId: MockIdentity.MockGetIdResponse = { _ in

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockIdentityProvider.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockIdentityProvider.swift
@@ -46,6 +46,9 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
     
     typealias MockResendConfirmationCodeOutputResponse = (ResendConfirmationCodeInput) async throws
     -> ResendConfirmationCodeOutputResponse
+    
+    typealias MockForgotPasswordOutputResponse = (ForgotPasswordInput) async throws
+    -> ForgotPasswordOutputResponse
 
     let mockSignUpResponse: MockSignUpResponse?
     let mockRevokeTokenResponse: MockRevokeTokenResponse?
@@ -59,6 +62,7 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
     let mockConfirmUserAttributeOutputResponse: MockConfirmUserAttributeOutputResponse?
     let mockChangePasswordOutputResponse: MockChangePasswordOutputResponse?
     let mockResendConfirmationCodeOutputResponse: MockResendConfirmationCodeOutputResponse?
+    let mockForgotPasswordOutputResponse: MockForgotPasswordOutputResponse?
 
     init(
         mockSignUpResponse: MockSignUpResponse? = nil,
@@ -72,7 +76,8 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
         mockUpdateUserAttributeResponse: MockUpdateUserAttributesOutputResponse? = nil,
         mockConfirmUserAttributeOutputResponse: MockConfirmUserAttributeOutputResponse? = nil,
         mockChangePasswordOutputResponse: MockChangePasswordOutputResponse? = nil,
-        mockResendConfirmationCodeOutputResponse: MockResendConfirmationCodeOutputResponse? = nil
+        mockResendConfirmationCodeOutputResponse: MockResendConfirmationCodeOutputResponse? = nil,
+        mockForgotPasswordOutputResponse: MockForgotPasswordOutputResponse? = nil
     ) {
         self.mockSignUpResponse = mockSignUpResponse
         self.mockRevokeTokenResponse = mockRevokeTokenResponse
@@ -86,6 +91,7 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
         self.mockConfirmUserAttributeOutputResponse = mockConfirmUserAttributeOutputResponse
         self.mockChangePasswordOutputResponse = mockChangePasswordOutputResponse
         self.mockResendConfirmationCodeOutputResponse = mockResendConfirmationCodeOutputResponse
+        self.mockForgotPasswordOutputResponse = mockForgotPasswordOutputResponse;
     }
 
     /// Throws InitiateAuthOutputError
@@ -142,5 +148,9 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
     
     func resendConfirmationCode(input: ResendConfirmationCodeInput) async throws -> ResendConfirmationCodeOutputResponse {
         return try await mockResendConfirmationCodeOutputResponse!(input)
+    }
+    
+    func forgotPassword(input: ForgotPasswordInput) async throws -> ForgotPasswordOutputResponse {
+        return try await mockForgotPasswordOutputResponse!(input)
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		485CB5C027B61F1E006CCEC7 /* SignedOutAuthSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB5BC27B61F1D006CCEC7 /* SignedOutAuthSessionTests.swift */; };
 		485CB5C127B61F1E006CCEC7 /* AuthSignOutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB5BD27B61F1D006CCEC7 /* AuthSignOutTests.swift */; };
 		485CB5C227B61F1E006CCEC7 /* AuthSRPSignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB5BE27B61F1D006CCEC7 /* AuthSRPSignInTests.swift */; };
+		97829201286B802E000DE190 /* AuthResetPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97829200286B802E000DE190 /* AuthResetPasswordTests.swift */; };
 		B43C26CA27BC9D54003F3BF7 /* AuthSignUpTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43C26C727BC9D54003F3BF7 /* AuthSignUpTests.swift */; };
 		B43C26CB27BC9D54003F3BF7 /* AuthConfirmSignUpTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43C26C827BC9D54003F3BF7 /* AuthConfirmSignUpTests.swift */; };
 		B43C26CC27BC9D54003F3BF7 /* AuthResendSignUpCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43C26C927BC9D54003F3BF7 /* AuthResendSignUpCodeTests.swift */; };
@@ -59,6 +60,7 @@
 		485CB5BC27B61F1D006CCEC7 /* SignedOutAuthSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignedOutAuthSessionTests.swift; sourceTree = "<group>"; };
 		485CB5BD27B61F1D006CCEC7 /* AuthSignOutTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthSignOutTests.swift; sourceTree = "<group>"; };
 		485CB5BE27B61F1D006CCEC7 /* AuthSRPSignInTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthSRPSignInTests.swift; sourceTree = "<group>"; };
+		97829200286B802E000DE190 /* AuthResetPasswordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthResetPasswordTests.swift; sourceTree = "<group>"; };
 		B43C26C727BC9D54003F3BF7 /* AuthSignUpTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthSignUpTests.swift; sourceTree = "<group>"; };
 		B43C26C827BC9D54003F3BF7 /* AuthConfirmSignUpTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthConfirmSignUpTests.swift; sourceTree = "<group>"; };
 		B43C26C927BC9D54003F3BF7 /* AuthResendSignUpCodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthResendSignUpCodeTests.swift; sourceTree = "<group>"; };
@@ -166,6 +168,7 @@
 				485CB5C427B61F5A006CCEC7 /* SignOutTests */,
 				485CB5C327B61F4A006CCEC7 /* SignInTests */,
 				485CB5B227B61EB4006CCEC7 /* Helpers */,
+				978291FF286B7F61000DE190 /* ResetPasswordTests */,
 				485CB5AF27B61EAA006CCEC7 /* AWSAuthBaseTest.swift */,
 				485CB5AE27B61EAA006CCEC7 /* README.md */,
 			);
@@ -213,6 +216,14 @@
 				B443B8C127BD707B009DA19B /* amplify-ios-staging */,
 			);
 			name = Packages;
+			sourceTree = "<group>";
+		};
+		978291FF286B7F61000DE190 /* ResetPasswordTests */ = {
+			isa = PBXGroup;
+			children = (
+				97829200286B802E000DE190 /* AuthResetPasswordTests.swift */,
+			);
+			path = ResetPasswordTests;
 			sourceTree = "<group>";
 		};
 		B43C26C627BC9D54003F3BF7 /* SignUpTests */ = {
@@ -372,6 +383,7 @@
 				484834BE27B6FD9B00649D11 /* AuthEnvironmentHelper.swift in Sources */,
 				484834BC27B6ED8800649D11 /* CredentialStoreConfigurationTests.swift in Sources */,
 				B43C26CC27BC9D54003F3BF7 /* AuthResendSignUpCodeTests.swift in Sources */,
+				97829201286B802E000DE190 /* AuthResetPasswordTests.swift in Sources */,
 				485105AA2840513C002D6FC8 /* AuthUserAttributesTests.swift in Sources */,
 				485CB5BF27B61F1E006CCEC7 /* SignedInAuthSessionTests.swift in Sources */,
 				B43C26CA27BC9D54003F3BF7 /* AuthSignUpTests.swift in Sources */,

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/ResetPasswordTests/AuthResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/ResetPasswordTests/AuthResetPasswordTests.swift
@@ -1,0 +1,73 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+import AWSCognitoAuthPlugin
+
+class AuthResetPasswordTests: AWSAuthBaseTest {
+
+    override func setUp() {
+        super.setUp()
+        initializeAmplify()
+    }
+
+    override func tearDown() async throws {
+        try await super.tearDown()
+        await Amplify.reset()
+        sleep(2)
+    }
+
+    /// Test if resetPassword returns userNotFound error for a non existing user
+    ///
+    /// - Given: A user which is not registered to the configured user pool
+    /// - When:
+    ///    - I invoke resetPassword with the user
+    /// - Then:
+    ///    - I should get a userNotFound error.
+    ///
+    func testUserNotFoundResetPassword() {
+        let resetPasswordExpectation = expectation(description: "Received event result from resetPassword")
+        _ = Amplify.Auth.resetPassword(for: "user-non-exists", options: nil) { result in
+            switch result {
+            case .success:
+                XCTFail("resetPassword with non existing user should not return result")
+            case .failure(let error):
+                guard let cognitoError = error.underlyingError as? AWSCognitoAuthError,
+                      case .userNotFound = cognitoError else {
+                    print(error)
+                    XCTFail("Should return userNotFound")
+                    return
+                }
+                resetPasswordExpectation.fulfill()
+            }
+        }
+        wait(for: [resetPasswordExpectation], timeout: networkTimeout)
+    }
+
+    /// Calling cancel in resetPassword operation should cancel
+    ///
+    /// - Given: A valid username
+    /// - When:
+    ///    - I invoke resetPassword with the username and then call cancel
+    /// - Then:
+    ///    - I should not get any result back
+    ///
+    func testCancelResetPassword() {
+        let username = "integTest\(UUID().uuidString)"
+
+        let operationExpectation = expectation(description: "Operation should not complete")
+        operationExpectation.isInverted = true
+        let operation = Amplify.Auth.resetPassword(for: username, options: nil) { result in
+            operationExpectation.fulfill()
+            XCTFail("Received result \(result)")
+        }
+        XCTAssertNotNil(operation, "resetPassword operations should not be nil")
+        operation.cancel()
+        wait(for: [operationExpectation], timeout: networkTimeout)
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Add resetPassword API implementation based on `aws-sdk-swift`.

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
~~- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
