### PR TITLE
fix(Auth): Fixing update user attribute helper

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/UpdateAttributesOperationHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/UpdateAttributesOperationHelper.swift
@@ -27,14 +27,8 @@ struct UpdateAttributesOperationHelper {
 
             let result = try await userPoolService.updateUserAttributes(input: input)
 
-            guard let codeDeliveryDetailsList = result.codeDeliveryDetailsList else {
-                let authError = AuthError.unknown("Unable to get Auth code delivery details",
-                                                  nil)
-                throw authError
-            }
-
             var finalResult = [AuthUserAttributeKey: AuthUpdateAttributeResult]()
-            for item in codeDeliveryDetailsList {
+            for item in result.codeDeliveryDetailsList ?? [] {
                 if let attribute = item.attributeName {
                     let authCodeDeliveryDetails = item.toAuthCodeDeliveryDetails()
                     let nextStep = AuthUpdateAttributeStep.confirmAttributeWithCode(authCodeDeliveryDetails, nil)

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/UserBehaviourTests/UserBehaviorUpdateAttributeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/UserBehaviourTests/UserBehaviorUpdateAttributeTests.swift
@@ -47,7 +47,7 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
         wait(for: [resultExpectation], timeout: apiTimeout)
     }
 
-    /// Test a updateUserAttributes call with invalid result
+    /// Test a updateUserAttributes call with empty code delivery result
     ///
     /// - Given: an auth plugin with mocked service. Mocked service calls should mock an empty response
     /// - When:

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/UserBehaviourTests/UserBehaviorUpdateAttributeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/OperationTests/UserBehaviourTests/UserBehaviorUpdateAttributeTests.swift
@@ -49,30 +49,24 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
 
     /// Test a updateUserAttributes call with invalid result
     ///
-    /// - Given: an auth plugin with mocked service. Mocked service calls should mock a invalid response
+    /// - Given: an auth plugin with mocked service. Mocked service calls should mock an empty response
     /// - When:
     ///    - I invoke updateUserAttributes with AuthUserAttribute
     /// - Then:
-    ///    - I should get an .unknown error
+    ///    - I should NOT get an error
     ///
-    func testUpdateUserAttributesWithInvalidResult() {
+    func testUpdateUserAttributesWithEmptyResult() {
 
         mockIdentityProvider = MockIdentityProvider(mockUpdateUserAttributeResponse: { _ in
             UpdateUserAttributesOutputResponse()
         })
         let resultExpectation = expectation(description: "Should receive a result")
         _ = plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com")) { result in
-            defer {
-                resultExpectation.fulfill()
-            }
             switch result {
             case .success:
-                XCTFail("Should return an error if the result from service is invalid")
+                resultExpectation.fulfill()
             case .failure(let error):
-                guard case .unknown = error else {
-                    XCTFail("Should produce an unknown error")
-                    return
-                }
+                XCTFail("Should not product any error")
             }
         }
         wait(for: [resultExpectation], timeout: apiTimeout)

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AuthUserAttributesTests/AuthUserAttributesTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AuthUserAttributesTests/AuthUserAttributesTests.swift
@@ -134,7 +134,7 @@ class AuthUserAttributesTests: AWSAuthBaseTest {
     func testSuccessfulUpdateOfMultipleAttributes() throws {
         let username = "integTest\(UUID().uuidString)"
         let password = "P123@\(UUID().uuidString)"
-        let updatedEmail = "\(username)@amazon.com"
+        let updatedFamilyName = "\(username)@amazon.com"
         let updatedName = "Name\(UUID().uuidString)"
 
         let signInExpectation = expectation(description: "SignIn operation should complete")
@@ -150,7 +150,7 @@ class AuthUserAttributesTests: AWSAuthBaseTest {
         let pluginOptions = AWSUpdateUserAttributesOptions(metadata: ["mydata": "myvalue"])
         let options = AuthUpdateUserAttributesRequest.Options(pluginOptions: pluginOptions)
         let attributes = [
-            AuthUserAttribute(.email, value: updatedEmail),
+            AuthUserAttribute(.familyName, value: updatedFamilyName),
             AuthUserAttribute(.name, value: updatedName)
         ]
         _ = Amplify.Auth.update(
@@ -169,8 +169,8 @@ class AuthUserAttributesTests: AWSAuthBaseTest {
         _ = Amplify.Auth.fetchUserAttributes(listener: { result in
             switch result {
             case .success(let attributes):
-                if let emailAttribute = attributes.filter({ $0.key == .email }).first {
-                    XCTAssertEqual(emailAttribute.value, updatedEmail)
+                if let emailAttribute = attributes.filter({ $0.key == .familyName }).first {
+                    XCTAssertEqual(emailAttribute.value, updatedFamilyName)
                 } else {
                     XCTFail("Email attribute not found")
                 }


### PR DESCRIPTION
*Description of changes:*
Fixing to avoid throwing an error when the `codeDeliveryDetailsList ` is nil. This could happen in cases where all the attributes don't require a code.  

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
