### PR TITLE
Add support for deletedUser, sessionExpired and confirmSignIn auth hub event

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/HubEvents/AuthHubEventHandler.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/HubEvents/AuthHubEventHandler.swift
@@ -45,7 +45,7 @@ class AuthHubEventHandler: AuthHubEventBehavior {
                 }
                 self?.handleSignInEvent(result)
 
-            /* TODO: Need to implement these hub events
+            
             case HubPayload.EventName.Auth.confirmSignInAPI:
                 guard let event = payload.data as? AWSAuthConfirmSignInOperation.OperationResult,
                     case let .success(result) = event else {
@@ -53,6 +53,7 @@ class AuthHubEventHandler: AuthHubEventBehavior {
                 }
                 self?.handleSignInEvent(result)
 
+            /* TODO: Need to implement these hub events
             case HubPayload.EventName.Auth.webUISignInAPI:
                 guard let event = payload.data as? AWSAuthWebUISignInOperation.OperationResult,
                     case let .success(result) = event else {
@@ -67,14 +68,14 @@ class AuthHubEventHandler: AuthHubEventBehavior {
                 }
                 self?.handleSignInEvent(result)
 
-
+             */
             case HubPayload.EventName.Auth.deleteUserAPI:
                 guard let event = payload.data as? AWSAuthDeleteUserOperation.OperationResult,
                     case .success = event else {
                         return
                 }
                 self?.sendUserDeletedEvent()
