### PR TITLE
chore(api): clean up and enable user pool integ test

### DIFF
--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -1,7 +1,7 @@
 name: Integration Tests
 on:
   push:
-    branches: [main]
+    branches: [chore/api-userpool-integ-tests]
 
 permissions:
     id-token: write
@@ -112,7 +112,6 @@ jobs:
           scheme: GraphQLWithIAMIntegrationTests
 
   api-graphqluserpool-integration-test:
-    if: ${{ false }}
     needs: [api-integration-test]
     runs-on: macos-latest
     environment: IntegrationTest

--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -1,7 +1,7 @@
 name: Integration Tests
 on:
   push:
-    branches: [chore/api-userpool-integ-tests]
+    branches: [main]
 
 permissions:
     id-token: write

--- a/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/GraphQLWithUserPoolIntegrationTests.xcscheme
+++ b/AmplifyPlugins/API/APICategoryPlugin.xcodeproj/xcshareddata/xcschemes/GraphQLWithUserPoolIntegrationTests.xcscheme
@@ -24,7 +24,7 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "GraphQLWithUserPoolIntegrationTests/testSetUpOnce()">
+                  Identifier = "GraphQLAuthDirectiveIntegrationTests">
                </Test>
             </SkippedTests>
          </TestableReference>

--- a/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/GraphQLWithUserPoolIntegrationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginIntegrationTests/GraphQL/GraphQLWithUserPoolIntegrationTests/GraphQLWithUserPoolIntegrationTests.swift
@@ -169,10 +169,10 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
         let completeInvoked = expectation(description: "request completed")
         let uuid = UUID().uuidString
 
-        // create a Todo mutation with a missing/invalid "description" variable value
+        // create a Todo mutation with a missing/invalid "name" variable value
         let request = GraphQLRequest(document: CreateTodoMutation.document,
                                      variables: CreateTodoMutation.variables(id: uuid,
-                                                                             name: "",
+                                                                             name: nil,
                                                                              description: nil),
                                      responseType: AWSAPICategoryPluginTestCommon.Todo?.self,
                                      decodePath: CreateTodoMutation.decodePath)
@@ -184,17 +184,13 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
                     return
                 }
 
-                guard case let .transformationError(rawResponse, error) = graphQLResponseError else {
-                    XCTFail("Missing transformation error")
+                guard case let .error(errors) = graphQLResponseError, let firstError = errors.first else {
+                    XCTFail("Missing errors")
                     return
                 }
-                guard case let .operationError(operationErrorDescription, _, operationError) = error else {
-                    XCTFail("Unexpected error type \(error)")
-                    return
-                }
-                XCTAssertNotNil(rawResponse)
-                XCTAssertNotNil(operationError)
-                XCTAssertEqual(operationErrorDescription, "valueNotFound")
+
+                XCTAssertEqual("Variable 'input' has coerced Null value for NonNull type 'String!'",
+                               firstError.message)
 
                 completeInvoked.fulfill()
             case .failure(let error):
@@ -447,17 +443,18 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
         let operation = Amplify.API.query(request: request) { event in
             switch event {
             case .success(let graphQLResponse):
-                guard case let .success(data) = graphQLResponse else {
-                    XCTFail("Missing successful response")
-                    return
+                switch graphQLResponse {
+                case .success(let data):
+                    guard let listTodos = data.listTodos else {
+                        XCTFail("Missing listTodos")
+                        return
+                    }
+                    XCTAssertTrue(!listTodos.items.isEmpty)
+                    listCompleteInvoked.fulfill()
+                case .failure(let error):
+                    print("\(error.underlyingError)")
+                    XCTFail("Unexpected .failed event: \(error)")
                 }
-                guard let listTodos = data.listTodos else {
-                    XCTFail("Missing listTodos")
-                    return
-                }
-
-                XCTAssertTrue(!listTodos.items.isEmpty)
-                listCompleteInvoked.fulfill()
             case .failure(let error):
                 XCTFail("Unexpected .failed event: \(error)")
             }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTestCommon/Model/Todo.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTestCommon/Model/Todo.swift
@@ -8,14 +8,11 @@
 import Foundation
 import Amplify
 
-/// TODO: Replace with AmplifyTestCommon's DataStore's geneated model
-/// This model corresponds to the resources created for the Todo graphQL endpoint. As a developer, this is
-/// hand-written from the codegen that created the API.swift that depends on AppSync sdk.
 struct Todo: Decodable {
    let typename: String
    let id: String
    let name: String
-   let description: String
+   let description: String?
 
    enum CodingKeys: String, CodingKey {
        case typename = "__typename"
@@ -48,14 +45,16 @@ class CreateTodoMutation {
             }\n}
         """
 
-    static func variables(id: String? = nil, name: String, description: String? = nil) -> [String: Any] {
+    static func variables(id: String? = nil, name: String?, description: String? = nil) -> [String: Any] {
         var input: [String: Any] = [:]
 
         if let id = id {
             input.updateValue(id, forKey: "id")
         }
 
-        input.updateValue(name, forKey: "name")
+        if let name = name {
+            input.updateValue(name, forKey: "name")
+        }
 
         if let description = description {
             input.updateValue(description, forKey: "description")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Overall this enables one test class called **GraphQLWithUserPoolIntegrationTests.swift** and makes sure the tests are passing based on the latest provisioning steps. 

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
