### PR TITLE
fix(Analytics): Remove support for different targeting region.

### DIFF
--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+ClientBehavior.swift
@@ -119,8 +119,8 @@ extension AWSPinpointAnalyticsPlugin {
 
     /// Retrieve the escape hatch to perform actions directly on PinpointClient.
     ///
-    /// - Returns: AWSPinpoint instance
-    public func getEscapeHatch() -> AWSPinpoint {
-        pinpoint.getEscapeHatch()
+    /// - Returns: PinpointClientProtocol instance
+    public func getEscapeHatch() -> PinpointClientProtocol {
+        pinpoint.pinpointClient
     }
 }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Configure.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Configure.swift
@@ -38,12 +38,15 @@ extension AWSPinpointAnalyticsPlugin {
         var isDebug = false
         #if DEBUG
         isDebug = true
-        Amplify.Logging.verbose("Setting PinpointContextConfiguration.isDebug to true")
+        log.verbose("Setting PinpointContextConfiguration.isDebug to true")
         #endif
+
+        if configuration.region != configuration.targetingRegion {
+            log.warn("Different regions between Analytics and Targeting is not supported. The Analytics region will be used.")
+        }
 
         let contextConfiguration = PinpointContextConfiguration(appId: configuration.appId,
                                                                 region: configuration.region,
-                                                                targetingRegion: configuration.targetingRegion,
                                                                 credentialsProvider: credentialsProvider,
                                                                 isDebug: isDebug,
                                                                 shouldTrackAppSessions: configuration.trackAppSessions,

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/AWSPinpointBehavior.swift
@@ -9,19 +9,12 @@ import Amplify
 import AWSPinpoint
 import Foundation
 
-/// Groups the `PinpointClientProtocol` instances used for Analytics and Targeting
-public struct AWSPinpoint {
-    let analyticsClient: PinpointClientProtocol
-    let targetingClient: PinpointClientProtocol
-}
-
 /// Implemented by `PinpointContext` as a pass through to the methods on `analyticClient` and `endpointClient`.
 /// This protocol allows a way to create a Mock and ensure plugin implementation is testable.
 protocol AWSPinpointBehavior {
     // MARK: Escape hatch
-    /// Returns the low-level `PinpointClientProcotol` clients used to interact with AWS Pinpoint for Analytics and Targeting.
-    /// - Returns:A `AWSPinpoint` containing the the lower level clients.
-    func getEscapeHatch() -> AWSPinpoint
+    /// The low-level `PinpointClientProcotol` client used to interact with AWS Pinpoint for Analytics and Targeting.
+    var pinpointClient: PinpointClientProtocol { get }
 
     // MARK: Analytics
     /// Creates a `PinpointEvent` with the specificed eventType

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/PinpointContext+AWSPinpointBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/PinpointContext+AWSPinpointBehavior.swift
@@ -6,9 +6,15 @@
 //
 
 import Amplify
+import AWSPinpoint
 import Foundation
 
 extension PinpointContext: AWSPinpointBehavior {
+
+    var pinpointClient: PinpointClientProtocol {
+        analyticsClient.pinpointClient
+    }
+
     func createEvent(withEventType eventType: String) -> PinpointEvent {
         analyticsClient.createEvent(withEventType: eventType)
     }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/PinpointContext.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/PinpointContext.swift
@@ -64,12 +64,10 @@ typealias Byte = Int
 // MARK: - PinpointContext
 /// The configuration object containing the necessary and optional configurations required to use AWSPinpoint
 struct PinpointContextConfiguration {
-    /// The Pinpoint AppId.
+    /// The Pinpoint Application ID
     let appId: String
-    /// The region used for Pinpoint Analytics
+    /// The Pinpoint region
     let region: String
-    /// The region used for Pinpoint Targeting
-    let targetingRegion: String
     /// Used to retrieve the proper AWSCredentials when creating the PinpointCLient
     let credentialsProvider: CredentialsProvider
     /// The max storage size to use for event storage in bytes. Defaults to 5 MB.
@@ -92,7 +90,6 @@ struct PinpointContextConfiguration {
 
     init(appId: String,
          region: String,
-         targetingRegion: String,
          credentialsProvider: CredentialsProvider,
          maxStorageSize: Byte = (1024 * 1024 * 5),
          isDebug: Bool = false,
@@ -101,7 +98,6 @@ struct PinpointContextConfiguration {
          sessionBackgroundTimeout: TimeInterval = 5) {
         self.appId = appId
         self.region = region
-        self.targetingRegion = targetingRegion
         self.credentialsProvider = credentialsProvider
         self.sessionBackgroundTimeout = sessionBackgroundTimeout
         self.maxStorageSize = maxStorageSize
@@ -141,14 +137,14 @@ class PinpointContext {
                                          archiver: archiver)
         uniqueId = Self.retrieveUniqueId(applicationId: configuration.appId, storage: storage)
 
-        let targetingPinpointClient = try PinpointClient(region: configuration.targetingRegion,
-                                                         credentialsProvider: configuration.credentialsProvider)
+        let pinpointClient = try PinpointClient(region: configuration.region,
+                                                credentialsProvider: configuration.credentialsProvider)
 
         endpointClient = EndpointClient(configuration: .init(appId: configuration.appId,
                                                              uniqueDeviceId: uniqueId,
                                                              isDebug: configuration.isDebug,
                                                              isOptOut: configuration.isApplicationLevelOptOut),
-                                        pinpointClient: targetingPinpointClient,
+                                        pinpointClient: pinpointClient,
                                         currentDevice: currentDevice,
                                         userDefaults: userDefaults)
 
@@ -166,14 +162,8 @@ class PinpointContext {
             return sessionClient.currentSession
         }
 
-        var analyticsPinpointClient = targetingPinpointClient
-        if configuration.region != configuration.targetingRegion {
-            analyticsPinpointClient = try PinpointClient(region: configuration.region,
-                                                         credentialsProvider: configuration.credentialsProvider)
-        }
-
         analyticsClient = try AnalyticsClient(applicationId: configuration.appId,
-                                              pinpointClient: analyticsPinpointClient,
+                                              pinpointClient: pinpointClient,
                                               endpointClient: endpointClient,
                                               sessionProvider: sessionProvider)
         sessionClient.analyticsClient = analyticsClient
@@ -184,13 +174,6 @@ class PinpointContext {
             sessionClient.startPinpointSession()
         }
         self.configuration = configuration
-    }
-
-    func getEscapeHatch() -> AWSPinpoint {
-        return AWSPinpoint(
-            analyticsClient: analyticsClient.pinpointClient,
-            targetingClient: endpointClient.pinpointClient
-        )
     }
 
     private static func legacyPreferencesFilePath(applicationId: String,

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSPinpoint.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSPinpoint.swift
@@ -83,10 +83,9 @@ public class MockAWSPinpoint: AWSPinpointBehavior {
 
     public init() {}
 
-    public func getEscapeHatch() -> AWSPinpoint {
+    public var pinpointClient: PinpointClientProtocol {
         escapeHatchCalled += 1
-        let client = try! PinpointClient(region: "us-east-1")
-        return AWSPinpoint(analyticsClient: client, targetingClient: client)
+        return try! PinpointClient(region: "us-east-1")
     }
 }
 


### PR DESCRIPTION
*Description of changes:*

Dropping support for different regions for Pinpoint Analytics and Pinpoint Targeting, so we only keep one low-level client for both operations.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] ~All integration tests pass~
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] ~PR title conforms to conventional commit style~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
