### PR TITLE
fix(datastore): remove blocking DispatchGroup from AWSMutationDatabaseAdapter.resolve

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
@@ -153,7 +153,6 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
                                         continuation.resume(with: result)
                                     }
                                 }
-                                
                             }
                         }
                         try await group.waitForAll()

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
@@ -143,17 +143,26 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
         case .dropCandidateWithError(let dataStoreError):
             completionPromise(.failure(dataStoreError))
         case .dropCandidateAndDeleteLocal:
-            // TODO: Handle errors from delete, and convert to async
-            let group = DispatchGroup()
-            localEvents.forEach {
-                group.enter()
-                storageAdapter.delete(MutationEvent.self,
-                                      modelSchema: MutationEvent.schema,
-                                      withId: $0.id,
-                                      condition: nil) { _ in group.leave() }
+            Task {
+                do {
+                    try await withThrowingTaskGroup(of: Void.self) { group in
+                        for localEvent in localEvents {
+                            group.addTask {
+                                try await withCheckedThrowingContinuation { continuation in
+                                    storageAdapter.delete(untypedModelType: MutationEvent.self, modelSchema: MutationEvent.schema, withId: localEvent.id, condition: nil) { result in
+                                        continuation.resume(with: result)
+                                    }
+                                }
+                                
+                            }
+                        }
+                        try await group.waitForAll()
+                    }
+                    completionPromise(.success(candidate))
+                } catch {
+                    completionPromise(.failure(causedBy: error))
+                }
             }
-            group.wait()
-            completionPromise(.success(candidate))
         case .saveCandidate:
             save(mutationEvent: candidate,
                  storageAdapter: storageAdapter,


### PR DESCRIPTION
*Description of changes:*
fix(datastore): remove blocking DispatchGroup from AWSMutationDatabaseAdapter.resolve

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
