### PR TITLE
fix(datastore): String conform to ModelIdentifierProtocol

### DIFF
--- a/Amplify/Categories/DataStore/Model/ModelIdentifiable.swift
+++ b/Amplify/Categories/DataStore/Model/ModelIdentifiable.swift
@@ -53,6 +53,15 @@ public protocol ModelIdentifierProtocol {
     var predicate: QueryPredicate { get }
 }
 
+extension Model.Identifier: ModelIdentifierProtocol {
+   public var fields: Fields {
+       [(name: ModelIdentifierFormat.Default.name, value: self)]
+   }
+   public var stringValue: String {
+       self
+   }
+}
+
 public extension ModelIdentifierProtocol {
     var stringValue: String {
         if fields.count == 1, let field = fields.first {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/pull/1752#discussion_r917123859

*Description of changes:*
When compiling Amplify DataStore's category APIs using Xcode 14 Beta 4, for an API like
```swift
func query<M: Model>(_ modelType: M.Type,
                         byIdentifier id: String,
                         completion: DataStoreCallback<M?>) where M: ModelIdentifiable,
                                                                  M.IdentifierFormat == ModelIdentifierFormat.Default
```

the error shown is
<img width="730" alt="image" src="https://user-images.githubusercontent.com/10602282/178066709-513a74f5-f45d-4b87-aefc-1582ec87cbb4.png">

There are two `Identifier`, where `M: Model` and `Model` contains `Identifier`:
![image](https://user-images.githubusercontent.com/1365977/182414483-e163bbba-8d2b-4612-933d-1f42f4f7b7ef.png)
and where `M: ModelIdentifiable`, and `ModelIdentifiable` contains `Identifer`:
![image](https://user-images.githubusercontent.com/1365977/182414782-c12e4eaf-a644-49c9-b771-ec7c641fc70b.png)

## Solution 

This PR adds a default conformance of String to ModelIdentifierProtocol. By conforming to `ModelIdentifierProtocol`, unfortunately makes all String values be able to return "fields" as `(name: "id", value: self)`. However, Model.Identifier is deprecated and can be removed in the future.

This change was tested on Xcode 14 beta 4 and back on Xcode 13.4.1 for any regressions

## Alternatives considered

## Alternative 1 
Changing Model's Identifier does not work because that would be a breaking change to the public API of Model.

## Alternative 2

Changing ModelIdentifiable's associated type `Identifier` to something like `IdentifierProtocol` 
```swift
/// Defines requirements for a model to be identifiable with a unique identifier
/// that can be either a single field or a combination of fields
public protocol ModelIdentifiable {
    associatedtype IdentifierFormat: AnyModelIdentifierFormat
    // associatedtype Identifier: ModelIdentifierProtocol
   associatedtype IdentifierProtocol: ModelIdentifierProtocol
}
```
will also not be ideal since that will require codegen changes, and impacts the DX of public APis
```swift
extension PostWithCompositeKey: ModelIdentifiable {
  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
  //public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom> // previously 
   public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom> // new
}

//extension PostWithCompositeKey.Identifier { // previously
extension PostWithCompositeKey.IdentifierProtocol { // alternative
  public static func identifier(id: String,
      title: String) -> Self {
    .make(fields: [(name: "id", value: id), (name: "title", value: title)])
  }
}
```

Call site in alternative 2 (no ideal DX):
```
// Previously
PostWithCompositeKey.Identifier.identifier(id: "123", title: "title")

// New
PostWithCompositeKey.IdentifierProtocol.identifier(id: "123", title: "title")
```



*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
