### PR TITLE
fix(Auth): Handling error when attempting device operations with a signed out user

### DIFF
--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginIntegrationTests.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginIntegrationTests.swift
@@ -70,6 +70,40 @@ class AWSPinpointAnalyticsPluginIntergrationTests: XCTestCase {
         Amplify.Analytics.identifyUser(userId, withProfile: userProfile)
 
         wait(for: [identifyUserEvent], timeout: TestCommonConstants.networkTimeout)
+
+        // Remove userId from the current endpoint
+        let targetingClient = escapeHatch().targetingClient
+        let currentProfile = targetingClient.currentEndpointProfile()
+        currentProfile.user?.userId = ""
+        targetingClient.update(currentProfile)
+    }
+
+    /// Run this test when the number of endpoints for the userId exceeds the limit.
+    /// The profile should have permissions to run the "mobiletargeting:DeleteUserEndpoints" action.
+    func skip_testDeleteEndpointsForUser() throws {
+        let userId = "userId"
+        let escapeHatch = escapeHatch()
+        let applicationId = escapeHatch.configuration.appId
+        guard let targetingConfiguration = escapeHatch.configuration.targetingServiceConfiguration else {
+            XCTFail("Targeting configuration is not defined.")
+            return
+        }
+
+        let deleteEndpointsRequest = AWSPinpointTargetingDeleteUserEndpointsRequest()!
+        deleteEndpointsRequest.userId = userId
+        deleteEndpointsRequest.applicationId = applicationId
+
+        let deleteExpectation = expectation(description: "Delete endpoints")
+        let lowLevelClient = lowLevelClient(from: targetingConfiguration)
+        lowLevelClient.deleteUserEndpoints(deleteEndpointsRequest) { response, error in
+            guard error == nil else {
+                XCTFail("Unexpected error when attempting to delete endpoints")
+                deleteExpectation.fulfill()
+                return
+            }
+            deleteExpectation.fulfill()
+        }
+        wait(for: [deleteExpectation], timeout: 1)
     }
 
     func testRecordEventsAreFlushed() {
@@ -79,6 +113,7 @@ class AWSPinpointAnalyticsPluginIntergrationTests: XCTestCase {
                 // TODO: Remove exposing AWSPinpointEvent
                 guard let pinpointEvents = payload.data as? [AWSPinpointEvent] else {
                     XCTFail("Missing data")
+                    flushEventsInvoked.fulfill()
                     return
                 }
                 XCTAssertNotNil(pinpointEvents)
@@ -116,5 +151,18 @@ class AWSPinpointAnalyticsPluginIntergrationTests: XCTestCase {
         XCTAssertNotNil(awsPinpoint.sessionClient)
         XCTAssertNotNil(awsPinpoint.configuration)
         XCTAssertTrue(awsPinpoint.configuration.enableAutoSessionRecording)
+    }
+
+    private func escapeHatch() -> AWSPinpoint {
+        guard let plugin = try? Amplify.Analytics.getPlugin(for: "awsPinpointAnalyticsPlugin"),
+              let analyticsPlugin = plugin as? AWSPinpointAnalyticsPlugin else {
+            fatalError("Unable to retrieve configuration")
+        }
+        return analyticsPlugin.getEscapeHatch()
+    }
+
+    private func lowLevelClient(from configuration: AWSServiceConfiguration) -> AWSPinpointTargeting {
+        AWSPinpointTargeting.register(with: configuration, forKey: "integrationTestsTargetingConfiguration")
+        return AWSPinpointTargeting.init(forKey: "integrationTestsTargetingConfiguration")
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Constants/AuthPluginErrorConstants.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Constants/AuthPluginErrorConstants.swift
@@ -143,6 +143,10 @@ struct AuthPluginErrorConstants {
     static let changePasswordUnableToSignInError: AuthPluginErrorString = (
     "Could not change password, the user session is expired",
     "Re-authenticate the user by using one of the signIn apis")
+
+    static let userSignedOutError: AuthPluginErrorString = (
+    "There is no user signed in to the Auth category",
+    "SignIn to Auth category by using one of the sign in methods and then try again")
 }
 
 // Field validation errors


### PR DESCRIPTION
*Description of changes:*
**Auth**
- Handling the `notSignedIn` error coming from `mobileClient` when the token can't be retrieved for a Device Operation so that it returns a `AuthError.signedOut` error.
- Updating integration tests to check:
  - a `deviceNotTraked` error when invoked for an unknown/untracked device
  - a `signedOut` error when invoked with a signed out user

**Analytics**
- Updating integration test to un-assign the current endpoint after testing `identifyUser`, to prevent for having multiple active endpoints for the same userId.

*Check points: (check or cross out if not relevant)*

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
