### PR TITLE
chore(datastore): remove semaphore usage from unit tests

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginTests.swift
@@ -126,20 +126,21 @@ class AWSDataStorePluginTests: XCTestCase {
                 }
             } receiveValue: { _ in }
 
-            let semaphore = DispatchSemaphore(value: 0)
+            let startCompleted = expectation(description: "start completed")
             plugin.start(completion: {_ in
                 XCTAssertNotNil(plugin.storageEngine)
                 XCTAssertNotNil(plugin.dataStorePublisher)
-                semaphore.signal()
+                startCompleted.fulfill()
             })
-            semaphore.wait()
+            wait(for: [startCompleted], timeout: 1.0)
 
+            let stopCompleted = expectation(description: "stop completed")
             plugin.stop(completion: { _ in
                 XCTAssertNil(plugin.storageEngine)
                 XCTAssertNotNil(plugin.dataStorePublisher)
-                semaphore.signal()
+                stopCompleted.fulfill()
             })
-            semaphore.wait()
+            wait(for: [stopCompleted], timeout: 1.0)
 
             storageEngine.responders[.startSync] = StartSyncResponder { _ in
                 count = self.expect(startExpectationOnSecondStart, count, 3)
@@ -195,20 +196,22 @@ class AWSDataStorePluginTests: XCTestCase {
                 }
             } receiveValue: { _ in }
 
-            let semaphore = DispatchSemaphore(value: 0)
+            let startCompleted = expectation(description: "start completed")
             plugin.start(completion: {_ in
                 XCTAssertNotNil(plugin.storageEngine)
                 XCTAssertNotNil(plugin.dataStorePublisher)
-                semaphore.signal()
+                startCompleted.fulfill()
             })
-            semaphore.wait()
+            wait(for: [startCompleted], timeout: 1.0)
 
+            let clearCompleted = expectation(description: "clear completed")
             plugin.clear(completion: { _ in
                 XCTAssertNil(plugin.storageEngine)
                 XCTAssertNotNil(plugin.dataStorePublisher)
-                semaphore.signal()
+                clearCompleted.fulfill()
             })
-            semaphore.wait()
+            wait(for: [clearCompleted], timeout: 1.0)
+
             storageEngine.responders[.startSync] = StartSyncResponder {_ in
                 count = self.expect(startExpectationOnSecondStart, count, 3)
             }
@@ -265,20 +268,21 @@ class AWSDataStorePluginTests: XCTestCase {
                 }
             } receiveValue: { _ in }
 
-            let semaphore = DispatchSemaphore(value: 0)
+            let queryCompleted = expectation(description: "query completed")
             plugin.query(ExampleWithEveryType.self, completion: {_ in
                 XCTAssertNotNil(plugin.storageEngine)
                 XCTAssertNotNil(plugin.dataStorePublisher)
-                semaphore.signal()
+                queryCompleted.fulfill()
             })
-            semaphore.wait()
+            wait(for: [queryCompleted], timeout: 1.0)
 
+            let clearCompleted = expectation(description: "clear completed")
             plugin.clear(completion: { _ in
                 XCTAssertNil(plugin.storageEngine)
                 XCTAssertNotNil(plugin.dataStorePublisher)
-                semaphore.signal()
+                clearCompleted.fulfill()
             })
