### PR TITLE
fix: remove dependencies on deprecated auth methods from amplify core

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
@@ -483,16 +483,6 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AWSPinpointAnalyticsPluginIntegrationTests"
-               BuildableName = "AWSPinpointAnalyticsPluginIntegrationTests"
-               BlueprintName = "AWSPinpointAnalyticsPluginIntegrationTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
+++ b/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
@@ -27,7 +27,7 @@ open class APIAuthProviderFactory {
 public protocol AmplifyAuthTokenProvider {
     typealias AuthToken = String
 
-    @available(*, deprecated, message: "Use getUserPoolAccessToken() instead")
+    @available(*, deprecated, renamed: "getUserPoolAccessToken")
     func getLatestAuthToken() -> Result<AuthToken, Error>
 
     func getUserPoolAccessToken() async throws -> String

--- a/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
+++ b/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
@@ -26,7 +26,9 @@ open class APIAuthProviderFactory {
 
 public protocol AmplifyAuthTokenProvider {
     typealias AuthToken = String
+    @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
     func getLatestAuthToken() -> Result<AuthToken, Error>
+    func getUserPoolAccessToken(completion: @escaping (Result<AuthToken, Error>) -> Void)
 }
 
 /// Amplify OIDC Auth Provider

--- a/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
+++ b/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
@@ -27,7 +27,7 @@ open class APIAuthProviderFactory {
 public protocol AmplifyAuthTokenProvider {
     typealias AuthToken = String
 
-    @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
+    @available(*, deprecated, message: "Use getUserPoolAccessToken() instead")
     func getLatestAuthToken() -> Result<AuthToken, Error>
 
     func getUserPoolAccessToken() async throws -> String

--- a/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
+++ b/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
@@ -29,6 +29,7 @@ public protocol AmplifyAuthTokenProvider {
     @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
     func getLatestAuthToken() -> Result<AuthToken, Error>
     func getUserPoolAccessToken(completion: @escaping (Result<AuthToken, Error>) -> Void)
+    func getUserPoolAccessToken() async throws -> String
 }
 
 /// Amplify OIDC Auth Provider

--- a/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
+++ b/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
@@ -26,9 +26,10 @@ open class APIAuthProviderFactory {
 
 public protocol AmplifyAuthTokenProvider {
     typealias AuthToken = String
+
     @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
     func getLatestAuthToken() -> Result<AuthToken, Error>
-    func getUserPoolAccessToken(completion: @escaping (Result<AuthToken, Error>) -> Void)
+
     func getUserPoolAccessToken() async throws -> String
 }
 

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
@@ -29,17 +29,6 @@ class AuthTokenProviderWrapper: AuthTokenProvider {
                                               error))
         }
     }
-
-    func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
-        wrappedAuthTokenProvider.getUserPoolAccessToken { result in
-            switch result {
-            case .success(let result):
-                completion(.success(result))
-            case .failure(let error):
-                completion(.failure(AuthError.service("Unable to get latest auth token", "", error)))
-            }
-        }
-    }
     
     func getUserPoolAccessToken() async throws -> String {
         try await wrappedAuthTokenProvider.getUserPoolAccessToken()

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
@@ -17,7 +17,7 @@ class AuthTokenProviderWrapper: AuthTokenProvider {
         self.wrappedAuthTokenProvider = tokenAuthProvider
     }
 
-    @available(*, deprecated, message: "Use getUserPoolAccessToken() instead")
+    @available(*, deprecated, renamed: "getUserPoolAccessToken")
     func getToken() -> Result<String, AuthError> {
         let result = wrappedAuthTokenProvider.getLatestAuthToken()
         switch result {

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
@@ -40,4 +40,8 @@ class AuthTokenProviderWrapper: AuthTokenProvider {
             }
         }
     }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        try await wrappedAuthTokenProvider.getUserPoolAccessToken()
+    }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
@@ -17,7 +17,7 @@ class AuthTokenProviderWrapper: AuthTokenProvider {
         self.wrappedAuthTokenProvider = tokenAuthProvider
     }
 
-    @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
+    @available(*, deprecated, message: "Use getUserPoolAccessToken() instead")
     func getToken() -> Result<String, AuthError> {
         let result = wrappedAuthTokenProvider.getLatestAuthToken()
         switch result {

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
@@ -17,6 +17,7 @@ class AuthTokenProviderWrapper: AuthTokenProvider {
         self.wrappedAuthTokenProvider = tokenAuthProvider
     }
 
+    @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
     func getToken() -> Result<String, AuthError> {
         let result = wrappedAuthTokenProvider.getLatestAuthToken()
         switch result {
@@ -29,4 +30,14 @@ class AuthTokenProviderWrapper: AuthTokenProvider {
         }
     }
 
+    func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+        wrappedAuthTokenProvider.getUserPoolAccessToken { result in
+            switch result {
+            case .success(let result):
+                completion(.success(result))
+            case .failure(let error):
+                completion(.failure(AuthError.service("Unable to get latest auth token", "", error)))
+            }
+        }
+    }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenURLRequestInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenURLRequestInterceptor.swift
@@ -17,7 +17,7 @@ struct AuthTokenURLRequestInterceptor: URLRequestInterceptor {
         self.authTokenProvider = authTokenProvider
     }
 
-    func intercept(_ request: URLRequest) throws -> URLRequest {
+    func intercept(_ request: URLRequest) async throws -> URLRequest {
 
         guard let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
             throw APIError.unknown("Could not get mutable request", "")
@@ -33,15 +33,14 @@ struct AuthTokenURLRequestInterceptor: URLRequestInterceptor {
                                 forHTTPHeaderField: URLRequestConstants.Header.contentType)
         mutableRequest.setValue(AWSAPIPluginsCore.baseUserAgent(),
                                 forHTTPHeaderField: URLRequestConstants.Header.userAgent)
-
-        let tokenResult = authTokenProvider.getToken()
-        guard case let .success(token) = tokenResult else {
-            if case let .failure(error) = tokenResult {
-                throw APIError.operationError("Failed to retrieve authorization token.", "", error)
-            }
-
-            return mutableRequest as URLRequest
+        
+        let token: String
+        do {
+            token = try await authTokenProvider.getUserPoolAccessToken()
+        } catch {
+            throw APIError.operationError("Failed to retrieve authorization token.", "", error)
         }
+        
         mutableRequest.setValue(token, forHTTPHeaderField: "authorization")
         return mutableRequest as URLRequest
     }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -127,6 +127,10 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
         func getToken() -> Result<String, AuthError> {
             .success("token")
         }
+        
+        func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+            completion(.success("token"))
+        }
     }
 
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -131,6 +131,10 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
         func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
             completion(.success("token"))
         }
+        
+        func getUserPoolAccessToken() async throws -> String {
+            "token"
+        }
     }
 
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -128,10 +128,6 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
             .success("token")
         }
         
-        func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
-            completion(.success("token"))
-        }
-        
         func getUserPoolAccessToken() async throws -> String {
             "token"
         }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -38,10 +38,6 @@ extension AuthTokenURLRequestInterceptorTests {
             .success(authorizationToken)
         }
         
