### PR TITLE
feat(auth): Add Remember Device API implementation

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+DeviceBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+DeviceBehavior.swift
@@ -34,6 +34,13 @@ extension AWSCognitoAuthPlugin: AuthCategoryDeviceBehavior {
     public func rememberDevice(
         options: AuthRememberDeviceOperation.Request.Options? = nil,
         listener: AuthRememberDeviceOperation.ResultListener?) -> AuthRememberDeviceOperation {
-            fatalError("Not implemented")
+            let options = options ?? AuthRememberDeviceRequest.Options()
+            let request = AuthRememberDeviceRequest(options: options)
+            let rememberDeviceOperation = AWSAuthRememberDeviceOperation(request,
+                                                                    authStateMachine: authStateMachine,
+                                                                    userPoolFactory: authEnvironment.cognitoUserPoolFactory,
+                                                                    resultListener: listener)
+            queue.addOperation(rememberDeviceOperation)
+            return rememberDeviceOperation
         }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/AWSAuthRememberDeviceOperation.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/AWSAuthRememberDeviceOperation.swift
@@ -1,0 +1,103 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import AWSPluginsCore
+import ClientRuntime
+import AWSCognitoIdentityProvider
+
+public class AWSAuthRememberDeviceOperation: AmplifyOperation<AuthRememberDeviceRequest, Void, AuthError>, AuthRememberDeviceOperation {
+    
+    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+    
+    private let authStateMachine: AuthStateMachine
+    private let userPoolFactory: CognitoUserPoolFactory
+    private let fetchAuthSessionHelper: FetchAuthSessionOperationHelper
+    
+    init(_ request: AuthRememberDeviceRequest,
+         authStateMachine: AuthStateMachine,
+         userPoolFactory: @escaping CognitoUserPoolFactory,
+         resultListener: ResultListener?) {
+        self.authStateMachine = authStateMachine
+        self.userPoolFactory = userPoolFactory
+        self.fetchAuthSessionHelper = FetchAuthSessionOperationHelper()
+        super.init(categoryType: .auth,
+                   eventName: HubPayload.EventName.Auth.fetchDevicesAPI,
+                   request: request,
+                   resultListener: resultListener)
+    }
+    
+    override public func main() {
+        if isCancelled {
+            finish()
+            return
+        }
+        
+        fetchAuthSessionHelper.fetch(authStateMachine) { [weak self] result in
+            switch result {
+            case .success(let session):
+                guard let cognitoTokenProvider = session as? AuthCognitoTokensProvider else {
+                    self?.dispatch(AuthError.unknown("Unable to fetch auth session", nil))
+                    return
+                }
+                
+                do {
+                    let tokens = try cognitoTokenProvider.getCognitoTokens().get()
+                    Task.init { [weak self] in
+                        await self?.rememberDevice(with: tokens.accessToken)
+                    }
+                } catch let error as AuthError {
+                    self?.dispatch(error)
+                } catch {
+                    self?.dispatch(AuthError.unknown("Unable to fetch auth session", error))
+                }
+            case .failure(let error):
+                self?.dispatch(error)
+            }
+        }
+    }
+    
+    func rememberDevice(with accessToken: String) async {
+        do {
+            let userPoolService = try userPoolFactory()
+            
+            // TODO: Pass in device key when implemented
+            let input = UpdateDeviceStatusInput(accessToken: accessToken,
+                                                deviceKey: nil,
+                                                deviceRememberedStatus: .remembered)
+            _ = try await userPoolService.updateDeviceStatus(input: input)
+            
+            if self.isCancelled {
+                finish()
+                return
+            }
+            
+            self.dispatch()
+        } catch let error as UpdateDeviceStatusOutputError {
+            self.dispatch(error.authError)
+        } catch let error as SdkError<UpdateDeviceStatusOutputError> {
+            self.dispatch(error.authError)
+        } catch let error as AuthError {
+            self.dispatch(error)
+        } catch let error {
+            let error = AuthError.unknown("Unable to create a Swift SDK user pool service", error)
+            self.dispatch(error)
+        }
+    }
+    
+    
+    private func dispatch() {
+        let result = OperationResult.success(())
+        dispatch(result: result)
+    }
+    
+    private func dispatch(_ error: AuthError) {
+        let result = OperationResult.failure(error)
+        dispatch(result: result)
+    }
+    
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/CognitoUserPoolBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/CognitoUserPoolBehavior.swift
@@ -66,4 +66,7 @@ protocol CognitoUserPoolBehavior {
     
     /// Lists the devices
     func listDevices(input: ListDevicesInput) async throws -> ListDevicesOutputResponse
+    
+    /// Updates the device status
+    func updateDeviceStatus(input: UpdateDeviceStatusInput) async throws -> UpdateDeviceStatusOutputResponse
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/UpdateDeviceStatusOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/UpdateDeviceStatusOutputError+AuthError.swift
@@ -1,0 +1,54 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import AWSCognitoIdentityProvider
+import Amplify
+
+extension UpdateDeviceStatusOutputError: AuthErrorConvertible {
+    
+    var authError: AuthError {
+        switch self {
+        case .internalErrorException(let exception):
+            return .unknown(exception.message ?? "Internal exception occurred")
+        case .invalidParameterException(let exception):
+            return AuthError.service(exception.message ?? "Invalid parameter error",
+                                     AuthPluginErrorConstants.invalidParameterError,
+                                     AWSCognitoAuthError.invalidParameter)
+        case .invalidUserPoolConfigurationException(let exception):
+            return .configuration(exception.message ?? "Invalid UserPool Configuration error",
+                                  AuthPluginErrorConstants.configurationError)
+        case .notAuthorizedException(let exception):
+            return .notAuthorized(exception.message ?? "Not authorized error",
+                                  AuthPluginErrorConstants.notAuthorizedError)
+        case .passwordResetRequiredException(let exception):
+            return .service(exception.message ?? "Password reset required error",
+                            AuthPluginErrorConstants.passwordResetRequired,
+                            AWSCognitoAuthError.passwordResetRequired)
+        case .resourceNotFoundException(let exception):
+            return .service(exception.message ?? "Resource not found error",
+                            AuthPluginErrorConstants.resourceNotFoundError,
+                            AWSCognitoAuthError.resourceNotFound)
+        case .tooManyRequestsException(let exception):
+            return .service(exception.message ?? "Too many requests error",
+                            AuthPluginErrorConstants.tooManyRequestError,
+                            AWSCognitoAuthError.requestLimitExceeded)
+        case .userNotConfirmedException(let userNotConfirmedException):
+            return .service(userNotConfirmedException.message ?? "User not confirmed error",
+                            AuthPluginErrorConstants.userNotConfirmedError,
+                            AWSCognitoAuthError.userNotConfirmed)
+        case .userNotFoundException(let exception):
+            return .service(exception.message ?? "User not found error",
+                            AuthPluginErrorConstants.userNotFoundError,
+                            AWSCognitoAuthError.userNotFound)
+        case .unknown(let serviceError):
+            let statusCode = serviceError._statusCode?.rawValue ?? -1
+            let message = serviceError._message ?? ""
+            return .unknown("Unknown service error occurred with status \(statusCode) \(message)")
+        }
+    }
+}

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/DeviceBehaviorTests/DeviceBehaviorRememberDeviceTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/DeviceBehaviorTests/DeviceBehaviorRememberDeviceTests.swift
@@ -1,0 +1,430 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+import XCTest
+import AWSCognitoIdentityProvider
+import Amplify
+@testable import AWSCognitoAuthPlugin
+@testable import AWSPluginsTestCommon
+
+class DeviceBehaviorRememberDeviceTests: AWSAuthDeviceBehaviorTests {
+    
+    override func setUp() {
+        super.setUp()
+        mockIdentityProvider = MockIdentityProvider(
+            mockRememberDeviceResponse: { _ in
+                try UpdateDeviceStatusOutputResponse(httpResponse: MockHttpResponse.ok)
+            }
+        )
+    }
+    
+    /// Test rememberDevice operation can be invoked
+    ///
+    /// - Given: Given a configured auth plugin
+    /// - When:
+    ///    - I call rememberDevice operation
+    /// - Then:
+    ///    - I should get a valid operation object
+    ///
+    func testRememberDeviceRequest() {
+        let options = AuthRememberDeviceRequest.Options()
+        let operation = plugin.rememberDevice(options: options)
+        XCTAssertNotNil(operation)
+    }
+    
+    /// Test rememberDevice operation can be invoked without options
+    ///
+    /// - Given: Given a configured auth plugin
+    /// - When:
+    ///    - I call rememberDevice operation
+    /// - Then:
+    ///    - I should get a valid operation object
+    ///
+    func testRememberDeviceRequestWithoutOptions() {
+        let operation = plugin.rememberDevice()
+        XCTAssertNotNil(operation)
+    }
+    
+    /// Test a successful rememberDevice call
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service calls should mock a successul response
+    /// - When:
+    ///    - I invoke rememberDevice
+    /// - Then:
+    ///    - I should get a successful result indicating device status updated
+    ///
+    func testSuccessfulRememberDevice() {
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.rememberDevice { result in
+            switch result {
+            case .success:
+                resultExpectation.fulfill()
+            case .failure(let error):
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    // MARK: - Service error for UpdateDeviceStatus
+    /// Test a rememberDevice with `InternalErrorException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InternalErrorException response for rememberDevice
+    ///
+    /// - When:
+    ///    - I invoke rememberDevice
+    /// - Then:
+    ///    - I should get a .unknown error
+    ///
+    func testRememberDeviceWithInternalErrorException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockRememberDeviceResponse: { _ in
+                throw UpdateDeviceStatusOutputError.internalErrorException(InternalErrorException(message: "internal error"))
+            }
+        )
+        
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.rememberDevice { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .success(let listDevicesResult):
+                XCTFail("Should not produce result - \(listDevicesResult)")
+            case .failure(let error):
+                guard case .unknown = error else {
+                    XCTFail("Should produce unknown error")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a rememberDevice call with InvalidParameterException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidParameterException response
+    ///
+    /// - When:
+    ///    - I invoke rememberDevice
+    /// - Then:
+    ///    - I should get a .service error with  .invalidParameter as underlyingError
+    ///
+    func testRememberDeviceWithInvalidParameterException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockRememberDeviceResponse: { _ in
+                throw UpdateDeviceStatusOutputError.invalidParameterException(InvalidParameterException(message: "invalid parameter"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.rememberDevice { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be invalidParameter \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a rememberDevice call with InvalidParameterException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidUserPoolConfigurationException response
+    ///
+    /// - When:
+    ///    - I invoke rememberDevice
+    /// - Then:
+    ///    - I should get a .configuration error
+    ///
+    func testRememberDeviceWithInvalidUserPoolConfigurationException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockRememberDeviceResponse: { _ in
+                throw UpdateDeviceStatusOutputError.invalidUserPoolConfigurationException(InvalidUserPoolConfigurationException(message: "invalid user pool configuration"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.rememberDevice { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .configuration = error else {
+                    XCTFail("Should produce configuration error instead of \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a rememberDevice call with NotAuthorizedException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   NotAuthorizedException response
+    ///
+    /// - When:
+    ///    - I invoke rememberDevice
+    /// - Then:
+    ///    - I should get a .notAuthorized error
+    ///
+    func testRememberDeviceWithNotAuthorizedException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockRememberDeviceResponse: { _ in
+                throw UpdateDeviceStatusOutputError.notAuthorizedException(NotAuthorizedException(message: "not authorized"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.rememberDevice { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .notAuthorized = error else {
+                    XCTFail("Should produce notAuthorized error instead of \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a rememberDevice call with PasswordResetRequiredException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   PasswordResetRequiredException response
+    ///
+    /// - When:
+    ///    - I invoke rememberDevice
+    /// - Then:
+    ///    - I should get a .service error with .passwordResetRequired as underlyingError
+    ///
+    func testRememberDeviceWithPasswordResetRequiredException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockRememberDeviceResponse: { _ in
+                throw UpdateDeviceStatusOutputError.passwordResetRequiredException(PasswordResetRequiredException(message: "password reset required"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.rememberDevice { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .passwordResetRequired = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be passwordResetRequired \(error)")
+                    return
+                }
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a rememberDevice call with ResourceNotFound response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   ResourceNotFoundException response
+    ///
+    /// - When:
+    ///    - I invoke rememberDevice
+    /// - Then:
+    ///    - I should get a .service error with .resourceNotFound as underlyingError
+    ///
+    func testRememberDeviceWithResourceNotFoundException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockRememberDeviceResponse: { _ in
+                throw UpdateDeviceStatusOutputError.resourceNotFoundException(ResourceNotFoundException(message: "resource not found"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.rememberDevice { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be resourceNotFound \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a rememberDevice call with TooManyRequestsException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   TooManyRequestsException response
+    ///
+    /// - When:
+    ///    - I invoke rememberDevice
+    /// - Then:
+    ///    - I should get a .service error with .requestLimitExceeded as underlyingError
+    ///
+    func testRememberDeviceWithTooManyRequestsException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockRememberDeviceResponse: { _ in
+                throw UpdateDeviceStatusOutputError.tooManyRequestsException(TooManyRequestsException(message: "too many requests"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.rememberDevice { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be requestLimitExceeded \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a rememberDevice call with UserNotFound response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   UserNotConfirmedException response
+    ///
+    /// - When:
+    ///    - I invoke rememberDevice
+    /// - Then:
+    ///    - I should get a .service error with .userNotConfirmed as underlyingError
+    ///
+    func testRememberDeviceWithUserNotConfirmedException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockRememberDeviceResponse: { _ in
+                throw UpdateDeviceStatusOutputError.userNotConfirmedException(UserNotConfirmedException(message: "user not confirmed"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.rememberDevice { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .userNotConfirmed = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be userNotFound \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test a rememberDevice call with UserNotFound response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   UserNotFoundException response
+    ///
+    /// - When:
+    ///    - I invoke rememberDevice
+    /// - Then:
+    ///    - I should get a .service error with .userNotFound as underlyingError
+    ///
+    func testRememberDeviceWithUserNotFoundException() {
+        
+        mockIdentityProvider = MockIdentityProvider(
+            mockRememberDeviceResponse: { _ in
+                throw UpdateDeviceStatusOutputError.userNotFoundException(UserNotFoundException(message: "user not found"))
+            }
+        )
+        let resultExpectation = expectation(description: "Should receive a result")
+        _ = plugin.rememberDevice { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            
+            switch result {
+            case .success:
+                XCTFail("Should return an error if the result from service is invalid")
+            case .failure(let error):
+                guard case .service(_, _, let underlyingError) = error else {
+                    XCTFail("Should produce service error instead of \(error)")
+                    return
+                }
+                guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+                    XCTFail("Underlying error should be userNotFound \(error)")
+                    return
+                }
+                
+            }
+        }
+        wait(for: [resultExpectation], timeout: networkTimeout)
+    }
+    
+}

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockIdentityProvider.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockIdentityProvider.swift
@@ -58,6 +58,9 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
     
     typealias MockListDevicesOutputResponse = (ListDevicesInput) async throws
     -> ListDevicesOutputResponse
+    
+    typealias MockRememberDeviceResponse = (UpdateDeviceStatusInput) async throws
+    -> UpdateDeviceStatusOutputResponse
 
     let mockSignUpResponse: MockSignUpResponse?
     let mockRevokeTokenResponse: MockRevokeTokenResponse?
@@ -75,6 +78,7 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
     let mockForgotPasswordOutputResponse: MockForgotPasswordOutputResponse?
     let mockConfirmForgotPasswordOutputResponse: MockConfirmForgotPasswordOutputResponse?
     let mockListDevicesOutputResponse: MockListDevicesOutputResponse?
+    let mockRememberDeviceResponse: MockRememberDeviceResponse?
 
     init(
         mockSignUpResponse: MockSignUpResponse? = nil,
@@ -92,7 +96,8 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
         mockDeleteUserOutputResponse: MockDeleteUserOutputResponse? = nil,
         mockForgotPasswordOutputResponse: MockForgotPasswordOutputResponse? = nil,
         mockConfirmForgotPasswordOutputResponse: MockConfirmForgotPasswordOutputResponse? = nil,
-        mockListDevicesOutputResponse: MockListDevicesOutputResponse? = nil
+        mockListDevicesOutputResponse: MockListDevicesOutputResponse? = nil,
+        mockRememberDeviceResponse: MockRememberDeviceResponse? = nil
     ) {
         self.mockSignUpResponse = mockSignUpResponse
         self.mockRevokeTokenResponse = mockRevokeTokenResponse
@@ -110,6 +115,7 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
         self.mockForgotPasswordOutputResponse = mockForgotPasswordOutputResponse
         self.mockConfirmForgotPasswordOutputResponse = mockConfirmForgotPasswordOutputResponse
         self.mockListDevicesOutputResponse = mockListDevicesOutputResponse
+        self.mockRememberDeviceResponse = mockRememberDeviceResponse
     }
 
     /// Throws InitiateAuthOutputError
@@ -182,5 +188,9 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
     
     func listDevices(input: ListDevicesInput) async throws -> ListDevicesOutputResponse {
         return try await mockListDevicesOutputResponse!(input)
+    }
+    
+    func updateDeviceStatus(input: UpdateDeviceStatusInput) async throws -> UpdateDeviceStatusOutputResponse {
+        return try await mockRememberDeviceResponse!(input)
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		485CB5C027B61F1E006CCEC7 /* SignedOutAuthSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB5BC27B61F1D006CCEC7 /* SignedOutAuthSessionTests.swift */; };
 		485CB5C127B61F1E006CCEC7 /* AuthSignOutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB5BD27B61F1D006CCEC7 /* AuthSignOutTests.swift */; };
 		485CB5C227B61F1E006CCEC7 /* AuthSRPSignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB5BE27B61F1D006CCEC7 /* AuthSRPSignInTests.swift */; };
+		9737C74E287E208400DA0D2B /* AuthRememberDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9737C74D287E208400DA0D2B /* AuthRememberDeviceTests.swift */; };
 		97829201286B802E000DE190 /* AuthResetPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97829200286B802E000DE190 /* AuthResetPasswordTests.swift */; };
 		97829203286E41FA000DE190 /* AuthConfirmResetPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97829202286E41FA000DE190 /* AuthConfirmResetPasswordTests.swift */; };
 		97B370C52878DA5A00F1C088 /* AuthFetchDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97B370C42878DA5A00F1C088 /* AuthFetchDeviceTests.swift */; };
@@ -66,6 +67,7 @@
 		485CB5BC27B61F1D006CCEC7 /* SignedOutAuthSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignedOutAuthSessionTests.swift; sourceTree = "<group>"; };
 		485CB5BD27B61F1D006CCEC7 /* AuthSignOutTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthSignOutTests.swift; sourceTree = "<group>"; };
 		485CB5BE27B61F1D006CCEC7 /* AuthSRPSignInTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthSRPSignInTests.swift; sourceTree = "<group>"; };
+		9737C74D287E208400DA0D2B /* AuthRememberDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRememberDeviceTests.swift; sourceTree = "<group>"; };
 		97829200286B802E000DE190 /* AuthResetPasswordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthResetPasswordTests.swift; sourceTree = "<group>"; };
 		97829202286E41FA000DE190 /* AuthConfirmResetPasswordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthConfirmResetPasswordTests.swift; sourceTree = "<group>"; };
 		97B370C42878DA5A00F1C088 /* AuthFetchDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFetchDeviceTests.swift; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 			isa = PBXGroup;
 			children = (
 				97B370C42878DA5A00F1C088 /* AuthFetchDeviceTests.swift */,
+				9737C74D287E208400DA0D2B /* AuthRememberDeviceTests.swift */,
 			);
 			path = DeviceTests;
 			sourceTree = "<group>";
@@ -412,6 +415,7 @@
 				484EDEB227F4FFBE000284B4 /* AuthEventIntegrationTests.swift in Sources */,
 				484834BE27B6FD9B00649D11 /* AuthEnvironmentHelper.swift in Sources */,
 				484834BC27B6ED8800649D11 /* CredentialStoreConfigurationTests.swift in Sources */,
+				9737C74E287E208400DA0D2B /* AuthRememberDeviceTests.swift in Sources */,
 				B43C26CC27BC9D54003F3BF7 /* AuthResendSignUpCodeTests.swift in Sources */,
 				97829201286B802E000DE190 /* AuthResetPasswordTests.swift in Sources */,
 				485105AA2840513C002D6FC8 /* AuthUserAttributesTests.swift in Sources */,

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/AuthFetchDeviceTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/AuthFetchDeviceTests.swift
@@ -26,13 +26,13 @@ class AuthFetchDeviceTests: AWSAuthBaseTest {
         sleep(2)
     }
 
-    /// Calling cancel in fetch devices operation should cancel
+    /// Calling fetch devices with a user signed in should return a successful result
     ///
     /// - Given: A valid username is registered and sign in - no device is remembered
     /// - When:
     ///    - I invoke fetchDevices with the username
     /// - Then:
-    ///    - I should not get a successful result with empty devices list
+    ///    - I should get a successful result with empty devices list
     ///
     func testSuccessfulFetchDevices() {
         

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/AuthRememberDeviceTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/AuthRememberDeviceTests.swift
@@ -1,0 +1,117 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+import AWSCognitoAuthPlugin
+
+class AuthRememberDeviceTests: AWSAuthBaseTest {
+    
+    var unsubscribeToken: UnsubscribeToken!
+    
+    override func setUp() {
+        super.setUp()
+        initializeAmplify()
+        AuthSessionHelper.clearSession()
+    }
+
+    override func tearDown() async throws {
+        try await super.tearDown()
+        await Amplify.reset()
+        AuthSessionHelper.clearSession()
+        sleep(2)
+    }
+
+/// TODO: Verify this test when an API for deviceKey is implemented
+//    /// Calling remember device should return a successful result
+//    ///
+//    /// - Given: A valid username is registered and sign in
+//    /// - When:
+//    ///    - I invoke rememberDevice followed by fetchDevices
+//    /// - Then:
+//    ///    - I should get a successful result for rememberDevice and fetchDevices should
+//    ///      contain the deviceKey used in rememberDevice
+//    ///
+//    func testSuccessfulRememberDevice() {
+//
+//        // register a user and signin
+//        let username = "integTest\(UUID().uuidString)"
+//        let password = "P123@\(UUID().uuidString)"
+//
+//        let signInExpectation = expectation(description: "SignIn event should be fired")
+//
+//        unsubscribeToken = Amplify.Hub.listen(to: .auth) { payload in
+//            switch payload.eventName {
+//            case HubPayload.EventName.Auth.signedIn:
+//                signInExpectation.fulfill()
+//            default:
+//                break
+//            }
+//        }
+//
+//        AuthSignInHelper.registerAndSignInUser(
+//            username: username,
+//            password: password,
+//            email: defaultTestEmail) { _, error in
+//                if let unwrappedError = error {
+//                    XCTFail("Unable to sign in with error: \(unwrappedError)")
+//                }
+//            }
+//        wait(for: [signInExpectation], timeout: networkTimeout)
+//
+//        // remember device
+//        let rememberDeviceExpectation = expectation(description: "Received result from rememberDevice")
+//        _ = Amplify.Auth.rememberDevice { result in
+//            switch result {
+//            case .success:
+//                rememberDeviceExpectation.fulfill()
+//            case .failure(let error):
+//                XCTFail("error remembering device \(error)")
+//            }
+//        }
+//        wait(for: [rememberDeviceExpectation], timeout: networkTimeout)
+//
+//
+//        // fetch devices
+//        let fetchDevicesExpectation = expectation(description: "Received result from fetchDevices")
+//        _ = Amplify.Auth.fetchDevices { result in
+//            switch result {
+//            case .success(let devices):
+//                XCTAssertNotNil(devices)
+//                XCTAssertGreaterThan(devices.count, 0)
+//                XCTAssertTrue(devices.contains { device in
+//                    device.id == deviceKey
+//                })
+//                fetchDevicesExpectation.fulfill()
+//            case .failure(let error):
+//                XCTFail("error fetching devices \(error)")
+//            }
+//        }
+//        wait(for: [fetchDevicesExpectation], timeout: networkTimeout)
+//    }
+    
+    
+    /// Calling cancel in rememberDevice operation should cancel
+    ///
+    /// - Given: A valid username
+    /// - When:
+    ///    - I invoke rememberDevice with the username and then call cancel
+    /// - Then:
+    ///    - I should not get any result back
+    ///
+    func testCancelRememberDevice() {
+        let operationExpectation = expectation(description: "Operation should not complete")
+        operationExpectation.isInverted = true
+        let operation = Amplify.Auth.rememberDevice { result in
+            operationExpectation.fulfill()
+            XCTFail("Received result \(result)")
+        }
+        XCTAssertNotNil(operation, "rememberDevice operations should not be nil")
+        operation.cancel()
+        wait(for: [operationExpectation], timeout: networkTimeout)
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Add Remember Device API implementation based on `aws-sdk-swift`

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
