### PR TITLE
fix(auth): Statemachine action for refreshing unauth credentials

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/RefreshSession/RefreshSessionState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/RefreshSession/RefreshSessionState+Resolver.swift
@@ -126,7 +126,8 @@ extension RefreshSessionState {
                     let amplifyCredentials = AmplifyCredentials.identityPoolOnly(
                         identityID: identityID,
                         credentials: credentials)
-                    return .init(newState: .refreshed(amplifyCredentials))
+                    let action = InformSessionRefreshed(credentials: amplifyCredentials)
+                    return .init(newState: .refreshed(amplifyCredentials), actions: [action])
                 }
                 return .from(oldState)
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/AuthorizationState/AuthorizationTestData.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/AuthorizationState/AuthorizationTestData.swift
@@ -53,4 +53,9 @@ extension AmplifyCredentials {
                                                    identityID: "identityId",
                                                    credentials: AuthAWSCognitoCredentials.expiredTestData)
     }
+
+    static var testDataIdentityPoolWithExpiredTokens: AmplifyCredentials {
+        AmplifyCredentials.identityPoolOnly(identityID: "identityId",
+                                            credentials: AuthAWSCognitoCredentials.testData)
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* UnAuth AWS Credentials refresh was not completing

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