-             */
+             
             case HubPayload.EventName.Auth.signOutAPI:
                 guard let event = payload.data as? AWSAuthSignOutOperation.OperationResult,
                     case .success = event else {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/AWSAuthConfirmSignUpOperation.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/AWSAuthConfirmSignUpOperation.swift
@@ -27,7 +27,7 @@ public class AWSAuthConfirmSignUpOperation: AmplifyConfirmSignUpOperation,
 
         self.stateMachine = stateMachine
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.signUpAPI,
+                   eventName: HubPayload.EventName.Auth.confirmSignUpAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/AWSAuthDeleteUserOperation.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/AWSAuthDeleteUserOperation.swift
@@ -25,7 +25,7 @@ public class AWSAuthDeleteUserOperation: AmplifyOperation<
         self.authStateMachine = authStateMachine
         self.fetchAuthSessionHelper = FetchAuthSessionOperationHelper()
         super.init(categoryType: .auth,
-                   eventName: HubPayload.EventName.Auth.confirmUserAttributesAPI,
+                   eventName: HubPayload.EventName.Auth.deleteUserAPI,
                    request: request,
                    resultListener: resultListener)
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/HubEventTests/AuthHubEventHandlerTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/HubEventTests/AuthHubEventHandlerTests.swift
@@ -4,34 +4,35 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
+import  Foundation
 
 import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
+import AWSCognitoIdentity
+import AWSCognitoIdentityProvider
 
 class AuthHubEventHandlerTests: XCTestCase {
 
-    var authHandler: AuthHubEventHandler!
-    override func setUp() {
-        try? Amplify.configure()
-        authHandler = AuthHubEventHandler()
-    }
-
-    override func tearDown() async throws {
-        await Amplify.reset()
-        authHandler = nil
-    }
-
+    let networkTimeout = TimeInterval(10)
+    var plugin: AWSCognitoAuthPlugin!
+    
     /// Test whether HubEvent emits a signedIn event for mocked signIn operation
     ///
     /// - Given: A listener to hub events
     /// - When:
-    ///    - I mock a succesful sign in operation event
+    ///    - I mock a succesful signInAPI operation event
     /// - Then:
     ///    - I should receive a signedIn hub event
     ///
     func testSignedInHubEvent() {
 
+        configurePluginForSignInEvent()
+        
+        let pluginOptions = AWSAuthSignInOptions(validationData: ["somekey": "somevalue"],
+                                                 metadata: ["somekey": "somevalue"])
+        let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
+        
         let hubEventExpectation = expectation(description: "Should receive the hub event")
         _ = Amplify.Hub.listen(to: .auth) { payload in
             switch payload.eventName {
@@ -41,10 +42,140 @@ class AuthHubEventHandlerTests: XCTestCase {
                 break
             }
         }
-        mockSuccessfulSignedInEvent()
-        wait(for: [hubEventExpectation], timeout: 10)
+        
+        _ = plugin.signIn(username: "username", password: "password", options: options) { result in
+            if case .failure(let error) = result {
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        
+        wait(for: [hubEventExpectation], timeout: networkTimeout)
     }
 
+    /// Test whether HubEvent emits a signOut event for mocked signOut operation
+    ///
+    /// - Given: A listener to hub events
+    /// - When:
+    ///    - I mock a succesful signOutAPI operation event
+    /// - Then:
+    ///    - I should receive a signedOut hub event
+    ///
+    func testSignedOutHubEvent() {
+
+        configurePluginForSignOutEvent()
+        
+        let hubEventExpectation = expectation(description: "Should receive the hub event")
+        _ = Amplify.Hub.listen(to: .auth) { payload in
+            switch payload.eventName {
+            case HubPayload.EventName.Auth.signedOut:
+                hubEventExpectation.fulfill()
+            default:
+                break
+            }
+        }
+        
+        _ = plugin.signOut(options: nil) { result in
+            if case .failure(let error) = result {
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        
+        wait(for: [hubEventExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test whether HubEvent emits a confirmSignedIn event for mocked signIn operation
+    ///
+    /// - Given: A listener to hub events
+    /// - When:
+    ///    - I mock a succesful confirmSignInAPI operation event
+    /// - Then:
+    ///    - I should receive a signedIn hub event
+    ///
+    func testConfirmSignedInHubEvent() {
+
+        configurePluginForConfirmSignInEvent()
+        
+        let hubEventExpectation = expectation(description: "Should receive the hub event")
+        _ = Amplify.Hub.listen(to: .auth) { payload in
+            switch payload.eventName {
+            case HubPayload.EventName.Auth.signedIn:
+                hubEventExpectation.fulfill()
+            default:
+                break
+            }
+        }
+        
+        _ = plugin.confirmSignIn(challengeResponse: "code") { result in
+            if case .failure(let error) = result {
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        
+        wait(for: [hubEventExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test whether HubEvent emits a deletedUser event for mocked delete user operation
+    ///
+    /// - Given: A listener to hub events
+    /// - When:
+    ///    - I mock a succesful deleteUserAPI operation event
+    /// - Then:
+    ///    - I should receive a user deleted hub event
+    ///
+    func testUserDeletedHubEvent() {
+
+        configurePluginForDeleteUserEvent()
+        
+        let hubEventExpectation = expectation(description: "Should receive the hub event")
+        _ = Amplify.Hub.listen(to: .auth) { payload in
+            switch payload.eventName {
+            case HubPayload.EventName.Auth.userDeleted:
+                hubEventExpectation.fulfill()
+            default:
+                break
+            }
+        }
+        
+        _ = plugin.deleteUser { result in
+            if case .failure(let error) = result {
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        
+        wait(for: [hubEventExpectation], timeout: networkTimeout)
+    }
+    
+    /// Test whether HubEvent emits a sessionExpired event for mocked fetchSession operation with expired tokens
+    ///
+    /// - Given: A listener to hub events
+    /// - When:
+    ///    - I mock a succesful fetchSessionAPI operation event with expired tokens
+    /// - Then:
+    ///    - I should receive a sessionExpired hub event
+    ///
+    func testSessionExpiredHubEvent() {
+
+        configurePluginForSessionExpiredEvent()
+        
+        let hubEventExpectation = expectation(description: "Should receive the hub event")
+        _ = Amplify.Hub.listen(to: .auth) { payload in
+            switch payload.eventName {
+            case HubPayload.EventName.Auth.sessionExpired:
+                hubEventExpectation.fulfill()
+            default:
+                break
+            }
+        }
+        
+        _ = plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options()) { result in
+            if case .failure(let error) = result {
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+        
+        wait(for: [hubEventExpectation], timeout: networkTimeout)
+    }
+    
     /* TODO: Enable these tests when the API's have been implemented
 
     /// Test whether HubEvent emits a mocked signedIn event for webUI signIn
@@ -120,18 +251,161 @@ class AuthHubEventHandlerTests: XCTestCase {
 
     }
      */
-    private func mockSuccessfulSignedInEvent() {
-        let mockResult = AuthSignInResult(nextStep: .done)
-        let mockEvent = AWSAuthSignInOperation.OperationResult.success(mockResult)
-        let mockRequest = AuthSignInRequest(username: "username",
-                                            password: "password",
-                                            options: AuthSignInRequest.Options())
-        let mockContext = AmplifyOperationContext(operationId: UUID(), request: mockRequest)
-        let mockPayload = HubPayload(eventName: HubPayload.EventName.Auth.signInAPI,
-                                     context: mockContext,
-                                     data: mockEvent)
-        Amplify.Hub.dispatch(to: .auth, payload: mockPayload)
-
+    
+    private func configurePluginForSignInEvent() {
+        let mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            InitiateAuthOutputResponse(
+                authenticationResult: .none,
+                challengeName: .passwordVerifier,
+                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                session: "someSession")
+        }, mockRespondToAuthChallengeResponse: { _ in
+            RespondToAuthChallengeOutputResponse(
+                authenticationResult: .init(
+                    accessToken: "accessToken",
+                    expiresIn: 300,
+                    idToken: "idToken",
+                    newDeviceMetadata: nil,
+                    refreshToken: "refreshToken",
+                    tokenType: ""),
+                challengeName: .none,
+                challengeParameters: [:],
+                session: "session")
+        })
+        
+        let initialState = AuthState.configured(.signedOut(.init(lastKnownUserName: nil)), .configured)
+        
+        configurePlugin(initialState: initialState, userPoolFactory: mockIdentityProvider)
     }
-
+    
+    private func configurePluginForConfirmSignInEvent() {
+        let initialState = AuthState.configured(
+            AuthenticationState.signingIn(.resolvingChallenge(.waitingForAnswer(.testData), .smsMfa)),
+            AuthorizationState.sessionEstablished(.testData))
+        
+        let mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+            return .testData()
+        })
+        
+        configurePlugin(initialState: initialState, userPoolFactory: mockIdentityProvider)
+    }
+    
+    private func configurePluginForDeleteUserEvent() {
+        let initialState = AuthState.configured(
+            AuthenticationState.signedIn(
+                SignedInData(userId: "test",
+                             userName: "test",
+                             signedInDate: Date(),
+                             signInMethod: .apiBased(.userSRP),
+                             cognitoUserPoolTokens: AWSCognitoUserPoolTokens.testData)),
+            AuthorizationState.sessionEstablished(AmplifyCredentials.testData))
+        
+        let mockIdentityProvider = MockIdentityProvider(
+            mockRevokeTokenResponse: { _ in
+                try RevokeTokenOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+            }, mockGlobalSignOutResponse: { _ in
+                try GlobalSignOutOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+            },
+            mockDeleteUserOutputResponse: { _ in
+                try DeleteUserOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+            }
+        )
+        
+        configurePlugin(initialState: initialState, userPoolFactory: mockIdentityProvider)
+    }
+    
+    private func configurePluginForSignOutEvent() {
+        let initialState = AuthState.configured(
+            AuthenticationState.signedIn(
+                SignedInData(userId: "test",
+                             userName: "test",
+                             signedInDate: Date(),
+                             signInMethod: .apiBased(.userSRP),
+                             cognitoUserPoolTokens: AWSCognitoUserPoolTokens.testData)),
+            AuthorizationState.sessionEstablished(AmplifyCredentials.testData))
+        
+        let mockIdentityProvider = MockIdentityProvider(
+            mockRevokeTokenResponse: { _ in
+                try RevokeTokenOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+            },
+            mockGlobalSignOutResponse: { _ in
+                try GlobalSignOutOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+            }
+        )
+        
+        configurePlugin(initialState: initialState, userPoolFactory: mockIdentityProvider)
+    }
+    
+    private func configurePluginForSessionExpiredEvent() {
+        let initialState = AuthState.configured(
+            AuthenticationState.signedIn(.testData),
+            AuthorizationState.sessionEstablished(
+                AmplifyCredentials.testDataWithExpiredTokens))
+        
+        let mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                throw try InitiateAuthOutputError.notAuthorizedException(
+                    NotAuthorizedException.init(httpResponse: .init(body: .empty, statusCode: .ok)))
+            })
+        
+        configurePlugin(initialState: initialState, userPoolFactory: mockIdentityProvider)
+    }
+    
+    private func configurePlugin(initialState: AuthState, userPoolFactory: CognitoUserPoolBehavior) {
+        plugin = AWSCognitoAuthPlugin()
+        
+        let getId: MockIdentity.MockGetIdResponse = { _ in
+            return .init(identityId: "mockIdentityId")
+        }
+        
+        let getCredentials: MockIdentity.MockGetCredentialsResponse = { _ in
+            let credentials = CognitoIdentityClientTypes.Credentials(accessKeyId: "accessKey",
+                                                                     expiration: Date(),
+                                                                     secretKey: "secret",
+                                                                     sessionToken: "session")
+            return .init(credentials: credentials, identityId: "responseIdentityID")
+        }
+        
+        let mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+        
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            identityPoolFactory: { mockIdentity },
+            userPoolFactory: { userPoolFactory })
+        
+        let statemachine = Defaults.makeDefaultAuthStateMachine(
+            initialState: initialState,
+            identityPoolFactory: { mockIdentity },
+            userPoolFactory: { userPoolFactory })
+        
+        _ = statemachine.listen { state in
+            switch state {
+            case .configured(_, let authorizationState):
+                
+                if case .waitingToStore(let credentials) = authorizationState {
+                    let authEvent = AuthEvent.init(
+                        eventType: .receivedCachedCredentials(credentials))
+                    statemachine.send(authEvent)
+                }
+            default: break
+            }
+        } onSubscribe: {}
+        
+        let authHandler = AuthHubEventHandler()
+        
+        plugin?.configure(
+            authConfiguration: Defaults.makeDefaultAuthConfigData(),
+            authEnvironment: environment,
+            authStateMachine: statemachine,
+            credentialStoreStateMachine: Defaults.makeDefaultCredentialStateMachine(),
+            hubEventHandler: authHandler)
+    }
+    
+    override func tearDown() async throws {
+        plugin = nil
+        await Amplify.reset()
+    }
+    
 }


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Add support for `userDeleted`,  `confirmSignIn`, `sessionExpired` Auth hub events

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