-        func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
-            completion(.success(authorizationToken))
-        }
-        
         func getUserPoolAccessToken() async throws -> String {
             authorizationToken
         }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -12,12 +12,12 @@ import AWSPluginsCore
 @testable import AWSAPIPlugin
 
 class AuthTokenURLRequestInterceptorTests: XCTestCase {
-    func testAuthTokenInterceptor() throws {
+    func testAuthTokenInterceptor() async throws {
         let mockTokenProvider = MockTokenProvider()
         let interceptor = AuthTokenURLRequestInterceptor(authTokenProvider: mockTokenProvider)
         let request = URLRequest(url: URL(string: "http://anapiendpoint.ca")!)
 
-        guard let headers = try interceptor.intercept(request).allHTTPHeaderFields else {
+        guard let headers = try await interceptor.intercept(request).allHTTPHeaderFields else {
             XCTFail("Failed retrieving headers")
             return
         }
@@ -40,6 +40,10 @@ extension AuthTokenURLRequestInterceptorTests {
         
         func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
             completion(.success(authorizationToken))
+        }
+        
+        func getUserPoolAccessToken() async throws -> String {
+            authorizationToken
         }
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -37,5 +37,9 @@ extension AuthTokenURLRequestInterceptorTests {
         func getToken() -> Result<String, AuthError> {
             .success(authorizationToken)
         }
+        
+        func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+            completion(.success(authorizationToken))
+        }
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
@@ -40,10 +40,6 @@ private class TestAuthTokenProvider: AmplifyAuthTokenProvider {
         .success(authToken)
     }
     
-    func getUserPoolAccessToken(completion: @escaping (Result<AuthToken, Error>) -> Void) {
-        completion(.success(authToken))
-    }
-    
     func getUserPoolAccessToken() async throws -> String {
         authToken
     }
@@ -54,10 +50,6 @@ private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         let error = APIError.networkError("Token error")
         return .failure(error)
-    }
-    
-    func getUserPoolAccessToken(completion: @escaping (Result<AuthToken, Error>) -> Void) {
-        completion(.success(authToken))
     }
     
     func getUserPoolAccessToken() async throws -> String {

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
@@ -38,6 +38,10 @@ private class TestAuthTokenProvider: AmplifyAuthTokenProvider {
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         .success(authToken)
     }
+    
+    func getUserPoolAccessToken(completion: @escaping (Result<AuthToken, Error>) -> Void) {
+        completion(.success(authToken))
+    }
 }
 
 private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
@@ -45,5 +49,9 @@ private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         let error = APIError.networkError("Token error")
         return .failure(error)
+    }
+    
+    func getUserPoolAccessToken(completion: @escaping (Result<AuthToken, Error>) -> Void) {
+        completion(.success(authToken))
     }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
@@ -35,12 +35,17 @@ class AuthenticationTokenAuthInterceptorTests: XCTestCase {
 // MARK: - Test token providers
 private class TestAuthTokenProvider: AmplifyAuthTokenProvider {
     let authToken = "token"
+    
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         .success(authToken)
     }
     
     func getUserPoolAccessToken(completion: @escaping (Result<AuthToken, Error>) -> Void) {
         completion(.success(authToken))
+    }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        authToken
     }
 }
 
@@ -53,5 +58,9 @@ private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
     
     func getUserPoolAccessToken(completion: @escaping (Result<AuthToken, Error>) -> Void) {
         completion(.success(authToken))
+    }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        authToken
     }
 }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
