### PR TITLE
fix(api): remove consumers of deprecated auth methods from API plugin

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
@@ -487,16 +487,6 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AWSPinpointAnalyticsPluginIntegrationTests"
-               BuildableName = "AWSPinpointAnalyticsPluginIntegrationTests"
-               BlueprintName = "AWSPinpointAnalyticsPluginIntegrationTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "AWSAPIPluginFunctionalTests"
                BuildableName = "AWSAPIPluginFunctionalTests"
                BlueprintName = "AWSAPIPluginFunctionalTests"

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
@@ -33,4 +33,8 @@ class AuthTokenProviderWrapper: AuthTokenProvider {
     func getUserPoolAccessToken() async throws -> String {
         try await wrappedAuthTokenProvider.getUserPoolAccessToken()
     }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        try await wrappedAuthTokenProvider.getUserPoolAccessToken()
+    }
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
@@ -33,8 +33,4 @@ class AuthTokenProviderWrapper: AuthTokenProvider {
     func getUserPoolAccessToken() async throws -> String {
         try await wrappedAuthTokenProvider.getUserPoolAccessToken()
     }
-    
-    func getUserPoolAccessToken() async throws -> String {
-        try await wrappedAuthTokenProvider.getUserPoolAccessToken()
-    }
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/OIDCAuthProviderWrapper.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/OIDCAuthProviderWrapper.swift
@@ -9,7 +9,7 @@ import Amplify
 import Foundation
 import AppSyncRealTimeClient
 
-class OIDCAuthProviderWrapper: OIDCAuthProvider {
+class OIDCAuthProviderWrapper: OIDCAuthProviderAsync {
 
     let authTokenProvider: AmplifyAuthTokenProvider
 
@@ -17,7 +17,7 @@ class OIDCAuthProviderWrapper: OIDCAuthProvider {
         self.authTokenProvider = authTokenProvider
     }
 
-    func getLatestAuthToken() -> Result<String, Error> {
-        return authTokenProvider.getLatestAuthToken()
+    func getLatestAuthToken() async throws -> String {
+        try await authTokenProvider.getUserPoolAccessToken()
     }
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift
@@ -9,7 +9,7 @@ import Foundation
 import AWSPluginsCore
 import AppSyncRealTimeClient
 
-class AWSOIDCAuthProvider: OIDCAuthProvider {
+class AWSOIDCAuthProvider: OIDCAuthProviderAsync {
 
     var authService: AWSAuthServiceBehavior
 
@@ -17,12 +17,7 @@ class AWSOIDCAuthProvider: OIDCAuthProvider {
         self.authService = authService
     }
 
-    func getLatestAuthToken() -> Result<String, Error> {
-        switch authService.getToken() {
-        case .success(let token):
-            return .success(token)
-        case .failure(let authError):
-            return .failure(authError)
-        }
+    func getLatestAuthToken() async throws -> String {
+        try await authService.getUserPoolAccessToken()
     }
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AWSSubscriptionConnectionFactory.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AWSSubscriptionConnectionFactory.swift
@@ -72,7 +72,7 @@ class AWSSubscriptionConnectionFactory: SubscriptionConnectionFactory {
             authInterceptor = APIKeyAuthInterceptor(apiKeyConfiguration.apiKey)
         case .amazonCognitoUserPools:
             let provider = AWSOIDCAuthProvider(authService: authService)
-            authInterceptor = OIDCAuthInterceptor(provider)
+            authInterceptor = OIDCAuthInterceptorAsync(provider)
         case .awsIAM(let awsIAMConfiguration):
             authInterceptor = IAMAuthInterceptor(authService.getCredentialsProvider(),
                                                  region: awsIAMConfiguration.region)
@@ -83,7 +83,7 @@ class AWSSubscriptionConnectionFactory: SubscriptionConnectionFactory {
                     "When instantiating AWSAPIPlugin pass in an instance of APIAuthProvider", nil)
             }
             let wrappedProvider = OIDCAuthProviderWrapper(authTokenProvider: oidcAuthProvider)
-            authInterceptor = OIDCAuthInterceptor(wrappedProvider)
+            authInterceptor = OIDCAuthInterceptorAsync(wrappedProvider)
         case .function:
             guard let functionAuthProvider = apiAuthProviderFactory.functionAuthProvider() else {
                 throw APIError.invalidConfiguration(

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -131,6 +131,10 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
         func getUserPoolAccessToken() async throws -> String {
             "token"
         }
+        
+        func getUserPoolAccessToken() async throws -> String {
+            "token"
+        }
     }
 
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -124,9 +124,6 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
     }
 
     struct MockTokenProvider: AuthTokenProvider {
-        func getToken() -> Result<String, AuthError> {
-            .success("token")
-        }
         
         func getUserPoolAccessToken() async throws -> String {
             "token"

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -128,10 +128,6 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
         func getUserPoolAccessToken() async throws -> String {
             "token"
         }
-        
-        func getUserPoolAccessToken() async throws -> String {
-            "token"
-        }
     }
 
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -33,10 +33,6 @@ class AuthTokenURLRequestInterceptorTests: XCTestCase {
 extension AuthTokenURLRequestInterceptorTests {
     class MockTokenProvider: AuthTokenProvider {
         let authorizationToken = "authorizationToken"
-
-        func getToken() -> Result<String, AuthError> {
-            .success(authorizationToken)
-        }
         
         func getUserPoolAccessToken() async throws -> String {
             authorizationToken

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -37,9 +37,5 @@ extension AuthTokenURLRequestInterceptorTests {
         func getUserPoolAccessToken() async throws -> String {
             authorizationToken
         }
-        
-        func getUserPoolAccessToken() async throws -> String {
-            authorizationToken
-        }
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -41,5 +41,9 @@ extension AuthTokenURLRequestInterceptorTests {
         func getUserPoolAccessToken() async throws -> String {
             authorizationToken
         }
+        
+        func getUserPoolAccessToken() async throws -> String {
+            authorizationToken
+        }
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
@@ -36,6 +36,7 @@ class AuthenticationTokenAuthInterceptorTests: XCTestCase {
 private class TestAuthTokenProvider: AmplifyAuthTokenProvider {
     let authToken = "token"
     
+    // TODO: Remove this after datastore dependencies are removed.
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         .success(authToken)
     }
@@ -51,6 +52,8 @@ private class TestAuthTokenProvider: AmplifyAuthTokenProvider {
 
 private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
     let authToken = "token"
+    
+    // TODO: Remove this after datastore dependencies are removed.
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         let error = APIError.networkError("Token error")
         return .failure(error)

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
@@ -44,10 +44,6 @@ private class TestAuthTokenProvider: AmplifyAuthTokenProvider {
     func getUserPoolAccessToken() async throws -> String {
         authToken
     }
-    
-    func getUserPoolAccessToken() async throws -> String {
-        authToken
-    }
 }
 
 private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
@@ -57,10 +53,6 @@ private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         let error = APIError.networkError("Token error")
         return .failure(error)
-    }
-    
-    func getUserPoolAccessToken() async throws -> String {
-        authToken
     }
     
     func getUserPoolAccessToken() async throws -> String {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
@@ -43,6 +43,10 @@ private class TestAuthTokenProvider: AmplifyAuthTokenProvider {
     func getUserPoolAccessToken() async throws -> String {
         authToken
     }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        authToken
+    }
 }
 
 private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
@@ -50,6 +54,10 @@ private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         let error = APIError.networkError("Token error")
         return .failure(error)
+    }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        authToken
     }
     
     func getUserPoolAccessToken() async throws -> String {

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
@@ -36,6 +36,7 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
         return .success(identityId ?? "IdentityId")
     }
 
+    //TODO: Remove this after datastore dependencies are removed.
     public func getToken() -> Result<String, AuthError> {
         .success("")
     }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
@@ -52,10 +52,6 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
     public func getUserPoolAccessToken() async throws -> String {
         ""
     }
-    
-    public func getUserPoolAccessToken() async throws -> String {
-        ""
-    }
 
     public func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
         if let error = getTokenClaimsError {

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
@@ -51,6 +51,10 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
     public func getUserPoolAccessToken() async throws -> String {
         ""
     }
+    
+    public func getUserPoolAccessToken() async throws -> String {
+        ""
+    }
 
     public func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
         if let error = getTokenClaimsError {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -139,9 +139,6 @@ public class AWSAuthService: AWSAuthServiceBehavior {
      `IncomingAsyncSubscriptionEventPublisher`
         - File Path: `AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift`
         - Uses: `getToken()`
-     `AWSOIDCAuthProvider`
-        - File Path: `AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift`
-        - Uses: `getToken()`
      */
     @available(*, deprecated, renamed: "getUserPoolAccessToken")
     public func getToken() -> Result<String, AuthError> {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -106,6 +106,32 @@ public class AWSAuthService: AWSAuthServiceBehavior {
             }
         }
     }
+    
+    /// Retrieves the Cognito token from the AuthCognitoTokensProvider
+    public func getUserPoolAccessToken() async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            Amplify.Auth.fetchAuthSession { [weak self] event in
+                switch event {
+                case .success(let session):
+                    guard let tokenResult = self?.getTokenString(from: session) else {
+                        let error = AuthError.unknown(
+                            "Did not receive a valid response from fetchAuthSession for get token."
+                        )
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    switch tokenResult {
+                    case .success(let token):
+                        continuation.resume(returning: token)
+                    case .failure(let error):
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
 
     // TODO: Remove this after calls to it are removed from API and DataStore plugins
     // MARK: List of Amplify internal usages of now deprecated AWSAuthServiceBehavior methods.

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -106,32 +106,6 @@ public class AWSAuthService: AWSAuthServiceBehavior {
             }
         }
     }
-    
-    /// Retrieves the Cognito token from the AuthCognitoTokensProvider
-    public func getUserPoolAccessToken() async throws -> String {
-        try await withCheckedThrowingContinuation { continuation in
-            Amplify.Auth.fetchAuthSession { [weak self] event in
-                switch event {
-                case .success(let session):
-                    guard let tokenResult = self?.getTokenString(from: session) else {
-                        let error = AuthError.unknown(
-                            "Did not receive a valid response from fetchAuthSession for get token."
-                        )
-                        continuation.resume(throwing: error)
-                        return
-                    }
-                    switch tokenResult {
-                    case .success(let token):
-                        continuation.resume(returning: token)
-                    case .failure(let error):
-                        continuation.resume(throwing: error)
-                    }
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
-    }
 
     // TODO: Remove this after calls to it are removed from API and DataStore plugins
     // MARK: List of Amplify internal usages of now deprecated AWSAuthServiceBehavior methods.

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -19,9 +19,6 @@ public protocol AWSAuthServiceBehavior: AnyObject {
      `IncomingAsyncSubscriptionEventPublisher`
         - File Path: `AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift`
         - Uses: `getToken()`
-     `AWSOIDCAuthProvider`
-        - File Path: `AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift`
-        - Uses: `getToken()`
      */
     @available(*, deprecated, renamed: "getUserPoolAccessToken")
     func getToken() -> Result<String, AuthError>

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -62,14 +62,6 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
             return token ?? "token"
         }
     }
-    
-    public func getUserPoolAccessToken() async throws -> String {
-        if let error = getTokenError {
-            throw error
-        } else {
-            return token ?? "token"
-        }
-    }
 
     public func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
         if let error = getTokenClaimsError {

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -61,6 +61,14 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
             return token ?? "token"
         }
     }
+    
+    public func getUserPoolAccessToken() async throws -> String {
+        if let error = getTokenError {
+            throw error
+        } else {
+            return token ?? "token"
+        }
+    }
 
     public func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
         if let error = getTokenClaimsError {

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -46,6 +46,7 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
         completion(.success(identityId ?? "IdentityId"))
     }
 
+    // TODO: Remove this after datastore dependencies are removed.
     public func getToken() -> Result<String, AuthError> {
         if let error = getTokenError {
             return .failure(error)

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -312,14 +312,6 @@ class MockOIDCAuthProvider: AmplifyOIDCAuthProvider {
             return "token"
         }
     }
-    
-    func getUserPoolAccessToken() async throws -> String {
-        if case let .success(token) = result {
-            return token
-        } else {
-            return "token"
-        }
-    }
 }
 
 class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
@@ -331,14 +323,6 @@ class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
             return result
         } else {
             return .success("token")
-        }
-    }
-    
-    func getUserPoolAccessToken() async throws -> String {
-        if case let .success(token) = result {
-            return token
-        } else {
-            return "token"
         }
     }
     

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -311,6 +311,14 @@ class MockOIDCAuthProvider: AmplifyOIDCAuthProvider {
             return "token"
         }
     }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        if case let .success(token) = result {
+            return token
+        } else {
+            return "token"
+        }
+    }
 }
 
 class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
@@ -321,6 +329,14 @@ class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
             return result
         } else {
             return .success("token")
+        }
+    }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        if case let .success(token) = result {
+            return token
+        } else {
+            return "token"
         }
     }
     

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -296,6 +296,7 @@ class MockAPIAuthProviderFactory: APIAuthProviderFactory {
 class MockOIDCAuthProvider: AmplifyOIDCAuthProvider {
     var result: Result<AuthToken, Error>?
 
+    //TODO: Remove this after datastore dependencies are removed.
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         if let result = result {
             return result
@@ -324,6 +325,7 @@ class MockOIDCAuthProvider: AmplifyOIDCAuthProvider {
 class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
     var result: Result<AuthToken, Error>?
 
+    //TODO: Remove this after datastore dependencies are removed.
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         if let result = result {
             return result

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
         "state": {
           "branch": null,
-          "revision": "36ed209d55aacc127356a387b51cef5f94ec9ac7",
-          "version": "2.0.0"
+          "revision": "da88cf1cab82e281e7277cd9feb9efc87a057041",
+          "version": "2.1.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let dependencies: [Package.Dependency] = [
     .package(
         name: "AppSyncRealTimeClient",
         url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
-        from: "2.0.0"
+        from: "2.1.1"
     ),
     .package(
         name: "AWSSwiftSDK",


### PR DESCRIPTION
*Description of changes:*
fix(api): remove consumers of deprecated auth methods from API plugin

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
