### PR TITLE
chore(Analytics): add skname and version to Pinpoint events

### DIFF
--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointBehavior.swift
@@ -18,12 +18,12 @@ public struct AWSPinpoint {
 /// Implemented by `PinpointContext` as a pass through to the methods on `analyticClient` and `endpointClient`.
 /// This protocol allows a way to create a Mock and ensure plugin implementation is testable.
 protocol AWSPinpointBehavior {
-    //MARK: Escape hatch
+    // MARK: Escape hatch
     /// Returns the low-level `PinpointClientProcotol` clients used to interact with AWS Pinpoint for Analytics and Targeting.
     /// - Returns:A `AWSPinpoint` containing the the lower level clients.
     func getEscapeHatch() -> AWSPinpoint
 
-    //MARK: Analytics
+    // MARK: Analytics
     /// Creates a `PinpointEvent` with the specificed eventType
     /// - Parameter eventType: The `PinpointEvent` to create
     /// - Returns: A new PinpointEvent with the specified event type
@@ -48,7 +48,7 @@ protocol AWSPinpointBehavior {
     /// - Returns: An array of successfully submitted events.
     @discardableResult func submitEvents() async throws -> [PinpointEvent]
 
-    //MARK: Targeting
+    // MARK: Targeting
     /// Returns the current endpoint profile.
     /// - Returns:A `PinpointEndpointProfile`  representing the current endpoint.
     func currentEndpointProfile() async -> PinpointEndpointProfile

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/AnalyticsClient.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/AnalyticsClient.swift
@@ -22,10 +22,10 @@ protocol AnalyticsClientBehaviour: Actor {
     func removeGlobalMetric(forKey key: String)
     func removeGlobalMetric(forKey key: String, forEventType eventType: String)
     func record(_ event: PinpointEvent) async throws
-    
+
     func setGlobalEventSourceAttributes(_ attributes: [String: Any]) throws
     func removeAllGlobalEventSourceAttributes()
-    
+
     @discardableResult func submitEvents() async throws -> [PinpointEvent]
 
     nonisolated func createAppleMonetizationEvent(with transaction: SKPaymentTransaction,
@@ -35,7 +35,7 @@ protocol AnalyticsClientBehaviour: Actor {
                                                     withQuantity quantity: Int,
                                         withCurrency currency: String) -> PinpointEvent
     nonisolated func createEvent(withEventType eventType: String) -> PinpointEvent
-    
+
 }
 
 typealias SessionProvider = () -> PinpointSession
@@ -93,19 +93,19 @@ actor AnalyticsClient: AnalyticsClientBehaviour {
         precondition(!key.isEmpty, "Attributes and metrics must have a valid key")
         eventTypeMetrics[eventType, default: [:]][key] = metric
     }
-    
+
     func setGlobalEventSourceAttributes(_ attributes: [String: Any]) throws {
         guard let attributes = attributes as? [String: String] else {
             return
         }
         globalEventSourceAttributes = attributes
         let sessionId = self.sessionProvider().sessionId
-        
+
         try eventRecorder.updateAttributesOfEvents(ofType: SessionClient.Constants.Events.start,
                                                    withSessionId: sessionId,
                                                    setAttributes: attributes)
     }
-    
+
     func removeGlobalAttribute(forKey key: String) {
         globalAttributes[key] = nil
     }
@@ -121,15 +121,14 @@ actor AnalyticsClient: AnalyticsClientBehaviour {
     func removeGlobalMetric(forKey key: String, forEventType eventType: String) {
         eventTypeMetrics[eventType]?[key] = nil
     }
-    
+
     func removeAllGlobalEventSourceAttributes() {
         for key in globalEventSourceAttributes.keys {
             removeGlobalAttribute(forKey: key)
         }
         globalEventSourceAttributes = [:]
     }
-    
-    
+
     // MARK: - Monetization events
     nonisolated func createAppleMonetizationEvent(with transaction: SKPaymentTransaction,
                                                   with product: SKProduct) -> PinpointEvent {
@@ -226,7 +225,7 @@ actor AnalyticsClient: AnalyticsClientBehaviour {
         for (key, metric) in globalMetrics {
             event.addMetric(metric, forKey: key)
         }
-        
+
         // Add event source attributes
         for (key, attribute) in globalEventSourceAttributes {
             // TODO: review this

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/EventRecorder.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/EventRecorder.swift
@@ -17,8 +17,7 @@ protocol AnalyticsEventRecording {
     /// Saves a pinpoint event to storage
     /// - Parameter event: A PinpointEvent
     func save(_ event: PinpointEvent) throws
-    
-    
+
     /// Updates attributes of the events with the provided session id
     /// - Parameters:
     ///   - ofType: event type
@@ -27,7 +26,7 @@ protocol AnalyticsEventRecording {
     func updateAttributesOfEvents(ofType: String,
                                   withSessionId: PinpointSession.SessionId,
                                   setAttributes: [String: String]) throws
-    
+
     /// Submit all locally stored events
     /// - Returns: A collection of events submitted to Pinpoint
     func submitAllEvents() async throws -> [PinpointEvent]
@@ -66,7 +65,7 @@ class EventRecorder: AnalyticsEventRecording {
         try storage.saveEvent(event)
         try self.storage.checkDiskSize(limit: Constants.pinpointClientByteLimitDefault)
     }
-    
+
     func updateAttributesOfEvents(ofType eventType: String,
                                   withSessionId sessionId: PinpointSession.SessionId,
                                   setAttributes attributes: [String: String]) throws {
@@ -203,7 +202,7 @@ class EventRecorder: AnalyticsEventRecording {
 
     private func retry(times: Int = Constants.defaultNumberOfRetriesForStorageOperations,
                        onErrorMessage: String,
-                       _ closure: () throws -> ()) {
+                       _ closure: () throws -> Void) {
         do {
             try closure()
         } catch {

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/PinpointEvent+PinpointClientTypes.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/PinpointEvent+PinpointClientTypes.swift
@@ -6,6 +6,7 @@
 //
 
 import AWSPinpoint
+import AWSPluginsCore
 import Foundation
 
 extension PinpointEvent {
@@ -17,13 +18,14 @@ extension PinpointEvent {
     }
 
     var clientTypeEvent: PinpointClientTypes.Event {
-        // TODO: get the swift sdk version and name
         return PinpointClientTypes.Event(appPackageName: Bundle.main.appPackageName,
                                          appTitle: Bundle.main.appName,
                                          appVersionCode: Bundle.main.appVersion,
                                          attributes: attributes,
+                                         clientSdkVersion: AmplifyAWSServiceConfiguration.version,
                                          eventType: eventType,
                                          metrics: metrics,
+                                         sdkName: AmplifyAWSServiceConfiguration.platformName,
                                          session: clientTypeSession,
                                          timestamp: eventDate.asISO8601String)
     }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/LocalStorage/AnalyticsEventSQLStorage.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/LocalStorage/AnalyticsEventSQLStorage.swift
@@ -100,10 +100,10 @@ class AnalyticsEventSQLStorage: AnalyticsEventStorage {
         let deleteStatement = "DELETE FROM Event"
         _ = try dbAdapter.executeQuery(deleteStatement, [])
     }
-    
+
     func updateEvents(ofType eventType: String,
                       withSessionId sessionId: PinpointSession.SessionId,
-                      setAttributes attributes: [String : String]) throws {
+                      setAttributes attributes: [String: String]) throws {
         let updateStatement = """
         UPDATE Event
         SET attributes = ?
@@ -115,7 +115,6 @@ class AnalyticsEventSQLStorage: AnalyticsEventStorage {
             sessionId,
             eventType])
     }
-    
 
     /// Get the oldest event with limit
     /// - Parameter limit: The number of query result to limit

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/LocalStorage/AnalyticsEventStorage.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/LocalStorage/AnalyticsEventStorage.swift
@@ -19,8 +19,7 @@ protocol AnalyticsEventStorage {
     func deleteOldestEvent() throws
     /// Delete all events from the Event table
     func deleteAllEvents() throws
-    
-    
+
     /// Update attributes of the events with the provided session identifier
     /// and type
     /// - Parameters:
@@ -30,7 +29,7 @@ protocol AnalyticsEventStorage {
     func updateEvents(ofType: String,
                       withSessionId: PinpointSession.SessionId,
                       setAttributes: [String: String]) throws
-    
+
     /// Get the oldest event with limit
     /// - Parameter limit: The number of query result to limit
     /// - Returns: A collection of PinpointEvent

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/LocalStorage/PinpointEvent+Bindings.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/LocalStorage/PinpointEvent+Bindings.swift
@@ -37,7 +37,7 @@ extension PinpointEvent {
             0 // RetryCount
         ]
     }
-    
+
     static func archiveEventAttributes(_ attributes: [String: String]) -> Binding? {
         guard let encodedAttributes = try? archiver.encode(attributes) else {
             return nil

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Notifications/AWSPinpointAnalyticsNotificationsBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Notifications/AWSPinpointAnalyticsNotificationsBehavior.swift
@@ -22,14 +22,12 @@ public protocol AWSPinpointAnalyticsNotificationsBehavior {
     /// - Returns:
     func interceptDidFinishLaunchingWithOptions(launchOptions: LaunchOptions) async -> Bool
 
-
     /// Invoke this method from the `- application:didRegisterForRemoteNotificationsWithDeviceToken:` application delegate
     /// method.
     ///
     /// The Pinpoint targeting client must intercept this callback in order to report campaign analytics correctly.
     /// - Parameter deviceToken: A token that identifies the device to APNs.
     func interceptDidRegisterForRemoteNotificationsWithDeviceToken(deviceToken: Data) async
-
 
     /// Invoke this method from the appropiate app delegate methods.
     ///

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AnalyticsEventStorageTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/AnalyticsEventStorageTests.swift
@@ -339,7 +339,7 @@ class AnalyticsEventStorageTests: XCTestCase {
             XCTFail("Failed to save a new event")
         }
     }
-    
+
     func testUpdateEvents() throws {
         try storage.deleteAllEvents()
         let eventType = "_session.start"
@@ -354,28 +354,28 @@ class AnalyticsEventStorageTests: XCTestCase {
         let event2 = PinpointEvent(id: "event-2",
                                    eventType: eventType,
                                    session: session)
-        
+
         let notASessionStartEvent = PinpointEvent(id: "event-3",
                                                   eventType: "another-event-type",
                                                   session: session)
-        
+
         let attributes = ["attr1": "value1", "attr2": "value2"]
-        
+
         try storage.saveEvent(event1)
         try storage.saveEvent(event2)
         try storage.saveEvent(notASessionStartEvent)
-        
+
         try storage.updateEvents(ofType: eventType,
                                  withSessionId: session.sessionId,
                                  setAttributes: attributes)
-        
+
         let savedEvents = try storage.getEventsWith(limit: 3)
-        
+
         XCTAssertEqual(savedEvents[0].id, event1.id)
         XCTAssertEqual(savedEvents[1].id, event2.id)
         XCTAssertEqual(savedEvents[0].attributes, attributes)
         XCTAssertEqual(savedEvents[1].attributes, attributes)
-        
+
         // event-3 should not have been updated
         XCTAssertEqual(savedEvents[2].id, notASessionStartEvent.id)
         XCTAssertNotEqual(savedEvents[2].attributes, attributes)

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAnalyticsEventStorage.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAnalyticsEventStorage.swift
@@ -41,7 +41,7 @@ class MockAnalyticsEventStorage: AnalyticsEventStorage {
     }
     func updateEvents(ofType: String,
                       withSessionId: PinpointSession.SessionId,
-                      setAttributes: [String : String]) throws {
+                      setAttributes: [String: String]) throws {
         updateEventsCallCount += 1
     }
 

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/Pinpoint/MockAnalyticsClient.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/Pinpoint/MockAnalyticsClient.swift
@@ -18,24 +18,24 @@ actor MockAnalyticsClient: AnalyticsClientBehaviour {
         addGlobalAttributeCalls.append((key, attribute))
     }
     func addGlobalAttribute(_ attribute: String, forKey key: String, forEventType eventType: String) {}
-    
+
     func addGlobalMetric(_ metric: Double, forKey key: String) {}
     func addGlobalMetric(_ metric: Double, forKey key: String, forEventType eventType: String) {}
-    
+
     var removeGlobalAttributeCalls = [(String, String?)]()
     func removeGlobalAttribute(forKey key: String) {
         removeGlobalAttributeCalls.append((key, nil))
     }
-    
+
     func removeGlobalAttribute(forKey key: String, forEventType eventType: String) {
         removeGlobalAttributeCalls.append((key, eventType))
     }
-    
+
     var removeGlobalMetricCalls = [(String, String?)]()
     func removeGlobalMetric(forKey key: String) {
         removeGlobalMetricCalls.append((key, nil))
     }
-    
+
     func removeGlobalMetric(forKey key: String, forEventType eventType: String) {
         removeGlobalMetricCalls.append((key, eventType))
     }
@@ -59,13 +59,13 @@ actor MockAnalyticsClient: AnalyticsClientBehaviour {
         }
         return PinpointEvent(eventType: eventType, session: PinpointSession(appId: "", uniqueId: ""))
     }
-    
-    func setGlobalEventSourceAttributes(_ attributes: [String : Any]) {
-        
+
+    func setGlobalEventSourceAttributes(_ attributes: [String: Any]) {
+
     }
-    
+
     func removeAllGlobalEventSourceAttributes() {
-        
+
     }
 
     private var recordExpectation: XCTestExpectation?

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/Pinpoint/MockEventRecorder.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/Pinpoint/MockEventRecorder.swift
@@ -15,15 +15,15 @@ class MockEventRecorder: AnalyticsEventRecording {
     var saveCount = 0
     var lastSavedEvent: PinpointEvent?
     var updateCount = 0
-    
+
     func save(_ event: PinpointEvent) throws {
         saveCount += 1
         lastSavedEvent = event
     }
-    
+
     func updateAttributesOfEvents(ofType: String,
                                   withSessionId: PinpointSession.SessionId,
-                                  setAttributes: [String : String]) throws {
+                                  setAttributes: [String: String]) throws {
         updateCount += 1
     }
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -9,8 +9,8 @@ import Foundation
 import AWSClientRuntime
 
 public class AmplifyAWSServiceConfiguration {
-    static let version = "1.26.2-swift-sdk-dev-preview.0"
-    static let platformName = "amplify-ios"
+    public static let version = "1.26.2-swift-sdk-dev-preview.0"
+    public static let platformName = "amplify-ios"
 
     public static func frameworkMetaData() -> FrameworkMetadata {
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* per recommendation by the Pinpoint team, provide Amplify iOS version and name as sdk name and version in events in `PinpointEvent+PinpointClientTypes.swift`.  Amplify iOS version and name is provided via `AmplifyAWSServiceConfiguration`
* fix swift lint errors

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