-            semaphore.wait()
+            wait(for: [clearCompleted], timeout: 1.0)
             storageEngine.responders[.query] = QueryResponder<ExampleWithEveryType> {_ in
                 count = self.expect(startExpectationOnQuery, count, 3)
                 return .success([])
@@ -356,20 +360,21 @@ class AWSDataStorePluginTests: XCTestCase {
                 publisherReceivedValue.fulfill()
             }
 
-            let semaphore = DispatchSemaphore(value: 0)
+            let startCompleted = expectation(description: "start completed")
             plugin.start(completion: {_ in
                 XCTAssertNotNil(plugin.storageEngine)
                 XCTAssertNotNil(plugin.dataStorePublisher)
-                semaphore.signal()
+                startCompleted.fulfill()
             })
-            semaphore.wait()
-
+            wait(for: [startCompleted], timeout: 1.0)
+            
+            let clearCompleted = expectation(description: "clear completed")
             plugin.clear(completion: { _ in
                 XCTAssertNil(plugin.storageEngine)
                 XCTAssertNotNil(plugin.dataStorePublisher)
-                semaphore.signal()
+                clearCompleted.fulfill()
             })
-            semaphore.wait()
+            wait(for: [clearCompleted], timeout: 1.0)
 
             let mockModel = MockSynced(id: "12345")
             try plugin.dataStorePublisher?.send(input: MutationEvent(model: mockModel,
@@ -435,20 +440,21 @@ class AWSDataStorePluginTests: XCTestCase {
                 publisherReceivedValue.fulfill()
             }
 
-            let semaphore = DispatchSemaphore(value: 0)
+            let startCompleted = expectation(description: "start completed")
             plugin.start(completion: {_ in
                 XCTAssertNotNil(plugin.storageEngine)
                 XCTAssertNotNil(plugin.dataStorePublisher)
-                semaphore.signal()
+                startCompleted.fulfill()
             })
-            semaphore.wait()
-
+            wait(for: [startCompleted], timeout: 1.0)
+            
+            let stopCompleted = expectation(description: "stop completed")
             plugin.stop(completion: { _ in
                 XCTAssertNil(plugin.storageEngine)
                 XCTAssertNotNil(plugin.dataStorePublisher)
-                semaphore.signal()
+                stopCompleted.fulfill()
             })
-            semaphore.wait()
+            wait(for: [stopCompleted], timeout: 1.0)
 
             let mockModel = MockSynced(id: "12345")
             try plugin.dataStorePublisher?.send(input: MutationEvent(model: mockModel,
@@ -508,13 +514,13 @@ class AWSDataStorePluginTests: XCTestCase {
                                         validAPIPluginKey: "MockAPICategoryPlugin",
                                         validAuthPluginKey: "MockAuthCategoryPlugin")
 
-        let semaphore = DispatchSemaphore(value: 0)
+        let startCompleted = expectation(description: "start completed")
         plugin.start(completion: {_ in
             XCTAssertNotNil(plugin.storageEngine)
             XCTAssertNotNil(plugin.dataStorePublisher)
-            semaphore.signal()
+            startCompleted.fulfill()
         })
-        semaphore.wait()
+        wait(for: [startCompleted], timeout: 1.0)
 
         storageEngine.mockPublisher.send(completion: .finished)
 
@@ -538,13 +544,13 @@ class AWSDataStorePluginTests: XCTestCase {
                                         validAPIPluginKey: "MockAPICategoryPlugin",
                                         validAuthPluginKey: "MockAuthCategoryPlugin")
 
-        let semaphore = DispatchSemaphore(value: 0)
+        let startCompleted = expectation(description: "start completed")
         plugin.start(completion: {_ in
             XCTAssertNotNil(plugin.storageEngine)
             XCTAssertNotNil(plugin.dataStorePublisher)
-            semaphore.signal()
+            startCompleted.fulfill()
         })
-        semaphore.wait()
+        wait(for: [startCompleted], timeout: 1.0)
 
         storageEngine.mockPublisher.send(completion: .failure(.internalOperation("", "", nil)))
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
@@ -70,13 +70,13 @@ class OutgoingMutationQueueMockStateTest: XCTestCase {
     }
 
     func testRequestingEvent_subscriptionSetup() throws {
-        let semaphore = DispatchSemaphore(value: 0)
+        let receivedSubscription = expectation(description: "state machine received receivedSubscription")
         stateMachine.pushExpectActionCriteria { action in
             XCTAssertEqual(action, OutgoingMutationQueue.Action.receivedSubscription)
-            semaphore.signal()
+            receivedSubscription.fulfill()
         }
         stateMachine.state = .starting(apiBehavior, publisher, reconciliationQueue)
-        semaphore.wait()
+        wait(for: [receivedSubscription], timeout: 1.0)
 
         let json = "{\"id\":\"1234\",\"title\":\"t\",\"content\":\"c\",\"createdAt\":\"2020-09-03T22:55:13.424Z\"}"
         let futureResult = MutationEvent(modelId: "1",

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/BaseDataStoreTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/BaseDataStoreTests.swift
@@ -82,7 +82,7 @@ class BaseDataStoreTests: XCTestCase {
     // MARK: - Utilities
 
     func populateData<M: Model>(_ models: [M]) {
-        let semaphore = DispatchSemaphore(value: 0)
+        let saveComplete = expectation(description: "save completed")
 
         func save(model: M, index: Int) {
             storageAdapter.save(model) {
@@ -92,21 +92,20 @@ class BaseDataStoreTests: XCTestCase {
                     if nextIndex < models.endIndex {
                         save(model: models[nextIndex], index: nextIndex)
                     } else {
-                        semaphore.signal()
+                        saveComplete.fulfill()
                     }
                 case .failure(let error):
                     XCTFail(error.errorDescription)
-                    semaphore.signal()
+                    saveComplete.fulfill()
                 }
             }
         }
 
         if let model = models.first {
             save(model: model, index: 0)
-            semaphore.wait()
+            wait(for: [saveComplete], timeout: 1.0)
         } else {
-            semaphore.signal()
+            saveComplete.fulfill()
         }
-
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
