### PR TITLE
fix(api): fix package reference in api integ test host app

### DIFF
--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
@@ -34,88 +34,10 @@
 		21698BF02889A163004BD994 /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 21698BEF2889A163004BD994 /* AWSCognitoAuthPlugin */; };
 		21698C082889B173004BD994 /* TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C062889B173004BD994 /* TestExtensions.swift */; };
 		21698C092889B173004BD994 /* TestCommonConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C072889B173004BD994 /* TestCommonConstants.swift */; };
-		21698C2A2889B1AE004BD994 /* PostStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C0B2889B1AD004BD994 /* PostStatus.swift */; };
-		21698C2B2889B1AE004BD994 /* AmplifyModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C0C2889B1AE004BD994 /* AmplifyModels.swift */; };
-		21698C2D2889B1AE004BD994 /* QPredGen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C0E2889B1AE004BD994 /* QPredGen.swift */; };
-		21698C2E2889B1AE004BD994 /* CustomerOrder+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C0F2889B1AE004BD994 /* CustomerOrder+Schema.swift */; };
-		21698C2F2889B1AE004BD994 /* UserFollowing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C102889B1AE004BD994 /* UserFollowing.swift */; };
-		21698C302889B1AE004BD994 /* OGCScenarioBPost+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C112889B1AE004BD994 /* OGCScenarioBPost+Schema.swift */; };
-		21698C312889B1AE004BD994 /* User+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C122889B1AE004BD994 /* User+Schema.swift */; };
-		21698C322889B1AE004BD994 /* RecordCover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C132889B1AE004BD994 /* RecordCover.swift */; };
-		21698C332889B1AE004BD994 /* Article.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C142889B1AE004BD994 /* Article.swift */; };
-		21698C342889B1AE004BD994 /* CustomerOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C152889B1AE004BD994 /* CustomerOrder.swift */; };
-		21698C352889B1AE004BD994 /* Record.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C162889B1AE004BD994 /* Record.swift */; };
-		21698C362889B1AE004BD994 /* OGCScenarioBMGroupPost+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C172889B1AE004BD994 /* OGCScenarioBMGroupPost+Schema.swift */; };
-		21698C372889B1AE004BD994 /* Comment+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C182889B1AE004BD994 /* Comment+Schema.swift */; };
-		21698C382889B1AE004BD994 /* Article+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C192889B1AE004BD994 /* Article+Schema.swift */; };
-		21698C392889B1AE004BD994 /* PostCommentModelRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C1A2889B1AE004BD994 /* PostCommentModelRegistration.swift */; };
-		21698C3A2889B1AE004BD994 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C1B2889B1AE004BD994 /* Comment.swift */; };
-		21698C3B2889B1AE004BD994 /* ScenarioATest6Post+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C1C2889B1AE004BD994 /* ScenarioATest6Post+Schema.swift */; };
-		21698C3C2889B1AE004BD994 /* ScenarioATest6Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C1D2889B1AE004BD994 /* ScenarioATest6Post.swift */; };
-		21698C3D2889B1AE004BD994 /* MockModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C1E2889B1AE004BD994 /* MockModels.swift */; };
-		21698C3E2889B1AE004BD994 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C1F2889B1AE004BD994 /* Post.swift */; };
-		21698C3F2889B1AE004BD994 /* UserFollowers+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C202889B1AE004BD994 /* UserFollowers+Schema.swift */; };
-		21698C402889B1AE004BD994 /* UserFollowers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C212889B1AE004BD994 /* UserFollowers.swift */; };
-		21698C412889B1AE004BD994 /* UserFollowing+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C222889B1AE004BD994 /* UserFollowing+Schema.swift */; };
-		21698C422889B1AE004BD994 /* QPredGen+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C232889B1AE004BD994 /* QPredGen+Schema.swift */; };
-		21698C432889B1AE004BD994 /* RecordCover+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C242889B1AE004BD994 /* RecordCover+Schema.swift */; };
-		21698C442889B1AE004BD994 /* Post+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C252889B1AE004BD994 /* Post+Schema.swift */; };
-		21698C452889B1AE004BD994 /* Record+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C262889B1AE004BD994 /* Record+Schema.swift */; };
-		21698C462889B1AE004BD994 /* OGCScenarioBMGroupPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C272889B1AE004BD994 /* OGCScenarioBMGroupPost.swift */; };
-		21698C472889B1AE004BD994 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C282889B1AE004BD994 /* User.swift */; };
-		21698C482889B1AE004BD994 /* OGCScenarioBPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C292889B1AE004BD994 /* OGCScenarioBPost.swift */; };
-		21698C642889CE60004BD994 /* Blog6+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C5E2889CE60004BD994 /* Blog6+Schema.swift */; };
-		21698C652889CE60004BD994 /* Post6+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C5F2889CE60004BD994 /* Post6+Schema.swift */; };
-		21698C662889CE60004BD994 /* Blog6.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C602889CE60004BD994 /* Blog6.swift */; };
-		21698C672889CE60004BD994 /* Comment6.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C612889CE60004BD994 /* Comment6.swift */; };
-		21698C682889CE60004BD994 /* Comment6+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C622889CE60004BD994 /* Comment6+Schema.swift */; };
-		21698C692889CE60004BD994 /* Post6.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C632889CE60004BD994 /* Post6.swift */; };
-		21698C702889CF5E004BD994 /* Post5+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C6A2889CF5D004BD994 /* Post5+Schema.swift */; };
-		21698C712889CF5E004BD994 /* User5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C6B2889CF5D004BD994 /* User5.swift */; };
-		21698C722889CF5E004BD994 /* PostEditor5+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C6C2889CF5D004BD994 /* PostEditor5+Schema.swift */; };
-		21698C732889CF5E004BD994 /* PostEditor5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C6D2889CF5D004BD994 /* PostEditor5.swift */; };
-		21698C742889CF5E004BD994 /* User5+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C6E2889CF5D004BD994 /* User5+Schema.swift */; };
-		21698C752889CF5E004BD994 /* Post5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C6F2889CF5D004BD994 /* Post5.swift */; };
-		21698C7A2889CF6D004BD994 /* Comment4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C762889CF6C004BD994 /* Comment4.swift */; };
-		21698C7B2889CF6D004BD994 /* Post4+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C772889CF6D004BD994 /* Post4+Schema.swift */; };
-		21698C7C2889CF6D004BD994 /* Post4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C782889CF6D004BD994 /* Post4.swift */; };
-		21698C7D2889CF6D004BD994 /* Comment4+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C792889CF6D004BD994 /* Comment4+Schema.swift */; };
-		21698C822889CF8A004BD994 /* Comment3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C7E2889CF8A004BD994 /* Comment3.swift */; };
-		21698C832889CF8A004BD994 /* Post3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C7F2889CF8A004BD994 /* Post3.swift */; };
-		21698C842889CF8A004BD994 /* Post3+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C802889CF8A004BD994 /* Post3+Schema.swift */; };
-		21698C852889CF8A004BD994 /* Comment3+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C812889CF8A004BD994 /* Comment3+Schema.swift */; };
-		21698C8A2889CFA9004BD994 /* Team2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C862889CFA9004BD994 /* Team2.swift */; };
-		21698C8B2889CFA9004BD994 /* Project2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C872889CFA9004BD994 /* Project2.swift */; };
-		21698C8C2889CFA9004BD994 /* Team2+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C882889CFA9004BD994 /* Team2+Schema.swift */; };
-		21698C8D2889CFA9004BD994 /* Project2+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C892889CFA9004BD994 /* Project2+Schema.swift */; };
-		21698C922889CFC0004BD994 /* Team1+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C8E2889CFC0004BD994 /* Team1+Schema.swift */; };
-		21698C932889CFC0004BD994 /* Project1+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C8F2889CFC0004BD994 /* Project1+Schema.swift */; };
-		21698C942889CFC0004BD994 /* Project1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C902889CFC0004BD994 /* Project1.swift */; };
-		21698C952889CFC0004BD994 /* Team1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C912889CFC0004BD994 /* Team1.swift */; };
-		21698C9C2889D0FB004BD994 /* HubListenerTestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C972889D0FB004BD994 /* HubListenerTestUtilities.swift */; };
-		21698C9F2889D0FB004BD994 /* AuthSignInHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C9A2889D0FB004BD994 /* AuthSignInHelper.swift */; };
-		21698CA02889D0FB004BD994 /* TypeRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C9B2889D0FB004BD994 /* TypeRegistry.swift */; };
-		21698CB02889D50D004BD994 /* ListStringContainer+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CA22889D50C004BD994 /* ListStringContainer+Schema.swift */; };
-		21698CB12889D50D004BD994 /* ScalarContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CA32889D50C004BD994 /* ScalarContainer.swift */; };
-		21698CB22889D50D004BD994 /* Nested+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CA42889D50C004BD994 /* Nested+Schema.swift */; };
-		21698CB32889D50D004BD994 /* ListIntContainer+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CA52889D50C004BD994 /* ListIntContainer+Schema.swift */; };
-		21698CB42889D50D004BD994 /* ScalarContainer+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CA62889D50C004BD994 /* ScalarContainer+Schema.swift */; };
-		21698CB52889D50D004BD994 /* EnumTestModel+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CA72889D50C004BD994 /* EnumTestModel+Schema.swift */; };
-		21698CB62889D50D004BD994 /* ListIntContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CA82889D50C004BD994 /* ListIntContainer.swift */; };
-		21698CB72889D50D004BD994 /* NestedTypeTestModel+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CA92889D50C004BD994 /* NestedTypeTestModel+Schema.swift */; };
-		21698CB82889D50D004BD994 /* ListStringContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CAA2889D50C004BD994 /* ListStringContainer.swift */; };
-		21698CB92889D50D004BD994 /* TestEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CAB2889D50C004BD994 /* TestEnum.swift */; };
-		21698CBA2889D50D004BD994 /* Nested.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CAC2889D50C004BD994 /* Nested.swift */; };
-		21698CBB2889D50D004BD994 /* NestedTypeTestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CAD2889D50C004BD994 /* NestedTypeTestModel.swift */; };
-		21698CBC2889D50D004BD994 /* Scalar+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CAE2889D50D004BD994 /* Scalar+Equatable.swift */; };
-		21698CBD2889D50D004BD994 /* EnumTestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CAF2889D50D004BD994 /* EnumTestModel.swift */; };
 		21698CC02889D5A9004BD994 /* CwlPreconditionTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 21698CBF2889D5A9004BD994 /* CwlPreconditionTesting */; };
 		21698CC72889D75F004BD994 /* GraphQLAuthDirectiveIntegrationTests+Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CC22889D75F004BD994 /* GraphQLAuthDirectiveIntegrationTests+Auth.swift */; };
 		21698CC92889D75F004BD994 /* SocialNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CC42889D75F004BD994 /* SocialNote.swift */; };
 		21698CCB2889D75F004BD994 /* GraphQLAuthDirectiveIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CC62889D75F004BD994 /* GraphQLAuthDirectiveIntegrationTests.swift */; };
