### PR TITLE
fix(datastore): Emit ModelSyncedEvent on sync finished event

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
@@ -26,9 +26,7 @@ enum IncomingModelSyncedEmitterEvent {
 ///     - Then send the mutation event which was used in the check above.
 @available(iOS 13.0, *)
 final class ModelSyncedEventEmitter {
-    private let queue = DispatchQueue(label: "com.amazonaws.ModelSyncedEventEmitterQueue",
-                                      target: DispatchQueue.global())
-    private let dispatchedModelSyncedEventLock = NSLock()
+    private let queue = DispatchQueue(label: "com.amazonaws.ModelSyncedEventEmitterQueue")
 
     private var syncOrchestratorSink: AnyCancellable?
     private var reconciliationQueueSink: AnyCancellable?

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
@@ -116,9 +116,10 @@ final class ModelSyncedEventEmitter {
         case .enqueued:
             recordsReceived += 1
         case .finished:
-            initialSyncOperationFinished = true
-            if recordsReceived == 0 {
+            if recordsReceived == 0 || recordsReceived == reconciledReceived {
                 sendModelSyncedEvent()
+            } else {
+                initialSyncOperationFinished = true
             }
         }
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/1864

*Description of changes:*
This PR assumes out of order events are received by the two streams of events, one from the sync operation and the other from the reconciliation events.

The sync operation updates "recordsReceived" while the reconciliation events update "recordsReconciled". If the last supposedly reconciliation event comes in before the sync operation sends the `.finished` event then in the previous code it would never emit the modelSynced event because `initialSyncOperationFinished` is set to true and it is checked within one of the reconciliation events.

This code adds another special case along with the "received records == 0" by checking that if this event comes after the reconciliation event and number of records received have been reconciled, then emit the modelSyncedEvent. 

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