@@ -48,10 +48,6 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
         completion(.success(identityId ?? "IdentityId"))
     }
     
-    public func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
-        completion(.success(""))
-    }
-    
     public func getUserPoolAccessToken() async throws -> String {
         ""
     }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
@@ -51,6 +51,10 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
     public func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
         completion(.success(""))
     }
+    
+    public func getUserPoolAccessToken() async throws -> String {
+        ""
+    }
 
     public func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
         if let error = getTokenClaimsError {

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
@@ -39,6 +39,18 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
     public func getToken() -> Result<String, AuthError> {
         .success("")
     }
+    
+    public func getIdentityID(completion: @escaping (Result<String, AuthError>) -> Void) {
+        if let error = getIdentityIdError {
+            completion(.failure(error))
+        }
+
+        completion(.success(identityId ?? "IdentityId"))
+    }
+    
+    public func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+        completion(.success(""))
+    }
 
     public func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
         if let error = getTokenClaimsError {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -108,7 +108,7 @@ public class AWSAuthService: AWSAuthServiceBehavior {
     }
 
     // TODO: Remove this after calls to it are removed from API and DataStore plugins
-    @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
+    @available(*, deprecated, message: "Use getUserPoolAccessToken() instead")
     public func getToken() -> Result<String, AuthError> {
         var result: Result<String, AuthError>?
         let semaphore = DispatchSemaphore(value: 0)

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -108,6 +108,15 @@ public class AWSAuthService: AWSAuthServiceBehavior {
     }
 
     // TODO: Remove this after calls to it are removed from API and DataStore plugins
+    // MARK: List of Amplify internal usages of now deprecated AWSAuthServiceBehavior methods.
+    /**
+     `IncomingAsyncSubscriptionEventPublisher`
+        - File Path: `AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift`
+        - Uses: `getToken()`
+     `AWSOIDCAuthProvider`
+        - File Path: `AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift`
+        - Uses: `getToken()`
+     */
     @available(*, deprecated, message: "Use getUserPoolAccessToken() instead")
     public func getToken() -> Result<String, AuthError> {
         var result: Result<String, AuthError>?

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -117,7 +117,7 @@ public class AWSAuthService: AWSAuthServiceBehavior {
         - File Path: `AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift`
         - Uses: `getToken()`
      */
-    @available(*, deprecated, message: "Use getUserPoolAccessToken() instead")
+    @available(*, deprecated, renamed: "getUserPoolAccessToken")
     public func getToken() -> Result<String, AuthError> {
         var result: Result<String, AuthError>?
         let semaphore = DispatchSemaphore(value: 0)

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -80,26 +80,6 @@ public class AWSAuthService: AWSAuthServiceBehavior {
         }
         return .success(convertedDictionary)
     }
-
-    /// Retrieves the Cognito token from the AuthCognitoTokensProvider
-    /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
-    public func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
-        Amplify.Auth.fetchAuthSession { [weak self] event in
-            switch event {
-            case .success(let session):
-                guard
-                    let tokenResult = self?.getTokenString(from: session)
-                else {
-                    return completion(.failure(.unknown("""
-                    Did not receive a valid response from fetchAuthSession for get token.
-                    """)))
-                }
-                completion(tokenResult)
-            case .failure(let error):
-                completion(.failure(error))
-            }
-        }
-    }
     
     /// Retrieves the Cognito token from the AuthCognitoTokensProvider
     public func getUserPoolAccessToken() async throws -> String {
@@ -127,6 +107,7 @@ public class AWSAuthService: AWSAuthServiceBehavior {
         }
     }
 
+    // TODO: Remove this after calls to it are removed from API and DataStore plugins
     @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
     public func getToken() -> Result<String, AuthError> {
         var result: Result<String, AuthError>?

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -38,32 +38,6 @@ public class AWSAuthService: AWSAuthServiceBehavior {
         }
     }
 
-    @available(*, deprecated, message: "Use getIdentityID(completion:) instead")
-    public func getIdentityId() -> Result<String, AuthError> {
-        var result: Result<String, AuthError>?
-        let semaphore = DispatchSemaphore(value: 0)
-        _ = Amplify.Auth.fetchAuthSession { event in
-            defer {
-                semaphore.signal()
-            }
-
-            switch event {
-            case .success(let session):
-                result = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
-            case .failure(let error):
-                result = .failure(error)
-
-            }
-        }
-        semaphore.wait()
-        guard let validResult = result else {
-            return .failure(AuthError.unknown("""
-               Did not receive a valid response from fetchAuthSession for identityId.
-               """))
-        }
-        return validResult
-    }
-
     // This algorithm was heavily based on the implementation here:
     // swiftlint:disable:next line_length
     //  https://github.com/aws-amplify/aws-sdk-ios/blob/main/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift#L29

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -26,6 +26,9 @@ public protocol AWSAuthServiceBehavior: AnyObject {
     /// Retrieves the token from the Auth token provider
     /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
     func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void)
+    
+    /// Retrieves the token from the Auth token provider
+    func getUserPoolAccessToken() async throws -> String
 }
 
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -14,7 +14,7 @@ public protocol AWSAuthServiceBehavior: AnyObject {
     func getCredentialsProvider() -> CredentialsProvider
 
     // TODO: Remove this after calls to it are removed from API and DataStore plugins
-    @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
+    @available(*, deprecated, message: "Use getUserPoolAccessToken() instead")
     func getToken() -> Result<String, AuthError>
 
     func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError>

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -13,7 +13,7 @@ public protocol AWSAuthServiceBehavior: AnyObject {
 
     func getCredentialsProvider() -> CredentialsProvider
 
-    // TODO: Remove this after 
+    // TODO: Remove this after calls to it are removed from API and DataStore plugins
     @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
     func getToken() -> Result<String, AuthError>
 
@@ -22,10 +22,6 @@ public protocol AWSAuthServiceBehavior: AnyObject {
     /// Retrieves the identity identifier of for the Auth service
     /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
     func getIdentityID(completion: @escaping (Result<String, AuthError>) -> Void)
-
-    /// Retrieves the token from the Auth token provider
-    /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
-    func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void)
     
     /// Retrieves the token from the Auth token provider
     func getUserPoolAccessToken() async throws -> String
@@ -34,11 +30,7 @@ public protocol AWSAuthServiceBehavior: AnyObject {
 
     // MARK: List of Amplify internal usages of now deprecated AWSAuthServiceBehavior methods.
     /**
-     `BasicUserPoolTokenProvider`
-        - File Path: `AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift`
-        - Uses: `getToken()`
      `AWSOIDCAuthProvider`
         - File Path: `AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift`
         - Uses: `getToken()`
      */
-

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -13,9 +13,7 @@ public protocol AWSAuthServiceBehavior: AnyObject {
 
     func getCredentialsProvider() -> CredentialsProvider
 
-    @available(*, deprecated, message: "Use getIdentityID(completion:) instead")
-    func getIdentityId() -> Result<String, AuthError>
-
+    // TODO: Remove this after 
     @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
     func getToken() -> Result<String, AuthError>
 
@@ -30,46 +28,14 @@ public protocol AWSAuthServiceBehavior: AnyObject {
     func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void)
 }
 
-extension AWSAuthServiceBehavior {
+
     // MARK: List of Amplify internal usages of now deprecated AWSAuthServiceBehavior methods.
     /**
-     `StorageAccessLevelAwarePrefixResolver`
-        - File Path: `AmplifyPlugins/Storage/AWSS3StoragePlugin/Configuration/AWSS3PluginPrefixResolver.swift`
-        - Uses: `getIdentityId()`
-     `IncomingAsyncSubscriptionEventPublisher`
-        - File Path: `AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift`
-        - Uses: `getToken()`
      `BasicUserPoolTokenProvider`
         - File Path: `AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift`
         - Uses: `getToken()`
      `AWSOIDCAuthProvider`
         - File Path: `AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift`
         - Uses: `getToken()`
-     `AWSAuthServiceBehavior` protocol extension.
-        Default implementation of new completion handler APIs to prevent breaking change.
-         - File Path: `AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift`
-         - Uses: `getToken()`, `getIdentityId()`
      */
 
-    /// Retrieves the identity identifier of for the Auth service
-    /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
-    /// - Note: This default implementation was added to prevent a breaking change,
-    /// and will be removed when the blocking API versions are removed.
-    public func getIdentityID(completion: @escaping (Result<String, AuthError>) -> Void) {
-        DispatchQueue.global().async { [weak self] in
-            guard let identityIdResult = self?.getIdentityId() else { return }
-            completion(identityIdResult)
-        }
-    }
-
-    /// Retrieves the token from the Auth token provider
-    /// - Parameter completion: Completion handler defined for the input `Result<String, AuthError>`
-    /// - Note: This default implementation was added to prevent a breaking change,
-    ///  and will be removed when the blocking API versions are removed.
-    public func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
-        DispatchQueue.global().async { [weak self] in
-            guard let tokenResult = self?.getToken() else { return }
-            completion(tokenResult)
-        }
-    }
-}

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -23,7 +23,7 @@ public protocol AWSAuthServiceBehavior: AnyObject {
         - File Path: `AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift`
         - Uses: `getToken()`
      */
-    @available(*, deprecated, message: "Use getUserPoolAccessToken() instead")
+    @available(*, deprecated, renamed: "getUserPoolAccessToken")
     func getToken() -> Result<String, AuthError>
 
     func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError>

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -14,6 +14,15 @@ public protocol AWSAuthServiceBehavior: AnyObject {
     func getCredentialsProvider() -> CredentialsProvider
 
     // TODO: Remove this after calls to it are removed from API and DataStore plugins
+    // MARK: List of Amplify internal usages of now deprecated AWSAuthServiceBehavior methods.
+    /**
+     `IncomingAsyncSubscriptionEventPublisher`
+        - File Path: `AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift`
+        - Uses: `getToken()`
+     `AWSOIDCAuthProvider`
+        - File Path: `AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift`
+        - Uses: `getToken()`
+     */
     @available(*, deprecated, message: "Use getUserPoolAccessToken() instead")
     func getToken() -> Result<String, AuthError>
 
@@ -26,11 +35,3 @@ public protocol AWSAuthServiceBehavior: AnyObject {
     /// Retrieves the token from the Auth token provider
     func getUserPoolAccessToken() async throws -> String
 }
-
-
-    // MARK: List of Amplify internal usages of now deprecated AWSAuthServiceBehavior methods.
-    /**
-     `AWSOIDCAuthProvider`
-        - File Path: `AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift`
-        - Uses: `getToken()`
-     */

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AmplifyAWSCredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AmplifyAWSCredentialsProvider.swift
@@ -29,26 +29,6 @@ public class AmplifyAWSCredentialsProvider: CredentialsProvider {
             }
         }
     }
-
-    public func getCredentials() throws -> Future<AWSCredentials> {
-        let future = Future<AWSCredentials>()
-        _  = Amplify.Auth.fetchAuthSession { result in
-
-            do {
-                let session = try result.get()
-                if let awsCredentialsProvider = session as? AuthAWSCredentialsProvider {
-                    let credentials = try awsCredentialsProvider.getAWSCredentials().get()
-                    future.fulfill(credentials.toAWSSDKCredentials())
-                } else {
-                    let error = AuthError.unknown("Auth session does not include AWS credentials information")
-                    future.fail(error)
-                }
-            } catch {
-                future.fail(error)
-            }
-        }
-        return future
-    }
 }
 
 extension AuthAWSCredentials {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift
@@ -9,7 +9,10 @@ import Foundation
 import Amplify
 
 public protocol AuthTokenProvider {
+    @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
     func getToken() -> Result<String, AuthError>
+    
+    func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void)
 }
 
 public struct BasicUserPoolTokenProvider: AuthTokenProvider {
@@ -20,6 +23,11 @@ public struct BasicUserPoolTokenProvider: AuthTokenProvider {
         self.authService = authService
     }
 
+    public func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+        authService.getUserPoolAccessToken(completion: completion)
+    }
+    
+    @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
     public func getToken() -> Result<String, AuthError> {
         return self.authService.getToken()
     }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift
@@ -9,10 +9,10 @@ import Foundation
 import Amplify
 
 public protocol AuthTokenProvider {
-    @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
-    func getToken() -> Result<String, AuthError>
     
     func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void)
+    
+    func getUserPoolAccessToken() async throws -> String
 }
 
 public struct BasicUserPoolTokenProvider: AuthTokenProvider {
@@ -27,8 +27,7 @@ public struct BasicUserPoolTokenProvider: AuthTokenProvider {
         authService.getUserPoolAccessToken(completion: completion)
     }
     
-    @available(*, deprecated, message: "Use getUserPoolAccessToken(completion:) instead")
-    public func getToken() -> Result<String, AuthError> {
-        return self.authService.getToken()
+    public func getUserPoolAccessToken() async throws -> String {
+        try await authService.getUserPoolAccessToken()
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift
@@ -9,9 +9,6 @@ import Foundation
 import Amplify
 
 public protocol AuthTokenProvider {
-    
-    func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void)
-    
     func getUserPoolAccessToken() async throws -> String
 }
 
@@ -21,10 +18,6 @@ public struct BasicUserPoolTokenProvider: AuthTokenProvider {
 
     public init(authService: AWSAuthServiceBehavior) {
         self.authService = authService
-    }
-
-    public func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
-        authService.getUserPoolAccessToken(completion: completion)
     }
     
     public func getUserPoolAccessToken() async throws -> String {

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -61,6 +61,14 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
             completion(.success(token ?? "token"))
         }
     }
+    
+    public func getUserPoolAccessToken() async throws -> String {
+        if let error = getTokenError {
+            throw error
+        } else {
+            return token ?? "token"
+        }
+    }
 
     public func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
         if let error = getTokenClaimsError {

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -54,14 +54,6 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
         return .success(token ?? "token")
     }
     
-    public func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
-        if let error = getTokenError {
-            completion(.failure(error))
-        } else {
-            completion(.success(token ?? "token"))
-        }
-    }
-    
     public func getUserPoolAccessToken() async throws -> String {
         if let error = getTokenError {
             throw error

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -53,6 +53,14 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
 
         return .success(token ?? "token")
     }
+    
+    public func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+        if let error = getTokenError {
+            completion(.failure(error))
+        } else {
+            completion(.success(token ?? "token"))
+        }
+    }
 
     public func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
         if let error = getTokenClaimsError {

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -304,14 +304,6 @@ class MockOIDCAuthProvider: AmplifyOIDCAuthProvider {
         }
     }
     
-    func getUserPoolAccessToken(completion: @escaping (Result<AuthToken, Error>) -> Void) {
-        if let result = result {
-            completion(result)
-        } else {
-            completion(.success("token"))
-        }
-    }
-    
     func getUserPoolAccessToken() async throws -> String {
         if case let .success(token) = result {
             return token
@@ -329,14 +321,6 @@ class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
             return result
         } else {
             return .success("token")
-        }
-    }
-    
-    func getUserPoolAccessToken(completion: @escaping (Result<AuthToken, Error>) -> Void) {
-        if let result = result {
-            completion(result)
-        } else {
-            completion(.success("token"))
         }
     }
     

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -311,6 +311,14 @@ class MockOIDCAuthProvider: AmplifyOIDCAuthProvider {
             completion(.success("token"))
         }
     }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        if case let .success(token) = result {
+            return token
+        } else {
+            return "token"
+        }
+    }
 }
 
 class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
@@ -329,6 +337,14 @@ class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
             completion(result)
         } else {
             completion(.success("token"))
+        }
+    }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        if case let .success(token) = result {
+            return token
+        } else {
+            return "token"
         }
     }
 }

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -303,6 +303,14 @@ class MockOIDCAuthProvider: AmplifyOIDCAuthProvider {
             return .success("token")
         }
     }
+    
+    func getUserPoolAccessToken(completion: @escaping (Result<AuthToken, Error>) -> Void) {
+        if let result = result {
+            completion(result)
+        } else {
+            completion(.success("token"))
+        }
+    }
 }
 
 class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
@@ -313,6 +321,14 @@ class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
             return result
         } else {
             return .success("token")
+        }
+    }
+    
+    func getUserPoolAccessToken(completion: @escaping (Result<AuthToken, Error>) -> Void) {
+        if let result = result {
+            completion(result)
+        } else {
+            completion(.success("token"))
         }
     }
 }


### PR DESCRIPTION
*Description of changes:*
fix: remove dependencies on deprecated auth methods from amplify core

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