-		21698CD02889E126004BD994 /* TestConfigHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C992889D0FB004BD994 /* TestConfigHelper.swift */; };
-		21698CD12889E201004BD994 /* TestConfigHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C992889D0FB004BD994 /* TestConfigHelper.swift */; };
-		21698CD22889E202004BD994 /* TestConfigHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698C992889D0FB004BD994 /* TestConfigHelper.swift */; };
 		21E73E6F28898D7900D7DB7E /* APIHostAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E73E6E28898D7900D7DB7E /* APIHostAppApp.swift */; };
 		21E73E7128898D7900D7DB7E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E73E7028898D7900D7DB7E /* ContentView.swift */; };
 		21E73E7328898D7A00D7DB7E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 21E73E7228898D7A00D7DB7E /* Assets.xcassets */; };
@@ -160,7 +82,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		21698A3B2889905F004BD994 /* amplify-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-ios"; path = ../../../../..; sourceTree = "<group>"; };
 		21698A7B28899804004BD994 /* AWSAPIPluginFunctionalTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSAPIPluginFunctionalTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		21698A882889980F004BD994 /* AWSAPIPluginGraphQLAPIKeyIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSAPIPluginGraphQLAPIKeyIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		21698A9528899818004BD994 /* AWSAPIPluginIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSAPIPluginIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -194,89 +115,12 @@
 		21698BD328899BFC004BD994 /* AWSAPICategoryPluginGraphQLAPIKeyIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSAPICategoryPluginGraphQLAPIKeyIntegrationTests.swift; sourceTree = "<group>"; };
 		21698C062889B173004BD994 /* TestExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestExtensions.swift; path = ../../../../../AmplifyTestCommon/TestExtensions.swift; sourceTree = "<group>"; };
 		21698C072889B173004BD994 /* TestCommonConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestCommonConstants.swift; path = ../../../../../AmplifyTestCommon/TestCommonConstants.swift; sourceTree = "<group>"; };
-		21698C0B2889B1AD004BD994 /* PostStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PostStatus.swift; path = ../../../../../../AmplifyTestCommon/Models/PostStatus.swift; sourceTree = "<group>"; };
-		21698C0C2889B1AE004BD994 /* AmplifyModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AmplifyModels.swift; path = ../../../../../../AmplifyTestCommon/Models/AmplifyModels.swift; sourceTree = "<group>"; };
-		21698C0D2889B1AE004BD994 /* schema.graphql */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = schema.graphql; path = ../../../../../../AmplifyTestCommon/Models/schema.graphql; sourceTree = "<group>"; };
-		21698C0E2889B1AE004BD994 /* QPredGen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = QPredGen.swift; path = ../../../../../../AmplifyTestCommon/Models/QPredGen.swift; sourceTree = "<group>"; };
-		21698C0F2889B1AE004BD994 /* CustomerOrder+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "CustomerOrder+Schema.swift"; path = "../../../../../../AmplifyTestCommon/Models/CustomerOrder+Schema.swift"; sourceTree = "<group>"; };
-		21698C102889B1AE004BD994 /* UserFollowing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserFollowing.swift; path = ../../../../../../AmplifyTestCommon/Models/UserFollowing.swift; sourceTree = "<group>"; };
-		21698C112889B1AE004BD994 /* OGCScenarioBPost+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "OGCScenarioBPost+Schema.swift"; path = "../../../../../../AmplifyTestCommon/Models/OGCScenarioBPost+Schema.swift"; sourceTree = "<group>"; };
-		21698C122889B1AE004BD994 /* User+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "User+Schema.swift"; path = "../../../../../../AmplifyTestCommon/Models/User+Schema.swift"; sourceTree = "<group>"; };
-		21698C132889B1AE004BD994 /* RecordCover.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RecordCover.swift; path = ../../../../../../AmplifyTestCommon/Models/RecordCover.swift; sourceTree = "<group>"; };
-		21698C142889B1AE004BD994 /* Article.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Article.swift; path = ../../../../../../AmplifyTestCommon/Models/Article.swift; sourceTree = "<group>"; };
-		21698C152889B1AE004BD994 /* CustomerOrder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CustomerOrder.swift; path = ../../../../../../AmplifyTestCommon/Models/CustomerOrder.swift; sourceTree = "<group>"; };
-		21698C162889B1AE004BD994 /* Record.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Record.swift; path = ../../../../../../AmplifyTestCommon/Models/Record.swift; sourceTree = "<group>"; };
-		21698C172889B1AE004BD994 /* OGCScenarioBMGroupPost+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "OGCScenarioBMGroupPost+Schema.swift"; path = "../../../../../../AmplifyTestCommon/Models/OGCScenarioBMGroupPost+Schema.swift"; sourceTree = "<group>"; };
-		21698C182889B1AE004BD994 /* Comment+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Comment+Schema.swift"; path = "../../../../../../AmplifyTestCommon/Models/Comment+Schema.swift"; sourceTree = "<group>"; };
-		21698C192889B1AE004BD994 /* Article+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Article+Schema.swift"; path = "../../../../../../AmplifyTestCommon/Models/Article+Schema.swift"; sourceTree = "<group>"; };
-		21698C1A2889B1AE004BD994 /* PostCommentModelRegistration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PostCommentModelRegistration.swift; path = ../../../../../../AmplifyTestCommon/Models/PostCommentModelRegistration.swift; sourceTree = "<group>"; };
-		21698C1B2889B1AE004BD994 /* Comment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Comment.swift; path = ../../../../../../AmplifyTestCommon/Models/Comment.swift; sourceTree = "<group>"; };
-		21698C1C2889B1AE004BD994 /* ScenarioATest6Post+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "ScenarioATest6Post+Schema.swift"; path = "../../../../../../AmplifyTestCommon/Models/ScenarioATest6Post+Schema.swift"; sourceTree = "<group>"; };
-		21698C1D2889B1AE004BD994 /* ScenarioATest6Post.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ScenarioATest6Post.swift; path = ../../../../../../AmplifyTestCommon/Models/ScenarioATest6Post.swift; sourceTree = "<group>"; };
-		21698C1E2889B1AE004BD994 /* MockModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MockModels.swift; path = ../../../../../../AmplifyTestCommon/Models/MockModels.swift; sourceTree = "<group>"; };
-		21698C1F2889B1AE004BD994 /* Post.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Post.swift; path = ../../../../../../AmplifyTestCommon/Models/Post.swift; sourceTree = "<group>"; };
-		21698C202889B1AE004BD994 /* UserFollowers+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UserFollowers+Schema.swift"; path = "../../../../../../AmplifyTestCommon/Models/UserFollowers+Schema.swift"; sourceTree = "<group>"; };
-		21698C212889B1AE004BD994 /* UserFollowers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserFollowers.swift; path = ../../../../../../AmplifyTestCommon/Models/UserFollowers.swift; sourceTree = "<group>"; };
-		21698C222889B1AE004BD994 /* UserFollowing+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UserFollowing+Schema.swift"; path = "../../../../../../AmplifyTestCommon/Models/UserFollowing+Schema.swift"; sourceTree = "<group>"; };
-		21698C232889B1AE004BD994 /* QPredGen+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "QPredGen+Schema.swift"; path = "../../../../../../AmplifyTestCommon/Models/QPredGen+Schema.swift"; sourceTree = "<group>"; };
-		21698C242889B1AE004BD994 /* RecordCover+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "RecordCover+Schema.swift"; path = "../../../../../../AmplifyTestCommon/Models/RecordCover+Schema.swift"; sourceTree = "<group>"; };
-		21698C252889B1AE004BD994 /* Post+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Post+Schema.swift"; path = "../../../../../../AmplifyTestCommon/Models/Post+Schema.swift"; sourceTree = "<group>"; };
-		21698C262889B1AE004BD994 /* Record+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Record+Schema.swift"; path = "../../../../../../AmplifyTestCommon/Models/Record+Schema.swift"; sourceTree = "<group>"; };
-		21698C272889B1AE004BD994 /* OGCScenarioBMGroupPost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OGCScenarioBMGroupPost.swift; path = ../../../../../../AmplifyTestCommon/Models/OGCScenarioBMGroupPost.swift; sourceTree = "<group>"; };
-		21698C282889B1AE004BD994 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = User.swift; path = ../../../../../../AmplifyTestCommon/Models/User.swift; sourceTree = "<group>"; };
-		21698C292889B1AE004BD994 /* OGCScenarioBPost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OGCScenarioBPost.swift; path = ../../../../../../AmplifyTestCommon/Models/OGCScenarioBPost.swift; sourceTree = "<group>"; };
-		21698C4A2889CD86004BD994 /* connection-schema.graphql */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "connection-schema.graphql"; path = "../../../../../../../AmplifyTestCommon/Models/Collection/connection-schema.graphql"; sourceTree = "<group>"; };
-		21698C5E2889CE60004BD994 /* Blog6+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Blog6+Schema.swift"; path = "../../../../../../../../AmplifyTestCommon/Models/Collection/6/Blog6+Schema.swift"; sourceTree = "<group>"; };
-		21698C5F2889CE60004BD994 /* Post6+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Post6+Schema.swift"; path = "../../../../../../../../AmplifyTestCommon/Models/Collection/6/Post6+Schema.swift"; sourceTree = "<group>"; };
-		21698C602889CE60004BD994 /* Blog6.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Blog6.swift; path = ../../../../../../../../AmplifyTestCommon/Models/Collection/6/Blog6.swift; sourceTree = "<group>"; };
-		21698C612889CE60004BD994 /* Comment6.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Comment6.swift; path = ../../../../../../../../AmplifyTestCommon/Models/Collection/6/Comment6.swift; sourceTree = "<group>"; };
-		21698C622889CE60004BD994 /* Comment6+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Comment6+Schema.swift"; path = "../../../../../../../../AmplifyTestCommon/Models/Collection/6/Comment6+Schema.swift"; sourceTree = "<group>"; };
-		21698C632889CE60004BD994 /* Post6.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Post6.swift; path = ../../../../../../../../AmplifyTestCommon/Models/Collection/6/Post6.swift; sourceTree = "<group>"; };
-		21698C6A2889CF5D004BD994 /* Post5+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Post5+Schema.swift"; path = "../../../../../../../../AmplifyTestCommon/Models/Collection/5/Post5+Schema.swift"; sourceTree = "<group>"; };
-		21698C6B2889CF5D004BD994 /* User5.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = User5.swift; path = ../../../../../../../../AmplifyTestCommon/Models/Collection/5/User5.swift; sourceTree = "<group>"; };
-		21698C6C2889CF5D004BD994 /* PostEditor5+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "PostEditor5+Schema.swift"; path = "../../../../../../../../AmplifyTestCommon/Models/Collection/5/PostEditor5+Schema.swift"; sourceTree = "<group>"; };
-		21698C6D2889CF5D004BD994 /* PostEditor5.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PostEditor5.swift; path = ../../../../../../../../AmplifyTestCommon/Models/Collection/5/PostEditor5.swift; sourceTree = "<group>"; };
-		21698C6E2889CF5D004BD994 /* User5+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "User5+Schema.swift"; path = "../../../../../../../../AmplifyTestCommon/Models/Collection/5/User5+Schema.swift"; sourceTree = "<group>"; };
-		21698C6F2889CF5D004BD994 /* Post5.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Post5.swift; path = ../../../../../../../../AmplifyTestCommon/Models/Collection/5/Post5.swift; sourceTree = "<group>"; };
-		21698C762889CF6C004BD994 /* Comment4.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Comment4.swift; path = ../../../../../../../../AmplifyTestCommon/Models/Collection/4/Comment4.swift; sourceTree = "<group>"; };
-		21698C772889CF6D004BD994 /* Post4+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Post4+Schema.swift"; path = "../../../../../../../../AmplifyTestCommon/Models/Collection/4/Post4+Schema.swift"; sourceTree = "<group>"; };
-		21698C782889CF6D004BD994 /* Post4.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Post4.swift; path = ../../../../../../../../AmplifyTestCommon/Models/Collection/4/Post4.swift; sourceTree = "<group>"; };
-		21698C792889CF6D004BD994 /* Comment4+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Comment4+Schema.swift"; path = "../../../../../../../../AmplifyTestCommon/Models/Collection/4/Comment4+Schema.swift"; sourceTree = "<group>"; };
-		21698C7E2889CF8A004BD994 /* Comment3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Comment3.swift; path = ../../../../../../../../AmplifyTestCommon/Models/Collection/3/Comment3.swift; sourceTree = "<group>"; };
-		21698C7F2889CF8A004BD994 /* Post3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Post3.swift; path = ../../../../../../../../AmplifyTestCommon/Models/Collection/3/Post3.swift; sourceTree = "<group>"; };
-		21698C802889CF8A004BD994 /* Post3+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Post3+Schema.swift"; path = "../../../../../../../../AmplifyTestCommon/Models/Collection/3/Post3+Schema.swift"; sourceTree = "<group>"; };
-		21698C812889CF8A004BD994 /* Comment3+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Comment3+Schema.swift"; path = "../../../../../../../../AmplifyTestCommon/Models/Collection/3/Comment3+Schema.swift"; sourceTree = "<group>"; };
-		21698C862889CFA9004BD994 /* Team2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Team2.swift; path = ../../../../../../../../AmplifyTestCommon/Models/Collection/2/Team2.swift; sourceTree = "<group>"; };
-		21698C872889CFA9004BD994 /* Project2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Project2.swift; path = ../../../../../../../../AmplifyTestCommon/Models/Collection/2/Project2.swift; sourceTree = "<group>"; };
-		21698C882889CFA9004BD994 /* Team2+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Team2+Schema.swift"; path = "../../../../../../../../AmplifyTestCommon/Models/Collection/2/Team2+Schema.swift"; sourceTree = "<group>"; };
-		21698C892889CFA9004BD994 /* Project2+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Project2+Schema.swift"; path = "../../../../../../../../AmplifyTestCommon/Models/Collection/2/Project2+Schema.swift"; sourceTree = "<group>"; };
-		21698C8E2889CFC0004BD994 /* Team1+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Team1+Schema.swift"; path = "../../../../../../../../AmplifyTestCommon/Models/Collection/1/Team1+Schema.swift"; sourceTree = "<group>"; };
-		21698C8F2889CFC0004BD994 /* Project1+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Project1+Schema.swift"; path = "../../../../../../../../AmplifyTestCommon/Models/Collection/1/Project1+Schema.swift"; sourceTree = "<group>"; };
-		21698C902889CFC0004BD994 /* Project1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Project1.swift; path = ../../../../../../../../AmplifyTestCommon/Models/Collection/1/Project1.swift; sourceTree = "<group>"; };
-		21698C912889CFC0004BD994 /* Team1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Team1.swift; path = ../../../../../../../../AmplifyTestCommon/Models/Collection/1/Team1.swift; sourceTree = "<group>"; };
-		21698C972889D0FB004BD994 /* HubListenerTestUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HubListenerTestUtilities.swift; path = ../../../../../../AmplifyTestCommon/Helpers/HubListenerTestUtilities.swift; sourceTree = "<group>"; };
-		21698C992889D0FB004BD994 /* TestConfigHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestConfigHelper.swift; path = ../../../../../../AmplifyTestCommon/Helpers/TestConfigHelper.swift; sourceTree = "<group>"; };
-		21698C9A2889D0FB004BD994 /* AuthSignInHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthSignInHelper.swift; path = ../../../../../../AmplifyTestCommon/Helpers/AuthSignInHelper.swift; sourceTree = "<group>"; };
-		21698C9B2889D0FB004BD994 /* TypeRegistry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TypeRegistry.swift; path = ../../../../../../AmplifyTestCommon/Helpers/TypeRegistry.swift; sourceTree = "<group>"; };
-		21698CA22889D50C004BD994 /* ListStringContainer+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "ListStringContainer+Schema.swift"; path = "../../../../../../../AmplifyTestCommon/Models/Scalar/ListStringContainer+Schema.swift"; sourceTree = "<group>"; };
-		21698CA32889D50C004BD994 /* ScalarContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ScalarContainer.swift; path = ../../../../../../../AmplifyTestCommon/Models/Scalar/ScalarContainer.swift; sourceTree = "<group>"; };
-		21698CA42889D50C004BD994 /* Nested+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Nested+Schema.swift"; path = "../../../../../../../AmplifyTestCommon/Models/Scalar/Nested+Schema.swift"; sourceTree = "<group>"; };
-		21698CA52889D50C004BD994 /* ListIntContainer+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "ListIntContainer+Schema.swift"; path = "../../../../../../../AmplifyTestCommon/Models/Scalar/ListIntContainer+Schema.swift"; sourceTree = "<group>"; };
-		21698CA62889D50C004BD994 /* ScalarContainer+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "ScalarContainer+Schema.swift"; path = "../../../../../../../AmplifyTestCommon/Models/Scalar/ScalarContainer+Schema.swift"; sourceTree = "<group>"; };
-		21698CA72889D50C004BD994 /* EnumTestModel+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "EnumTestModel+Schema.swift"; path = "../../../../../../../AmplifyTestCommon/Models/Scalar/EnumTestModel+Schema.swift"; sourceTree = "<group>"; };
-		21698CA82889D50C004BD994 /* ListIntContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ListIntContainer.swift; path = ../../../../../../../AmplifyTestCommon/Models/Scalar/ListIntContainer.swift; sourceTree = "<group>"; };
-		21698CA92889D50C004BD994 /* NestedTypeTestModel+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NestedTypeTestModel+Schema.swift"; path = "../../../../../../../AmplifyTestCommon/Models/Scalar/NestedTypeTestModel+Schema.swift"; sourceTree = "<group>"; };
-		21698CAA2889D50C004BD994 /* ListStringContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ListStringContainer.swift; path = ../../../../../../../AmplifyTestCommon/Models/Scalar/ListStringContainer.swift; sourceTree = "<group>"; };
-		21698CAB2889D50C004BD994 /* TestEnum.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestEnum.swift; path = ../../../../../../../AmplifyTestCommon/Models/Scalar/TestEnum.swift; sourceTree = "<group>"; };
-		21698CAC2889D50C004BD994 /* Nested.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Nested.swift; path = ../../../../../../../AmplifyTestCommon/Models/Scalar/Nested.swift; sourceTree = "<group>"; };
-		21698CAD2889D50C004BD994 /* NestedTypeTestModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NestedTypeTestModel.swift; path = ../../../../../../../AmplifyTestCommon/Models/Scalar/NestedTypeTestModel.swift; sourceTree = "<group>"; };
-		21698CAE2889D50D004BD994 /* Scalar+Equatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Scalar+Equatable.swift"; path = "../../../../../../../AmplifyTestCommon/Models/Scalar/Scalar+Equatable.swift"; sourceTree = "<group>"; };
-		21698CAF2889D50D004BD994 /* EnumTestModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EnumTestModel.swift; path = ../../../../../../../AmplifyTestCommon/Models/Scalar/EnumTestModel.swift; sourceTree = "<group>"; };
 		21698CC22889D75F004BD994 /* GraphQLAuthDirectiveIntegrationTests+Auth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQLAuthDirectiveIntegrationTests+Auth.swift"; sourceTree = "<group>"; };
 		21698CC32889D75F004BD994 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		21698CC42889D75F004BD994 /* SocialNote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocialNote.swift; sourceTree = "<group>"; };
 		21698CC52889D75F004BD994 /* GraphQLAuthDirectiveIntegrationTests+Support.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQLAuthDirectiveIntegrationTests+Support.swift"; sourceTree = "<group>"; };
 		21698CC62889D75F004BD994 /* GraphQLAuthDirectiveIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQLAuthDirectiveIntegrationTests.swift; sourceTree = "<group>"; };
+		21D335B7289867FC00657B12 /* amplify-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-ios-staging"; path = ../../../..; sourceTree = "<group>"; };
 		21E73E6B28898D7900D7DB7E /* APIHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = APIHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		21E73E6E28898D7900D7DB7E /* APIHostAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIHostAppApp.swift; sourceTree = "<group>"; };
 		21E73E7028898D7900D7DB7E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -453,166 +297,18 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		21698C0A2889B18E004BD994 /* Models */ = {
+		21D335B6289867FC00657B12 /* Packages */ = {
 			isa = PBXGroup;
 			children = (
-				21698CA12889D4F3004BD994 /* Scalars */,
-				21698C492889B1C2004BD994 /* Connection */,
-				21698C0C2889B1AE004BD994 /* AmplifyModels.swift */,
-				21698C142889B1AE004BD994 /* Article.swift */,
-				21698C192889B1AE004BD994 /* Article+Schema.swift */,
-				21698C1B2889B1AE004BD994 /* Comment.swift */,
-				21698C182889B1AE004BD994 /* Comment+Schema.swift */,
-				21698C152889B1AE004BD994 /* CustomerOrder.swift */,
-				21698C0F2889B1AE004BD994 /* CustomerOrder+Schema.swift */,
-				21698C1E2889B1AE004BD994 /* MockModels.swift */,
-				21698C272889B1AE004BD994 /* OGCScenarioBMGroupPost.swift */,
-				21698C172889B1AE004BD994 /* OGCScenarioBMGroupPost+Schema.swift */,
-				21698C292889B1AE004BD994 /* OGCScenarioBPost.swift */,
-				21698C112889B1AE004BD994 /* OGCScenarioBPost+Schema.swift */,
-				21698C1F2889B1AE004BD994 /* Post.swift */,
-				21698C252889B1AE004BD994 /* Post+Schema.swift */,
-				21698C1A2889B1AE004BD994 /* PostCommentModelRegistration.swift */,
-				21698C0B2889B1AD004BD994 /* PostStatus.swift */,
-				21698C0E2889B1AE004BD994 /* QPredGen.swift */,
-				21698C232889B1AE004BD994 /* QPredGen+Schema.swift */,
-				21698C162889B1AE004BD994 /* Record.swift */,
-				21698C262889B1AE004BD994 /* Record+Schema.swift */,
-				21698C132889B1AE004BD994 /* RecordCover.swift */,
-				21698C242889B1AE004BD994 /* RecordCover+Schema.swift */,
-				21698C1D2889B1AE004BD994 /* ScenarioATest6Post.swift */,
-				21698C1C2889B1AE004BD994 /* ScenarioATest6Post+Schema.swift */,
-				21698C0D2889B1AE004BD994 /* schema.graphql */,
-				21698C282889B1AE004BD994 /* User.swift */,
-				21698C122889B1AE004BD994 /* User+Schema.swift */,
-				21698C212889B1AE004BD994 /* UserFollowers.swift */,
-				21698C202889B1AE004BD994 /* UserFollowers+Schema.swift */,
-				21698C102889B1AE004BD994 /* UserFollowing.swift */,
-				21698C222889B1AE004BD994 /* UserFollowing+Schema.swift */,
+				21D335B7289867FC00657B12 /* amplify-ios-staging */,
 			);
-			path = Models;
-			sourceTree = "<group>";
-		};
-		21698C492889B1C2004BD994 /* Connection */ = {
-			isa = PBXGroup;
-			children = (
-				21698C4C2889CD94004BD994 /* 1 */,
-				21698C4D2889CD9E004BD994 /* 2 */,
-				21698C4E2889CDA7004BD994 /* 3 */,
-				21698C4F2889CDAB004BD994 /* 4 */,
-				21698C502889CDAE004BD994 /* 5 */,
-				21698C512889CDB3004BD994 /* 6 */,
-				21698C4A2889CD86004BD994 /* connection-schema.graphql */,
-			);
-			path = Connection;
-			sourceTree = "<group>";
-		};
-		21698C4C2889CD94004BD994 /* 1 */ = {
-			isa = PBXGroup;
-			children = (
-				21698C902889CFC0004BD994 /* Project1.swift */,
-				21698C8F2889CFC0004BD994 /* Project1+Schema.swift */,
-				21698C912889CFC0004BD994 /* Team1.swift */,
-				21698C8E2889CFC0004BD994 /* Team1+Schema.swift */,
-			);
-			path = 1;
-			sourceTree = "<group>";
-		};
-		21698C4D2889CD9E004BD994 /* 2 */ = {
-			isa = PBXGroup;
-			children = (
-				21698C872889CFA9004BD994 /* Project2.swift */,
-				21698C892889CFA9004BD994 /* Project2+Schema.swift */,
-				21698C862889CFA9004BD994 /* Team2.swift */,
-				21698C882889CFA9004BD994 /* Team2+Schema.swift */,
-			);
-			path = 2;
-			sourceTree = "<group>";
-		};
-		21698C4E2889CDA7004BD994 /* 3 */ = {
-			isa = PBXGroup;
-			children = (
-				21698C7E2889CF8A004BD994 /* Comment3.swift */,
-				21698C812889CF8A004BD994 /* Comment3+Schema.swift */,
-				21698C7F2889CF8A004BD994 /* Post3.swift */,
-				21698C802889CF8A004BD994 /* Post3+Schema.swift */,
-			);
-			path = 3;
-			sourceTree = "<group>";
-		};
-		21698C4F2889CDAB004BD994 /* 4 */ = {
-			isa = PBXGroup;
-			children = (
-				21698C762889CF6C004BD994 /* Comment4.swift */,
-				21698C792889CF6D004BD994 /* Comment4+Schema.swift */,
-				21698C782889CF6D004BD994 /* Post4.swift */,
-				21698C772889CF6D004BD994 /* Post4+Schema.swift */,
-			);
-			path = 4;
-			sourceTree = "<group>";
-		};
-		21698C502889CDAE004BD994 /* 5 */ = {
-			isa = PBXGroup;
-			children = (
-				21698C6F2889CF5D004BD994 /* Post5.swift */,
-				21698C6A2889CF5D004BD994 /* Post5+Schema.swift */,
-				21698C6D2889CF5D004BD994 /* PostEditor5.swift */,
-				21698C6C2889CF5D004BD994 /* PostEditor5+Schema.swift */,
-				21698C6B2889CF5D004BD994 /* User5.swift */,
-				21698C6E2889CF5D004BD994 /* User5+Schema.swift */,
-			);
-			path = 5;
-			sourceTree = "<group>";
-		};
-		21698C512889CDB3004BD994 /* 6 */ = {
-			isa = PBXGroup;
-			children = (
-				21698C602889CE60004BD994 /* Blog6.swift */,
-				21698C5E2889CE60004BD994 /* Blog6+Schema.swift */,
-				21698C612889CE60004BD994 /* Comment6.swift */,
-				21698C622889CE60004BD994 /* Comment6+Schema.swift */,
-				21698C632889CE60004BD994 /* Post6.swift */,
-				21698C5F2889CE60004BD994 /* Post6+Schema.swift */,
-			);
-			path = 6;
-			sourceTree = "<group>";
-		};
-		21698C962889D0EB004BD994 /* Helpers */ = {
-			isa = PBXGroup;
-			children = (
-				21698C9A2889D0FB004BD994 /* AuthSignInHelper.swift */,
-				21698C972889D0FB004BD994 /* HubListenerTestUtilities.swift */,
-				21698C992889D0FB004BD994 /* TestConfigHelper.swift */,
-				21698C9B2889D0FB004BD994 /* TypeRegistry.swift */,
-			);
-			path = Helpers;
-			sourceTree = "<group>";
-		};
-		21698CA12889D4F3004BD994 /* Scalars */ = {
-			isa = PBXGroup;
-			children = (
-				21698CAF2889D50D004BD994 /* EnumTestModel.swift */,
-				21698CA72889D50C004BD994 /* EnumTestModel+Schema.swift */,
-				21698CA82889D50C004BD994 /* ListIntContainer.swift */,
-				21698CA52889D50C004BD994 /* ListIntContainer+Schema.swift */,
-				21698CAA2889D50C004BD994 /* ListStringContainer.swift */,
-				21698CA22889D50C004BD994 /* ListStringContainer+Schema.swift */,
-				21698CAC2889D50C004BD994 /* Nested.swift */,
-				21698CA42889D50C004BD994 /* Nested+Schema.swift */,
-				21698CAD2889D50C004BD994 /* NestedTypeTestModel.swift */,
-				21698CA92889D50C004BD994 /* NestedTypeTestModel+Schema.swift */,
-				21698CAE2889D50D004BD994 /* Scalar+Equatable.swift */,
-				21698CA32889D50C004BD994 /* ScalarContainer.swift */,
-				21698CA62889D50C004BD994 /* ScalarContainer+Schema.swift */,
-				21698CAB2889D50C004BD994 /* TestEnum.swift */,
-			);
-			path = Scalars;
+			name = Packages;
 			sourceTree = "<group>";
 		};
 		21E73E6228898D7800D7DB7E = {
 			isa = PBXGroup;
 			children = (
-				21E73E7C28898DF200D7DB7E /* Packages */,
+				21D335B6289867FC00657B12 /* Packages */,
 				21E73E6D28898D7900D7DB7E /* APIHostApp */,
 				21698A7C28899805004BD994 /* AWSAPIPluginFunctionalTests */,
 				21698A9628899818004BD994 /* AWSAPIPluginIntegrationTests */,
@@ -636,8 +332,6 @@
 		21E73E6D28898D7900D7DB7E /* APIHostApp */ = {
 			isa = PBXGroup;
 			children = (
-				21698C962889D0EB004BD994 /* Helpers */,
-				21698C0A2889B18E004BD994 /* Models */,
 				21698C072889B173004BD994 /* TestCommonConstants.swift */,
 				21698C062889B173004BD994 /* TestExtensions.swift */,
 				21E73E6E28898D7900D7DB7E /* APIHostAppApp.swift */,
@@ -654,14 +348,6 @@
 				21E73E7528898D7A00D7DB7E /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
-			sourceTree = "<group>";
-		};
-		21E73E7C28898DF200D7DB7E /* Packages */ = {
-			isa = PBXGroup;
-			children = (
-				21698A3B2889905F004BD994 /* amplify-ios */,
-			);
-			path = Packages;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -867,7 +553,6 @@
 				21698ABE2889996A004BD994 /* GraphQLTestBase.swift in Sources */,
 				21698AC22889996A004BD994 /* GraphQLConnectionScenario4Tests.swift in Sources */,
 				21698AC52889996A004BD994 /* GraphQLConnectionScenario2Tests.swift in Sources */,
-				21698CD02889E126004BD994 /* TestConfigHelper.swift in Sources */,
 				21698ABD2889996A004BD994 /* GraphQLConnectionScenario6Tests.swift in Sources */,
 				21698AC32889996A004BD994 /* GraphQLModelBasedTests.swift in Sources */,
 				21698AC12889996A004BD994 /* GraphQLConnectionScenario3Tests+Subscribe.swift in Sources */,
@@ -883,7 +568,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				21698BD428899BFD004BD994 /* AWSAPICategoryPluginGraphQLAPIKeyIntegrationTests.swift in Sources */,
-				21698CD12889E201004BD994 /* TestConfigHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -894,7 +578,6 @@
 				21698BB328899B61004BD994 /* GraphQLWithIAMIntegrationTests.swift in Sources */,
 				21698BB628899B61004BD994 /* Todo.swift in Sources */,
 				21698CCB2889D75F004BD994 /* GraphQLAuthDirectiveIntegrationTests.swift in Sources */,
-				21698CD22889E202004BD994 /* TestConfigHelper.swift in Sources */,
 				21698CC72889D75F004BD994 /* GraphQLAuthDirectiveIntegrationTests+Auth.swift in Sources */,
 				21698BC028899B6D004BD994 /* GraphQLWithUserPoolIntegrationTests.swift in Sources */,
 				21698CC92889D75F004BD994 /* SocialNote.swift in Sources */,
@@ -908,85 +591,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				21698C932889CFC0004BD994 /* Project1+Schema.swift in Sources */,
-				21698C842889CF8A004BD994 /* Post3+Schema.swift in Sources */,
-				21698C942889CFC0004BD994 /* Project1.swift in Sources */,
-				21698C392889B1AE004BD994 /* PostCommentModelRegistration.swift in Sources */,
-				21698C9C2889D0FB004BD994 /* HubListenerTestUtilities.swift in Sources */,
-				21698C9F2889D0FB004BD994 /* AuthSignInHelper.swift in Sources */,
-				21698C342889B1AE004BD994 /* CustomerOrder.swift in Sources */,
-				21698C822889CF8A004BD994 /* Comment3.swift in Sources */,
-				21698CB42889D50D004BD994 /* ScalarContainer+Schema.swift in Sources */,
-				21698C3C2889B1AE004BD994 /* ScenarioATest6Post.swift in Sources */,
-				21698C3E2889B1AE004BD994 /* Post.swift in Sources */,
-				21698C362889B1AE004BD994 /* OGCScenarioBMGroupPost+Schema.swift in Sources */,
-				21698C332889B1AE004BD994 /* Article.swift in Sources */,
-				21698C482889B1AE004BD994 /* OGCScenarioBPost.swift in Sources */,
-				21698C702889CF5E004BD994 /* Post5+Schema.swift in Sources */,
-				21698C8B2889CFA9004BD994 /* Project2.swift in Sources */,
-				21698C462889B1AE004BD994 /* OGCScenarioBMGroupPost.swift in Sources */,
-				21698C402889B1AE004BD994 /* UserFollowers.swift in Sources */,
-				21698C652889CE60004BD994 /* Post6+Schema.swift in Sources */,
-				21698CBD2889D50D004BD994 /* EnumTestModel.swift in Sources */,
-				21698C432889B1AE004BD994 /* RecordCover+Schema.swift in Sources */,
-				21698C3F2889B1AE004BD994 /* UserFollowers+Schema.swift in Sources */,
-				21698C352889B1AE004BD994 /* Record.swift in Sources */,
-				21698C8D2889CFA9004BD994 /* Project2+Schema.swift in Sources */,
 				21E73E7128898D7900D7DB7E /* ContentView.swift in Sources */,
-				21698C2D2889B1AE004BD994 /* QPredGen.swift in Sources */,
-				21698C8C2889CFA9004BD994 /* Team2+Schema.swift in Sources */,
-				21698C722889CF5E004BD994 /* PostEditor5+Schema.swift in Sources */,
-				21698C322889B1AE004BD994 /* RecordCover.swift in Sources */,
-				21698C832889CF8A004BD994 /* Post3.swift in Sources */,
-				21698C642889CE60004BD994 /* Blog6+Schema.swift in Sources */,
-				21698C922889CFC0004BD994 /* Team1+Schema.swift in Sources */,
-				21698C7C2889CF6D004BD994 /* Post4.swift in Sources */,
-				21698C7B2889CF6D004BD994 /* Post4+Schema.swift in Sources */,
-				21698CB92889D50D004BD994 /* TestEnum.swift in Sources */,
-				21698CB22889D50D004BD994 /* Nested+Schema.swift in Sources */,
-				21698C662889CE60004BD994 /* Blog6.swift in Sources */,
-				21698CBC2889D50D004BD994 /* Scalar+Equatable.swift in Sources */,
-				21698C692889CE60004BD994 /* Post6.swift in Sources */,
-				21698C682889CE60004BD994 /* Comment6+Schema.swift in Sources */,
-				21698CB02889D50D004BD994 /* ListStringContainer+Schema.swift in Sources */,
-				21698CB52889D50D004BD994 /* EnumTestModel+Schema.swift in Sources */,
-				21698C452889B1AE004BD994 /* Record+Schema.swift in Sources */,
-				21698C382889B1AE004BD994 /* Article+Schema.swift in Sources */,
-				21698C672889CE60004BD994 /* Comment6.swift in Sources */,
-				21698C952889CFC0004BD994 /* Team1.swift in Sources */,
-				21698CB32889D50D004BD994 /* ListIntContainer+Schema.swift in Sources */,
-				21698C3B2889B1AE004BD994 /* ScenarioATest6Post+Schema.swift in Sources */,
-				21698C2F2889B1AE004BD994 /* UserFollowing.swift in Sources */,
-				21698C7A2889CF6D004BD994 /* Comment4.swift in Sources */,
-				21698CB62889D50D004BD994 /* ListIntContainer.swift in Sources */,
-				21698CBB2889D50D004BD994 /* NestedTypeTestModel.swift in Sources */,
-				21698C312889B1AE004BD994 /* User+Schema.swift in Sources */,
-				21698C2A2889B1AE004BD994 /* PostStatus.swift in Sources */,
-				21698C3D2889B1AE004BD994 /* MockModels.swift in Sources */,
-				21698C412889B1AE004BD994 /* UserFollowing+Schema.swift in Sources */,
-				21698C742889CF5E004BD994 /* User5+Schema.swift in Sources */,
-				21698C8A2889CFA9004BD994 /* Team2.swift in Sources */,
-				21698CA02889D0FB004BD994 /* TypeRegistry.swift in Sources */,
-				21698CB82889D50D004BD994 /* ListStringContainer.swift in Sources */,
-				21698C372889B1AE004BD994 /* Comment+Schema.swift in Sources */,
 				21698C082889B173004BD994 /* TestExtensions.swift in Sources */,
 				21698C092889B173004BD994 /* TestCommonConstants.swift in Sources */,
-				21698C732889CF5E004BD994 /* PostEditor5.swift in Sources */,
-				21698C422889B1AE004BD994 /* QPredGen+Schema.swift in Sources */,
-				21698C442889B1AE004BD994 /* Post+Schema.swift in Sources */,
-				21698CB12889D50D004BD994 /* ScalarContainer.swift in Sources */,
-				21698C852889CF8A004BD994 /* Comment3+Schema.swift in Sources */,
-				21698C3A2889B1AE004BD994 /* Comment.swift in Sources */,
-				21698C712889CF5E004BD994 /* User5.swift in Sources */,
-				21698C2B2889B1AE004BD994 /* AmplifyModels.swift in Sources */,
-				21698C302889B1AE004BD994 /* OGCScenarioBPost+Schema.swift in Sources */,
-				21698CB72889D50D004BD994 /* NestedTypeTestModel+Schema.swift in Sources */,
 				21E73E6F28898D7900D7DB7E /* APIHostAppApp.swift in Sources */,
-				21698C2E2889B1AE004BD994 /* CustomerOrder+Schema.swift in Sources */,
-				21698C472889B1AE004BD994 /* User.swift in Sources */,
-				21698CBA2889D50D004BD994 /* Nested.swift in Sources */,
-				21698C752889CF5E004BD994 /* Post5.swift in Sources */,
-				21698C7D2889CF6D004BD994 /* Comment4+Schema.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Removes the hack for adding AmplifyTestCommon files to the integration test app
- Adds the local swift package, renamed to `amplify-ios-staging` like AuthHostApp's set up

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
