### PR TITLE
fix(datastore): remove blocking semaphore in MutationEvent.pendingMutationEvents

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
@@ -50,14 +50,15 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
 
         MutationEvent.pendingMutationEvents(
             for: mutationEvent.modelId,
-            storageAdapter: storageAdapter) { result in
+            storageAdapter: storageAdapter) { [weak self] result in
+                guard let self = self else { return }
                 switch result {
                 case .failure(let dataStoreError):
                     completionPromise(.failure(dataStoreError))
                 case .success(let localMutationEvents):
-                    let mutationDisposition = disposition(for: mutationEvent,
+                    let mutationDisposition = self.disposition(for: mutationEvent,
                                                           given: localMutationEvents)
-                    resolve(candidate: mutationEvent,
+                    self.resolve(candidate: mutationEvent,
                             localEvents: localMutationEvents,
                             per: mutationDisposition,
                             storageAdapter: storageAdapter,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -160,9 +160,6 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
     func queryPendingMutations(forModelIds modelIds: [Model.Identifier]) -> Future<[MutationEvent], DataStoreError> {
         Future<[MutationEvent], DataStoreError> { promise in
             var result: Result<[MutationEvent], DataStoreError> = .failure(Self.unfulfilledDataStoreError())
-//            defer {
-//                promise(result)
-//            }
             guard !self.isCancelled else {
                 self.log.info("\(#function) - cancelled, aborting")
                 result = .success([])

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -160,23 +160,26 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
     func queryPendingMutations(forModelIds modelIds: [Model.Identifier]) -> Future<[MutationEvent], DataStoreError> {
         Future<[MutationEvent], DataStoreError> { promise in
             var result: Result<[MutationEvent], DataStoreError> = .failure(Self.unfulfilledDataStoreError())
-            defer {
-                promise(result)
-            }
+//            defer {
+//                promise(result)
+//            }
             guard !self.isCancelled else {
                 self.log.info("\(#function) - cancelled, aborting")
                 result = .success([])
+                promise(result)
                 return
             }
             guard let storageAdapter = self.storageAdapter else {
                 let error = DataStoreError.nilStorageAdapter()
                 self.notifyDropped(count: modelIds.count, error: error)
                 result = .failure(error)
+                promise(result)
                 return
             }
 
             guard !modelIds.isEmpty else {
                 result = .success([])
+                promise(result)
                 return
             }
 
@@ -189,6 +192,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
                 case .success(let mutationEvents):
                     result = .success(mutationEvents)
                 }
+                promise(result)
             }
         }
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
@@ -53,7 +53,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         let predicate = MutationEvent.keys.id == SyncEngineTestBase.mutationEventId(for: post)
@@ -69,7 +69,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1)
     }
 
     /// - Given: An existing MutationEvent of type .create
@@ -105,7 +105,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         let predicate = MutationEvent.keys.id == SyncEngineTestBase.mutationEventId(for: post)
@@ -160,7 +160,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             deleteResultReceived.fulfill()
         }
 
-        wait(for: [deleteResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         let predicate = MutationEvent.keys.id == SyncEngineTestBase.mutationEventId(for: post)
@@ -175,7 +175,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     // MARK: - Existing == .update
@@ -210,7 +210,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         let predicate = MutationEvent.keys.id == SyncEngineTestBase.mutationEventId(for: post)
@@ -264,7 +264,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         let predicate = MutationEvent.keys.id == SyncEngineTestBase.mutationEventId(for: post)
@@ -319,7 +319,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         let predicate = MutationEvent.keys.id == SyncEngineTestBase.mutationEventId(for: post)
@@ -373,7 +373,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         let predicate = MutationEvent.keys.id == SyncEngineTestBase.mutationEventId(for: post)
@@ -429,7 +429,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         let predicate = MutationEvent.keys.id == SyncEngineTestBase.mutationEventId(for: post)
@@ -482,7 +482,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         storageAdapter.query(MutationEvent.self, predicate: nil) { result in
@@ -533,7 +533,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         storageAdapter.query(MutationEvent.self, predicate: nil) { result in
@@ -585,7 +585,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         storageAdapter.query(MutationEvent.self, predicate: nil) { result in
@@ -638,7 +638,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         storageAdapter.query(MutationEvent.self, predicate: nil) { result in
@@ -653,7 +653,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     /// - Given: A mutation queue with an in-process .create event
@@ -690,7 +690,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             saveResultReceived.fulfill()
         }
 
-        wait(for: [saveResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         storageAdapter.query(MutationEvent.self, predicate: nil) { result in
@@ -708,7 +708,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     /// - Given: A mutation queue with an in-process .create event
@@ -743,7 +743,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             deleteResultReceived.fulfill()
         }
 
-        wait(for: [deleteResultReceived], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let mutationEventVerified = expectation(description: "Verified mutation event")
         storageAdapter.query(MutationEvent.self, predicate: nil) { result in
@@ -758,7 +758,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -120,12 +120,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         queue.start()
 
-        wait(for: [event1Saved,
-                   event2Saved,
-                   event3Saved], timeout: 5.0, enforceOrder: true)
-        wait(for: [eventsSentViaPublisher1,
-            eventsSentViaPublisher2,
-            eventsSentViaPublisher3], timeout: 2.0)
+        await waitForExpectations(timeout: 5.0)
     }
 
     /// - Given: An AWSModelReconciliationQueue that has been buffering events with a selective sync configuration
@@ -194,10 +189,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         queue.start()
 
-        wait(for: [event1Saved,
-                   event3Saved], timeout: 5.0, enforceOrder: true)
-        wait(for: [eventsSentViaPublisher1,
-                   eventsSentViaPublisher3], timeout: 2.0)
+        await waitForExpectations(timeout: 5.0)
     }
 
     /// - Given: An AWSModelReconciliationQueue that has been buffering events
@@ -398,10 +390,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
         let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
         subscriptionEventsSubject.send(.mutationEvent(mutationSync))
 
-        wait(for: [event1ShouldNotBeProcessed,
-                   event2ShouldNotBeProcessed,
-                   event3ShouldBeProcessed,
-                   eventsSentViaPublisher3], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -289,10 +289,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         queue.start()
 
-        wait(for: [allEventsProcessed,
-                   eventsSentViaPublisher1,
-                   eventsSentViaPublisher2,
-                   eventsSentViaPublisher3], timeout: 5.0)
+        await waitForExpectations(timeout: 5.0)
     }
 
     /// - Given: A started AWSModelReconciliationQueue with no pending events
@@ -359,10 +356,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         queue.start()
 
-        wait(for: [event1ShouldBeProcessed,
-                   event2ShouldBeProcessed,
-                   eventsSentViaPublisher1,
-                   eventsSentViaPublisher2], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let event1ShouldNotBeProcessed = expectation(description: "Event 1 should not be processed")
         event1ShouldNotBeProcessed.isInverted = true

--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
-let platforms: [SupportedPlatform] = [.iOS(.v13), .macOS(.v10_15)]
+let platforms: [SupportedPlatform] = [.iOS(.v13)]
 let dependencies: [Package.Dependency] = [
     .package(
         url: "https://github.com/stephencelis/SQLite.swift.git",

--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
-let platforms: [SupportedPlatform] = [.iOS(.v13)]
+let platforms: [SupportedPlatform] = [.iOS(.v13), .macOS(.v10_15)]
 let dependencies: [Package.Dependency] = [
     .package(
         url: "https://github.com/stephencelis/SQLite.swift.git",


### PR DESCRIPTION
*Description of changes:*
fix(datastore): remove blocking semaphore in MutationEvent.pendingMutationEvents

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
