### PR TITLE
feat(Analytics): Fixing issues when submitting events

### DIFF
--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+ClientBehavior.swift
@@ -101,7 +101,7 @@ extension AWSPinpointAnalyticsPlugin {
 
         Task {
             do {
-                let submittedEvents: [PinpointEvent] = try await pinpoint.submitEvents()
+                let submittedEvents = try await pinpoint.submitEvents().asAnalyticsEventArray()
                 Amplify.Hub.dispatchFlushEvents(submittedEvents)
             } catch {
                 Amplify.Hub.dispatchFlushEvents(AnalyticsErrorHelper.getDefaultError(error))

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/AnalyticsClient.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/AnalyticsClient.swift
@@ -235,11 +235,3 @@ extension AnalyticsClient {
     typealias PinpointEventAttributes = [String: String]
     typealias PinpointEventMetrics = [String: Double]
 }
-
-extension Date {
-    typealias Millisecond = Int64
-
-    var utcTimeMillis: Millisecond {
-        return Int64(self.timeIntervalSince1970 * 1000)
-    }
-}

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/EventRecorder.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/EventRecorder.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import Amplify
 import AWSPinpoint
 import ClientRuntime
 import Foundation
@@ -57,10 +58,11 @@ class EventRecorder: AnalyticsEventRecording {
     /// If event submission succeeds, the event is removed from local storage
     /// - Returns: A collection of events submitted to Pinpoint
     func submitAllEvents() async throws -> [PinpointEvent] {
-        let publicEndpoint = await endpointClient.currentPublicEndpoint()
+        submittedEvents = []
         let eventsBatch = try getBatchRecords()
         if eventsBatch.count > 0 {
-            try await processBatch(eventsBatch, publicEndpoint: publicEndpoint)
+            let endpointProfile = await endpointClient.currentEndpointProfile()
+            try await processBatch(eventsBatch, endpointProfile: endpointProfile)
         }
         return submittedEvents
     }
@@ -69,30 +71,76 @@ class EventRecorder: AnalyticsEventRecording {
         return try storage.getEventsWith(limit: Constants.maxEventsSubmittedPerBatch)
     }
 
-    private func processBatch(_ eventBatch: [PinpointEvent], publicEndpoint: PinpointClientTypes.PublicEndpoint) async throws {
-        try await submit(pinpointEvents: eventBatch, publicEndpoint: publicEndpoint)
+    private func processBatch(_ eventBatch: [PinpointEvent], endpointProfile: PinpointEndpointProfile) async throws {
+        try await submit(pinpointEvents: eventBatch, endpointProfile: endpointProfile)
         try storage.removeFailedEvents()
         let nextEventsBatch = try getBatchRecords()
         if nextEventsBatch.count > 0 {
-            try await processBatch(nextEventsBatch, publicEndpoint: publicEndpoint)
+            try await processBatch(nextEventsBatch, endpointProfile: endpointProfile)
         }
     }
 
-    private func submit(pinpointEvents: [PinpointEvent], publicEndpoint: PinpointClientTypes.PublicEndpoint) async throws {
+    private func submit(pinpointEvents: [PinpointEvent],
+                        endpointProfile: PinpointEndpointProfile) async throws {
         var clientEvents = [String: PinpointClientTypes.Event]()
+        var pinpointEventsById = [String: PinpointEvent]()
         for event in pinpointEvents {
-            clientEvents[UUID().uuidString] = event.clientTypeEvent
-            let eventsBatch = PinpointClientTypes.EventsBatch(endpoint: publicEndpoint, events: clientEvents)
-            let batchItem: [String: PinpointClientTypes.EventsBatch] = [self.appId: eventsBatch]
-            let eventRequest = PinpointClientTypes.EventsRequest(batchItem: batchItem)
-            let putEventsInput = PutEventsInput(applicationId: self.appId, eventsRequest: eventRequest)
+            clientEvents[event.id] = event.clientTypeEvent
+            pinpointEventsById[event.id] = event
+        }
 
-            do {
-                _ = try await pinpointClient.putEvents(input: putEventsInput)
-                try self.storage.deleteEvent(eventId: event.id)
-                self.submittedEvents.append(event)
-            } catch {
-                if let sdkError = error as? SdkError<Any>, sdkError.isRetryable {
+        let publicEndpoint = endpointClient.convertToPublicEndpoint(endpointProfile)
+        let eventsBatch = PinpointClientTypes.EventsBatch(endpoint: publicEndpoint,
+                                                          events: clientEvents)
+        let batchItem = [endpointProfile.endpointId: eventsBatch]
+        let putEventsInput = PutEventsInput(applicationId: appId,
+                                            eventsRequest: .init(batchItem: batchItem))
+
+        do {
+            let response = try await pinpointClient.putEvents(input: putEventsInput)
+            guard let results = response.eventsResponse?.results else {
+                log.error("Unexpected response from server when atempting to submit events.")
+                return
+            }
+
+            let endpointResponseMap = results.compactMap { $0.value.endpointItemResponse }
+            for endpointResponse in endpointResponseMap {
+                if Constants.StatusCode.ok == endpointResponse.statusCode {
+                    log.verbose("EndpointProfile updated successfully.")
+                } else {
+                    log.error("Unable to update EndpointProfile. Error: \(endpointResponse.message ?? "Unknown")")
+                }
+            }
+
+            let eventsResponseMap = results.compactMap { $0.value.eventsItemResponse }
+            for (eventId, eventResponse) in eventsResponseMap.flatMap({ $0 }) {
+                guard let event = pinpointEventsById[eventId] else { continue }
+                if Constants.StatusCode.ok == eventResponse.statusCode,
+                   Constants.acceptedResponseMessage == eventResponse.message {
+                    // On successful submission, add the event to the list of submitted events and delete it from the local storage
+                    log.verbose("Successful submit for event with id \(eventId)")
+                    submittedEvents.append(event)
+                    try self.storage.deleteEvent(eventId: event.id)
+                } else if Constants.StatusCode.badRequest == eventResponse.statusCode {
+                    // Mark event as dirty
+                    log.error("Server rejected submission of event. Event with id \(eventId) will be marked dirty.")
+                    try storage.setDirtyEvent(eventId: eventId)
+                } else {
+                    // Mark event as retryable
+                    log.warn("Unable to successfully deliver event with id \(eventId) to the server. It will be updated with retry count += 1.")
+                    try storage.incrementEventRetry(eventId: eventId)
+                }
+            }
+
+        } catch {
+            // This means all events were rejected, so we will update them all in the local storage accodingly
+            var isRetryable = false
+            if let sdkError = error as? SdkError<Any> {
+                isRetryable = sdkError.isRetryable
+            }
+
+            for event in pinpointEvents {
+                if isRetryable {
                     try self.storage.incrementEventRetry(eventId: event.id)
                 } else {
                     try self.storage.setDirtyEvent(eventId: event.id)
@@ -102,11 +150,19 @@ class EventRecorder: AnalyticsEventRecording {
     }
 }
 
+extension EventRecorder: DefaultLogger {}
+
 extension EventRecorder {
     private struct Constants {
+        struct StatusCode {
+            static let ok = 202
+            static let badRequest = 400
+        }
+
         static let maxEventsSubmittedPerBatch = 100
         static let pinpointClientByteLimitDefault = 5 * 1024 * 1024 // 5MB
         static let pinpointClientBatchRecordByteLimitDefault = 512 * 1024 // 0.5MB
         static let pinpointClientBatchRecordByteLimitMax = 4 * 1024 * 1024 // 4MB
+        static let acceptedResponseMessage = "Accepted"
     }
 }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/PinpointEvent+AnalyticsEvent.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/PinpointEvent+AnalyticsEvent.swift
@@ -1,0 +1,32 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Foundation
+
+extension PinpointEvent {
+    func asAnalyticsEvent() -> AnalyticsEvent {
+        var properties: AnalyticsProperties = [:]
+
+        for attribute in attributes {
+            properties[attribute.key] = attribute.value
+        }
+
+        for metric in metrics {
+            properties[metric.key] = metric.value
+        }
+
+        return BasicAnalyticsEvent(name: eventType,
+                                   properties: properties)
+    }
+}
+
+extension Array where Element == PinpointEvent {
+    func asAnalyticsEventArray() -> [AnalyticsEvent] {
+        map { $0.asAnalyticsEvent() }
+    }
+}

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/PinpointEvent+PinpointClientTypes.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/PinpointEvent+PinpointClientTypes.swift
@@ -31,18 +31,18 @@ extension PinpointEvent {
 
 extension Bundle {
     var appPackageName: String {
-        return object(forInfoDictionaryKey: "CFBundleIdentifier") as? String ?? ""
+        object(forInfoDictionaryKey: "CFBundleIdentifier") as? String ?? ""
     }
 
     var appName: String {
-        return object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? ""
+        object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? ""
     }
 
     var appBuild: String {
-        return object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
+        object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
     }
 
     var appVersion: String {
-        return object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+        object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
     }
 }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/PinpointEvent+PinpointClientTypes.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/PinpointEvent+PinpointClientTypes.swift
@@ -10,31 +10,39 @@ import Foundation
 
 extension PinpointEvent {
     var clientTypeSession: PinpointClientTypes.Session {
-        return PinpointClientTypes.Session(duration: Int(session.duration), id: session.sessionId, startTimestamp: session.startTime.iso8601FractionalSeconds(), stopTimestamp: session.stopTime?.iso8601FractionalSeconds())
+        return PinpointClientTypes.Session(duration: Int(session.duration),
+                                           id: session.sessionId,
+                                           startTimestamp: session.startTime.asISO8601String,
+                                           stopTimestamp: session.stopTime?.asISO8601String)
     }
 
     var clientTypeEvent: PinpointClientTypes.Event {
-        let timeStamp = Date(timeIntervalSince1970: TimeInterval(eventTimestamp)).iso8601FractionalSeconds()
-
         // TODO: get the swift sdk version and name
-        return PinpointClientTypes.Event(appPackageName: Bundle.main.appPackageName, appTitle: Bundle.main.appName, appVersionCode: Bundle.main.appVersion, attributes: attributes, clientSdkVersion: "", eventType: eventType, metrics: metrics, sdkName: "", session: clientTypeSession, timestamp: timeStamp)
+        return PinpointClientTypes.Event(appPackageName: Bundle.main.appPackageName,
+                                         appTitle: Bundle.main.appName,
+                                         appVersionCode: Bundle.main.appVersion,
+                                         attributes: attributes,
+                                         eventType: eventType,
+                                         metrics: metrics,
+                                         session: clientTypeSession,
+                                         timestamp: eventDate.asISO8601String)
     }
 }
 
 extension Bundle {
     var appPackageName: String {
-        return Bundle.main.object(forInfoDictionaryKey: "CFBundleIdentifier") as? String ?? ""
+        return object(forInfoDictionaryKey: "CFBundleIdentifier") as? String ?? ""
     }
 
     var appName: String {
-        return Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? ""
+        return object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? ""
     }
 
     var appBuild: String {
-        return Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
+        return object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
     }
 
     var appVersion: String {
-        return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+        return object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
     }
 }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/PinpointEvent.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/PinpointEvent.swift
@@ -11,18 +11,18 @@ import Foundation
 class PinpointEvent: AnalyticsPropertiesModel {
     let id: String
     let eventType: String
-    let eventTimestamp: Date.Millisecond
+    let eventDate: Date
     let session: PinpointSession
     private(set) lazy var attributes: [String: String] = [:]
     private(set) lazy var metrics: [String: Double] = [:]
 
     init(id: String = UUID().uuidString,
          eventType: String,
-         eventTimestamp: Date.Millisecond = Date().utcTimeMillis,
+         eventDate: Date = Date(),
          session: PinpointSession) {
         self.id = id
         self.eventType = eventType
-        self.eventTimestamp = eventTimestamp
+        self.eventDate = eventDate
         self.session = session
     }
 
@@ -73,7 +73,7 @@ class PinpointEvent: AnalyticsPropertiesModel {
 extension PinpointEvent: Equatable {
     static func == (lhs: PinpointEvent, rhs: PinpointEvent) -> Bool {
         return lhs.eventType == rhs.eventType
-        && lhs.eventTimestamp == rhs.eventTimestamp
+        && lhs.eventDate == rhs.eventDate
         && lhs.session == rhs.session
         && lhs.attributes == rhs.attributes
         && lhs.metrics == rhs.metrics

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Endpoint/EndpointClient.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Endpoint/EndpointClient.swift
@@ -215,7 +215,7 @@ actor EndpointClient: EndpointClientBehaviour {
     }
 
     nonisolated private func getChannelType(from endpointProfile: PinpointEndpointProfile) -> PinpointClientTypes.ChannelType {
-        return endpointProfile.isDebug ? .apns : .apnsSandbox
+        return endpointProfile.isDebug ? .apnsSandbox : .apns
     }
 
     nonisolated private func getEffectiveDateIso8601FractionalSeconds(from endpointProfile: PinpointEndpointProfile) -> String {

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Endpoint/EndpointClient.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Endpoint/EndpointClient.swift
@@ -19,7 +19,7 @@ protocol EndpointClientBehaviour: Actor {
     func removeAttributes(forKey key: String)
     func addMetric(_ metric: Double, forKey key: String)
     func removeMetric(forKey key: String)
-    func currentPublicEndpoint() -> PinpointClientTypes.PublicEndpoint
+    nonisolated func convertToPublicEndpoint(_ endpointProfile: PinpointEndpointProfile) -> PinpointClientTypes.PublicEndpoint
 }
 
 actor EndpointClient: EndpointClientBehaviour {
@@ -197,8 +197,7 @@ actor EndpointClient: EndpointClientBehaviour {
                                    endpointRequest: endpointRequest)
     }
 
-    func currentPublicEndpoint() -> PinpointClientTypes.PublicEndpoint {
-        let endpointProfile = currentEndpointProfile()
+    nonisolated func convertToPublicEndpoint(_ endpointProfile: PinpointEndpointProfile) -> PinpointClientTypes.PublicEndpoint {
         let channelType = getChannelType(from: endpointProfile)
         let effectiveDate = getEffectiveDateIso8601FractionalSeconds(from: endpointProfile)
         let optOut = getOptOut(from: endpointProfile)
@@ -215,15 +214,15 @@ actor EndpointClient: EndpointClientBehaviour {
         return publicEndpoint
     }
 
-    private func getChannelType(from endpointProfile: PinpointEndpointProfile) -> PinpointClientTypes.ChannelType {
+    nonisolated private func getChannelType(from endpointProfile: PinpointEndpointProfile) -> PinpointClientTypes.ChannelType {
         return endpointProfile.isDebug ? .apns : .apnsSandbox
     }
 
-    private func getEffectiveDateIso8601FractionalSeconds(from endpointProfile: PinpointEndpointProfile) -> String {
-        endpointProfile.effectiveDate.iso8601FractionalSeconds()
+    nonisolated private func getEffectiveDateIso8601FractionalSeconds(from endpointProfile: PinpointEndpointProfile) -> String {
+        endpointProfile.effectiveDate.asISO8601String
     }
 
-    private func getOptOut(from endpointProfile: PinpointEndpointProfile) -> String {
+    nonisolated private func getOptOut(from endpointProfile: PinpointEndpointProfile) -> String {
         return endpointProfile.isOptOut ? EndpointClient.Constants.OptOut.all : EndpointClient.Constants.OptOut.none
     }
 }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Session/PinpointSession.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Session/PinpointSession.swift
@@ -36,7 +36,7 @@ class PinpointSession: Codable {
 
     var duration: Date.Millisecond {
         let endTime = stopTime ?? Date()
-        return endTime.utcTimeMillis - startTime.utcTimeMillis
+        return endTime.millisecondsSince1970 - startTime.millisecondsSince1970
     }
 
     func stop() {

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Extensions/AWSPinpointAnalyticsPlugin+HubCategory.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Extensions/AWSPinpointAnalyticsPlugin+HubCategory.swift
@@ -31,7 +31,7 @@ extension HubCategory {
         dispatch(to: .analytics, payload: payload)
     }
 
-    func dispatchFlushEvents(_ pinpointEventss: [PinpointEvent]) {
+    func dispatchFlushEvents(_ pinpointEventss: [AnalyticsEvent]) {
         let payload = HubPayload(eventName: HubPayload.EventName.Analytics.flushEvents, data: pinpointEventss)
         dispatch(to: .analytics, payload: payload)
     }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Extensions/Date+Formatting.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Extensions/Date+Formatting.swift
@@ -1,0 +1,37 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension DateFormatter {
+    static let iso8601Formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }()
+}
+
+extension Date {
+    typealias Millisecond = Int64
+
+    var millisecondsSince1970: Millisecond {
+        return Int64(self.timeIntervalSince1970 * 1000)
+    }
+
+    var asISO8601String: String {
+        return DateFormatter.iso8601Formatter.string(from: self)
+    }
+}
+
+extension Date.Millisecond {
+    var asDate: Date {
+        return Date(timeIntervalSince1970: TimeInterval(self / 1000))
+            .addingTimeInterval(TimeInterval(Double(self % 1000) / 1000 ))
+    }
+}

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginClientBehaviorTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AWSPinpointAnalyticsPluginClientBehaviorTests.swift
@@ -338,12 +338,12 @@ class AWSPinpointAnalyticsPluginClientBehaviorTests: AWSPinpointAnalyticsPluginT
         _ = plugin.listen(to: .analytics, isIncluded: nil) { payload in
             if payload.eventName == HubPayload.EventName.Analytics.flushEvents {
                 methodWasInvokedOnPlugin.fulfill()
-                guard let pinpointEvents = payload.data as? [PinpointEvent] else {
+                guard let analyticsEvents = payload.data as? [AnalyticsEvent] else {
                     XCTFail("Missing data")
                     return
                 }
 
-                XCTAssertNotNil(pinpointEvents)
+                XCTAssertNotNil(analyticsEvents)
             }
         }
 

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/EventRecorderTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/EventRecorderTests.swift
@@ -41,7 +41,7 @@ class EventRecorderTests: XCTestCase {
     /// - Then: the event is saved to storage followed by a disk size check
     func testSaveEvent() {
         let session = PinpointSession(sessionId: "1", startTime: Date(), stopTime: nil)
-        let event = PinpointEvent(id: "1", eventType: "eventType", eventTimestamp: Date().utcTimeMillis, session: session)
+        let event = PinpointEvent(id: "1", eventType: "eventType", eventDate: Date(), session: session)
 
         XCTAssertEqual(storage.events.count, 0)
         XCTAssertEqual(storage.checkDiskSizeCallCount, 1)

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/Pinpoint/MockEndpointClient.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/Pinpoint/MockEndpointClient.swift
@@ -47,7 +47,7 @@ actor MockEndpointClient: EndpointClientBehaviour {
 
     func removeMetric(forKey key: String) {}
 
-    func currentPublicEndpoint() -> PinpointClientTypes.PublicEndpoint {
+    nonisolated func convertToPublicEndpoint(_ endpointProfile: PinpointEndpointProfile) -> PinpointClientTypes.PublicEndpoint {
         return PinpointClientTypes.PublicEndpoint()
     }
 }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Pinpoint/EndpointClientTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Pinpoint/EndpointClientTests.swift
@@ -150,8 +150,9 @@ class EndpointClientTests: XCTestCase {
         XCTAssertEqual(userDefaults.saveCount, 1)
     }
 
-    func testCurrentPublicEndpoint_shouldReturnPublicEndpoint() async {
-        let publicEndpoint = await endpointClient.currentPublicEndpoint()
+    func testConvertToPublicEndpoint_shouldReturnPublicEndpoint() async {
+        let endpointProfile = await endpointClient.currentEndpointProfile()
+        let publicEndpoint = endpointClient.convertToPublicEndpoint(endpointProfile)
         let mockModel = MockDevice()
         XCTAssertNotNil(publicEndpoint)
         XCTAssertNil(publicEndpoint.address)

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Pinpoint/EndpointClientTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Pinpoint/EndpointClientTests.swift
@@ -158,7 +158,7 @@ class EndpointClientTests: XCTestCase {
         XCTAssertNil(publicEndpoint.address)
         XCTAssertEqual(publicEndpoint.attributes?.count, 0)
         XCTAssertEqual(publicEndpoint.metrics?.count, 0)
-        XCTAssertEqual(publicEndpoint.channelType, .apnsSandbox)
+        XCTAssertEqual(publicEndpoint.channelType, .apns)
         XCTAssertEqual(publicEndpoint.optOut, "ALL")
         XCTAssertEqual(publicEndpoint.demographic?.appVersion, mockModel.appVersion)
         XCTAssertEqual(publicEndpoint.demographic?.make, "apple")


### PR DESCRIPTION
**Description of changes:**

This PR does a couple of things, but mainly focuses in fixing some issues that prevented events from being submitted to the Pinpoint backend and/or to show correctly in the console:
- Forced the ISO8061 format to have an explicit trailing `Z` instead of the `+0000` offset, as otherwise the request was rejected. Did so by creating our own `DateFormatter` and extensions so that it's easier to use.
- Fixed the Event timestamp being calculated wrong before submission (they were stored in milliseconds but used as seconds, resulting in dates many many years in the future 😆 )
- Removed the empty string we were using for the `SdkVersion`, as it was rejected otherwise. A `nil` value is accepted for now, but I've kept the `//TODO` comment so we don't forget to follow up.
- According to the documentation for `EventRequest`:
  >   The batch of events to process. For each item in a batch, the endpoint ID acts as a key that has an EventsBatch object as its value.
 
  So i've changed it to use the `endpointId` as key, instead of the `applicationId`. This meant replacing `EndpointClient.currentPublicEndpoint` with a new `EndpointClient.convertToPublicEndpoint(:)` instead. 

---

Some optimizations were also made:
- We were sending one `putEvent` request per each event, even though the API supports to have many of them in a single request. I've made the change to submit all of them together and properly report/update the ones that succeeded/failed accordingly.
- Changed the storage type for attributes and metrics to be `Blob` instead of encoded String, in order to keep backwards compatibility for migrating customers that might have data in their local db (the legacy SDK used Blob)
- Changed the result we report on `dispatchFlushEvents` to be a `[AnalyticsEvent]` to avoid exposing internal implementations and to allow consumers to cast the result (`PinpointEvent` is an internal class)

---
Finally, some small tweaks:
- Renamed the `Date.utcTimeMillis` extension method to the much better `Date.millisecondsSince1970` name, which is also consistent with the existing `timeintervalSince1970`.
- Decided to have a `Date` instead of `Date.Millisecond` in the `PinpointEvent` class. What matters is what we store in the DB, so it was more friendly to directly work with dates.

----

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] ~All integration tests pass~
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
