### PR TITLE
feat(Auth): Adding support for confirming newPasswordRequired challenge

### DIFF
--- a/Amplify/Categories/Auth/Request/AuthConfirmSignInRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthConfirmSignInRequest.swift
@@ -28,12 +28,17 @@ public extension AuthConfirmSignInRequest {
 
     struct Options {
 
+        /// User attributes to be passed in when confirming a sign with NEW_PASSWORD_REQUIRED challenge
+        public let userAttributes: [AuthUserAttribute]?
+
         /// Extra plugin specific options, only used in special circumstances when the existing options do not provide
         /// a way to utilize the underlying auth plugin functionality. See plugin documentation for expected
         /// key/values
         public let pluginOptions: Any?
 
-        public init(pluginOptions: Any? = nil) {
+        public init(userAttributes: [AuthUserAttribute]? = nil,
+                    pluginOptions: Any? = nil) {
+            self.userAttributes = userAttributes
             self.pluginOptions = pluginOptions
         }
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/VerifySignInChallenge.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/VerifySignInChallenge.swift
@@ -15,7 +15,7 @@ struct VerifySignInChallenge: Action {
 
     let challenge: RespondToAuthChallenge
 
-    let answer: String
+    let confirmSignEventData: ConfirmSignInEventData
 
     func execute(withDispatcher dispatcher: EventDispatcher, environment: Environment) {
         logVerbose("\(#fileID) Starting execution", environment: environment)
@@ -28,7 +28,15 @@ struct VerifySignInChallenge: Action {
             let responseKey = try challenge.getChallengeKey()
             let userPoolClientId = userpoolEnv.userPoolConfiguration.clientId
 
-            var challengeResponses = ["USERNAME": username, responseKey: answer]
+            var challengeResponses = [
+                "USERNAME": username,
+                responseKey: confirmSignEventData.answer
+            ]
+
+            // Add the attributes to the challenge response
+            confirmSignEventData.attributes.forEach {
+                challengeResponses[$0.key] = $0.value
+            }
 
             if let clientSecret = userpoolEnv.userPoolConfiguration.clientSecret {
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AuthChallengeType.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AuthChallengeType.swift
@@ -8,7 +8,7 @@
 import Foundation
 import AWSCognitoIdentityProvider
 
-public enum AuthChallengeType {
+enum AuthChallengeType {
 
     case smsMfa
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/AWSAuthConfirmSignInOperation.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/AWSAuthConfirmSignInOperation.swift
@@ -102,8 +102,17 @@ public class AWSAuthConfirmSignInOperation: AmplifyConfirmSignInOperation,
         token: AuthStateMachine.StateChangeListenerToken?) {
             switch challengeState {
             case .waitingForAnswer:
-                let answer = self.request.challengeResponse
-                let event = SignInChallengeEvent(eventType: .verifyChallengeAnswer(answer))
+                // Convert the attributes to [String: String]
+                let attributePrefix = AuthPluginConstants.cognitoIdentityUserUserAttributePrefix
+                let attributes = request.options.userAttributes?.reduce(
+                    into: [String: String]()) {
+                        $0[attributePrefix + $1.key.rawValue] = $1.value
+                    } ?? [:]
+                let confirmSignInData = ConfirmSignInEventData(
+                    answer: self.request.challengeResponse,
+                    attributes: attributes)
+                let event = SignInChallengeEvent(
+                    eventType: .verifyChallengeAnswer(confirmSignInData))
                 self.authStateMachine.send(event)
 
             case .verifying:

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/ConfirmSignInEventData.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/ConfirmSignInEventData.swift
@@ -1,0 +1,31 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+struct ConfirmSignInEventData {
+
+    let answer: String
+    let attributes: [String: String]
+
+}
+
+extension ConfirmSignInEventData: Equatable { }
+
+extension ConfirmSignInEventData: CustomDebugDictionaryConvertible {
+    var debugDictionary: [String: Any] {
+        [
+            "answer": answer.masked(),
+            "attributes": attributes
+        ]
+    }
+}
+extension ConfirmSignInEventData: CustomDebugStringConvertible {
+    var debugDescription: String {
+        debugDictionary.debugDescription
+    }
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/RespondToAuthChallenge.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/RespondToAuthChallenge.swift
@@ -48,6 +48,7 @@ extension RespondToAuthChallenge {
         switch challenge {
         case .customChallenge: return "ANSWER"
         case .smsMfa: return "SMS_MFA_CODE"
+        case .newPasswordRequired: return "NEW_PASSWORD"
         default:
             let message = "UnSupported challenge response \(challenge)"
             let error = SignInError.unknown(message: message)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/SignUpEventData.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/SignUpEventData.swift
@@ -27,7 +27,8 @@ extension SignUpEventData: CustomDebugDictionaryConvertible {
     var debugDictionary: [String: Any] {
         [
             "username": username.masked(),
-            "password": password.redacted()
+            "password": password.redacted(),
+            "attributes": attributes
         ]
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInChallengeEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInChallengeEvent.swift
@@ -13,7 +13,7 @@ struct SignInChallengeEvent: StateMachineEvent {
 
         case waitForAnswer(RespondToAuthChallenge)
 
-        case verifyChallengeAnswer(String)
+        case verifyChallengeAnswer(ConfirmSignInEventData)
 
         case verified
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SignIn/SignInChallengeState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SignIn/SignInChallengeState+Resolver.swift
@@ -28,9 +28,11 @@ extension SignInChallengeState {
 
             case .waitingForAnswer(let challenge):
 
-                if case .verifyChallengeAnswer(let answer) = event.isChallengeEvent {
-                    let action = VerifySignInChallenge(challenge: challenge, answer: answer)
-                    return .init(newState: .verifying(challenge, answer), actions: [action])
+                if case .verifyChallengeAnswer(let answerEventData) = event.isChallengeEvent {
+                    let action = VerifySignInChallenge(
+                        challenge: challenge,
+                        confirmSignEventData: answerEventData)
+                    return .init(newState: .verifying(challenge, answerEventData.answer), actions: [action])
                 }
                 return .from(oldState)
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Constants/AuthPluginConstants.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Constants/AuthPluginConstants.swift
@@ -12,4 +12,7 @@ struct AuthPluginConstants {
     /// The time interval  under which the refresh of  UserPool or awsCredentials tokens will happen
     static let sessionRefreshInterval: TimeInterval = 2 * 60
 
+    /// Prefix for the attribute that will be used in the Cognito API calls
+    static let cognitoIdentityUserUserAttributePrefix = "userAttributes."
+
 }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/xcshareddata/xcschemes/AuthHostApp.xcscheme
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/xcshareddata/xcschemes/AuthHostApp.xcscheme
@@ -47,6 +47,9 @@
                <Test
                   Identifier = "AuthCustomSignInTests/testSuccessfulSignInWithCustomAuthSRP()">
                </Test>
+               <Test
+                  Identifier = "AuthSRPSignInTests/testNewPasswordRequired()">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>


### PR DESCRIPTION
*Description of changes:*
The purpose of the PR is to add support for new password required for confirm sign in API. 

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
