### PR TITLE
Implement Task.sleep with seconds

### DIFF
--- a/Amplify/Core/Support/Task+Seconds.swift
+++ b/Amplify/Core/Support/Task+Seconds.swift
@@ -1,0 +1,15 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Task where Success == Never, Failure == Never {
+    static func sleep(seconds: Double) async throws {
+        let nanoseconds = UInt64(seconds * Double(NSEC_PER_SEC))
+        try await Task.sleep(nanoseconds: nanoseconds)
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Task has a sleep function which uses nanoseconds. A double value for seconds is easier to use.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
