### PR TITLE
feat(datastore): Remove synchronous load from List

### DIFF
--- a/Amplify/Categories/DataStore/Model/Collection/List+Model.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+Model.swift
@@ -42,15 +42,11 @@ public class List<ModelType: Model>: Collection, Codable, ExpressibleByArrayLite
             case .loaded(let elements):
                 return elements
             case .notLoaded:
-                let result = listProvider.load()
-                switch result {
-                case .success(let elements):
-                    loadedState = .loaded(elements)
-                    return elements
-                case .failure(let error):
-                    Amplify.log.error(error: error)
-                    return []
-                }
+                let error: CoreError = .listOperation("Call `fetch` to lazy load the list before accessing `elements`",
+                                                      "",
+                                                      nil)
+                Amplify.log.error(error: error)
+                return []
             }
         }
         set {

--- a/Amplify/Categories/DataStore/Model/Collection/List+Model.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+Model.swift
@@ -42,10 +42,9 @@ public class List<ModelType: Model>: Collection, Codable, ExpressibleByArrayLite
             case .loaded(let elements):
                 return elements
             case .notLoaded:
-                let error: CoreError = .listOperation("Call `fetch` to lazy load the list before accessing `elements`",
-                                                      "",
-                                                      nil)
-                Amplify.log.error(error: error)
+                let message = "Call `fetch` to lazy load the list before accessing `elements`."
+                Amplify.log.error(message)
+                assertionFailure(message)
                 return []
             }
         }

--- a/Amplify/Categories/DataStore/Model/Collection/List+Pagination.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+Pagination.swift
@@ -17,15 +17,9 @@ extension List {
         case .loaded:
             return listProvider.hasNextPage()
         case .notLoaded:
-            let result = listProvider.load()
-            switch result {
-            case .success(let elements):
-                self.elements = elements
-                return listProvider.hasNextPage()
-            case .failure(let coreError):
-                Amplify.log.error(error: coreError)
-                return false
-            }
+            let error: CoreError = .listOperation("Call `fetch` to lazy load the list before using this method", "", nil)
+            Amplify.log.error(error: error)
+            return false
         }
     }
 
@@ -36,15 +30,9 @@ extension List {
         case .loaded:
             listProvider.getNextPage(completion: completion)
         case .notLoaded:
-            let result = listProvider.load()
-            switch result {
-            case .success(let elements):
-                self.elements = elements
-                listProvider.getNextPage(completion: completion)
-            case .failure(let coreError):
-                Amplify.log.error(error: coreError)
-                completion(.failure(coreError))
-            }
+            let error: CoreError = .listOperation("Call `fetch` to lazy load the list before using this method", "", nil)
+            Amplify.log.error(error: error)
+            completion(.failure(error))
         }
     }
 }

--- a/Amplify/Categories/DataStore/Model/Collection/List+Pagination.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+Pagination.swift
@@ -17,8 +17,9 @@ extension List {
         case .loaded:
             return listProvider.hasNextPage()
         case .notLoaded:
-            let error: CoreError = .listOperation("Call `fetch` to lazy load the list before using this method", "", nil)
-            Amplify.log.error(error: error)
+            let message = "Call `fetch` to lazy load the list before using this method."
+            Amplify.log.error(message)
+            assertionFailure(message)
             return false
         }
     }
@@ -30,8 +31,10 @@ extension List {
         case .loaded:
             listProvider.getNextPage(completion: completion)
         case .notLoaded:
-            let error: CoreError = .listOperation("Call `fetch` to lazy load the list before using this method", "", nil)
+            let message = "Call `fetch` to lazy load the list before using this method."
+            let error: CoreError = .listOperation(message, "", nil)
             Amplify.log.error(error: error)
+            assertionFailure(message)
             completion(.failure(error))
         }
     }

