### PR TITLE
Implements async API AmplifyInProcessReportingOperation for use with Storage and any InProcessReporting operation

### DIFF
--- a/Amplify/Categories/Storage/StorageCategory+Async.swift
+++ b/Amplify/Categories/Storage/StorageCategory+Async.swift
@@ -1,0 +1,49 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension StorageCategory {
+
+    public func getURL(key: String,
+                options: StorageGetURLOperation.Request.Options?) async throws -> StorageGetURLOperation.Success {
+        try await plugin.getURL(key: key, options: options)
+    }
+
+    public func downloadData(key: String,
+                      options: StorageDownloadDataOperation.Request.Options?) async throws -> StorageDownloadDataOperation {
+        try await plugin.downloadData(key: key, options: options)
+    }
+
+    public func downloadFile(key: String,
+                      local: URL,
+                      options: StorageDownloadFileOperation.Request.Options?) async throws -> StorageDownloadFileOperation {
+        try await plugin.downloadFile(key: key, local: local, options: options)
+    }
+
+    public func uploadData(key: String,
+                    data: Data,
+                    options: StorageUploadDataOperation.Request.Options?) async throws -> StorageUploadDataOperation {
+        try await plugin.uploadData(key: key, data: data, options: options)
+    }
+
+    public func uploadFile(key: String,
+                    local: URL,
+                    options: StorageUploadFileOperation.Request.Options?) async throws -> StorageUploadFileOperation {
+        try await plugin.uploadFile(key: key, local: local, options: options)
+    }
+
+    public func remove(key: String,
+                options: StorageRemoveOperation.Request.Options?) async throws -> StorageRemoveOperation.Success {
+        try await plugin.remove(key: key, options: options)
+    }
+
+    public func list(options: StorageListOperation.Request.Options?) async throws -> StorageListOperation.Success {
+        try await plugin.list(options: options)
+    }
+
+}

