### PR TITLE
fix(datastore): Add default value for where predicate

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
@@ -55,8 +55,8 @@ extension DataStoreCategory: DataStoreBaseBehavior {
     public func delete<M: Model>(_ modelType: M.Type,
                                  withIdentifier id: String,
                                  where predicate: QueryPredicate? = nil,
-                                 completion: @escaping DataStoreCallback<Void>)
-    where M: ModelIdentifiable, M.IdentifierFormat == ModelIdentifierFormat.Default {
+                                 completion: @escaping DataStoreCallback<Void>) where M: ModelIdentifiable,
+                                                                                      M.IdentifierFormat == ModelIdentifierFormat.Default {
 
         plugin.delete(modelType, withIdentifier: id, where: predicate, completion: completion)
     }

--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
@@ -20,8 +20,7 @@ extension DataStoreCategory: DataStoreBaseBehavior {
 
     public func query<M: Model>(_ modelType: M.Type,
                                 byIdentifier id: String,
-                                completion: (DataStoreResult<M?>) -> Void) where M: ModelIdentifiable,
-                                                                                 M.IdentifierFormat == ModelIdentifierFormat.Default {
+                                completion: (DataStoreResult<M?>) -> Void) where M: ModelIdentifiable, M.IdentifierFormat == ModelIdentifierFormat.Default {
         plugin.query(modelType, byIdentifier: id, completion: completion)
     }
 
@@ -54,16 +53,16 @@ extension DataStoreCategory: DataStoreBaseBehavior {
 
     public func delete<M: Model>(_ modelType: M.Type,
                                  withIdentifier id: String,
-                                 where predicate: QueryPredicate?,
-                                 completion: @escaping DataStoreCallback<Void>) where M: ModelIdentifiable,
-                                                                                      M.IdentifierFormat == ModelIdentifierFormat.Default {
+                                 where predicate: QueryPredicate? = nil,
+                                 completion: @escaping DataStoreCallback<Void>)
+    where M: ModelIdentifiable, M.IdentifierFormat == ModelIdentifierFormat.Default {
 
         plugin.delete(modelType, withIdentifier: id, where: predicate, completion: completion)
     }
 
     public func delete<M: Model>(_ modelType: M.Type,
                                  withIdentifier id: ModelIdentifier<M, M.IdentifierFormat>,
-                                 where predicate: QueryPredicate?,
+                                 where predicate: QueryPredicate? = nil,
                                  completion: @escaping DataStoreCallback<Void>) where M: ModelIdentifiable {
         plugin.delete(modelType, withIdentifier: id, where: predicate, completion: completion)
     }

--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
@@ -20,7 +20,8 @@ extension DataStoreCategory: DataStoreBaseBehavior {
 
     public func query<M: Model>(_ modelType: M.Type,
                                 byIdentifier id: String,
-                                completion: (DataStoreResult<M?>) -> Void) where M: ModelIdentifiable, M.IdentifierFormat == ModelIdentifierFormat.Default {
+                                completion: (DataStoreResult<M?>) -> Void) where M: ModelIdentifiable,
+                                                                                 M.IdentifierFormat == ModelIdentifierFormat.Default {
         plugin.query(modelType, byIdentifier: id, completion: completion)
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -9,6 +9,7 @@ import Amplify
 import AWSPluginsCore
 
 extension AWSDataStorePlugin: DataStoreBaseBehavior {
+
     // MARK: - Save
     public func save<M: Model>(_ model: M,
                                where condition: QueryPredicate? = nil,
@@ -179,7 +180,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
 
     public func delete<M: Model>(_ modelType: M.Type,
                                  withIdentifier identifier: String,
-                                 where predicate: QueryPredicate?,
+                                 where predicate: QueryPredicate? = nil,
                                  completion: @escaping DataStoreCallback<Void>) where M: ModelIdentifiable,
                                                                                       M.IdentifierFormat == ModelIdentifierFormat.Default {
        deleteByIdentifier(modelType,
@@ -191,7 +192,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
 
     public func delete<M: Model>(_ modelType: M.Type,
                                  withIdentifier identifier: ModelIdentifier<M, M.IdentifierFormat>,
-                                 where predicate: QueryPredicate?,
+                                 where predicate: QueryPredicate? = nil,
                                  completion: @escaping DataStoreCallback<Void>) where M: ModelIdentifiable {
         deleteByIdentifier(modelType,
                            modelSchema: modelType.schema,


### PR DESCRIPTION
*Issue #, if available:*
Merging to: https://github.com/aws-amplify/amplify-ios/pull/1752

*Description of changes:*
Add default value for `where` predicate 
*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
