### PR TITLE
feat(auth): Add Confirm Reset Password API implementation

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
@@ -138,7 +138,17 @@ extension AWSCognitoAuthPlugin: AuthCategoryBehavior {
                                      options: AuthConfirmResetPasswordOperation.Request.Options?,
                                      listener: AuthConfirmResetPasswordOperation.ResultListener?)
     -> AuthConfirmResetPasswordOperation {
-        fatalError("Not implemented")
+        let options = options ?? AuthConfirmResetPasswordRequest.Options()
+        let request = AuthConfirmResetPasswordRequest(username: username,
+                                                      newPassword: newPassword,
+                                                      confirmationCode: confirmationCode,
+                                                      options: options)
+        let confirmResetPasswordOperation = AWSAuthConfirmResetPasswordOperation(request,
+                                                                         userPoolFactory: authEnvironment.cognitoUserPoolFactory,
+                                                                         authConfiguration: authConfiguration,
+                                                                         resultListener: listener)
+        queue.addOperation(confirmResetPasswordOperation)
+        return confirmResetPasswordOperation
     }
 
     public func deleteUser(listener: AuthDeleteUserOperation.ResultListener?) -> AuthDeleteUserOperation {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthConfirmResetPasswordOperation.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthConfirmResetPasswordOperation.swift
@@ -1,0 +1,104 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import AWSPluginsCore
+import ClientRuntime
+import AWSCognitoIdentityProvider
+
+public class AWSAuthConfirmResetPasswordOperation: AmplifyOperation< AuthConfirmResetPasswordRequest, Void, AuthError>, AuthConfirmResetPasswordOperation {
+
+    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+    private let userPoolFactory: CognitoUserPoolFactory
+    private var authConfiguration: AuthConfiguration
+
+    init(_ request: AuthConfirmResetPasswordRequest,
+         userPoolFactory: @escaping CognitoUserPoolFactory,
+         authConfiguration: AuthConfiguration,
+         resultListener: ResultListener?) {
+        self.userPoolFactory = userPoolFactory
+        self.authConfiguration = authConfiguration
+        super.init(categoryType: .auth,
+                   eventName: HubPayload.EventName.Auth.resetPasswordAPI,
+                   request: request,
+                   resultListener: resultListener)
+    }
+
+    override public func main() {
+        if isCancelled {
+            finish()
+            return
+        }
+
+        if let validationError = request.hasError() {
+            dispatch(validationError)
+            finish()
+            return
+        }
+
+        Task.init { [weak self] in
+            await self?.confirmResetPassword()
+        }
+    }
+
+    func confirmResetPassword() async {
+        do {
+            let userPoolService = try userPoolFactory()
+            let clientMetaData = (request.options.pluginOptions
+                                  as? AWSResendSignUpCodeOptions)?.metadata ?? [:]
+
+            let userPoolConfigurationData: UserPoolConfigurationData
+            switch authConfiguration {
+            case .userPools(let data):
+                userPoolConfigurationData = data
+            case .userPoolsAndIdentityPools(let data, _):
+                userPoolConfigurationData = data
+            case .identityPools:
+                let error = AuthError.configuration("UserPool configuration is missing", AuthPluginErrorConstants.configurationError)
+                throw error
+            }
+
+
+            let input = ConfirmForgotPasswordInput(clientId: userPoolConfigurationData.clientId,
+                                                   clientMetadata: clientMetaData,
+                                                   confirmationCode: request.confirmationCode,
+                                                   password: request.newPassword,
+                                                   username: request.username)
+
+            let _ = try await userPoolService.confirmForgotPassword(input: input)
+            
+            if self.isCancelled {
+                finish()
+                return
+            }
+            
+            self.dispatch()
+        } catch let error as ConfirmForgotPasswordOutputError {
+            self.dispatch(error.authError)
+        } catch let error as SdkError<ConfirmForgotPasswordOutputError> {
+            self.dispatch(error.authError)
+        } catch let error as AuthError {
+            self.dispatch(error)
+        } catch let error {
+            let error = AuthError.unknown("Unable to create a Swift SDK user pool service", error)
+            self.dispatch(error)
+        }
+    }
+
+    private func dispatch() {
+        let result = OperationResult.success(())
+        dispatch(result: result)
+        finish()
+    }
+
+    private func dispatch(_ error: AuthError) {
+        let result = OperationResult.failure(error)
+        dispatch(result: result)
+        Amplify.log.error(error: error)
+        finish()
+    }
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthConfirmResetPasswordOperation.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/UserOperations/AWSAuthConfirmResetPasswordOperation.swift
@@ -23,7 +23,7 @@ public class AWSAuthConfirmResetPasswordOperation: AmplifyOperation< AuthConfirm
         self.userPoolFactory = userPoolFactory
         self.authConfiguration = authConfiguration
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.resetPasswordAPI,
+                   eventName: HubPayload.EventName.Auth.confirmResetPasswordAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/CognitoUserPoolBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/CognitoUserPoolBehavior.swift
@@ -59,4 +59,8 @@ protocol CognitoUserPoolBehavior {
     /// Resets password
     /// Throws ForgotPasswordOutputError
     func forgotPassword(input: ForgotPasswordInput) async throws -> ForgotPasswordOutputResponse
+    
+    /// Confirm Reset password
+    /// Throws ConfirmForgotPasswordOutputError
+    func confirmForgotPassword(input: ConfirmForgotPasswordInput) async throws -> ConfirmForgotPasswordOutputResponse
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ConfirmForgotPasswordOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ConfirmForgotPasswordOutputError+AuthError.swift
@@ -1,0 +1,78 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import AWSCognitoIdentityProvider
+import Amplify
+
+extension ConfirmForgotPasswordOutputError: AuthErrorConvertible {
+    var authError: AuthError {
+        switch self {
+        case .codeMismatchException(let exception):
+            return AuthError.service(exception.message ?? "Provided code does not match what the server was expecting.",
+                                     AuthPluginErrorConstants.codeMismatchError,
+                                     AWSCognitoAuthError.codeMismatch)
+        case .expiredCodeException(let exception):
+            return AuthError.service(exception.message ?? "Provided code has expired.",
+                                     AuthPluginErrorConstants.codeExpiredError,
+                                     AWSCognitoAuthError.codeExpired)
+        case .internalErrorException(let exception):
+            return .unknown(exception.message ?? "Internal exception occurred")
+        case .invalidLambdaResponseException(let exception):
+            return .service(exception.message ?? "Invalid lambda response error",
+                            AuthPluginErrorConstants.lambdaError,
+                            AWSCognitoAuthError.lambda)
+        case .invalidParameterException(let exception):
+            return AuthError.service(exception.message ?? "Invalid parameter error",
+                                     AuthPluginErrorConstants.invalidParameterError,
+                                     AWSCognitoAuthError.invalidParameter)
+        case .invalidPasswordException(let exception):
+            return AuthError.service(exception.message ?? "Invalid password error",
+                                     AuthPluginErrorConstants.invalidPasswordError,
+                                     AWSCognitoAuthError.invalidPassword)
+        case .limitExceededException(let exception):
+            return .service(exception.message ?? "Limit exceeded error",
+                            AuthPluginErrorConstants.limitExceededError,
+                            AWSCognitoAuthError.limitExceeded)
+        case .notAuthorizedException(let exception):
+            return AuthError.notAuthorized(exception.message ?? "Not authorized error",
+                                           AuthPluginErrorConstants.notAuthorizedError)
+        case .resourceNotFoundException(let exception):
+            return AuthError.service(exception.message ?? "Resource not found error",
+                                     AuthPluginErrorConstants.resourceNotFoundError,
+                                     AWSCognitoAuthError.resourceNotFound)
+        case .tooManyFailedAttemptsException(let exception):
+            return AuthError.service(exception.message ?? "Too many failed attempts error",
+                                     AuthPluginErrorConstants.tooManyFailedError,
+                                     AWSCognitoAuthError.failedAttemptsLimitExceeded)
+        case .tooManyRequestsException(let exception):
+            return AuthError.service(exception.message ?? "Too many requests error",
+                                     AuthPluginErrorConstants.tooManyRequestError,
+                                     AWSCognitoAuthError.requestLimitExceeded)
+        case .unexpectedLambdaException(let exception):
+            return .service(exception.message ?? "Unexpected lambda error",
+                            AuthPluginErrorConstants.lambdaError,
+                            AWSCognitoAuthError.lambda)
+        case .userLambdaValidationException(let exception):
+            return .service(exception.message ?? "User lambda validation error",
+                            AuthPluginErrorConstants.lambdaError,
+                            AWSCognitoAuthError.lambda)
+        case .userNotConfirmedException(let userNotConfirmedException):
+            return .service(userNotConfirmedException.message ?? "User not confirmed error",
+                            AuthPluginErrorConstants.userNotConfirmedError,
+                            AWSCognitoAuthError.userNotConfirmed)
+        case .userNotFoundException(let exception):
+            return AuthError.service(exception.message ?? "User not found error",
+                                     AuthPluginErrorConstants.userNotFoundError,
+                                     AWSCognitoAuthError.userNotFound)
+        case .unknown(let serviceError):
+            let statusCode = serviceError._statusCode?.rawValue ?? -1
+            let message = serviceError._message ?? ""
+            return .unknown("Unknown service error occurred with status \(statusCode) \(message)")
+        }
+    }
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Request/AuthConfirmResetPasswordRequest+Validation.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Request/AuthConfirmResetPasswordRequest+Validation.swift
@@ -1,0 +1,33 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+import Amplify
+
+extension AuthConfirmResetPasswordRequest {
+    
+    func hasError() -> AuthError? {
+        guard !username.isEmpty else {
+            return AuthError.validation(
+                AuthPluginErrorConstants.confirmResetPasswordUsernameError.field,
+                AuthPluginErrorConstants.confirmResetPasswordUsernameError.errorDescription,
+                AuthPluginErrorConstants.confirmResetPasswordUsernameError.recoverySuggestion)
+        }
+        guard !newPassword.isEmpty else {
+            return AuthError.validation(
+                AuthPluginErrorConstants.confirmResetPasswordNewPasswordError.field,
+                AuthPluginErrorConstants.confirmResetPasswordNewPasswordError.errorDescription,
+                AuthPluginErrorConstants.confirmResetPasswordNewPasswordError.recoverySuggestion)
+        }
+        guard !confirmationCode.isEmpty else {
+            return AuthError.validation(
+                AuthPluginErrorConstants.confirmResetPasswordCodeError.field,
+                AuthPluginErrorConstants.confirmResetPasswordCodeError.errorDescription,
+                AuthPluginErrorConstants.confirmResetPasswordCodeError.recoverySuggestion)
+        }
+        return nil
+    }
+    
+}

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/ClientBehaviorTests/ClientBehaviorConfirmResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/ClientBehaviorTests/ClientBehaviorConfirmResetPasswordTests.swift
@@ -1,0 +1,804 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+import XCTest
+import AWSCognitoIdentity
+import AWSCognitoIdentityProvider
+@testable import Amplify
+@testable import AWSCognitoAuthPlugin
+@testable import AWSPluginsTestCommon
+
+class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
+    
+    override func setUp() {
+        super.setUp()
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                try ConfirmForgotPasswordOutputResponse(httpResponse: MockHttpResponse.ok)
+            }
+        )
+    }
+    
+    /// Test confirmResetPassword operation can be invoked
+    ///
+    /// - Given: Given a configured auth plugin
+    /// - When:
+    ///    - I call confirmResetPassword operation
+    /// - Then:
+    ///    - I should get a valid operation object
+    ///
+    func testConfirmResetPasswordRequest() {
+        let pluginOptions = ["key": "value"]
+        let options = AuthConfirmResetPasswordRequest.Options(pluginOptions: pluginOptions)
+        let operation = plugin.confirmResetPassword(for: "username",
+                                                       with: "password",
+                                                       confirmationCode: "code",
+                                                       options: options)
+        XCTAssertNotNil(operation)
+    }
+    
+    /// Test confirmResetPassword operation can be invoked without options
+    ///
+    /// - Given: Given a configured auth plugin
+    /// - When:
+    ///    - I call confirmResetPassword operation
+    /// - Then:
+    ///    - I should get a valid operation object
+    ///
+    func testConfirmResetPasswordRequestWithoutOptions() {
+        let operation = plugin.confirmResetPassword(for: "username", with: "password", confirmationCode: "code")
+        XCTAssertNotNil(operation)
+    }
+    
+    
+    /// Test a successful confirmResetPassword call
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service calls should mock a successul response
+    /// - When:
+    ///    - I invoke confirmSignup with a valid username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get a successful result
+    ///
+    func testSuccessfulConfirmResetPassword() {
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                try ConfirmForgotPasswordOutputResponse(httpResponse: MockHttpResponse.ok)
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            switch result {
+            case .success:
+                resultExpectation.fulfill()
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with empty username
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a successul response
+    /// - When:
+    ///    - I invoke confirmResetPassword with an empty username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get an .validation error
+    ///
+    func testConfirmResetPasswordWithEmptyUserName() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                try ConfirmForgotPasswordOutputResponse(httpResponse: MockHttpResponse.ok)
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success:
+                XCTFail("Should not succeed")
+            case .failure(let error):
+                guard case .validation = error else {
+                    XCTFail("Should produce validation error instead of \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with empty new password
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a successul response
+    /// - When:
+    ///    - I invoke confirmResetPassword with a valid username, an empty new password and a confirmation code
+    /// - Then:
+    ///    - I should get an .validation error
+    ///
+    func testConfirmResetPasswordWithEmptyNewPassword() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                try ConfirmForgotPasswordOutputResponse(httpResponse: MockHttpResponse.ok)
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success:
+                XCTFail("Should not succeed")
+            case .failure(let error):
+                guard case .validation = error else {
+                    XCTFail("Should produce validation error instead of \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with CodeMismatchException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   CodeMismatchException response
+    /// - When:
+    ///    - I invoke confirmResetPassword with a valid username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .codeMismatch as underlyingError
+    ///
+    func testConfirmResetPasswordWithCodeMismatchException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                throw ConfirmForgotPasswordOutputError.codeMismatchException(CodeMismatchException(message: "code mismatch"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .codeMismatch = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be codeMismatch \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with CodeExpiredException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   CodeExpiredException response
+    /// - When:
+    ///    - I invoke confirmResetPassword with a valid username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .codeExpired as underlyingError
+    ///
+    func testConfirmResetPasswordWithExpiredCodeException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                throw ConfirmForgotPasswordOutputError.expiredCodeException(ExpiredCodeException(message: "code expired"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .codeExpired = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be codeExpired \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with InternalErrorException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a InternalErrorException response
+    /// - When:
+    ///    - I invoke confirmResetPassword with a valid username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get an .unknown error
+    ///
+    func testConfirmResetPasswordWithInternalErrorException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                throw ConfirmForgotPasswordOutputError.internalErrorException(InternalErrorException(message: "internal error"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .unknown = error else {
+                    XCTFail("Should produce an unknown error instead of \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with InvalidLambdaResponseException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidLambdaResponseException response
+    /// - When:
+    ///    - I invoke confirmResetPassword with a valid username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .lambda as underlyingError
+    ///
+    func testConfirmResetPasswordWithInvalidLambdaResponseException() {
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                throw ConfirmForgotPasswordOutputError.invalidLambdaResponseException(InvalidLambdaResponseException(message: "invalid lambda"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be lambda \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with InvalidParameterException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidParameterException response
+    ///
+    /// - When:
+    ///    - I invoke confirmResetPassword with a valid username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get a .service error with  .invalidParameter as underlyingError
+    ///
+    func testConfirmResetPasswordWithInvalidParameterException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                throw ConfirmForgotPasswordOutputError.invalidParameterException(InvalidParameterException(message: "invalid parameter"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be invalidParameter \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with InvalidParameterException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidPasswordException response
+    ///
+    /// - When:
+    ///    - I invoke confirmResetPassword with a valid username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .invalidPassword as underlyingError
+    ///
+    func testConfirmResetPasswordWithInvalidPasswordException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                throw ConfirmForgotPasswordOutputError.invalidPasswordException(InvalidPasswordException(message: "invalid password"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .invalidPassword = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be invalidPassword \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with LimitExceededException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   LimitExceededException response
+    ///
+    /// - When:
+    ///    - I invoke confirmResetPassword with a valid username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get a .limitExceeded error
+    ///
+    func testConfirmResetPasswordWithLimitExceededException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                throw ConfirmForgotPasswordOutputError.limitExceededException(LimitExceededException(message: "limit exceeded"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be limitExceeded \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with NotAuthorizedException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   NotAuthorizedException response
+    ///
+    /// - When:
+    ///    - I invoke confirmResetPassword with a valid username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get a .notAuthorized error
+    ///
+    func testConfirmResetPasswordWithNotAuthorizedException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                throw ConfirmForgotPasswordOutputError.notAuthorizedException(NotAuthorizedException(message: "not authorized"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .notAuthorized = error else {
+                    XCTFail("Should produce notAuthorized error instead of \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with ResourceNotFoundException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   ResourceNotFoundException response
+    ///
+    /// - When:
+    ///    - I invoke confirmResetPassword with a valid username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get a .resourceNotFound error
+    ///
+    func testConfirmResetPasswordWithResourceNotFoundException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                throw ConfirmForgotPasswordOutputError.resourceNotFoundException(ResourceNotFoundException(message: "resource not found"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be failedAttemptsLimitExceeded \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with TooManyFailedAttempts response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   TooManyFailedAttemptsException response
+    ///
+    /// - When:
+    ///    - I invoke confirmResetPassword with a valid username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .failedAttemptsLimitExceeded as underlyingError
+    ///
+    func testConfirmResetPasswordWithTooManyFailedAttemptsException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                throw ConfirmForgotPasswordOutputError.tooManyFailedAttemptsException(TooManyFailedAttemptsException(message: "too many failed attempts"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .failedAttemptsLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be failedAttemptsLimitExceeded \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with TooManyRequestsException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   TooManyRequestsException response
+    ///
+    /// - When:
+    ///    - I invoke confirmResetPassword with a valid username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .requestLimitExceeded as underlyingError
+    ///
+    func testConfirmResetPasswordWithTooManyRequestsException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                throw ConfirmForgotPasswordOutputError.tooManyRequestsException(TooManyRequestsException(message: "too many requests"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be requestLimitExceeded \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with UnexpectedLambdaException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   UnexpectedLambdaException response
+    ///
+    /// - When:
+    ///    - I invoke confirmResetPassword with a valid username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .lambda as underlyingError
+    ///
+    func testConfirmResetPasswordWithUnexpectedLambdaException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                throw ConfirmForgotPasswordOutputError.unexpectedLambdaException(UnexpectedLambdaException(message: "unexpected lambda"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be lambda \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with UserLambdaValidationException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   UserLambdaValidationException response
+    ///
+    /// - When:
+    ///    - I invoke confirmResetPassword with a valid username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .lambda as underlyingError
+    ///
+    func testConfirmResetPasswordWithUserLambdaValidationException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                throw ConfirmForgotPasswordOutputError.userLambdaValidationException(UserLambdaValidationException(message: "user lambda invalid"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be lambda \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with UserNotFound response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   UserNotConfirmedException response
+    ///
+    /// - When:
+    ///    - I invoke confirmResetPassword with a valid username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get a .userNotConfirmed error
+    ///
+    func testConfirmResetPasswordWithUserNotConfirmedException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                throw ConfirmForgotPasswordOutputError.userNotConfirmedException(UserNotConfirmedException(message: "user not confirmed"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .userNotConfirmed = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be userNotFound \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a confirmResetPassword call with UserNotFound response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   UserNotFoundException response
+    ///
+    /// - When:
+    ///    - I invoke confirmResetPassword with a valid username, a new password and a confirmation code
+    /// - Then:
+    ///    - I should get a .userNotFound error
+    ///
+    func testConfirmResetPasswordWithUserNotFoundException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { _ in
+                throw ConfirmForgotPasswordOutputError.userNotFoundException(UserNotFoundException(message: "user not found"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.confirmResetPassword(for: "username",
+                                           with: "newpassword",
+                                           confirmationCode: "code",
+                                           options: nil) { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be userNotFound \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+}

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockIdentityProvider.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockIdentityProvider.swift
@@ -52,6 +52,9 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
 
     typealias MockDeleteUserOutputResponse = (DeleteUserInput) async throws
     -> DeleteUserOutputResponse
+    
+    typealias MockConfirmForgotPasswordOutputResponse = (ConfirmForgotPasswordInput) async throws
+    -> ConfirmForgotPasswordOutputResponse
 
     let mockSignUpResponse: MockSignUpResponse?
     let mockRevokeTokenResponse: MockRevokeTokenResponse?
@@ -67,6 +70,7 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
     let mockResendConfirmationCodeOutputResponse: MockResendConfirmationCodeOutputResponse?
     let mockDeleteUserOutputResponse: MockDeleteUserOutputResponse?
     let mockForgotPasswordOutputResponse: MockForgotPasswordOutputResponse?
+    let mockConfirmForgotPasswordOutputResponse: MockConfirmForgotPasswordOutputResponse?
 
     init(
         mockSignUpResponse: MockSignUpResponse? = nil,
@@ -82,7 +86,8 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
         mockChangePasswordOutputResponse: MockChangePasswordOutputResponse? = nil,
         mockResendConfirmationCodeOutputResponse: MockResendConfirmationCodeOutputResponse? = nil,
         mockDeleteUserOutputResponse: MockDeleteUserOutputResponse? = nil,
-        mockForgotPasswordOutputResponse: MockForgotPasswordOutputResponse? = nil
+        mockForgotPasswordOutputResponse: MockForgotPasswordOutputResponse? = nil,
+        mockConfirmForgotPasswordOutputResponse: MockConfirmForgotPasswordOutputResponse? = nil
     ) {
         self.mockSignUpResponse = mockSignUpResponse
         self.mockRevokeTokenResponse = mockRevokeTokenResponse
@@ -98,6 +103,7 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
         self.mockResendConfirmationCodeOutputResponse = mockResendConfirmationCodeOutputResponse
         self.mockDeleteUserOutputResponse = mockDeleteUserOutputResponse
         self.mockForgotPasswordOutputResponse = mockForgotPasswordOutputResponse
+        self.mockConfirmForgotPasswordOutputResponse = mockConfirmForgotPasswordOutputResponse
     }
 
     /// Throws InitiateAuthOutputError
@@ -162,5 +168,9 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
     
     func forgotPassword(input: ForgotPasswordInput) async throws -> ForgotPasswordOutputResponse {
         return try await mockForgotPasswordOutputResponse!(input)
+    }
+    
+    func confirmForgotPassword(input: ConfirmForgotPasswordInput) async throws -> ConfirmForgotPasswordOutputResponse {
+        return try await mockConfirmForgotPasswordOutputResponse!(input)
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		485CB5C127B61F1E006CCEC7 /* AuthSignOutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB5BD27B61F1D006CCEC7 /* AuthSignOutTests.swift */; };
 		485CB5C227B61F1E006CCEC7 /* AuthSRPSignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB5BE27B61F1D006CCEC7 /* AuthSRPSignInTests.swift */; };
 		97829201286B802E000DE190 /* AuthResetPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97829200286B802E000DE190 /* AuthResetPasswordTests.swift */; };
+		97829203286E41FA000DE190 /* AuthConfirmResetPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97829202286E41FA000DE190 /* AuthConfirmResetPasswordTests.swift */; };
 		B43C26CA27BC9D54003F3BF7 /* AuthSignUpTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43C26C727BC9D54003F3BF7 /* AuthSignUpTests.swift */; };
 		B43C26CB27BC9D54003F3BF7 /* AuthConfirmSignUpTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43C26C827BC9D54003F3BF7 /* AuthConfirmSignUpTests.swift */; };
 		B43C26CC27BC9D54003F3BF7 /* AuthResendSignUpCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43C26C927BC9D54003F3BF7 /* AuthResendSignUpCodeTests.swift */; };
@@ -63,6 +64,7 @@
 		485CB5BD27B61F1D006CCEC7 /* AuthSignOutTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthSignOutTests.swift; sourceTree = "<group>"; };
 		485CB5BE27B61F1D006CCEC7 /* AuthSRPSignInTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthSRPSignInTests.swift; sourceTree = "<group>"; };
 		97829200286B802E000DE190 /* AuthResetPasswordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthResetPasswordTests.swift; sourceTree = "<group>"; };
+		97829202286E41FA000DE190 /* AuthConfirmResetPasswordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthConfirmResetPasswordTests.swift; sourceTree = "<group>"; };
 		B43C26C727BC9D54003F3BF7 /* AuthSignUpTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthSignUpTests.swift; sourceTree = "<group>"; };
 		B43C26C827BC9D54003F3BF7 /* AuthConfirmSignUpTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthConfirmSignUpTests.swift; sourceTree = "<group>"; };
 		B43C26C927BC9D54003F3BF7 /* AuthResendSignUpCodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthResendSignUpCodeTests.swift; sourceTree = "<group>"; };
@@ -233,6 +235,7 @@
 			isa = PBXGroup;
 			children = (
 				97829200286B802E000DE190 /* AuthResetPasswordTests.swift */,
+				97829202286E41FA000DE190 /* AuthConfirmResetPasswordTests.swift */,
 			);
 			path = ResetPasswordTests;
 			sourceTree = "<group>";
@@ -398,6 +401,7 @@
 				485105AA2840513C002D6FC8 /* AuthUserAttributesTests.swift in Sources */,
 				485CB5BF27B61F1E006CCEC7 /* SignedInAuthSessionTests.swift in Sources */,
 				B43C26CA27BC9D54003F3BF7 /* AuthSignUpTests.swift in Sources */,
+				97829203286E41FA000DE190 /* AuthConfirmResetPasswordTests.swift in Sources */,
 				4821B2F2286B5F74000EC1D7 /* AuthDeleteUserTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/ResetPasswordTests/AuthConfirmResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/ResetPasswordTests/AuthConfirmResetPasswordTests.swift
@@ -1,0 +1,73 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+import AWSCognitoAuthPlugin
+
+class AuthConfirmResetPasswordTests: AWSAuthBaseTest {
+    
+    override func setUp() {
+        super.setUp()
+        initializeAmplify()
+    }
+    
+    override func tearDown() async throws {
+        try await super.tearDown()
+        await Amplify.reset()
+        sleep(2)
+    }
+    
+    /// Test if confirmResetPassword returns userNotFound error for a non existing user
+    ///
+    /// - Given: A user which is not registered to the configured user pool
+    /// - When:
+    ///    - I invoke confirmResetPassword with the user
+    /// - Then:
+    ///    - I should get a userNotFound error.
+    ///
+    func testUserNotFoundResetPassword() {
+        let confirmResetPasswordExpectation = expectation(description: "Received event result from resetPassword")
+        _ = Amplify.Auth.confirmResetPassword(for: "user-non-exists", with: "password", confirmationCode: "123", options: nil) { result in
+            switch result {
+            case .success:
+                XCTFail("resetPassword with non existing user should not return result")
+            case .failure(let error):
+                guard let cognitoError = error.underlyingError as? AWSCognitoAuthError,
+                      case .userNotFound = cognitoError else {
+                          print(error)
+                          XCTFail("Should return userNotFound")
+                          return
+                      }
+                confirmResetPasswordExpectation.fulfill()
+            }
+        }
+        wait(for: [confirmResetPasswordExpectation], timeout: networkTimeout)
+    }
+    
+    /// Calling cancel in confirmResetPassword operation should cancel
+    ///
+    /// - Given: A valid username
+    /// - When:
+    ///    - I invoke confirmResetPassword with the username and then call cancel
+    /// - Then:
+    ///    - I should not get any result back
+    ///
+    func testCancelResetPassword() {
+        let username = "integTest\(UUID().uuidString)"
+        
+        let operationExpectation = expectation(description: "Operation should not complete")
+        operationExpectation.isInverted = true
+        let operation = Amplify.Auth.confirmResetPassword(for: username, with: "password", confirmationCode: "123", options: nil) { result in
+            operationExpectation.fulfill()
+            XCTFail("Received result \(result)")
+        }
+        XCTAssertNotNil(operation, "confirmResetPassword operations should not be nil")
+        operation.cancel()
+        wait(for: [operationExpectation], timeout: networkTimeout)
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Add confirm reset password API implementation based on `aws-swift-sdk`

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
