### PR TITLE
fix(datastore): Make CascadeDeleteOperation Async

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/ModelStorageBehavior.swift
@@ -38,6 +38,10 @@ protocol ModelStorageBehavior {
                           modelSchema: ModelSchema,
                           filter: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>)
+    
+    func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
+                          filter: QueryPredicate) async -> DataStoreResult<[M]>
 
     func query<M: Model>(_ modelType: M.Type,
                          predicate: QueryPredicate?,
@@ -51,6 +55,12 @@ protocol ModelStorageBehavior {
                          sort: [QuerySortDescriptor]?,
                          paginationInput: QueryPaginationInput?,
                          completion: DataStoreCallback<[M]>)
+    
+    func query<M: Model>(_ modelType: M.Type,
+                         modelSchema: ModelSchema,
+                         predicate: QueryPredicate?,
+                         sort: [QuerySortDescriptor]?,
+                         paginationInput: QueryPaginationInput?) async -> DataStoreResult<[M]>
 
 }
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/StorageEngineAdapter+UntypedModel.swift
@@ -65,5 +65,19 @@ extension SQLiteStorageEngineAdapter {
             completion(.failure(causedBy: error))
         }
     }
-
+    
+    func query(modelSchema: ModelSchema,
+               predicate: QueryPredicate? = nil) async -> DataStoreResult<[Model]> {
+        guard let connection = connection else {
+            return .failure(.nilSQLiteConnection())
+        }
+        do {
+            let statement = SelectStatement(from: modelSchema, predicate: predicate)
+            let rows = try connection.prepare(statement.stringValue).run(statement.variables)
+            let result: [Model] = try rows.convertToUntypedModel(using: modelSchema, statement: statement)
+            return .success(result)
+        } catch {
+            return .failure(causedBy: error)
+        }
+    }
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
@@ -264,6 +264,21 @@ final class StorageEngine: StorageEngineBehavior {
                                                             filter: filter) { completion($0) }
         operationQueue.addOperation(cascadeDeleteOperation)
     }