--- a/Amplify/Categories/DataStore/Model/Internal/ModelListProvider.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelListProvider.swift
@@ -23,9 +23,6 @@ public protocol ModelListMarker { }
 public protocol ModelListProvider {
     associatedtype Element: Model
 
-    /// Retrieve the array of `Element` from the data source.
-    func load() -> Result<[Element], CoreError>
-
     ///  Retrieve the array of `Element` from the data source asychronously.
     func load(completion: @escaping (Result<[Element], CoreError>) -> Void)
 
@@ -44,7 +41,6 @@ public protocol ModelListProvider {
 /// application making any change to these `public` types should be backward compatible, otherwise it will be a breaking
 /// change.
 public struct AnyModelListProvider<Element: Model>: ModelListProvider {
-    private let loadClosure: () -> Result<[Element], CoreError>
     private let loadWithCompletionClosure: (@escaping (Result<[Element], CoreError>) -> Void) -> Void
     private let hasNextPageClosure: () -> Bool
     private let getNextPageClosure: (@escaping (Result<List<Element>, CoreError>) -> Void) -> Void
@@ -52,15 +48,11 @@ public struct AnyModelListProvider<Element: Model>: ModelListProvider {
     public init<Provider: ModelListProvider>(
         provider: Provider
     ) where Provider.Element == Self.Element {
-        self.loadClosure = provider.load
         self.loadWithCompletionClosure = provider.load(completion:)
         self.hasNextPageClosure = provider.hasNextPage
         self.getNextPageClosure = provider.getNextPage(completion:)
     }
 
-    public func load() -> Result<[Element], CoreError> {
-        loadClosure()
-    }
 
     public func load(completion: @escaping (Result<[Element], CoreError>) -> Void) {
         loadWithCompletionClosure(completion)

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListProvider.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListProvider.swift
@@ -82,33 +82,6 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
 
     // MARK: APIs
 
-    public func load() -> Result<[Element], CoreError> {
-        switch loadedState {
-        case .loaded(let elements, _, _):
-            return .success(elements)
-        case .notLoaded(let associatedId, let associatedField):
-            let semaphore = DispatchSemaphore(value: 0)
-            var loadResult: Result<[Element], CoreError> = .failure(
-                .listOperation("API query failed to complete.",
-                               AmplifyErrorMessages.reportBugToAWS(),
-                               nil))
-            load(associatedId: associatedId, associatedField: associatedField) { result in
-                defer {
-                    semaphore.signal()
-                }
-                switch result {
-                case .success(let elements):
-                    loadResult = .success(elements)
-                case .failure(let error):
-                    Amplify.API.log.error(error: error)
-                    loadResult = .failure(error)
-                }
-            }
-            semaphore.wait()
-            return loadResult
-        }
-    }
-
     public func load(completion: @escaping (Result<[Element], CoreError>) -> Void) {
         switch loadedState {
         case .loaded(let elements, _, _):
@@ -206,7 +179,14 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
             case .success(let graphQLResponse):
                 switch graphQLResponse {
                 case .success(let nextPageList):
-                    completion(.success(nextPageList))
+                    nextPageList.fetch { fetchResult in
+                        switch fetchResult {
+                        case .success:
+                            completion(.success(nextPageList))
+                        case .failure(let error):
+                            completion(.failure(error))
+                        }
+                    }
                 case .failure(let graphQLError):
                     Amplify.API.log.error(error: graphQLError)
                     completion(.failure(.listOperation("""

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/ListTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/ListTests.swift
@@ -37,6 +37,11 @@ class ListTests: XCTestCase {
         ]
 
         let result = try decoder.decodeToResponseType(graphQLData)
-        XCTAssertEqual(result.count, 2)
+        let fetchCompleted = expectation(description: "Fetch completed")
+        result.fetch { _ in
+            XCTAssertEqual(result.count, 2)
+            fetchCompleted.fulfill()
+        }
+        wait(for: [fetchCompleted], timeout: 1)
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLResponseDecoder+DecodeDataTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLResponseDecoder+DecodeDataTests.swift
@@ -110,7 +110,12 @@ extension GraphQLResponseDecoderTests {
 
         let result = try decoder.decodeToResponseType(graphQLData)
         XCTAssertNotNil(result)
-        XCTAssertEqual(result.count, 2)
+        let fetchCompleted = expectation(description: "Fetch completed")
+        result.fetch { _ in
+            XCTAssertEqual(result.count, 2)
+            fetchCompleted.fulfill()
+        }
+        wait(for: [fetchCompleted], timeout: 1)
         XCTAssertFalse(result.hasNextPage())
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Core/DataStoreListProvider.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Core/DataStoreListProvider.swift
@@ -43,29 +43,6 @@ public class DataStoreListProvider<Element: Model>: ModelListProvider {
         self.loadedState = .loaded(elements)
     }
 
-    public func load() -> Result<[Element], CoreError> {
-        let semaphore = DispatchSemaphore(value: 0)
-        var loadResult: Result<[Element], CoreError> = .failure(
-            .listOperation("DataStore query failed to complete.",
-                           AmplifyErrorMessages.shouldNotHappenReportBugToAWS(),
-                           nil))
-        load { result in
-            defer {
-                semaphore.signal()
-            }
-            switch result {
-            case .success(let elements):
-                loadResult = .success(elements)
-            case .failure(let error):
-                Amplify.DataStore.log.error(error: error)
-                assertionFailure(error.errorDescription)
-                loadResult = .failure(error)
-            }
-        }
-        semaphore.wait()
-        return loadResult
-    }
-
     public func load(completion: (Result<[Element], CoreError>) -> Void) {
         switch loadedState {
         case .loaded(let elements):

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/DataStoreListProviderFunctionalTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/DataStoreListProviderFunctionalTests.swift
@@ -14,25 +14,6 @@ import XCTest
 
 class DataStoreListProviderFunctionalTests: BaseDataStoreTests {
 
-    func testDataStoreListProviderWithAssociationDataShouldLoad() {
-        let postId = preparePost4DataForTest()
-        let provider = DataStoreListProvider<Comment4>(associatedId: postId, associatedField: "post")
-        guard case .notLoaded = provider.loadedState else {
-            XCTFail("Should not be loaded")
-            return
-        }
-        let results = provider.load()
-        guard case .loaded = provider.loadedState else {
-            XCTFail("Should be loaded")
-            return
-        }
-        guard case .success(let comments) = results else {
-            XCTFail("Should be .success")
-            return
-        }
-        XCTAssertEqual(comments.count, 2)
-    }
-
     func testDataStoreListProviderWithAssociationDataShouldLoadWithCompletion() {
         let postId = preparePost4DataForTest()
         let provider = DataStoreListProvider<Comment4>(associatedId: postId, associatedField: "post")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/ListTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/ListTests.swift
@@ -16,46 +16,6 @@ class ListTests: BaseDataStoreTests {
 
     /// - Given: a list a `Post` and a few comments associated with it
     /// - When:
-    ///   - the `post.comments` is accessed synchronously
-    /// - Then:
-    ///   - the list should be correctly loaded and populated
-    func testSynchronousLazyLoad() {
-        let expect = expectation(description: "a lazy list should return the correct results")
-
-        let postId = preparePostDataForTest()
-
-        Amplify.DataStore.query(Post.self, byId: postId) {
-            switch $0 {
-            case .success(let result):
-                if let post = result {
-                    if let comments = post.comments {
-                        guard case .notLoaded = comments.loadedState else {
-                            XCTFail("Should not be loaded")
-                            return
-                        }
-                        XCTAssertEqual(comments.count, 2)
-                        guard case .loaded = comments.loadedState else {
-                            XCTFail("Should be loaded")
-                            return
-                        }
-                    } else {
-                        XCTFail("post.comments should not be nil")
-                    }
-                } else {
-                    XCTFail("Failed to query recently saved post by id")
-                }
-                expect.fulfill()
-            case .failure(let error):
-                XCTFail(error.errorDescription)
-                expect.fulfill()
-            }
-        }
-
-        wait(for: [expect], timeout: 1)
-    }
-
-    /// - Given: a list a `Post` and a few comments associated with it
-    /// - When:
     ///   - the `post.comments` is accessed asynchronously with a callback
     /// - Then:
     ///   - the list should be correctly loaded and populated

--- a/AmplifyTests/CategoryTests/DataStore/Model/ListPaginationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/Model/ListPaginationTests.swift
@@ -74,6 +74,16 @@ extension ListTests {
             XCTFail("Should not be loaded")
             return
         }
+        let fetchCompleted = expectation(description: "Fetch completed")
+        list.fetch { result in
+            switch result {
+            case .success:
+                fetchCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("Failed with error \(error)")
+            }
+        }
+        wait(for: [fetchCompleted], timeout: 1)
         XCTAssertTrue(list.hasNextPage())
         guard case .loaded = list.loadedState else {
             XCTFail("Should be loaded")
@@ -105,6 +115,16 @@ extension ListTests {
             XCTFail("Should not be loaded")
             return
         }
+        let fetchCompleted = expectation(description: "Fetch completed")
+        list.fetch { result in
+            switch result {
+            case .success:
+                fetchCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("Failed with error \(error)")
+            }
+        }
+        wait(for: [fetchCompleted], timeout: 1)
         let getNextPageComplete = expectation(description: "get next page completed")
         list.getNextPage { result in
             switch result {

--- a/AmplifyTests/CategoryTests/DataStore/Model/ListTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/Model/ListTests.swift
@@ -56,14 +56,6 @@ class ListTests: XCTestCase {
             self.nextPage = nextPage
         }
 
-        public func load() -> Result<[Element], CoreError> {
-            if let error = error {
-                return .failure(error)
-            } else {
-                return .success(elements)
-            }
-        }
-
         public func load(completion: (Result<[Element], CoreError>) -> Void) {
             if let error = error {
                 completion(.failure(error))
@@ -103,6 +95,16 @@ class ListTests: XCTestCase {
 
         let serializedData = try ListTests.encode(json: data)
         let list = try ListTests.decode(serializedData, responseType: BasicModel.self)
+        let fetchCompleted = expectation(description: "Fetch completed")
+        list.fetch { result in
+            switch result {
+            case .success:
+                fetchCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("Failed with error \(error)")
+            }
+        }
+        wait(for: [fetchCompleted], timeout: 1)
         XCTAssertEqual(list.count, 2)
         XCTAssertEqual(list.startIndex, 0)
         XCTAssertEqual(list.endIndex, 2)
@@ -130,6 +132,16 @@ class ListTests: XCTestCase {
         let serializedData = try ListTests.encode(json: data)
         let list = try ListTests.decode(serializedData, responseType: BasicModel.self)
         XCTAssertNotNil(list)
+        let fetchCompleted = expectation(description: "Fetch completed")
+        list.fetch { result in
+            switch result {
+            case .success:
+                fetchCompleted.fulfill()
+            case .failure(let error):
+                XCTFail("Failed with error \(error)")
+            }
+        }
+        wait(for: [fetchCompleted], timeout: 1)
         XCTAssertEqual(list.count, 2)
         XCTAssertEqual(list.startIndex, 0)
         XCTAssertEqual(list.endIndex, 2)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This removes the behavior of implicitly lazy loading elements from the list when accessed, and requires explicit `fetch` call to be made access the elements.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
