### PR TITLE
fix(Auth): Handling unableToSign error on changePassword 

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Constants/AuthPluginErrorConstants.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Constants/AuthPluginErrorConstants.swift
@@ -139,6 +139,10 @@ struct AuthPluginErrorConstants {
     static let changePasswordSignedOutError: AuthPluginErrorString = (
     "Could not change password, there is no user signed in to the Auth category",
     "Change password require a user signed in to Auth category, use one of the signIn apis to signIn")
+
+    static let changePasswordUnableToSignInError: AuthPluginErrorString = (
+    "Could not change password, the user session is expired",
+    "Re-authenticate the user by using one of the signIn apis")
 }
 
 // Field validation errors


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-ios/issues/1985

*Description of changes:*
With the changes made in https://github.com/aws-amplify/aws-sdk-ios/pull/4215, an `.unableToSignIn` error will be returned when the token is expired, so we need to propagate a proper error message to Amplify users.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] ~All integration tests pass~
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
