### PR TITLE
fix(datastore): Remove DispatchSemaphore - RemoteSyncEngine.performInitialSync

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
@@ -342,12 +342,12 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
                 self.remoteSyncTopicPublisher.send(.performedInitialSync)
                 self.stateMachine.notify(action: .performedInitialSync)
             }
+            self.initialSyncOrchestrator = nil
         }
     }
 
     private func activateCloudSubscriptions() {
         log.debug(#function)
-        self.initialSyncOrchestrator = nil
         guard let reconciliationQueue = reconciliationQueue else {
             let error = DataStoreError.internalOperation("reconciliationQueue is unexpectedly `nil`", "", nil)
             stateMachine.notify(action: .errored(error))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously the code would use a semaphore to block on returning from `performInitialSync()` but it doesn't matter if it returns since the call to `self.stateMachine.notify(action: .performedInitialSync)` is what transitioned the state to perform the next action. Since we are no longer blocking, `performInitialSync` will return, and the `stateMachine.notify` will cause it to move onto `activateCloudSubscriptions()`, which now sets `self.initialSyncOrchestrator = nil`.

### Alternatives discussion

The current PR appears to be a feasible solution but couples `activateCloudSubscriptions` with the previous action, it knows that it's the step after performInitialSync and sets `initialSyncOrchestrator` to nil. Was the semaphore there because the following would have no effect? 

```swift
initialSyncOrchestrator.sync { [weak self] result in
            defer {
                // semaphore.signal()
                self?.initialSyncOrchestrator = nil // would this work?
            }

            guard let self = self else {
                return
            }
            if case .failure(let dataStoreError) = result {
                self.log.error(dataStoreError.errorDescription)
                self.log.error(dataStoreError.recoverySuggestion)
                if let underlyingError = dataStoreError.underlyingError {
                    self.log.error("\(underlyingError)")
                }
                self.stateMachine.notify(action: .errored(dataStoreError))
            } else {
                self.log.info("Successfully finished sync")
                self.remoteSyncTopicPublisher.send(.performedInitialSync)
                self.stateMachine.notify(action: .performedInitialSync)
            }
        }
```

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
