### PR TITLE
fix(datastore): remove consumers of deprecated auth methods from the DataStore plugin

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
@@ -487,16 +487,6 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AWSPinpointAnalyticsPluginIntegrationTests"
-               BuildableName = "AWSPinpointAnalyticsPluginIntegrationTests"
-               BlueprintName = "AWSPinpointAnalyticsPluginIntegrationTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "AWSAPIPluginFunctionalTests"
                BuildableName = "AWSAPIPluginFunctionalTests"
                BlueprintName = "AWSAPIPluginFunctionalTests"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
@@ -493,6 +493,16 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AWSPinpointAnalyticsPluginIntegrationTests"
+               BuildableName = "AWSPinpointAnalyticsPluginIntegrationTests"
+               BlueprintName = "AWSPinpointAnalyticsPluginIntegrationTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Amplify/Categories/API/Operation/RetryableGraphQLOperation.swift
+++ b/Amplify/Categories/API/Operation/RetryableGraphQLOperation.swift
@@ -21,7 +21,7 @@ public protocol RetryableGraphQLOperationBehavior: Operation, DefaultLogger {
     /// GraphQLOperation concrete type
     associatedtype OperationType: AnyGraphQLOperation
 
-    typealias RequestFactory = () -> GraphQLRequest<Payload>
+    typealias RequestFactory = () async -> GraphQLRequest<Payload>
     typealias OperationFactory = (GraphQLRequest<Payload>, @escaping OperationResultListener) -> OperationType
     typealias OperationResultListener = OperationType.ResultListener
 
@@ -64,7 +64,9 @@ extension RetryableGraphQLOperationBehavior {
         let wrappedResultListener: OperationResultListener = { result in
             if case let .failure(error) = result, self.shouldRetry(error: error as? APIError) {
                 self.log.debug("\(error)")
-                self.start(request: self.requestFactory())
+                Task {
+                    self.start(request: await self.requestFactory())
+                }
                 return
             }
 
@@ -95,7 +97,7 @@ public final class RetryableGraphQLOperation<Payload: Decodable>: Operation, Ret
     public var resultListener: OperationResultListener
     public var operationFactory: OperationFactory
 
-    public init(requestFactory: @escaping () -> GraphQLRequest<Payload>,
+    public init(requestFactory: @escaping RequestFactory,
                 maxRetries: Int,
                 resultListener: @escaping OperationResultListener,
                 _ operationFactory: @escaping OperationFactory) {
@@ -105,8 +107,11 @@ public final class RetryableGraphQLOperation<Payload: Decodable>: Operation, Ret
         self.operationFactory = operationFactory
         self.resultListener = resultListener
     }
+    
     public override func main() {
-        start(request: requestFactory())
+        Task {
+            start(request: await requestFactory())
+        }
     }
 
     public override func cancel() {
@@ -154,7 +159,9 @@ public final class RetryableGraphQLSubscriptionOperation<Payload: Decodable>: Op
         self.resultListener = resultListener
     }
     public override func main() {
-        start(request: requestFactory())
+        Task {
+            start(request: await requestFactory())
+        }
     }
 
     public override func cancel() {

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
@@ -33,4 +33,8 @@ class AuthTokenProviderWrapper: AuthTokenProvider {
     func getUserPoolAccessToken() async throws -> String {
         try await wrappedAuthTokenProvider.getUserPoolAccessToken()
     }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        try await wrappedAuthTokenProvider.getUserPoolAccessToken()
+    }
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
@@ -33,8 +33,4 @@ class AuthTokenProviderWrapper: AuthTokenProvider {
     func getUserPoolAccessToken() async throws -> String {
         try await wrappedAuthTokenProvider.getUserPoolAccessToken()
     }
-    
-    func getUserPoolAccessToken() async throws -> String {
-        try await wrappedAuthTokenProvider.getUserPoolAccessToken()
-    }
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptor.swift
@@ -19,9 +19,9 @@ class AuthenticationTokenAuthInterceptor: AuthInterceptorAsync {
         self.authTokenProvider = authTokenProvider
     }
 
-    func interceptMessage(_ message: AppSyncMessage, for endpoint: URL) -> AppSyncMessage {
+    func interceptMessage(_ message: AppSyncMessage, for endpoint: URL) async -> AppSyncMessage {
         let host = endpoint.host!
-        guard let authToken = getAuthToken() else {
+        guard let authToken = await getAuthToken() else {
             log.warn("Missing authentication token for subscription")
             return message
         }
@@ -45,9 +45,9 @@ class AuthenticationTokenAuthInterceptor: AuthInterceptorAsync {
     func interceptConnection(
         _ request: AppSyncConnectionRequest,
         for endpoint: URL
-    ) -> AppSyncConnectionRequest {
+    ) async -> AppSyncConnectionRequest {
         let host = endpoint.host!
-        guard let authToken = getAuthToken() else {
+        guard let authToken = await getAuthToken() else {
             log.warn("Missing authentication token for subscription request")
             return request
         }
@@ -71,8 +71,8 @@ class AuthenticationTokenAuthInterceptor: AuthInterceptorAsync {
         return signedRequest
     }
 
-    private func getAuthToken() -> AmplifyAuthTokenProvider.AuthToken? {
-        try? authTokenProvider.getLatestAuthToken().get()
+    private func getAuthToken() async -> AmplifyAuthTokenProvider.AuthToken? {
+        try? await authTokenProvider.getUserPoolAccessToken()
     }
 }
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/OIDCAuthProviderWrapper.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/OIDCAuthProviderWrapper.swift
@@ -9,7 +9,7 @@ import Amplify
 import Foundation
 import AppSyncRealTimeClient
 
-class OIDCAuthProviderWrapper: OIDCAuthProvider {
+class OIDCAuthProviderWrapper: OIDCAuthProviderAsync {
 
     let authTokenProvider: AmplifyAuthTokenProvider
 
@@ -17,7 +17,7 @@ class OIDCAuthProviderWrapper: OIDCAuthProvider {
         self.authTokenProvider = authTokenProvider
     }
 
-    func getLatestAuthToken() -> Result<String, Error> {
-        return authTokenProvider.getLatestAuthToken()
+    func getLatestAuthToken() async throws -> String {
+        try await authTokenProvider.getUserPoolAccessToken()
     }
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift
@@ -9,7 +9,7 @@ import Foundation
 import AWSPluginsCore
 import AppSyncRealTimeClient
 
-class AWSOIDCAuthProvider: OIDCAuthProvider {
+class AWSOIDCAuthProvider: OIDCAuthProviderAsync {
 
     var authService: AWSAuthServiceBehavior
 
@@ -17,12 +17,7 @@ class AWSOIDCAuthProvider: OIDCAuthProvider {
         self.authService = authService
     }
 
-    func getLatestAuthToken() -> Result<String, Error> {
-        switch authService.getToken() {
-        case .success(let token):
-            return .success(token)
-        case .failure(let authError):
-            return .failure(authError)
-        }
+    func getLatestAuthToken() async throws -> String {
+        try await authService.getUserPoolAccessToken()
     }
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AWSSubscriptionConnectionFactory.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AWSSubscriptionConnectionFactory.swift
@@ -72,7 +72,7 @@ class AWSSubscriptionConnectionFactory: SubscriptionConnectionFactory {
             authInterceptor = APIKeyAuthInterceptor(apiKeyConfiguration.apiKey)
         case .amazonCognitoUserPools:
             let provider = AWSOIDCAuthProvider(authService: authService)
-            authInterceptor = OIDCAuthInterceptor(provider)
+            authInterceptor = OIDCAuthInterceptorAsync(provider)
         case .awsIAM(let awsIAMConfiguration):
             authInterceptor = IAMAuthInterceptor(authService.getCredentialsProvider(),
                                                  region: awsIAMConfiguration.region)
@@ -83,7 +83,7 @@ class AWSSubscriptionConnectionFactory: SubscriptionConnectionFactory {
                     "When instantiating AWSAPIPlugin pass in an instance of APIAuthProvider", nil)
             }
             let wrappedProvider = OIDCAuthProviderWrapper(authTokenProvider: oidcAuthProvider)
-            authInterceptor = OIDCAuthInterceptor(wrappedProvider)
+            authInterceptor = OIDCAuthInterceptorAsync(wrappedProvider)
         case .function:
             guard let functionAuthProvider = apiAuthProviderFactory.functionAuthProvider() else {
                 throw APIError.invalidConfiguration(

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -132,6 +132,10 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
         func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
             completion(.success("token"))
         }
+        
+        func getUserPoolAccessToken() async throws -> String {
+            "token"
+        }
     }
 
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -131,6 +131,10 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
         func getUserPoolAccessToken() async throws -> String {
             "token"
         }
+        
+        func getUserPoolAccessToken() async throws -> String {
+            "token"
+        }
     }
 
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -128,6 +128,10 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
         func getUserPoolAccessToken() async throws -> String {
             "token"
         }
+        
+        func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+            completion(.success("token"))
+        }
     }
 
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -124,9 +124,6 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
     }
 
     struct MockTokenProvider: AuthTokenProvider {
-        func getToken() -> Result<String, AuthError> {
-            .success("token")
-        }
         
         func getUserPoolAccessToken() async throws -> String {
             "token"

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -128,10 +128,6 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
         func getUserPoolAccessToken() async throws -> String {
             "token"
         }
-        
-        func getUserPoolAccessToken() async throws -> String {
-            "token"
-        }
     }
 
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -129,10 +129,6 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
             "token"
         }
         
-        func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
-            completion(.success("token"))
-        }
-        
         func getUserPoolAccessToken() async throws -> String {
             "token"
         }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -33,10 +33,6 @@ class AuthTokenURLRequestInterceptorTests: XCTestCase {
 extension AuthTokenURLRequestInterceptorTests {
     class MockTokenProvider: AuthTokenProvider {
         let authorizationToken = "authorizationToken"
-
-        func getToken() -> Result<String, AuthError> {
-            .success(authorizationToken)
-        }
         
         func getUserPoolAccessToken() async throws -> String {
             authorizationToken

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -37,9 +37,5 @@ extension AuthTokenURLRequestInterceptorTests {
         func getUserPoolAccessToken() async throws -> String {
             authorizationToken
         }
-        
-        func getUserPoolAccessToken() async throws -> String {
-            authorizationToken
-        }
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -41,5 +41,9 @@ extension AuthTokenURLRequestInterceptorTests {
         func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
             completion(.success(authorizationToken))
         }
+        
+        func getUserPoolAccessToken() async throws -> String {
+            authorizationToken
+        }
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -41,5 +41,9 @@ extension AuthTokenURLRequestInterceptorTests {
         func getUserPoolAccessToken() async throws -> String {
             authorizationToken
         }
+        
+        func getUserPoolAccessToken() async throws -> String {
+            authorizationToken
+        }
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -37,5 +37,9 @@ extension AuthTokenURLRequestInterceptorTests {
         func getUserPoolAccessToken() async throws -> String {
             authorizationToken
         }
+        
+        func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+            completion(.success(authorizationToken))
+        }
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -38,10 +38,6 @@ extension AuthTokenURLRequestInterceptorTests {
             authorizationToken
         }
         
-        func getUserPoolAccessToken(completion: @escaping (Result<String, AuthError>) -> Void) {
-            completion(.success(authorizationToken))
-        }
-        
         func getUserPoolAccessToken() async throws -> String {
             authorizationToken
         }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
@@ -44,20 +44,18 @@ private class TestAuthTokenProvider: AmplifyAuthTokenProvider {
     func getUserPoolAccessToken() async throws -> String {
         authToken
     }
-    
-    func getUserPoolAccessToken() async throws -> String {
-        authToken
-    }
 }
 
 private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
+    
+    // TODO: Remove this after datastore dependencies are removed.
+    func getLatestAuthToken() -> Result<AuthToken, Error> {
+        .success(authToken)
+    }
+    
     let authToken = "token"
     
     func getUserPoolAccessToken() async throws -> String {
         throw "Token error"
-    }
-    
-    func getUserPoolAccessToken() async throws -> String {
-        authToken
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
@@ -44,6 +44,10 @@ private class TestAuthTokenProvider: AmplifyAuthTokenProvider {
     func getUserPoolAccessToken() async throws -> String {
         authToken
     }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        authToken
+    }
 }
 
 private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
@@ -53,6 +57,10 @@ private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         let error = APIError.networkError("Token error")
         return .failure(error)
+    }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        authToken
     }
     
     func getUserPoolAccessToken() async throws -> String {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
@@ -36,6 +36,7 @@ class AuthenticationTokenAuthInterceptorTests: XCTestCase {
 private class TestAuthTokenProvider: AmplifyAuthTokenProvider {
     let authToken = "token"
     
+    // TODO: Remove this after datastore dependencies are removed.
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         .success(authToken)
     }
@@ -51,6 +52,8 @@ private class TestAuthTokenProvider: AmplifyAuthTokenProvider {
 
 private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
     let authToken = "token"
+    
+    // TODO: Remove this after datastore dependencies are removed.
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         let error = APIError.networkError("Token error")
         return .failure(error)

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
@@ -44,10 +44,6 @@ private class TestAuthTokenProvider: AmplifyAuthTokenProvider {
     func getUserPoolAccessToken() async throws -> String {
         authToken
     }
-    
-    func getUserPoolAccessToken() async throws -> String {
-        authToken
-    }
 }
 
 private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
@@ -57,10 +53,6 @@ private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         let error = APIError.networkError("Token error")
         return .failure(error)
-    }
-    
-    func getUserPoolAccessToken() async throws -> String {
-        authToken
     }
     
     func getUserPoolAccessToken() async throws -> String {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
@@ -43,6 +43,10 @@ private class TestAuthTokenProvider: AmplifyAuthTokenProvider {
     func getUserPoolAccessToken() async throws -> String {
         authToken
     }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        authToken
+    }
 }
 
 private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
@@ -50,6 +54,10 @@ private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         let error = APIError.networkError("Token error")
         return .failure(error)
+    }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        authToken
     }
     
     func getUserPoolAccessToken() async throws -> String {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
@@ -13,20 +13,20 @@ import AppSyncRealTimeClient
 
 class AuthenticationTokenAuthInterceptorTests: XCTestCase {
 
-    func testAuthenticationTokenInterceptor() throws {
+    func testAuthenticationTokenInterceptor() async throws {
         let url = URL(string: "http://awssubscriptionurl.ca")!
         let request = AppSyncConnectionRequest(url: url)
         let interceptor = AuthenticationTokenAuthInterceptor(authTokenProvider: TestAuthTokenProvider())
-        let interceptedRequest = interceptor.interceptConnection(request, for: url)
+        let interceptedRequest = await interceptor.interceptConnection(request, for: url)
 
         XCTAssertNotNil(interceptedRequest.url.query)
     }
 
-    func testDoesNotAddAuthHeaderIfTokenProviderReturnsError() throws {
+    func testDoesNotAddAuthHeaderIfTokenProviderReturnsError() async throws {
         let url = URL(string: "http://awssubscriptionurl.ca")!
         let request = AppSyncConnectionRequest(url: url)
         let interceptor = AuthenticationTokenAuthInterceptor(authTokenProvider: TestFailingAuthTokenProvider())
-        let interceptedRequest = interceptor.interceptConnection(request, for: url)
+        let interceptedRequest = await interceptor.interceptConnection(request, for: url)
 
         XCTAssertNil(interceptedRequest.url.query)
     }
@@ -53,14 +53,8 @@ private class TestAuthTokenProvider: AmplifyAuthTokenProvider {
 private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
     let authToken = "token"
     
-    // TODO: Remove this after datastore dependencies are removed.
-    func getLatestAuthToken() -> Result<AuthToken, Error> {
-        let error = APIError.networkError("Token error")
-        return .failure(error)
-    }
-    
     func getUserPoolAccessToken() async throws -> String {
-        authToken
+        throw "Token error"
     }
     
     func getUserPoolAccessToken() async throws -> String {

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
@@ -52,6 +52,10 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
     public func getUserPoolAccessToken() async throws -> String {
         ""
     }
+    
+    public func getUserPoolAccessToken() async throws -> String {
+        ""
+    }
 
     public func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
         if let error = getTokenClaimsError {

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
@@ -36,6 +36,7 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
         return .success(identityId ?? "IdentityId")
     }
 
+    //TODO: Remove this after datastore dependencies are removed.
     public func getToken() -> Result<String, AuthError> {
         .success("")
     }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
@@ -52,10 +52,6 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
     public func getUserPoolAccessToken() async throws -> String {
         ""
     }
-    
-    public func getUserPoolAccessToken() async throws -> String {
-        ""
-    }
 
     public func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
         if let error = getTokenClaimsError {

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
@@ -51,6 +51,10 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
     public func getUserPoolAccessToken() async throws -> String {
         ""
     }
+    
+    public func getUserPoolAccessToken() async throws -> String {
+        ""
+    }
 
     public func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
         if let error = getTokenClaimsError {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthModeStrategy.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthModeStrategy.swift
@@ -31,7 +31,7 @@ public enum AuthModeStrategyType {
 
 /// Methods for checking user current status
 public protocol AuthModeStrategyDelegate: AnyObject {
-    func isUserLoggedIn() -> Bool
+    func isUserLoggedIn() async -> Bool
 }
 
 /// Represents an authorization strategy used by DataStore
@@ -41,8 +41,7 @@ public protocol AuthModeStrategy: AnyObject {
 
     init()
 
-    func authTypesFor(schema: ModelSchema,
-                      operation: ModelOperation) -> AWSAuthorizationTypeIterator
+    func authTypesFor(schema: ModelSchema, operation: ModelOperation) async -> AWSAuthorizationTypeIterator
 }
 
 /// AuthorizationType iterator with an extra `count` property used
@@ -188,13 +187,13 @@ public class AWSMultiAuthModeStrategy: AuthModeStrategy {
     ///   - operation: model operation
     /// - Returns: an iterator for the applicable auth rules
     public func authTypesFor(schema: ModelSchema,
-                             operation: ModelOperation) -> AWSAuthorizationTypeIterator {
+                             operation: ModelOperation) async -> AWSAuthorizationTypeIterator {
         var applicableAuthRules = schema.authRules
             .filter(modelOperation: operation)
             .sorted(by: AWSMultiAuthModeStrategy.comparator)
 
         // if there isn't a user signed in, returns only public or custom rules
-        if let authDelegate = authDelegate, !authDelegate.isUserLoggedIn() {
+        if let authDelegate = authDelegate, await !authDelegate.isUserLoggedIn() {
             applicableAuthRules = applicableAuthRules.filter { rule in
                 return rule.allow == .public || rule.allow == .custom
             }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -139,9 +139,6 @@ public class AWSAuthService: AWSAuthServiceBehavior {
      `IncomingAsyncSubscriptionEventPublisher`
         - File Path: `AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift`
         - Uses: `getToken()`
-     `AWSOIDCAuthProvider`
-        - File Path: `AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift`
-        - Uses: `getToken()`
      */
     @available(*, deprecated, renamed: "getUserPoolAccessToken")
     public func getToken() -> Result<String, AuthError> {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -106,6 +106,32 @@ public class AWSAuthService: AWSAuthServiceBehavior {
             }
         }
     }
+    
+    /// Retrieves the Cognito token from the AuthCognitoTokensProvider
+    public func getUserPoolAccessToken() async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            Amplify.Auth.fetchAuthSession { [weak self] event in
+                switch event {
+                case .success(let session):
+                    guard let tokenResult = self?.getTokenString(from: session) else {
+                        let error = AuthError.unknown(
+                            "Did not receive a valid response from fetchAuthSession for get token."
+                        )
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    switch tokenResult {
+                    case .success(let token):
+                        continuation.resume(returning: token)
+                    case .failure(let error):
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
 
     // TODO: Remove this after calls to it are removed from API and DataStore plugins
     // MARK: List of Amplify internal usages of now deprecated AWSAuthServiceBehavior methods.

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -106,32 +106,6 @@ public class AWSAuthService: AWSAuthServiceBehavior {
             }
         }
     }
-    
-    /// Retrieves the Cognito token from the AuthCognitoTokensProvider
-    public func getUserPoolAccessToken() async throws -> String {
-        try await withCheckedThrowingContinuation { continuation in
-            Amplify.Auth.fetchAuthSession { [weak self] event in
-                switch event {
-                case .success(let session):
-                    guard let tokenResult = self?.getTokenString(from: session) else {
-                        let error = AuthError.unknown(
-                            "Did not receive a valid response from fetchAuthSession for get token."
-                        )
-                        continuation.resume(throwing: error)
-                        return
-                    }
-                    switch tokenResult {
-                    case .success(let token):
-                        continuation.resume(returning: token)
-                    case .failure(let error):
-                        continuation.resume(throwing: error)
-                    }
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
-    }
 
     // TODO: Remove this after calls to it are removed from API and DataStore plugins
     // MARK: List of Amplify internal usages of now deprecated AWSAuthServiceBehavior methods.

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -19,9 +19,6 @@ public protocol AWSAuthServiceBehavior: AnyObject {
      `IncomingAsyncSubscriptionEventPublisher`
         - File Path: `AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift`
         - Uses: `getToken()`
-     `AWSOIDCAuthProvider`
-        - File Path: `AmplifyPlugins/API/AWSAPICategoryPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift`
-        - Uses: `getToken()`
      */
     @available(*, deprecated, renamed: "getUserPoolAccessToken")
     func getToken() -> Result<String, AuthError>

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AuthModeStrategyTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AuthModeStrategyTests.swift
@@ -24,9 +24,9 @@ class AuthModeStrategyTests: XCTestCase {
     // Given: multi-auth strategy and a model schema
     // When: authTypesFor for .create operation is called
     // Then: auth types are returned in order according to priority rules
-    func testMultiAuthShouldRespectAuthPriorityRules() {
+    func testMultiAuthShouldRespectAuthPriorityRules() async {
         let authMode = AWSMultiAuthModeStrategy()
-        var authTypesIterator = authMode.authTypesFor(schema: ModelWithOwnerAndPublicAuth.schema, operation: .create)
+        var authTypesIterator = await authMode.authTypesFor(schema: ModelWithOwnerAndPublicAuth.schema, operation: .create)
         XCTAssertEqual(authTypesIterator.count, 2)
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
         XCTAssertEqual(authTypesIterator.next(), .apiKey)
@@ -35,9 +35,9 @@ class AuthModeStrategyTests: XCTestCase {
     // Given: multi-auth strategy and a model schema without auth provider
     // When: auth types are requested
     // Then: default values based on the auth strategy should be returned
-    func testMultiAuthShouldReturnDefaultAuthTypes() {
+    func testMultiAuthShouldReturnDefaultAuthTypes() async {
         let authMode = AWSMultiAuthModeStrategy()
-        var authTypesIterator = authMode.authTypesFor(schema: ModelNoProvider.schema, operation: .read)
+        var authTypesIterator = await authMode.authTypesFor(schema: ModelNoProvider.schema, operation: .read)
         XCTAssertEqual(authTypesIterator.count, 2)
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
         XCTAssertEqual(authTypesIterator.next(), .apiKey)
@@ -46,9 +46,9 @@ class AuthModeStrategyTests: XCTestCase {
     // Given: multi-auth strategy and a model schema with 4 auth rules
     // When: authTypesFor for .create operation is called
     // Then: applicable auth types are ordered according to priority rules
-    func testMultiAuthPriorityAuthRulesOrder() {
+    func testMultiAuthPriorityAuthRulesOrder() async {
         let authMode = AWSMultiAuthModeStrategy()
-        var authTypesIterator = authMode.authTypesFor(schema: ModelAllStrategies.schema, operation: .read)
+        var authTypesIterator = await authMode.authTypesFor(schema: ModelAllStrategies.schema, operation: .read)
         XCTAssertEqual(authTypesIterator.count, 4)
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
@@ -59,9 +59,9 @@ class AuthModeStrategyTests: XCTestCase {
     // Given: multi-auth strategy and a model schema multiple public rules
     // When: authTypesFor for .create operation is called
     // Then: applicable auth types are ordered according to priority rules
-    func testMultiAuthPriorityAuthRulesOrderSameStrategy() {
+    func testMultiAuthPriorityAuthRulesOrderSameStrategy() async {
         let authMode = AWSMultiAuthModeStrategy()
-        var authTypesIterator = authMode.authTypesFor(schema: ModelWithMultiplePublicRules.schema, operation: .read)
+        var authTypesIterator = await authMode.authTypesFor(schema: ModelWithMultiplePublicRules.schema, operation: .read)
         XCTAssertEqual(authTypesIterator.count, 4)
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
         XCTAssertEqual(authTypesIterator.next(), .openIDConnect)
@@ -73,9 +73,9 @@ class AuthModeStrategyTests: XCTestCase {
     // When: authTypesFor for .create operation is called
     // Then: applicable auth types returned are only the
     //       auth types allowed on the given operation
-    func testMultiAuthPriorityAuthPerOperation() {
+    func testMultiAuthPriorityAuthPerOperation() async {
         let authMode = AWSMultiAuthModeStrategy()
-        var authTypesIterator = authMode.authTypesFor(schema: ModelAllStrategies.schema, operation: .create)
+        var authTypesIterator = await authMode.authTypesFor(schema: ModelAllStrategies.schema, operation: .create)
         XCTAssertEqual(authTypesIterator.count, 2)
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
@@ -84,12 +84,12 @@ class AuthModeStrategyTests: XCTestCase {
     // Given: multi-auth strategy a model schema
     // When: authTypesFor for .create operation is called for unauthenticated user
     // Then: applicable auth types returned are only public rules
-    func testMultiAuthPriorityUnauthenticatedUser() {
+    func testMultiAuthPriorityUnauthenticatedUser() async {
         let authMode = AWSMultiAuthModeStrategy()
         let delegate = UnauthenticatedUserDelegate()
         authMode.authDelegate = delegate
 
-        var authTypesIterator = authMode.authTypesFor(schema: ModelWithOwnerAndPublicAuth.schema,
+        var authTypesIterator = await authMode.authTypesFor(schema: ModelWithOwnerAndPublicAuth.schema,
                                                       operation: .create)
         XCTAssertEqual(authTypesIterator.count, 1)
         XCTAssertEqual(authTypesIterator.next(), .apiKey)
@@ -98,9 +98,9 @@ class AuthModeStrategyTests: XCTestCase {
     // Given: multi-auth model schema with a custom strategy
     // When: authTypesFor for .create operation is called
     // Then: applicable auth types returned respect the priority rules
-    func testMultiAuthPriorityWithCustomStrategy() {
+    func testMultiAuthPriorityWithCustomStrategy() async {
         let authMode = AWSMultiAuthModeStrategy()
-        var authTypesIterator = authMode.authTypesFor(schema: ModelWithCustomStrategy.schema,
+        var authTypesIterator = await authMode.authTypesFor(schema: ModelWithCustomStrategy.schema,
                                                       operation: .create)
         XCTAssertEqual(authTypesIterator.count, 3)
         XCTAssertEqual(authTypesIterator.next(), .function)
@@ -111,12 +111,12 @@ class AuthModeStrategyTests: XCTestCase {
     // Given: multi-auth model schema with a custom strategy
     // When: authTypesFor for .create operation is called for unauthenticated user
     // Then: applicable auth types returned are public rules or custom
-    func testMultiAuthPriorityUnauthenticatedUserWithCustom() {
+    func testMultiAuthPriorityUnauthenticatedUserWithCustom() async {
         let authMode = AWSMultiAuthModeStrategy()
         let delegate = UnauthenticatedUserDelegate()
         authMode.authDelegate = delegate
 
-        var authTypesIterator = authMode.authTypesFor(schema: ModelWithCustomStrategy.schema,
+        var authTypesIterator = await authMode.authTypesFor(schema: ModelWithCustomStrategy.schema,
                                                       operation: .create)
         XCTAssertEqual(authTypesIterator.count, 2)
         XCTAssertEqual(authTypesIterator.next(), .function)

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -62,14 +62,6 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
             return token ?? "token"
         }
     }
-    
-    public func getUserPoolAccessToken() async throws -> String {
-        if let error = getTokenError {
-            throw error
-        } else {
-            return token ?? "token"
-        }
-    }
 
     public func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
         if let error = getTokenClaimsError {

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -62,6 +62,14 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
             return token ?? "token"
         }
     }
+    
+    public func getUserPoolAccessToken() async throws -> String {
+        if let error = getTokenError {
+            throw error
+        } else {
+            return token ?? "token"
+        }
+    }
 
     public func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
         if let error = getTokenClaimsError {

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -61,6 +61,14 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
             return token ?? "token"
         }
     }
+    
+    public func getUserPoolAccessToken() async throws -> String {
+        if let error = getTokenError {
+            throw error
+        } else {
+            return token ?? "token"
+        }
+    }
 
     public func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError> {
         if let error = getTokenClaimsError {

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -46,6 +46,7 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
         completion(.success(identityId ?? "IdentityId"))
     }
 
+    // TODO: Remove this after datastore dependencies are removed.
     public func getToken() -> Result<String, AuthError> {
         if let error = getTokenError {
             return .failure(error)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
@@ -36,7 +36,7 @@ class SyncMutationToCloudOperation: AsynchronousOperation {
          networkReachabilityPublisher: AnyPublisher<ReachabilityUpdate, Never>? = nil,
          currentAttemptNumber: Int = 1,
          requestRetryablePolicy: RequestRetryablePolicy? = RequestRetryablePolicy(),
-         completion: @escaping GraphQLOperation<MutationSync<AnyModel>>.ResultListener) {
+         completion: @escaping GraphQLOperation<MutationSync<AnyModel>>.ResultListener) async {
         self.mutationEvent = mutationEvent
         self.api = api
         self.networkReachabilityPublisher = networkReachabilityPublisher
@@ -47,7 +47,8 @@ class SyncMutationToCloudOperation: AsynchronousOperation {
 
         if let modelSchema = ModelRegistry.modelSchema(from: mutationEvent.modelName),
            let mutationType = GraphQLMutationType(rawValue: mutationEvent.mutationType) {
-            self.authTypesIterator = authModeStrategy.authTypesFor(schema: modelSchema,
+            
+            self.authTypesIterator = await authModeStrategy.authTypesFor(schema: modelSchema,
                                                                    operation: mutationType.toModelOperation())
         }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+AuthModeStrategyDelegate.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+AuthModeStrategyDelegate.swift
@@ -11,18 +11,19 @@ import Foundation
 import AWSPluginsCore
 
 extension RemoteSyncEngine: AuthModeStrategyDelegate {
-    func isUserLoggedIn() -> Bool {
-        // if OIDC is used as authentication provider
-        // use `getLatestAuthToken`
-        var isLoggedInWithOIDC = false
-
+    
+    func isUserLoggedIn() async -> Bool {
         if let authProviderFactory = api as? APICategoryAuthProviderFactoryBehavior,
            let oidcAuthProvider = authProviderFactory.apiAuthProviderFactory().oidcAuthProvider() {
-            switch oidcAuthProvider.getLatestAuthToken() {
-            case .failure:
-                isLoggedInWithOIDC = false
-            case .success:
+            
+            // if OIDC is used as authentication provider
+            // use `getUserPoolAccessToken`
+            var isLoggedInWithOIDC = false
+            do {
+                _ = try await oidcAuthProvider.getUserPoolAccessToken()
                 isLoggedInWithOIDC = true
+            } catch {
+                isLoggedInWithOIDC = false
             }
 
             return isLoggedInWithOIDC

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -272,24 +272,26 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
             }
         }
     }
-
+    
     private func initializeSubscriptions(api: APICategoryGraphQLBehavior,
                                          storageAdapter: StorageEngineAdapter) {
-        log.debug(#function)
-        let syncableModelSchemas = ModelRegistry.modelSchemas.filter { $0.isSyncable }
-        reconciliationQueue = reconciliationQueueFactory(syncableModelSchemas,
-                                                         api,
-                                                         storageAdapter,
-                                                         dataStoreConfiguration.syncExpressions,
-                                                         auth,
-                                                         authModeStrategy,
-                                                         nil)
-        reconciliationQueueSink = reconciliationQueue?
-            .publisher
-            .sink(
-                receiveCompletion: { [weak self] in self?.onReceiveCompletion(receiveCompletion: $0) },
-                receiveValue: { [weak self] in self?.onReceive(receiveValue: $0) }
-            )
+        Task {
+            log.debug(#function)
+            let syncableModelSchemas = ModelRegistry.modelSchemas.filter { $0.isSyncable }
+            reconciliationQueue = await reconciliationQueueFactory(syncableModelSchemas,
+                                                                   api,
+                                                                   storageAdapter,
+                                                                   dataStoreConfiguration.syncExpressions,
+                                                                   auth,
+                                                                   authModeStrategy,
+                                                                   nil)
+            reconciliationQueueSink = reconciliationQueue?
+                .publisher
+                .sink(
+                    receiveCompletion: { [weak self] in self?.onReceiveCompletion(receiveCompletion: $0) },
+                    receiveValue: { [weak self] in self?.onReceive(receiveValue: $0) }
+                )
+        }
     }
 
     private func performInitialSync() {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -26,9 +26,9 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
          api: APICategoryGraphQLBehavior,
          modelPredicate: QueryPredicate?,
          auth: AuthCategoryBehavior?,
-         authModeStrategy: AuthModeStrategy) {
+         authModeStrategy: AuthModeStrategy) async {
         self.subscriptionEventSubject = PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>()
-        self.asyncEvents = IncomingAsyncSubscriptionEventPublisher(modelSchema: modelSchema,
+        self.asyncEvents = await IncomingAsyncSubscriptionEventPublisher(modelSchema: modelSchema,
                                                                    api: api,
                                                                    modelPredicate: modelPredicate,
                                                                    auth: auth,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -51,7 +51,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
          modelPredicate: QueryPredicate?,
          auth: AuthCategoryBehavior?,
          authModeStrategy: AuthModeStrategy,
-         awsAuthService: AWSAuthServiceBehavior? = nil) {
+         awsAuthService: AWSAuthServiceBehavior? = nil) async {
         self.onCreateConnected = false
         self.onUpdateConnected = false
         self.onDeleteConnected = false
@@ -72,7 +72,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
 
         // onCreate operation
         let onCreateValueListener = onCreateValueListenerHandler(event:)
-        let onCreateAuthTypeProvider = authModeStrategy.authTypesFor(schema: modelSchema,
+        let onCreateAuthTypeProvider = await authModeStrategy.authTypesFor(schema: modelSchema,
                                                                      operation: .create)
         self.onCreateValueListener = onCreateValueListener
         self.onCreateOperation = RetryableGraphQLSubscriptionOperation(
@@ -93,7 +93,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
 
         // onUpdate operation
         let onUpdateValueListener = onUpdateValueListenerHandler(event:)
-        let onUpdateAuthTypeProvider = authModeStrategy.authTypesFor(schema: modelSchema,
+        let onUpdateAuthTypeProvider = await authModeStrategy.authTypesFor(schema: modelSchema,
                                                                      operation: .update)
         self.onUpdateValueListener = onUpdateValueListener
         self.onUpdateOperation = RetryableGraphQLSubscriptionOperation(
@@ -114,7 +114,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
 
         // onDelete operation
         let onDeleteValueListener = onDeleteValueListenerHandler(event:)
-        let onDeleteAuthTypeProvider = authModeStrategy.authTypesFor(schema: modelSchema,
+        let onDeleteAuthTypeProvider = await authModeStrategy.authTypesFor(schema: modelSchema,
                                                                      operation: .delete)
         self.onDeleteValueListener = onDeleteValueListener
         self.onDeleteOperation = RetryableGraphQLSubscriptionOperation(

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -202,7 +202,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
         let request: GraphQLRequest<Payload>
         if modelSchema.hasAuthenticationRules,
             let _ = auth,
-            case .success(let tokenString) = awsAuthService.getToken(),
+            let tokenString = try? await awsAuthService.getUserPoolAccessToken(),
             case .success(let claims) = awsAuthService.getTokenClaims(tokenString: tokenString) {
             request = GraphQLRequest<Payload>.subscription(to: modelSchema,
                                                            subscriptionType: subscriptionType,
@@ -210,7 +210,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
                                                            authType: authType)
         } else if modelSchema.hasAuthenticationRules,
             let oidcAuthProvider = hasOIDCAuthProviderAvailable(api: api),
-            case .success(let tokenString) = oidcAuthProvider.getLatestAuthToken(),
+            let tokenString = try? await oidcAuthProvider.getUserPoolAccessToken(),
             case .success(let claims) = awsAuthService.getTokenClaims(tokenString: tokenString) {
             request = GraphQLRequest<Payload>.subscription(to: modelSchema,
                                                            subscriptionType: subscriptionType,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -198,7 +198,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
                                api: APICategoryGraphQLBehavior,
                                auth: AuthCategoryBehavior?,
                                authType: AWSAuthorizationType?,
-                               awsAuthService: AWSAuthServiceBehavior) -> GraphQLRequest<Payload> {
+                               awsAuthService: AWSAuthServiceBehavior) async -> GraphQLRequest<Payload> {
         let request: GraphQLRequest<Payload>
         if modelSchema.hasAuthenticationRules,
             let _ = auth,
@@ -288,7 +288,7 @@ extension IncomingAsyncSubscriptionEventPublisher {
                                      authTypeProvider: AWSAuthorizationTypeIterator) -> RetryableGraphQLOperation<Payload>.RequestFactory {
         var authTypes = authTypeProvider
         return {
-            return IncomingAsyncSubscriptionEventPublisher.makeAPIRequest(for: modelSchema,
+            return await IncomingAsyncSubscriptionEventPublisher.makeAPIRequest(for: modelSchema,
                                                                           subscriptionType: subscriptionType,
                                                                           api: api,
                                                                           auth: auth,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
@@ -39,7 +39,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try saveMutationEvent(of: .create, for: post)
             try setUpDataStore()
-            try startAmplifyAndWaitForSync()
+            try await startAmplifyAndWaitForSync()
         }
 
         let saveResultReceived = expectation(description: "Save result received")
@@ -89,7 +89,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             try saveMutationEvent(of: .create, for: post)
             try savePost(post)
             try setUpDataStore()
-            try startAmplifyAndWaitForSync()
+            try await startAmplifyAndWaitForSync()
         }
 
         var mutatedPost = post
@@ -145,7 +145,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             try saveMutationEvent(of: .create, for: post)
             try savePost(post)
             try setUpDataStore()
-            try startAmplifyAndWaitForSync()
+            try await startAmplifyAndWaitForSync()
         }
 
         let deleteResultReceived = expectation(description: "Delete result received")
@@ -196,7 +196,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try saveMutationEvent(of: .update, for: post)
             try setUpDataStore()
-            try startAmplifyAndWaitForSync()
+            try await startAmplifyAndWaitForSync()
         }
 
         let saveResultReceived = expectation(description: "Save result received")
@@ -248,7 +248,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             try saveMutationEvent(of: .update, for: post)
             try savePost(post)
             try setUpDataStore()
-            try startAmplifyAndWaitForSync()
+            try await startAmplifyAndWaitForSync()
         }
 
         var mutatedPost = post
@@ -304,7 +304,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             try saveMutationEvent(of: .update, for: post)
             try savePost(post)
             try setUpDataStore()
-            try startAmplifyAndWaitForSync()
+            try await startAmplifyAndWaitForSync()
         }
 
         let saveResultReceived = expectation(description: "Delete result received")
@@ -359,7 +359,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try saveMutationEvent(of: .delete, for: post)
             try setUpDataStore()
-            try startAmplifyAndWaitForSync()
+            try await startAmplifyAndWaitForSync()
         }
 
         let saveResultReceived = expectation(description: "Save result received")
@@ -413,7 +413,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             try saveMutationEvent(of: .delete, for: post)
             try savePost(post)
             try setUpDataStore()
-            try startAmplifyAndWaitForSync()
+            try await startAmplifyAndWaitForSync()
         }
 
         var mutatedPost = post
@@ -468,7 +468,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
         await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try setUpDataStore()
-            try startAmplifyAndWaitForSync()
+            try await startAmplifyAndWaitForSync()
         }
 
         let saveResultReceived = expectation(description: "Save result received")
@@ -519,7 +519,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try savePost(post)
             try setUpDataStore()
-            try startAmplifyAndWaitForSync()
+            try await startAmplifyAndWaitForSync()
         }
 
         let saveResultReceived = expectation(description: "Save result received")
@@ -570,7 +570,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try savePost(post)
             try setUpDataStore()
-            try startAmplifyAndWaitForSync()
+            try await startAmplifyAndWaitForSync()
         }
 
         let saveResultReceived = expectation(description: "Save result received")
@@ -623,7 +623,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
         await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try setUpDataStore()
-            try startAmplifyAndWaitForSync()
+            try await startAmplifyAndWaitForSync()
             try saveMutationEvent(of: .create, for: post, inProcess: true)
         }
 
@@ -672,7 +672,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
         await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try setUpDataStore()
-            try startAmplifyAndWaitForSync()
+            try await startAmplifyAndWaitForSync()
             try savePost(post)
             try saveMutationEvent(of: .create, for: post, inProcess: true)
         }
@@ -726,7 +726,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
         await tryOrFail {
             try setUpStorageAdapter(preCreating: [Post.self, Comment.self])
             try setUpDataStore()
-            try startAmplifyAndWaitForSync()
+            try await startAmplifyAndWaitForSync()
             try savePost(post)
             try saveMutationEvent(of: .create, for: post, inProcess: true)
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
@@ -90,14 +90,6 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         let expectedFinalContent = "FINAL UPDATE"
         let version = AtomicValue(initialValue: 0)
 
-        let networkUnavailable = expectation(description: "networkUnavailable")
-        let networkAvailableAgain = expectation(description: "networkAvailableAgain")
-
-        setUpNetworkStatusListener(
-            fulfillingWhenNetworkUnavailable: networkUnavailable,
-            fulfillingWhenNetworkAvailableAgain: networkAvailableAgain
-        )
-
         // Set up API responder chain
 
         // The first response is a success for the initial "Create" mutation
@@ -118,23 +110,10 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
             listenerDelay: 0.25
         )
 
-        // Once we've rejected some mutations due to an unreachable network, we'll allow the final
-        // mutation to succeed. This is where we will assert that we've seen the last mutation
-        // to be processed
-        let expectedFinalContentReceived = expectation(description: "expectedFinalContentReceived")
-        let acceptSubsequentMutations = setUpSubsequentMutationRequestResponder(
-            for: try post.eraseToAnyModel(),
-            fulfilling: expectedFinalContentReceived,
-            whenContentContains: expectedFinalContent,
-            incrementing: version
-        )
-
         // Start by accepting the initial "create" mutation
         apiPlugin.responders = [.mutateRequestListener: acceptInitialMutation]
 
         try await startAmplifyAndWaitForSync()
-        
-        print("blah")
 
         // Save initial model
         let createdNewItem = expectation(description: "createdNewItem")
@@ -146,7 +125,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
             }
         }
 
-        wait(for: [createdNewItem, apiRespondedWithSuccess], timeout: 0.1)
+        await waitForExpectations(timeout: 0.1)
 
         // Set the responder to reject the mutation. Make sure to push a retry advice before sending
         // a new mutation.
@@ -175,7 +154,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
                 savedUpdate1.fulfill()
             }
         }
-        wait(for: [savedUpdate1], timeout: 0.1)
+        await waitForExpectations(timeout: 0.1)
 
         // At this point, the MutationEvent table (the backing store for the outgoing mutation
         // queue) has only a record for the interim update. It is marked as `inProcess: true`,
@@ -187,6 +166,11 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         // the RemoteSyncEngine will stop the outgoing mutation queue. We will set the retry
         // advice interval to be very high, so it will be preempted by the "network available"
         // message we send later.
+        
+        let networkUnavailable = expectation(description: "networkUnavailable")
+        setUpNetworkUnavailableListener(
+            fulfillingWhenNetworkUnavailable: networkUnavailable
+        )
 
         reachabilitySubject.send(ReachabilityUpdate(isOnline: false))
         let noNetworkCompletion = Subscribers
@@ -196,7 +180,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
 
         // Assert that DataStore has pushed the no-network event. This isn't strictly necessary for
         // correct operation of the queue.
-        wait(for: [networkUnavailable], timeout: 0.1)
+        await waitForExpectations(timeout: 0.1)
 
         // At this point, the MutationEvent table has only a record for update1. It is marked as
         // `inProcess: false`, because the mutation queue has been fully cancelled by the cleanup
@@ -219,7 +203,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
                 savedUpdate2.fulfill()
             }
         }
-        wait(for: [savedUpdate2], timeout: 0.1)
+        await waitForExpectations(timeout: 0.1)
 
         // At this point, the MutationEvent table has only a record for update2. It is marked as
         // `inProcess: false`, because the mutation queue has been fully cancelled.
@@ -238,7 +222,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
                 savedFinalUpdate.fulfill()
             }
         }
-        wait(for: [savedFinalUpdate], timeout: 0.1)
+        await waitForExpectations(timeout: 0.1)
 
         let syncStarted = expectation(description: "syncStarted")
         setUpSyncStartedListener(
@@ -249,13 +233,30 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         setUpOutboxEmptyListener(
             fulfillingWhenOutboxEmpty: outboxEmpty
         )
+        
+        // Once we've rejected some mutations due to an unreachable network, we'll allow the final
+        // mutation to succeed. This is where we will assert that we've seen the last mutation
+        // to be processed
+        let expectedFinalContentReceived = expectation(description: "expectedFinalContentReceived")
+        let acceptSubsequentMutations = setUpSubsequentMutationRequestResponder(
+            for: try post.eraseToAnyModel(),
+            fulfilling: expectedFinalContentReceived,
+            whenContentContains: expectedFinalContent,
+            incrementing: version
+        )
 
         // Turn on network. This will preempt the retry timer and immediately start processing
         // the queue. We expect the mutation queue to restart, poll the MutationEvent table, pick
         // up the final update, and process it.
+        let networkAvailableAgain = expectation(description: "networkAvailableAgain")
+
+        setUpNetworkAvailableListener(
+            fulfillingWhenNetworkAvailableAgain: networkAvailableAgain
+        )
+        
         apiPlugin.responders = [.mutateRequestListener: acceptSubsequentMutations]
         reachabilitySubject.send(ReachabilityUpdate(isOnline: true))
-        wait(for: [networkAvailableAgain, syncStarted, outboxEmpty, expectedFinalContentReceived], timeout: 5.0)
+        await waitForExpectations(timeout: 5.0)
     }
 
     // MARK: - Utilities
@@ -331,15 +332,9 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
 
     }
 
-    private func setUpNetworkStatusListener(
-        fulfillingWhenNetworkUnavailable networkUnavailable: XCTestExpectation,
-        fulfillingWhenNetworkAvailableAgain networkAvailableAgain: XCTestExpectation
+    private func setUpNetworkUnavailableListener(
+        fulfillingWhenNetworkUnavailable networkUnavailable: XCTestExpectation
     ) {
-        // We expect 2 "network available" notifications: the initial notification sent from the
-        // RemoteSyncEngine when it first `start()`s and subscribes to the reachability publisher,
-        // and the notification after we restore connectivity later in the test.
-        let shouldFulfillNetworkAvailableAgain = AtomicValue(initialValue: false)
-
         Amplify
             .Hub
             .publisher(for: .dataStore)
@@ -351,20 +346,34 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
                     return
                 }
 
-                if networkStatusEvent.active {
-                    if shouldFulfillNetworkAvailableAgain.get() {
-                        networkAvailableAgain.fulfill()
-                    }
-                } else {
-                    // If the received event is an "unavailable" message, we should fulfill the
-                    // "network available" expectation the next time we receive an "available" message.
-                    shouldFulfillNetworkAvailableAgain.set(true)
+                if !networkStatusEvent.active {
                     networkUnavailable.fulfill()
                 }
             }
             .store(in: &cancellables)
     }
-
+    
+    private func setUpNetworkAvailableListener(
+        fulfillingWhenNetworkAvailableAgain networkAvailableAgain: XCTestExpectation
+    ) {
+        Amplify
+            .Hub
+            .publisher(for: .dataStore)
+            .print("### DataStore listener \(Date()) - ")
+            .filter { $0.eventName == HubPayload.EventName.DataStore.networkStatus }
+            .sink { payload in
+                guard let networkStatusEvent = payload.data as? NetworkStatusEvent else {
+                    XCTFail("Failed to cast payload data as NetworkStatusEvent")
+                    return
+                }
+                
+                if networkStatusEvent.active {
+                    networkAvailableAgain.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
     private func setUpSyncStartedListener(
         fulfillingWhenSyncStarted syncStarted: XCTestExpectation
     ) {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
@@ -80,7 +80,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
     ///   - I restore the network
     /// - Then:
     ///   - The sync engine submits the most recent update to the service
-    func testLastMutationSentWhenNoNetwork() throws {
+    func testLastMutationSentWhenNoNetwork() async throws {
         // NOTE: The state descriptions in this test are approximate, especially as regards the
         // values of the MutationEvent table. Processing happens asynchronously, so it is important
         // to only assert the behavior we care about (which is that the final update happens after
@@ -132,7 +132,9 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         // Start by accepting the initial "create" mutation
         apiPlugin.responders = [.mutateRequestListener: acceptInitialMutation]
 
-        try startAmplifyAndWaitForSync()
+        try await startAmplifyAndWaitForSync()
+        
+        print("blah")
 
         // Save initial model
         let createdNewItem = expectation(description: "createdNewItem")

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
@@ -79,7 +79,7 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
             }
         }
 
-        try startAmplifyAndWaitForSync()
+        try await startAmplifyAndWaitForSync()
 
         Amplify.DataStore.save(post) { _ in }
         await waitForExpectations(timeout: 5.0, handler: nil)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
@@ -33,7 +33,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         ModelRegistry.register(modelType: Comment.self)
     }
 
-    func testRetryOnTimeoutOfWaiting() throws {
+    func testRetryOnTimeoutOfWaiting() async throws {
         let expectMutationRequestCompletion = expectation(description: "Expect to complete mutation request")
         let expectFirstCallToAPIMutate = expectation(description: "First call to API.mutate")
         let expectSecondCallToAPIMutate = expectation(description: "Second call to API.mutate")
@@ -67,7 +67,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
             expectMutationRequestCompletion.fulfill()
         }
 
-        let operation = SyncMutationToCloudOperation(mutationEvent: mutationEvent,
+        let operation = await SyncMutationToCloudOperation(mutationEvent: mutationEvent,
                                                      api: mockAPIPlugin,
                                                      authModeStrategy: AWSDefaultAuthModeStrategy(),
                                                      networkReachabilityPublisher: publisher,
@@ -103,7 +103,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         wait(for: [expectMutationRequestCompletion], timeout: defaultAsyncWaitTimeout)
     }
 
-    func testRetryOnChangeReachability() throws {
+    func testRetryOnChangeReachability() async throws {
         let mockRequestRetryPolicy = MockRequestRetryablePolicy()
         let waitForeverToRetry = RequestRetryAdvice(shouldRetry: true, retryInterval: .seconds(secondsInADay))
         mockRequestRetryPolicy.pushOnRetryRequestAdvice(response: waitForeverToRetry)
@@ -139,7 +139,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         let completion: GraphQLOperation<MutationSync<AnyModel>>.ResultListener = { _ in
             expectMutationRequestCompletion.fulfill()
         }
-        let operation = SyncMutationToCloudOperation(mutationEvent: mutationEvent,
+        let operation = await SyncMutationToCloudOperation(mutationEvent: mutationEvent,
                                                      api: mockAPIPlugin,
                                                      authModeStrategy: AWSDefaultAuthModeStrategy(),
                                                      networkReachabilityPublisher: publisher,
@@ -176,7 +176,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         wait(for: [expectMutationRequestCompletion], timeout: defaultAsyncWaitTimeout)
     }
 
-    func testAbilityToCancel() throws {
+    func testAbilityToCancel() async throws {
         let mockRequestRetryPolicy = MockRequestRetryablePolicy()
         let waitForeverToRetry = RequestRetryAdvice(shouldRetry: true, retryInterval: .seconds(secondsInADay))
         mockRequestRetryPolicy.pushOnRetryRequestAdvice(response: waitForeverToRetry)
@@ -212,7 +212,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
                 break
             }
         }
-        let operation = SyncMutationToCloudOperation(mutationEvent: mutationEvent,
+        let operation = await SyncMutationToCloudOperation(mutationEvent: mutationEvent,
                                                      api: mockAPIPlugin,
                                                      authModeStrategy: AWSDefaultAuthModeStrategy(),
                                                      networkReachabilityPublisher: publisher,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -34,9 +34,9 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     }
     var operationQueue: OperationQueue!
 
-    func initEventQueue(modelSchemas: [ModelSchema]) -> AWSIncomingEventReconciliationQueue {
+    func initEventQueue(modelSchemas: [ModelSchema]) async -> AWSIncomingEventReconciliationQueue {
         let modelReconciliationQueueFactory = MockModelReconciliationQueue.init
-        return AWSIncomingEventReconciliationQueue(
+        return await AWSIncomingEventReconciliationQueue(
             modelSchemas: modelSchemas,
             api: apiPlugin,
             storageAdapter: storageAdapter,
@@ -47,10 +47,10 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
 
     // This test case attempts to hit a race condition, and may be required to execute multiple times
     // in order to demonstrate the bug
-    func testTwoConnectionStatusUpdatesAtSameTime() {
+    func testTwoConnectionStatusUpdatesAtSameTime() async {
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
 
-        let eventQueue = initEventQueue(modelSchemas: [Post.schema, Comment.schema])
+        let eventQueue = await initEventQueue(modelSchemas: [Post.schema, Comment.schema])
         eventQueue.start()
 
         // We need to keep this in scope for the duration of the test or else Combine will release the listeners.
@@ -73,15 +73,15 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        waitForExpectations(timeout: 2)
+        await waitForExpectations(timeout: 2)
 
         // Take action on the sink to prevent compiler warnings about unused variables.
         sink.cancel()
     }
 
-    func testSubscriptionFailedWithSingleModelUnauthorizedError() {
+    func testSubscriptionFailedWithSingleModelUnauthorizedError() async {
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
-        let eventQueue = initEventQueue(modelSchemas: [Post.schema])
+        let eventQueue = await initEventQueue(modelSchemas: [Post.schema])
         eventQueue.start()
 
         let sink = eventQueue.publisher.sink(receiveCompletion: { _ in
@@ -103,16 +103,16 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        waitForExpectations(timeout: 2)
+        await waitForExpectations(timeout: 2)
 
         sink.cancel()
     }
 
     // This test case tests that initialized event is received even if only one
     // model subscriptions out of two failed - Post subscription will fail but Comment will succeed
-    func testSubscriptionFailedWithMultipleModels() {
+    func testSubscriptionFailedWithMultipleModels() async {
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
-        let eventQueue = initEventQueue(modelSchemas: [Post.schema, Comment.schema])
+        let eventQueue = await initEventQueue(modelSchemas: [Post.schema, Comment.schema])
         eventQueue.start()
 
         let sink = eventQueue.publisher.sink(receiveCompletion: { _ in
@@ -137,14 +137,14 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        waitForExpectations(timeout: 2)
+        await waitForExpectations(timeout: 2)
 
         sink.cancel()
     }
 
-    func testSubscriptionFailedWithSingleModelOperationDisabled() {
+    func testSubscriptionFailedWithSingleModelOperationDisabled() async {
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
-        let eventQueue = initEventQueue(modelSchemas: [Post.schema])
+        let eventQueue = await initEventQueue(modelSchemas: [Post.schema])
         eventQueue.start()
 
         let sink = eventQueue.publisher.sink(receiveCompletion: { _ in
@@ -167,7 +167,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        waitForExpectations(timeout: 2)
+        await waitForExpectations(timeout: 2)
 
         sink.cancel()
     }
@@ -176,9 +176,9 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     // model subscriptions out of two succeeded
     // Post subscription will fail with a "OperationDisabled",
     // but Comment subscription will succeed
-    func testSubscriptionFailedBecauseOfOperationDisabledWithMultipleModels() {
+    func testSubscriptionFailedBecauseOfOperationDisabledWithMultipleModels() async {
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
-        let eventQueue = initEventQueue(modelSchemas: [Post.schema])
+        let eventQueue = await initEventQueue(modelSchemas: [Post.schema])
         eventQueue.start()
 
         let sink = eventQueue.publisher.sink(receiveCompletion: { _ in
@@ -203,7 +203,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        waitForExpectations(timeout: 2)
+        await waitForExpectations(timeout: 2)
 
         sink.cancel()
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
@@ -56,7 +56,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
         await tryOrFail {
             try setUpDataStore(modelRegistration: MockModelRegistration())
             mockRemoteSyncEngineFor_testUpdateAfterDelete()
-            try startAmplifyAndWaitForSync()
+            try await startAmplifyAndWaitForSync()
         }
         wait(for: [expectationListener], timeout: 2.0)
 
@@ -148,7 +148,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
         await tryOrFail {
             try setUpDataStore(modelRegistration: MockModelRegistration())
             mockRemoteSyncEngineFor_testDeleteWithNoLocalModel()
-            try startAmplifyAndWaitForSync()
+            try await startAmplifyAndWaitForSync()
         }
         wait(for: [expectationListener], timeout: 1.0)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -20,14 +20,14 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
     ///    - I publish incoming events
     /// - Then:
     ///    - The queue does not process them
-    func testBuffersBeforeStart() throws {
+    func testBuffersBeforeStart() async throws {
         let eventsNotSaved = expectation(description: "Events not saved")
         eventsNotSaved.isInverted = true
         storageAdapter.responders[.saveUntypedModel] = SaveUntypedModelResponder { _, _ in
             eventsNotSaved.fulfill()
         }
 
-        let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
+        let queue = await AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
                                                 api: apiPlugin,
                                                 reconcileAndSaveQueue: reconcileAndSaveQueue,
@@ -59,7 +59,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
     ///    - I `start()` the queue
     /// - Then:
     ///    - It processes buffered events in order
-    func testProcessesBufferedEvents() throws {
+    func testProcessesBufferedEvents() async throws {
         let event1Saved = expectation(description: "Event 1 saved")
         let event2Saved = expectation(description: "Event 2 saved")
         let event3Saved = expectation(description: "Event 3 saved")
@@ -78,7 +78,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
             completion(.success(model))
         }
 
-        let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
+        let queue = await AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
                                                 api: apiPlugin,
                                                 reconcileAndSaveQueue: reconcileAndSaveQueue,
@@ -133,7 +133,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
     ///    - I `start()` the queue
     /// - Then:
     ///    - It processes buffered events in order, that evaluate true against the predicate
-    func testProcessesEventsWithSelectiveSync() throws {
+    func testProcessesEventsWithSelectiveSync() async throws {
         let event1Saved = expectation(description: "Event 1 saved")
         let event3Saved = expectation(description: "Event 3 saved")
         storageAdapter.responders[.saveUntypedModel] = SaveUntypedModelResponder { model, completion in
@@ -153,7 +153,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
         let syncExpression = DataStoreSyncExpression.syncExpression(MockSynced.schema, where: {
             MockSynced.keys.id == "id-1" || MockSynced.keys.id == "id-3"
         })
-        let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
+        let queue = await AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
                                                 api: apiPlugin,
                                                 reconcileAndSaveQueue: reconcileAndSaveQueue,
@@ -205,7 +205,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
     ///    - I `start()` the queue
     /// - Then:
     ///    - It processes buffered events one at a time
-    func testProcessesBufferedEventsSerially() throws {
+    func testProcessesBufferedEventsSerially() async throws {
         // This test relies on knowledge of the Reconciliation queue's internal behavior: specifically, that it saves
         // an event's metadata as the last step.
 
@@ -247,7 +247,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                 completion(.success(mutationSyncMetadata))
         }
 
-        let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
+        let queue = await AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
                                                 api: apiPlugin,
                                                 reconcileAndSaveQueue: reconcileAndSaveQueue,
@@ -300,7 +300,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
     ///    - I submit a new event
     /// - Then:
     ///    - The new event immediately processes
-    func testProcessesNewEvents() throws {
+    func testProcessesNewEvents() async throws {
         // Return a successful MockSynced save
         storageAdapter.responders[.saveUntypedModel] = SaveUntypedModelResponder { model, completion in
             completion(.success(model))
@@ -321,7 +321,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
                 completion(.success(mutationSyncMetadata))
         }
 
-        let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
+        let queue = await AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
                                                 api: apiPlugin,
                                                 reconcileAndSaveQueue: reconcileAndSaveQueue,
@@ -426,9 +426,9 @@ extension ModelReconciliationQueueBehaviorTests {
         return .failure(dataStoreError)
     }
 
-    func testProcessingUnauthorizedError() {
+    func testProcessingUnauthorizedError() async {
         let eventSentViaPublisher = expectation(description: "Sent via publisher")
-        let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
+        let queue = await AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
                                                 api: apiPlugin,
                                                 reconcileAndSaveQueue: reconcileAndSaveQueue,
@@ -448,9 +448,9 @@ extension ModelReconciliationQueueBehaviorTests {
         wait(for: [eventSentViaPublisher], timeout: 1.0)
     }
 
-    func testProcessingOperationDisabledError() {
+    func testProcessingOperationDisabledError() async {
         let eventSentViaPublisher = expectation(description: "Sent via publisher")
-        let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
+        let queue = await AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
                                                 api: apiPlugin,
                                                 reconcileAndSaveQueue: reconcileAndSaveQueue,
@@ -470,9 +470,9 @@ extension ModelReconciliationQueueBehaviorTests {
         wait(for: [eventSentViaPublisher], timeout: 1.0)
     }
 
-    func testProcessingUnhandledErrors() {
+    func testProcessingUnhandledErrors() async {
         let eventSentViaPublisher = expectation(description: "Sent via publisher")
-        let queue = AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
+        let queue = await AWSModelReconciliationQueue(modelSchema: MockSynced.schema,
                                                 storageAdapter: storageAdapter,
                                                 api: apiPlugin,
                                                 reconcileAndSaveQueue: reconcileAndSaveQueue,

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -312,14 +312,6 @@ class MockOIDCAuthProvider: AmplifyOIDCAuthProvider {
             return "token"
         }
     }
-    
-    func getUserPoolAccessToken() async throws -> String {
-        if case let .success(token) = result {
-            return token
-        } else {
-            return "token"
-        }
-    }
 }
 
 class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
@@ -331,14 +323,6 @@ class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
             return result
         } else {
             return .success("token")
-        }
-    }
-    
-    func getUserPoolAccessToken() async throws -> String {
-        if case let .success(token) = result {
-            return token
-        } else {
-            return "token"
         }
     }
     

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -312,6 +312,14 @@ class MockOIDCAuthProvider: AmplifyOIDCAuthProvider {
             return "token"
         }
     }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        if case let .success(token) = result {
+            return token
+        } else {
+            return "token"
+        }
+    }
 }
 
 class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
@@ -323,6 +331,14 @@ class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
             return result
         } else {
             return .success("token")
+        }
+    }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        if case let .success(token) = result {
+            return token
+        } else {
+            return "token"
         }
     }
     

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -311,6 +311,14 @@ class MockOIDCAuthProvider: AmplifyOIDCAuthProvider {
             return "token"
         }
     }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        if case let .success(token) = result {
+            return token
+        } else {
+            return "token"
+        }
+    }
 }
 
 class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
@@ -321,6 +329,14 @@ class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
             return result
         } else {
             return .success("token")
+        }
+    }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        if case let .success(token) = result {
+            return token
+        } else {
+            return "token"
         }
     }
     

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -296,6 +296,7 @@ class MockAPIAuthProviderFactory: APIAuthProviderFactory {
 class MockOIDCAuthProvider: AmplifyOIDCAuthProvider {
     var result: Result<AuthToken, Error>?
 
+    //TODO: Remove this after datastore dependencies are removed.
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         if let result = result {
             return result
@@ -324,6 +325,7 @@ class MockOIDCAuthProvider: AmplifyOIDCAuthProvider {
 class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
     var result: Result<AuthToken, Error>?
 
+    //TODO: Remove this after datastore dependencies are removed.
     func getLatestAuthToken() -> Result<AuthToken, Error> {
         if let result = result {
             return result

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
         "state": {
           "branch": null,
-          "revision": "36ed209d55aacc127356a387b51cef5f94ec9ac7",
-          "version": "2.0.0"
+          "revision": "da88cf1cab82e281e7277cd9feb9efc87a057041",
+          "version": "2.1.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let dependencies: [Package.Dependency] = [
     .package(
         name: "AppSyncRealTimeClient",
         url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
-        from: "2.0.0"
+        from: "2.1.1"
     ),
     .package(
         name: "AWSSwiftSDK",


### PR DESCRIPTION
*Description of changes:*
remove consumers of deprecated auth methods from the DataStore plugin

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~[ ] Documentation update for the change if required~~
- [ ] PR title conforms to conventional commit style
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
