### PR TITLE
fix: make TaskGroups wait for all tasks to complete during resets

### DIFF
--- a/Amplify/Categories/API/Internal/APICategory+Resettable.swift
+++ b/Amplify/Categories/API/Internal/APICategory+Resettable.swift
@@ -18,8 +18,8 @@ extension AmplifyAPICategory: Resettable {
                     self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
                 }
             }
+            await taskGroup.waitForAll()
         }
-
         log.verbose("Resetting ModelRegistry and ModelListDecoderRegistry")
         ModelRegistry.reset()
         ModelListDecoderRegistry.reset()

--- a/Amplify/Categories/Analytics/Internal/AnalyticsCategory+Resettable.swift
+++ b/Amplify/Categories/Analytics/Internal/AnalyticsCategory+Resettable.swift
@@ -18,9 +18,8 @@ extension AnalyticsCategory: Resettable {
                     self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
                 }
             }
+            await taskGroup.waitForAll()
         }
-
         isConfigured = false
     }
-
 }

--- a/Amplify/Categories/Auth/Internal/AuthCategory+Resettable.swift
+++ b/Amplify/Categories/Auth/Internal/AuthCategory+Resettable.swift
@@ -18,9 +18,8 @@ extension AuthCategory: Resettable {
                     self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
                 }
             }
+            await taskGroup.waitForAll()
         }
-
         isConfigured = false
     }
-
 }

--- a/Amplify/Categories/DataStore/Internal/DataStoreCategory+Resettable.swift
+++ b/Amplify/Categories/DataStore/Internal/DataStoreCategory+Resettable.swift
@@ -18,8 +18,8 @@ extension DataStoreCategory: Resettable {
                     self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
                 }
             }
+            await taskGroup.waitForAll()
         }
-
         log.verbose("Resetting ModelRegistry and ModelListDecoderRegistry")
         ModelRegistry.reset()
         ModelListDecoderRegistry.reset()

--- a/Amplify/Categories/Geo/Internal/GeoCategory+Resettable.swift
+++ b/Amplify/Categories/Geo/Internal/GeoCategory+Resettable.swift
@@ -18,8 +18,8 @@ extension GeoCategory: Resettable {
                     self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
                 }
             }
+            await taskGroup.waitForAll()
         }
-
         isConfigured = false
     }
 }

--- a/Amplify/Categories/Hub/Internal/HubCategory+Resettable.swift
+++ b/Amplify/Categories/Hub/Internal/HubCategory+Resettable.swift
@@ -18,8 +18,8 @@ extension HubCategory: Resettable {
                     self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
                 }
             }
+            await taskGroup.waitForAll()
         }
-
         configurationState = .pendingConfiguration
     }
 }

--- a/Amplify/Categories/Predictions/Internal/PredictionsCategory+Resettable.swift
+++ b/Amplify/Categories/Predictions/Internal/PredictionsCategory+Resettable.swift
@@ -18,9 +18,8 @@ extension PredictionsCategory: Resettable {
                     self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
                 }
             }
+            await taskGroup.waitForAll()
         }
-
         isConfigured = false
     }
-
 }

--- a/Amplify/Categories/Storage/Internal/StorageCategory+Resettable.swift
+++ b/Amplify/Categories/Storage/Internal/StorageCategory+Resettable.swift
@@ -18,9 +18,8 @@ extension StorageCategory: Resettable {
                     self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
                 }
             }
+            await taskGroup.waitForAll()
         }
-
         isConfigured = false
     }
-
 }


### PR DESCRIPTION
*Description of changes:*
make TaskGroups wait for all tasks to complete in category resets

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