--- a/Amplify/Categories/Storage/StorageCategoryBehavior.swift
+++ b/Amplify/Categories/Storage/StorageCategoryBehavior.swift
@@ -16,6 +16,7 @@ public protocol StorageCategoryBehavior {
     ///   - options: Parameters to specific plugin behavior
     ///   - resultListener: Triggered when the operation is complete
     /// - Returns: An operation object that provides notifications and actions related to the execution of the work
+    @available(*, deprecated, message: "Use async alternative")
     @discardableResult
     func getURL(key: String,
                 options: StorageGetURLOperation.Request.Options?,
@@ -29,6 +30,7 @@ public protocol StorageCategoryBehavior {
     ///   - progressListener: Triggered intermittently to represent the ongoing progress of this operation
     ///   - resultListener: Triggered when the download is complete
     /// - Returns: An operation object that provides notifications and actions related to the execution of the work
+    @available(*, deprecated, message: "Use async alternative")
     @discardableResult
     func downloadData(key: String,
                       options: StorageDownloadDataOperation.Request.Options?,
@@ -44,6 +46,7 @@ public protocol StorageCategoryBehavior {
     ///   - progressListener: Triggered intermittently to represent the ongoing progress of this operation
     ///   - resultListener: Triggered when the download is complete
     /// - Returns: An operation object that provides notifications and actions related to the execution of the work
+    @available(*, deprecated, message: "Use async alternative")
     @discardableResult
     func downloadFile(key: String,
                       local: URL,
@@ -60,6 +63,7 @@ public protocol StorageCategoryBehavior {
     ///   - progressListener: Triggered intermittently to represent the ongoing progress of this operation
     ///   - resultListener: Triggered when the upload is complete
     /// - Returns: An operation object that provides notifications and actions related to the execution of the work
+    @available(*, deprecated, message: "Use async alternative")
     @discardableResult
     func uploadData(key: String,
                     data: Data,
@@ -76,6 +80,7 @@ public protocol StorageCategoryBehavior {
     ///   - progressListener: Triggered intermittently to represent the ongoing progress of this operation
     ///   - resultListener: Triggered when the upload is complete
     /// - Returns: An operation object that provides notifications and actions related to the execution of the work
+    @available(*, deprecated, message: "Use async alternative")
     @discardableResult
     func uploadFile(key: String,
                     local: URL,
@@ -90,6 +95,7 @@ public protocol StorageCategoryBehavior {
     ///   - options: Parameters to specific plugin behavior
     ///   - resultListener: Triggered when the remove is complete
     /// - Returns: An operation object that provides notifications and actions related to the execution of the work
+    @available(*, deprecated, message: "Use async alternative")
     @discardableResult
     func remove(key: String,
                 options: StorageRemoveOperation.Request.Options?,
@@ -101,7 +107,76 @@ public protocol StorageCategoryBehavior {
     ///   - options: Parameters to specific plugin behavior
     ///   - resultListener: Triggered when the list is complete
     /// - Returns: An operation object that provides notifications and actions related to the execution of the work
+    @available(*, deprecated, message: "Use async alternative")
     @discardableResult
     func list(options: StorageListOperation.Request.Options?,
               resultListener: StorageListOperation.ResultListener?) -> StorageListOperation
+
+    /// Retrieve the remote URL for the object from storage.
+    ///
+    /// - Parameters:
+    ///   - key: The unique identifier for the object in storage.
+    ///   - options: Parameters to specific plugin behavior
+    /// - Returns: The URL
+    func getURL(key: String,
+                options: StorageGetURLOperation.Request.Options?) async throws -> StorageGetURLOperation.Success
+
+    /// Retrieve the object from storage into memory.
+    ///
+    /// - Parameters:
+    ///   - key: The unique identifier for the object in storage
+    ///   - options: Options to adjust the behavior of this request, including plugin-options
+    /// - Returns: An operation object that provides notifications and actions related to the execution of the work
+    func downloadData(key: String,
+                      options: StorageDownloadDataOperation.Request.Options?) async throws -> StorageDownloadDataOperation
+
+    /// Download to file the object from storage.
+    ///
+    /// - Parameters:
+    ///   - key: The unique identifier for the object in storage.
+    ///   - local: The local file to download the object to.
+    ///   - options: Parameters to specific plugin behavior
+    /// - Returns: An operation object that provides notifications and actions related to the execution of the work
+    func downloadFile(key: String,
+                      local: URL,
+                      options: StorageDownloadFileOperation.Request.Options?) async throws -> StorageDownloadFileOperation
+
+    /// Upload data to storage
+    ///
+    /// - Parameters:
+    ///   - key: The unique identifier of the object in storage.
+    ///   - data: The data in memory to be uploaded
+    ///   - options: Parameters to specific plugin behavior
+    /// - Returns: An operation object that provides notifications and actions related to the execution of the work
+    func uploadData(key: String,
+                    data: Data,
+                    options: StorageUploadDataOperation.Request.Options?) async throws -> StorageUploadDataOperation
+
+    /// Upload local file to storage
+    ///
+    /// - Parameters:
+    ///   - key: The unique identifier of the object in storage.
+    ///   - local: The path to a local file.
+    ///   - options: Parameters to specific plugin behavior
+    /// - Returns: An operation object that provides notifications and actions related to the execution of the work
+    func uploadFile(key: String,
+                    local: URL,
+                    options: StorageUploadFileOperation.Request.Options?) async throws -> StorageUploadFileOperation
+
+    /// Delete object from storage
+    ///
+    /// - Parameters:
+    ///   - key: The unique identifier of the object in storage.
+    ///   - options: Parameters to specific plugin behavior
+    /// - Returns: Key of object which was deleted
+    func remove(key: String,
+                options: StorageRemoveOperation.Request.Options?) async throws -> StorageRemoveOperation.Success
+
+    /// List the object identifiers under the heiarchy specified by the path, relative to access level, from storage
+    ///
+    /// - Parameters:
+    ///   - options: Parameters to specific plugin behavior
+    /// - Returns: List of keys
+    func list(options: StorageListOperation.Request.Options?) async throws -> StorageListOperation.Success
+
 }

--- a/Amplify/Core/Support/AsyncChannel.swift
+++ b/Amplify/Core/Support/AsyncChannel.swift
@@ -1,0 +1,88 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public actor AsyncChannel<Element: Sendable>: AsyncSequence {
+    public struct Iterator: AsyncIteratorProtocol, Sendable {
+        private let channel: AsyncChannel<Element>
+
+        public init(_ channel: AsyncChannel<Element>) {
+            self.channel = channel
+        }
+
+        public mutating func next() async -> Element? {
+            await channel.next()
+        }
+    }
+
+    public enum InternalFailure: Error {
+        case cannotSendAfterTerminated
+    }
+    public typealias ChannelContinuation = CheckedContinuation<Element?, Never>
+
+    private var continuations: [ChannelContinuation] = []
+    private var elements: [Element] = []
+    private var terminated: Bool = false
+
+    private var hasNext: Bool {
+        !continuations.isEmpty && !elements.isEmpty
+    }
+
+    private var canTerminate: Bool {
+        terminated && elements.isEmpty && !continuations.isEmpty
+    }
+
+    public init() {
+    }
+
+    public nonisolated func makeAsyncIterator() -> Iterator {
+        Iterator(self)
+    }
+
+    public func next() async -> Element? {
+        await withCheckedContinuation { (continuation: ChannelContinuation) in
+            continuations.append(continuation)
+            processNext()
+        }
+    }
+
+    public func send(_ element: Element) throws {
+        guard !terminated else {
+            throw InternalFailure.cannotSendAfterTerminated
+        }
+        elements.append(element)
+        processNext()
+    }
+
+    public func finish() {
+        terminated = true
+        processNext()
+    }
+
+    private func processNext() {
+        if canTerminate {
+            let contination = continuations.removeFirst()
+            assert(continuations.isEmpty)
+            assert(elements.isEmpty)
+            contination.resume(returning: nil)
+            return
+        }
+
+        guard hasNext else {
+            return
+        }
+
+        assert(!continuations.isEmpty)
+        assert(!elements.isEmpty)
+
+        let contination = continuations.removeFirst()
+        let element = elements.removeFirst()
+
+        contination.resume(returning: element)
+    }
+}

--- a/Amplify/Core/Support/AsyncThrowingChannel.swift
+++ b/Amplify/Core/Support/AsyncThrowingChannel.swift
@@ -1,0 +1,110 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public actor AsyncThrowingChannel<Element: Sendable, Failure: Error>: AsyncSequence {
+    public struct Iterator: AsyncIteratorProtocol, Sendable {
+        private let channel: AsyncThrowingChannel<Element, Failure>
+
+        public init(_ channel: AsyncThrowingChannel<Element, Failure>) {
+            self.channel = channel
+        }
+
+        public mutating func next() async throws -> Element? {
+            try await channel.next()
+        }
+    }
+
+    public enum InternalFailure: Error {
+        case cannotSendAfterTerminated
+    }
+    public typealias ChannelContinuation = CheckedContinuation<Element?, Error>
+
+    private var continuations: [ChannelContinuation] = []
+    private var elements: [Element] = []
+    private var terminated: Bool = false
+    private var error: Error? = nil
+
+    private var hasNext: Bool {
+        !continuations.isEmpty && !elements.isEmpty
+    }
+
+    private var canFail: Bool {
+        error != nil && !continuations.isEmpty
+    }
+
+    private var canTerminate: Bool {
+        terminated && elements.isEmpty && !continuations.isEmpty
+    }
+
+    public init() {
+    }
+
+    public nonisolated func makeAsyncIterator() -> Iterator {
+        Iterator(self)
+    }
+
+    public func next() async throws -> Element? {
+        try await withCheckedThrowingContinuation { (continuation: ChannelContinuation) in
+            continuations.append(continuation)
+            processNext()
+        }
+    }
+
+    public func send(_ element: Element) throws {
+        guard !terminated else {
+            throw InternalFailure.cannotSendAfterTerminated
+        }
+        elements.append(element)
+        processNext()
+    }
+
+
+    public func fail(_ error: Error) where Failure == Error {
+        self.error = error
+        processNext()
+    }
+
+    public func finish() {
+        terminated = true
+        processNext()
+    }
+
+    private func processNext() {
+        if canFail {
+            let contination = continuations.removeFirst()
+            assert(continuations.isEmpty)
+            assert(elements.isEmpty)
+            assert(error != nil)
+            if let error = error {
+                contination.resume(throwing: error)
+                return
+            }
+        }
+
+        if canTerminate {
+            let contination = continuations.removeFirst()
+            assert(continuations.isEmpty)
+            assert(elements.isEmpty)
+            contination.resume(returning: nil)
+            return
+        }
+
+        guard hasNext else {
+            return
+        }
+
+        assert(!continuations.isEmpty)
+        assert(!elements.isEmpty)
+
+        let contination = continuations.removeFirst()
+        let element = elements.removeFirst()
+
+        contination.resume(returning: element)
+    }
+}

--- a/Amplify/Core/Support/Task+Seconds.swift
+++ b/Amplify/Core/Support/Task+Seconds.swift
@@ -1,0 +1,15 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Task where Success == Never, Failure == Never {
+    static func sleep(seconds: Double) async throws {
+        let nanoseconds = UInt64(seconds * Double(NSEC_PER_SEC))
+        try await Task.sleep(nanoseconds: nanoseconds)
+    }
+}

--- a/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin+Async.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePlugin/AWSS3StoragePlugin+Async.swift
@@ -1,0 +1,151 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+import AWSS3
+import Amplify
+import AWSPluginsCore
+
+extension AWSS3StoragePlugin {
+
+    public func getURL(key: String,
+                       options: StorageGetURLOperation.Request.Options?) async throws -> StorageGetURLOperation.Success {
+        try await withCheckedThrowingContinuation { continuation in
+            let options = options ?? StorageGetURLRequest.Options()
+            let request = StorageGetURLRequest(key: key, options: options)
+            let operation = AWSS3StorageGetURLOperation(request,
+                                                        storageConfiguration: storageConfiguration,
+                                                        storageService: storageService,
+                                                        authService: authService) { result in
+                switch result {
+                case .success(let success):
+                    continuation.resume(returning: success)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+
+            }
+
+            self.queue.addOperation(operation)
+        }
+    }
+
+    public func downloadData(key: String,
+                             options: StorageDownloadDataOperation.Request.Options?) async throws -> StorageDownloadDataOperation {
+        let options = options ?? StorageDownloadDataRequest.Options()
+        let request = StorageDownloadDataRequest(key: key, options: options)
+        let operation = AWSS3StorageDownloadDataOperation(request,
+                                                          storageConfiguration: storageConfiguration,
+                                                          storageService: storageService,
+                                                          authService: authService,
+                                                          progressListener: nil,
+                                                          resultListener: nil)
+
+        queue.addOperation(operation)
+
+        return operation
+    }
+
+    public func downloadFile(key: String,
+                             local: URL,
+                             options: StorageDownloadFileOperation.Request.Options?) async throws -> StorageDownloadFileOperation {
+        let options = options ?? StorageDownloadFileRequest.Options()
+        let request = StorageDownloadFileRequest(key: key, local: local, options: options)
+        let operation = AWSS3StorageDownloadFileOperation(request,
+                                                          storageConfiguration: storageConfiguration,
+                                                          storageService: storageService,
+                                                          authService: authService,
+                                                          progressListener: nil,
+                                                          resultListener: nil)
+
+        queue.addOperation(operation)
+
+        return operation
+    }
+
+    public func uploadData(key: String,
+                           data: Data,
+                           options: StorageUploadDataOperation.Request.Options?) async throws -> StorageUploadDataOperation {
+        let options = options ?? StorageUploadDataRequest.Options()
+        let request = StorageUploadDataRequest(key: key, data: data, options: options)
+
+        let operation = AWSS3StorageUploadDataOperation(request,
+                                                        storageConfiguration: storageConfiguration,
+                                                        storageService: storageService,
+                                                        authService: authService,
+                                                        progressListener: nil,
+                                                        resultListener: nil)
+
+        queue.addOperation(operation)
+
+        return operation
+    }
+
+    public func uploadFile(key: String,
+                           local: URL,
+                           options: StorageUploadFileOperation.Request.Options?) async throws -> StorageUploadFileOperation {
+
+        let options = options ?? StorageUploadFileRequest.Options()
+        let request = StorageUploadFileRequest(key: key, local: local, options: options)
+
+        let operation = AWSS3StorageUploadFileOperation(request,
+                                                        storageConfiguration: storageConfiguration,
+                                                        storageService: storageService,
+                                                        authService: authService,
+                                                        progressListener: nil,
+                                                        resultListener: nil)
+
+        queue.addOperation(operation)
+
+        return operation
+    }
+
+    public func remove(key: String,
+                       options: StorageRemoveOperation.Request.Options?) async throws -> StorageRemoveOperation.Success {
+        try await withCheckedThrowingContinuation { continuation in
+            let options = options ?? StorageRemoveRequest.Options()
+            let request = StorageRemoveRequest(key: key, options: options)
+            let operation = AWSS3StorageRemoveOperation(request,
+                                                        storageConfiguration: storageConfiguration,
+                                                        storageService: storageService,
+                                                        authService: authService) { result in
+                switch result {
+                case .success(let success):
+                    continuation.resume(returning: success)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+
+            }
+
+            self.queue.addOperation(operation)
+        }
+    }
+
+    public func list(options: StorageListOperation.Request.Options?) async throws -> StorageListOperation.Success {
+        try await withCheckedThrowingContinuation { continuation in
+            let options = options ?? StorageListRequest.Options()
+            let request = StorageListRequest(options: options)
+            let operation = AWSS3StorageListOperation(request,
+                                                          storageConfiguration: storageConfiguration,
+                                                          storageService: storageService,
+                                                          authService: authService) { result in
+                switch result {
+                case .success(let success):
+                    continuation.resume(returning: success)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+
+            }
+            self.queue.addOperation(operation)
+        }
+
+    }
+
+}

--- a/AmplifyTests/CoreTests/AsyncChannelTests.swift
+++ b/AmplifyTests/CoreTests/AsyncChannelTests.swift
@@ -1,0 +1,215 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+
+final class AsyncChannelTests: XCTestCase {
+    enum Failure: Error {
+        case unluckyNumber
+    }
+    let sleepSeconds = 0.1
+
+    func testNumberSequence() async throws {
+        let input = [1, 2, 3, 4, 5]
+        let channel = AsyncChannel<Int>()
+
+        // load all numbers into the channel with delays
+        Task {
+            try await send(elements: input, channel: channel, sleepSeconds: sleepSeconds)
+        }
+
+        var output: [Int] = []
+
+        print("-- before --")
+        for await element in channel {
+            print(element)
+            output.append(element)
+        }
+        print("-- after --")
+
+        XCTAssertEqual(input, output)
+    }
+
+    func testStringSequence() async throws {
+        let input = ["one", "two", "three", "four", "five"]
+        let channel = AsyncChannel<String>()
+
+        // load all strings into the channel with delays
+        Task {
+            try await send(elements: input, channel: channel, sleepSeconds: sleepSeconds)
+        }
+
+        var output: [String] = []
+
+        print("-- before --")
+        for await element in channel {
+            print(element)
+            output.append(element)
+        }
+        print("-- after --")
+
+        XCTAssertEqual(input, output)
+    }
+
+    func testSendAfterFinishing() async throws {
+        let input = ["a", "b", "c"]
+        let channel = AsyncChannel<String>()
+
+        // load all strings into the channel with delays
+        Task {
+            try await send(elements: input, channel: channel, sleepSeconds: sleepSeconds)
+            var thrown: Error? = nil
+            do {
+                try await channel.send("z")
+            } catch {
+                thrown = error
+            }
+            XCTAssertNotNil(thrown)
+        }
+
+        var output: [String] = []
+
+        print("-- before --")
+        for await element in channel {
+            print(element)
+            output.append(element)
+        }
+        print("-- after --")
+
+        XCTAssertEqual(input, output)
+    }
+
+    func testSendAfterFinishingThrowing() async throws {
+        let input = ["x", "y", "z"]
+        let channel = AsyncThrowingChannel<String, Error>()
+
+        // load all strings into the channel with delays
+        Task {
+            try await send(elements: input, channel: channel, sleepSeconds: sleepSeconds)
+            var thrown: Error? = nil
+            do {
+                try await channel.send("a")
+            } catch {
+                thrown = error
+            }
+            XCTAssertNotNil(thrown)
+        }
+
+        var output: [String] = []
+
+        print("-- before --")
+        for try await element in channel {
+            print(element)
+            output.append(element)
+        }
+        print("-- after --")
+
+        XCTAssertEqual(input, output)
+    }
+
+    func testSucceedingSequence() async throws {
+        let input = [3, 7, 14, 21]
+        let channel = AsyncThrowingChannel<Int, Error>()
+
+        // load all numbers into the channel with delays
+        Task {
+            try await send(elements: input, channel: channel, sleepSeconds: sleepSeconds) { element in
+                if element == 13 {
+                    throw Failure.unluckyNumber
+                } else {
+                    return element
+                }
+            }
+        }
+
+        var output: [Int] = []
+        var thrown: Error? = nil
+
+        print("-- before --")
+        do {
+            for try await element in channel {
+                print(element)
+                output.append(element)
+            }
+        } catch {
+            thrown = error
+        }
+        print("-- after --")
+
+        XCTAssertNil(thrown)
+        XCTAssertEqual(input, output)
+    }
+
+    func testFailingSequence() async throws {
+        let input = [3, 7, 13, 21]
+        let channel = AsyncThrowingChannel<Int, Error>()
+
+        // load all numbers into the channel with delays
+        Task {
+            try await send(elements: input, channel: channel, sleepSeconds: sleepSeconds) { element in
+                if element == 13 {
+                    throw Failure.unluckyNumber
+                } else {
+                    return element
+                }
+            }
+        }
+
+        var output: [Int] = []
+        var thrown: Error? = nil
+
+        print("-- before --")
+        do {
+            for try await element in channel {
+                print(element)
+                output.append(element)
+            }
+        } catch {
+            thrown = error
+        }
+        print("-- after --")
+
+        XCTAssertNotNil(thrown)
+        let expected = Array(input[0..<2])
+        XCTAssertEqual(expected, output)
+    }
+
+    private func send<Element>(elements: [Element], channel: AsyncChannel<Element>, sleepSeconds: Double = 0.1) async throws {
+        var index = 0
+        while index < elements.count {
+            try await Task.sleep(seconds: sleepSeconds)
+            let element = elements[index]
+            try await channel.send(element)
+
+            index += 1
+        }
+        await channel.finish()
+    }
+
+    private func send<Element>(elements: [Element], channel: AsyncThrowingChannel<Element, Error>, sleepSeconds: Double = 0.1, processor: ((Element) throws -> Element)? = nil) async throws {
+        var index = 0
+        while index < elements.count {
+            try await Task.sleep(seconds: sleepSeconds)
+            let element = elements[index]
+            if let processor = processor {
+                do {
+                    let processed = try processor(element)
+                    try await channel.send(processed)
+                } catch {
+                    print("throwing \(error)")
+                    await channel.fail(error)
+                }
+            } else {
+                try await channel.send(element)
+            }
+
+            index += 1
+        }
+        await channel.finish()
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

#2056

*Description of changes:*

The code below will not work with any instance of `AmplifyInProcessReportingOperation` which will report using the generic types for InProcess, Success and Failure.

```swift
for try await element in operation.sequence {
    switch element {
    case .inProcess(let progress):
        print("Progress: \(progress)")
    case .success(let success):
        print("Success: \(success)")
    case .failure(let error):
        print("Error: \(error)")
    }
}
```

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
