### PR TITLE
fix(datastore): Rename ModelIdentifiable.Identifier to IdentifierProtocol

### DIFF
--- a/Amplify/Categories/DataStore/Model/ModelIdentifiable.swift
+++ b/Amplify/Categories/DataStore/Model/ModelIdentifiable.swift
@@ -28,7 +28,7 @@ public enum ModelIdentifierFormat {
 /// that can be either a single field or a combination of fields
 public protocol ModelIdentifiable {
     associatedtype IdentifierFormat: AnyModelIdentifierFormat
-    associatedtype Identifier: ModelIdentifierProtocol
+    associatedtype IdentifierProtocol: ModelIdentifierProtocol
 }
 
 /// Defines a `ModelIdentifier` requirements.
@@ -51,15 +51,6 @@ public protocol ModelIdentifierProtocol {
     var values: [Persistable] { get }
 
     var predicate: QueryPredicate { get }
-}
-
-extension Model.Identifier: ModelIdentifierProtocol {
-   public var fields: Fields {
-       [(name: ModelIdentifierFormat.Default.name, value: self)]
-   }
-   public var stringValue: String {
-       self
-   }
 }
 
 public extension ModelIdentifierProtocol {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata+Schema.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata+Schema.swift
@@ -39,6 +39,6 @@ extension MutationSyncMetadata {
 
 
 extension MutationSyncMetadata: ModelIdentifiable {
-    public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Default>
+    public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Default>
     public typealias IdentifierFormat = ModelIdentifierFormat.Default
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
@@ -609,7 +609,7 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the variables match the expected values
     func testDeleteStatementFromModelWithCustomPK() {
-        let identifier = ModelExplicitCustomPk.Identifier.identifier(userId: "userId")
+        let identifier = ModelExplicitCustomPk.IdentifierProtocol.identifier(userId: "userId")
         let statement = DeleteStatement(modelSchema: ModelExplicitCustomPk.schema,
                                         withIdentifier: identifier)
 
@@ -631,8 +631,8 @@ class SQLStatementTests: XCTestCase {
     ///   - check if the generated SQL statement is valid
     ///   - check if the variables match the expected values
     func testDeleteStatementFromModelWithCompositePK() {
-        let identifier = ModelCompositePk.Identifier.identifier(id: "id",
-                                                        dob: Temporal.DateTime.now())
+        let identifier = ModelCompositePk.IdentifierProtocol.identifier(id: "id",
+                                                                        dob: Temporal.DateTime.now())
         let statement = DeleteStatement(modelSchema: ModelCompositePk.schema,
                                         withIdentifier: identifier)
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/SQLModelValueConverterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/SQLModelValueConverterTests.swift
@@ -143,7 +143,7 @@ class SQLModelValueConverterTests: BaseDataStoreTests {
             "__typename": "CommentWithCompositeKey"
         ]
         let bindings = DynamicModel(id: commentId, values: model).sqlValues(modelSchema: CommentWithCompositeKey.schema)
-        let expectedPostIdentifier = PostWithCompositeKey.Identifier.identifier(id: postId, title: postTitle)
+        let expectedPostIdentifier = PostWithCompositeKey.IdentifierProtocol.identifier(id: postId, title: postTitle)
 
         XCTAssertEqual(bindings[0] as? String, commentId)
         XCTAssertEqual(bindings[1] as? String, commentContent)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/CascadeDeleteOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Storage/CascadeDeleteOperationTests.swift
@@ -117,7 +117,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         XCTAssertEqual(queriedModel[0].dob, model.dob)
 
         let completed = expectation(description: "operation completed")
-        let identifier = ModelCompositePk.Identifier.identifier(id: modelId, dob: modelDob)
+        let identifier = ModelCompositePk.IdentifierProtocol.identifier(id: modelId, dob: modelDob)
         let operation = CascadeDeleteOperation(storageAdapter: storageAdapter,
                                                syncEngine: nil,
                                                modelType: ModelCompositePk.self,
@@ -421,7 +421,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         }
 
         let completed = expectation(description: "operation completed")
-        let identifier = ModelCompositePk.Identifier.identifier(id: modelId, dob: modelDob)
+        let identifier = ModelCompositePk.IdentifierProtocol.identifier(id: modelId, dob: modelDob)
         let operation = CascadeDeleteOperation(storageAdapter: storageAdapter,
                                                syncEngine: syncEngine,
                                                modelType: ModelCompositePk.self,
@@ -721,7 +721,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         }
 
         let completed = expectation(description: "operation completed")
-        let identifier = PostWithCompositeKey.Identifier.identifier(id: post.id, title: post.title)
+        let identifier = PostWithCompositeKey.IdentifierProtocol.identifier(id: post.id, title: post.title)
         let operation = CascadeDeleteOperation(storageAdapter: storageAdapter,
                                                syncEngine: syncEngine,
                                                modelType: PostWithCompositeKey.self,

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/CommentWithCompositeKey+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/CommentWithCompositeKey+Schema.swift
@@ -44,10 +44,10 @@ extension CommentWithCompositeKey {
 
 extension CommentWithCompositeKey: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension CommentWithCompositeKey.Identifier {
+extension CommentWithCompositeKey.IdentifierProtocol {
   public static func identifier(id: String,
       content: String) -> Self {
     .make(fields: [(name: "id", value: id), (name: "content", value: content)])

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/CommentWithCompositeKeyAndIndex+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/CommentWithCompositeKeyAndIndex+Schema.swift
@@ -45,10 +45,10 @@ extension CommentWithCompositeKeyAndIndex {
 
 extension CommentWithCompositeKeyAndIndex: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension CommentWithCompositeKeyAndIndex.Identifier {
+extension CommentWithCompositeKeyAndIndex.IdentifierProtocol {
   public static func identifier(id: String,
       content: String) -> Self {
     .make(fields: [(name: "id", value: id), (name: "content", value: content)])

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/CommentWithCompositeKeyUnidirectional+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/CommentWithCompositeKeyUnidirectional+Schema.swift
@@ -46,10 +46,10 @@ extension CommentWithCompositeKeyUnidirectional {
 
 extension CommentWithCompositeKeyUnidirectional: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension CommentWithCompositeKeyUnidirectional.Identifier {
+extension CommentWithCompositeKeyUnidirectional.IdentifierProtocol {
   public static func identifier(id: String,
       content: String) -> Self {
     .make(fields: [(name: "id", value: id), (name: "content", value: content)])

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/ModelCompositeIntPk+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/ModelCompositeIntPk+Schema.swift
@@ -43,10 +43,10 @@ extension ModelCompositeIntPk {
 
 extension ModelCompositeIntPk: ModelIdentifiable {
     public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-    public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+    public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension ModelCompositeIntPk.Identifier {
+extension ModelCompositeIntPk.IdentifierProtocol {
     public static func identifier(id: String, serial: Int) -> Self {
         .make(fields: [(name: "id", value: id), (name: "serial", value: serial)])
     }

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/ModelCompositePk+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/ModelCompositePk+Schema.swift
@@ -43,10 +43,10 @@ extension ModelCompositePk {
 
 extension ModelCompositePk: ModelIdentifiable {
     public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-    public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+    public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension ModelCompositePk.Identifier {
+extension ModelCompositePk.IdentifierProtocol {
     public static func identifier(id: String, dob: Temporal.DateTime) -> Self {
         .make(fields: [(name: "id", value: id), (name: "dob", value: dob)])
     }

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/ModelCompositePkBelongsTo+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/ModelCompositePkBelongsTo+Schema.swift
@@ -50,10 +50,10 @@ extension ModelCompositePkBelongsTo {
 
 extension ModelCompositePkBelongsTo: ModelIdentifiable {
     public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-    public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+    public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension ModelCompositePkBelongsTo.Identifier {
+extension ModelCompositePkBelongsTo.IdentifierProtocol {
     public static func identifier(id: String, dob: Temporal.DateTime) -> Self {
         .make(fields: [(name: "id", value: id), (name: "dob", value: dob)])
     }

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/ModelCompositePkWithAssociation+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/ModelCompositePkWithAssociation+Schema.swift
@@ -48,10 +48,10 @@ extension ModelCompositePkWithAssociation {
 
 extension ModelCompositePkWithAssociation: ModelIdentifiable {
     public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-    public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+    public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension ModelCompositePkWithAssociation.Identifier {
+extension ModelCompositePkWithAssociation.IdentifierProtocol {
     public static func identifier(id: String, dob: Temporal.DateTime) -> Self {
         .make(fields: [(name: "id", value: id), (name: "dob", value: dob)])
     }

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/ModelCustomPkDefined+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/ModelCustomPkDefined+Schema.swift
@@ -45,10 +45,10 @@ extension ModelCustomPkDefined {
 
 extension ModelCustomPkDefined: ModelIdentifiable {
     public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-    public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+    public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension ModelCustomPkDefined.Identifier {
+extension ModelCustomPkDefined.IdentifierProtocol {
     public static func identifier(id: String, dob: Temporal.DateTime) -> Self {
         .make(fields: [(name: "id", value: id), (name: "dob", value: dob)])
     }

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/ModelExplicitCustomPk+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/ModelExplicitCustomPk+Schema.swift
@@ -41,10 +41,10 @@ extension ModelExplicitCustomPk {
 
 extension ModelExplicitCustomPk: ModelIdentifiable {
     public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-    public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+    public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension ModelExplicitCustomPk.Identifier {
+extension ModelExplicitCustomPk.IdentifierProtocol {
     public static func identifier(userId: String) -> Self {
         .make(fields: [(name: "userId", value: userId)])
     }

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/ModelExplicitDefaultPk+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/ModelExplicitDefaultPk+Schema.swift
@@ -41,10 +41,10 @@ extension ModelExplicitDefaultPk {
 
 extension ModelExplicitDefaultPk: ModelIdentifiable {
     public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-    public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+    public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension ModelExplicitDefaultPk.Identifier {
+extension ModelExplicitDefaultPk.IdentifierProtocol {
     public static func identifier(id: String) -> Self {
         .make(fields: [(name: "id", value: id)])
     }

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/ModelImplicitDefaultPk+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/ModelImplicitDefaultPk+Schema.swift
@@ -37,5 +37,5 @@ extension ModelImplicitDefaultPk {
 
 extension ModelImplicitDefaultPk: ModelIdentifiable {
     public typealias IdentifierFormat = ModelIdentifierFormat.Default
-    public typealias Identifier = DefaultModelIdentifier<Self>
+    public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
 }

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/PostTagsWithCompositeKey+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/PostTagsWithCompositeKey+Schema.swift
@@ -45,5 +45,5 @@ extension PostTagsWithCompositeKey {
 
 extension PostTagsWithCompositeKey: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
 }

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithCompositeKey+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithCompositeKey+Schema.swift
@@ -44,10 +44,10 @@ extension PostWithCompositeKey {
 
 extension PostWithCompositeKey: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension PostWithCompositeKey.Identifier {
+extension PostWithCompositeKey.IdentifierProtocol {
   public static func identifier(id: String,
       title: String) -> Self {
     .make(fields: [(name: "id", value: id), (name: "title", value: title)])

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithCompositeKeyAndIndex+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithCompositeKeyAndIndex+Schema.swift
@@ -44,10 +44,10 @@ extension PostWithCompositeKeyAndIndex {
 
 extension PostWithCompositeKeyAndIndex: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension PostWithCompositeKeyAndIndex.Identifier {
+extension PostWithCompositeKeyAndIndex.IdentifierProtocol {
   public static func identifier(id: String,
       title: String) -> Self {
     .make(fields: [(name: "id", value: id), (name: "title", value: title)])

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithCompositeKeyUnidirectional+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithCompositeKeyUnidirectional+Schema.swift
@@ -47,10 +47,10 @@ extension PostWithCompositeKeyUnidirectional {
 
 extension PostWithCompositeKeyUnidirectional: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension PostWithCompositeKeyUnidirectional.Identifier {
+extension PostWithCompositeKeyUnidirectional.IdentifierProtocol {
   public static func identifier(id: String,
       title: String) -> Self {
     .make(fields: [(name: "id", value: id), (name: "title", value: title)])

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithTagsCompositeKey+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/PostWithTagsCompositeKey+Schema.swift
@@ -44,10 +44,10 @@ extension PostWithTagsCompositeKey {
 
 extension PostWithTagsCompositeKey: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension PostWithTagsCompositeKey.Identifier {
+extension PostWithTagsCompositeKey.IdentifierProtocol {
   public static func identifier(postId: String,
       title: String) -> Self {
     .make(fields: [(name: "postId", value: postId), (name: "title", value: title)])

--- a/AmplifyTestCommon/Models/CustomPrimaryKey/TagWithCompositeKey+Schema.swift
+++ b/AmplifyTestCommon/Models/CustomPrimaryKey/TagWithCompositeKey+Schema.swift
@@ -44,10 +44,10 @@ extension TagWithCompositeKey {
 
 extension TagWithCompositeKey: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension TagWithCompositeKey.Identifier {
+extension TagWithCompositeKey.IdentifierProtocol {
   public static func identifier(id: String,
       name: String) -> Self {
     .make(fields: [(name: "id", value: id), (name: "name", value: name)])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We originally started seeing this issue on Xcode 14 Beta 3 and Beta 4 here: https://github.com/aws-amplify/amplify-ios/pull/1752#discussion_r917123859

The attempted fix from https://github.com/aws-amplify/amplify-ios/pull/2067 to add default conformance for String seems to allow the API to compile.

We saw that this fix actually doesn't work at the call site of the API:
<img width="1525" alt="image" src="https://user-images.githubusercontent.com/1365977/182903188-34a1c1e7-31bd-49af-90b9-cc0ac6d269bc.png">

In this example, it appears Model.Identifier defined in Amplify continues to conflict with ModelExplicitDefaultPK.Identifier (codegenerated into ModelExplicitDefaultPK+Schema.swift).

This PR goes with the alternative 2 from https://github.com/aws-amplify/amplify-ios/pull/2067 to rename ModelIdentifiable.IdentifierProtocol so that the two "Identifier" will stop conflicting.

This requires a codegen change as well https://github.com/aws-amplify/amplify-codegen/pull/467

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