+    
+    func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
+                          filter: QueryPredicate) async -> DataStoreResult<[M]>{
+        await withCheckedContinuation { continuation in
+            let cascadeDeleteOperation = CascadeDeleteOperation(storageAdapter: storageAdapter,
+                                                                syncEngine: syncEngine,
+                                                                modelType: modelType,
+                                                                modelSchema: modelSchema,
+                                                                filter: filter) { result in
+                continuation.resume(returning: result)
+            }
+            operationQueue.addOperation(cascadeDeleteOperation)
+        }
+    }
 
     func query<M: Model>(_ modelType: M.Type,
                          modelSchema: ModelSchema,
@@ -277,6 +292,18 @@ final class StorageEngine: StorageEngineBehavior {
                                     sort: sort,
                                     paginationInput: paginationInput,
                                     completion: completion)
+    }
+    
+    func query<M: Model>(_ modelType: M.Type,
+                         modelSchema: ModelSchema,
+                         predicate: QueryPredicate?,
+                         sort: [QuerySortDescriptor]?,
+                         paginationInput: QueryPaginationInput?) async -> DataStoreResult<[M]> {
+        await storageAdapter.query(modelType,
+                                    modelSchema: modelSchema,
+                                    predicate: predicate,
+                                    sort: sort,
+                                    paginationInput: paginationInput)
     }
 
     func query<M: Model>(_ modelType: M.Type,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngineAdapter.swift
@@ -36,6 +36,9 @@ protocol StorageEngineAdapter: AnyObject, ModelStorageBehavior, ModelStorageErro
     func query(modelSchema: ModelSchema,
                predicate: QueryPredicate?,
                completion: DataStoreCallback<[Model]>)
+    
+    func query(modelSchema: ModelSchema,
+               predicate: QueryPredicate?) async -> DataStoreResult<[Model]>
 
     // MARK: - Synchronous APIs
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/CascadeDeleteOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/CascadeDeleteOperationTests.swift
@@ -581,7 +581,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
 
     // MARK: - Internal testing
 
-    func testSingle() {
+    func testSingle() async {
         let restaurant = Restaurant(restaurantName: "restaurant1")
         guard case .success = saveModelSynchronous(model: restaurant) else {
             XCTFail("Failed to save")
@@ -594,7 +594,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
                                                modelSchema: Restaurant.schema,
                                                withIdentifier: identifier) { _ in }
 
-        let result = operation.queryAndDeleteTransaction()
+        let result = await operation.queryAndDeleteTransaction()
         switch result {
         case .success(let queryAndDeleteResult):
             XCTAssertEqual(queryAndDeleteResult.deletedModels.count, 1)
@@ -632,7 +632,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         wait(for: [receivedMutationEvent, expectedFailures, expectedSuccess], timeout: 1)
     }
 
-    func testDeleteWithAssociatedModels() {
+    func testDeleteWithAssociatedModels() async {
         let restaurant = Restaurant(restaurantName: "restaurant1")
         let lunchStandardMenu = Menu(name: "Standard", menuType: .lunch, restaurant: restaurant)
         let oysters = Dish(dishName: "Fried oysters", menu: lunchStandardMenu)
@@ -658,7 +658,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
 
-        let result = operation.queryAndDeleteTransaction()
+        let result = await operation.queryAndDeleteTransaction()
         switch result {
         case .success(let queryAndDeleteResult):
             XCTAssertEqual(queryAndDeleteResult.deletedModels.count, 1)
@@ -708,7 +708,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         XCTAssertEqual(submittedEvents[2].modelName, Restaurant.modelName)
     }
 
-    func testDeleteWithAssociatedModelsAndCompositePK() {
+    func testDeleteWithAssociatedModelsAndCompositePK() async {
         let post = PostWithCompositeKey(id: "post-id", title: "title")
         let comment = CommentWithCompositeKey(id: "comment-id", content: "comment-content", post: post)
 
@@ -735,7 +735,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
 
-        let result = operation.queryAndDeleteTransaction()
+        let result = await operation.queryAndDeleteTransaction()
         switch result {
         case .success(let queryAndDeleteResult):
             XCTAssertEqual(queryAndDeleteResult.deletedModels.count, 1)
@@ -782,7 +782,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         XCTAssertEqual(submittedEvents[1].modelName, PostWithCompositeKey.modelName)
     }
 
-    func testDeleteWithAssociatedModels_SingleFailure() {
+    func testDeleteWithAssociatedModels_SingleFailure() async {
         let restaurant = Restaurant(restaurantName: "restaurant1")
         let lunchStandardMenu = Menu(name: "Standard", menuType: .lunch, restaurant: restaurant)
         let oysters = Dish(dishName: "Fried oysters", menu: lunchStandardMenu)
@@ -808,7 +808,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
 
-        let result = operation.queryAndDeleteTransaction()
+        let result = await operation.queryAndDeleteTransaction()
         switch result {
         case .success(let queryAndDeleteResult):
             XCTAssertEqual(queryAndDeleteResult.deletedModels.count, 1)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
@@ -53,7 +53,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         let predicate = MutationEvent.keys.id == SyncEngineTestBase.mutationEventId(for: post)
@@ -69,7 +69,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     /// - Given: An existing MutationEvent of type .create
@@ -105,7 +105,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         let predicate = MutationEvent.keys.id == SyncEngineTestBase.mutationEventId(for: post)
@@ -125,7 +125,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     /// - Given: An existing MutationEvent of type .create
@@ -160,7 +160,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             deleteResultReceived.fulfill()
         }
 
-        wait(for: [deleteResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         let predicate = MutationEvent.keys.id == SyncEngineTestBase.mutationEventId(for: post)
@@ -175,7 +175,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     // MARK: - Existing == .update
@@ -210,7 +210,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         let predicate = MutationEvent.keys.id == SyncEngineTestBase.mutationEventId(for: post)
@@ -228,7 +228,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     /// - Given: An existing MutationEvent of type .update
@@ -264,7 +264,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         let predicate = MutationEvent.keys.id == SyncEngineTestBase.mutationEventId(for: post)
@@ -284,7 +284,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     /// - Given: An existing MutationEvent of type .update
@@ -319,7 +319,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         let predicate = MutationEvent.keys.id == SyncEngineTestBase.mutationEventId(for: post)
@@ -338,7 +338,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     // MARK: - Existing == .delete
@@ -373,7 +373,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         let predicate = MutationEvent.keys.id == SyncEngineTestBase.mutationEventId(for: post)
@@ -392,7 +392,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     // test_<existing>_<candidate>
@@ -429,7 +429,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         let predicate = MutationEvent.keys.id == SyncEngineTestBase.mutationEventId(for: post)
@@ -448,7 +448,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     // MARK: - Empty queue tests
@@ -482,7 +482,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         storageAdapter.query(MutationEvent.self, predicate: nil) { result in
@@ -500,7 +500,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     /// - Given: An empty mutation queue
@@ -533,7 +533,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         storageAdapter.query(MutationEvent.self, predicate: nil) { result in
@@ -551,7 +551,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     /// - Given: An empty mutation queue
@@ -585,7 +585,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         storageAdapter.query(MutationEvent.self, predicate: nil) { result in
@@ -603,7 +603,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     // MARK: - In-process queue tests
@@ -638,7 +638,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         storageAdapter.query(MutationEvent.self, predicate: nil) { result in
@@ -653,7 +653,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     /// - Given: A mutation queue with an in-process .create event
@@ -690,7 +690,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         storageAdapter.query(MutationEvent.self, predicate: nil) { result in
@@ -708,7 +708,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     /// - Given: A mutation queue with an in-process .create event
@@ -743,7 +743,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             deleteResultReceived.fulfill()
         }
 
-        wait(for: [deleteResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         storageAdapter.query(MutationEvent.self, predicate: nil) { result in
@@ -758,7 +758,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This started off by removing the DispatchSemaphore in CascadeDeleteOperation.queryAssociatedModels which then cacaded to a few other changes to make the calling code use `async`.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
