### PR TITLE
fix(datastore): Remove DispatchSemaphore in CascadeDeleteOperation

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/CascadeDeleteOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/CascadeDeleteOperation.swift
@@ -72,8 +72,7 @@ public class CascadeDeleteOperation<M: Model>: AsynchronousOperation {
     }
 
     override public func main() {
-        let transactionResult = queryAndDeleteTransaction()
-        syncIfNeededAndFinish(transactionResult)
+        queryAndDelete()
     }
 
     struct QueryAndDeleteResult<M: Model> {
@@ -81,100 +80,112 @@ public class CascadeDeleteOperation<M: Model>: AsynchronousOperation {
         let associatedModels: [(ModelName, Model)]
     }
 
-    func queryAndDeleteTransaction() -> DataStoreResult<QueryAndDeleteResult<M>> {
+    func queryAndDelete() {
+        do {
+            try storageAdapter.transaction {
+                Task {
+                    let transactionResult = await queryAndDeleteTransaction()
+                    syncIfNeededAndFinish(transactionResult)
+                }
+            }
+        } catch {
+            syncIfNeededAndFinish(.failure(causedBy: error))
+        }
+    }
+    
+    func queryAndDeleteTransaction() async -> DataStoreResult<QueryAndDeleteResult<M>> {
         var queriedResult: DataStoreResult<[M]>?
         var deletedResult: DataStoreResult<[M]>?
         var associatedModels: [(ModelName, Model)] = []
-
-        let queryCompletionBlock: DataStoreCallback<[M]> = { queryResult in
-            queriedResult = queryResult
-            guard case .success(let queriedModels) = queryResult else {
-                return
+        
+        queriedResult = await withCheckedContinuation { continuation in
+            self.storageAdapter.query(self.modelType,
+                                      modelSchema: self.modelSchema,
+                                      predicate: self.deleteInput.predicate,
+                                      sort: nil,
+                                      paginationInput: nil) { result in
+                continuation.resume(returning: result)
             }
-
-            guard !queriedModels.isEmpty else {
-                guard case .withIdentifierAndCondition(let identifier, _) = self.deleteInput else {
-                    // Query did not return any results, treat this as a successful no-op delete.
+        }
+        guard case .success(let queriedModels) = queriedResult else {
+            return collapseResults(queryResult: queriedResult,
+                                   deleteResult: deletedResult,
+                                   associatedModels: associatedModels)
+        }
+        guard !queriedModels.isEmpty else {
+            guard case .withIdentifierAndCondition(let identifier, _) = self.deleteInput else {
+                // Query did not return any results, treat this as a successful no-op delete.
+                deletedResult = .success([M]())
+                return collapseResults(queryResult: queriedResult,
+                                                        deleteResult: deletedResult,
+                                                        associatedModels: associatedModels)
+            }
+            
+            // Query using the computed predicate did not return any results, check if model actually exists.
+            do {
+                if try self.storageAdapter.exists(self.modelSchema, withIdentifier: identifier, predicate: nil) {
+                    queriedResult = .failure(
+                        DataStoreError.invalidCondition(
+                            "Delete failed due to condition did not match existing model instance.",
+                            "Subsequent deletes will continue to fail until the model instance is updated."))
+                } else {
                     deletedResult = .success([M]())
-                    return
                 }
-
-                // Query using the computed predicate did not return any results, check if model actually exists.
-                do {
-                    if try self.storageAdapter.exists(self.modelSchema, withIdentifier: identifier, predicate: nil) {
-                        queriedResult = .failure(
-                            DataStoreError.invalidCondition(
-                                "Delete failed due to condition did not match existing model instance.",
-                                "Subsequent deletes will continue to fail until the model instance is updated."))
-                    } else {
-                        deletedResult = .success([M]())
-                    }
-                } catch {
-                    queriedResult = .failure(DataStoreError.invalidOperation(causedBy: error))
-                }
-
-                return
+            } catch {
+                queriedResult = .failure(DataStoreError.invalidOperation(causedBy: error))
             }
-
-            let modelIds = queriedModels.map { $0.identifier(schema: self.modelSchema).stringValue }
-            associatedModels = self.recurseQueryAssociatedModels(modelSchema: self.modelSchema, ids: modelIds)
-            let deleteCompletionWrapper: DataStoreCallback<[M]> = { deleteResult in
-                deletedResult = deleteResult
-            }
+            
+            return collapseResults(queryResult: queriedResult,
+                                                    deleteResult: deletedResult,
+                                                    associatedModels: associatedModels)
+        }
+        
+        let modelIds = queriedModels.map { $0.identifier(schema: self.modelSchema).stringValue }
+        
+        associatedModels = await self.recurseQueryAssociatedModels(modelSchema: self.modelSchema, ids: modelIds)
+        
+        deletedResult = await withCheckedContinuation { continuation in
             self.storageAdapter.delete(self.modelType,
                                        modelSchema: self.modelSchema,
-                                       filter: self.deleteInput.predicate,
-                                       completion: deleteCompletionWrapper)
-        }
-
-        do {
-            try storageAdapter.transaction {
-                storageAdapter.query(modelType,
-                                     modelSchema: modelSchema,
-                                     predicate: deleteInput.predicate,
-                                     sort: nil,
-                                     paginationInput: nil,
-                                     completion: queryCompletionBlock)
+                                       filter: self.deleteInput.predicate) { result in
+                continuation.resume(returning: result)
             }
-        } catch {
-            return .failure(causedBy: error)
         }
-
         return collapseResults(queryResult: queriedResult,
                                deleteResult: deletedResult,
                                associatedModels: associatedModels)
     }
 
-    func recurseQueryAssociatedModels(modelSchema: ModelSchema, ids: [String]) -> [(ModelName, Model)] {
+    func recurseQueryAssociatedModels(modelSchema: ModelSchema, ids: [String]) async -> [(ModelName, Model)] {
         var associatedModels: [(ModelName, Model)] = []
         for (_, modelField) in modelSchema.fields {
             guard modelField.hasAssociation,
-                modelField.isOneToOne || modelField.isOneToMany,
-                let associatedModelName = modelField.associatedModelName,
-                let associatedField = modelField.associatedField,
-                let associatedModelSchema = ModelRegistry.modelSchema(from: associatedModelName) else {
-                    continue
+                  modelField.isOneToOne || modelField.isOneToMany,
+                  let associatedModelName = modelField.associatedModelName,
+                  let associatedField = modelField.associatedField,
+                  let associatedModelSchema = ModelRegistry.modelSchema(from: associatedModelName) else {
+                continue
             }
-
+            
             guard let modelSchema = ModelRegistry.modelSchema(from: associatedModelName) else {
                 log.error("Failed to lookup associate model \(associatedModelName)")
                 return []
             }
-
-            let queriedModels = queryAssociatedModels(associatedModelSchema: modelSchema,
-                                                      associatedField: associatedField,
-                                                      ids: ids)
+            
+            let queriedModels = await queryAssociatedModels(associatedModelSchema: modelSchema,
+                                                            associatedField: associatedField,
+                                                            ids: ids)
+                
             let associatedModelIds = queriedModels.map { $0.1.identifier(schema: modelSchema).stringValue }
             associatedModels.append(contentsOf: queriedModels)
-            associatedModels.append(contentsOf: recurseQueryAssociatedModels(modelSchema: associatedModelSchema,
-                                                                            ids: associatedModelIds))
+            associatedModels.append(contentsOf: await recurseQueryAssociatedModels(modelSchema: associatedModelSchema,                                           ids: associatedModelIds))
         }
         return associatedModels
     }
 
     func queryAssociatedModels(associatedModelSchema modelSchema: ModelSchema,
                                associatedField: ModelField,
-                               ids: [String]) -> [(ModelName, Model)] {
+                               ids: [String]) async -> [(ModelName, Model)] {
         var queriedModels: [(ModelName, Model)] = []
         let chunkedArrays = ids.chunked(into: SQLiteStorageEngineAdapter.maxNumberOfPredicates)
         for chunkedArray in chunkedArrays {
@@ -184,22 +195,19 @@ public class CascadeDeleteOperation<M: Model>: AsynchronousOperation {
                 queryPredicates.append(QueryPredicateOperation(field: associatedField.name, operator: .equals(id)))
             }
             let groupedQueryPredicates = QueryPredicateGroup(type: .or, predicates: queryPredicates)
-
-            let sempahore = DispatchSemaphore(value: 0)
-            storageAdapter.query(modelSchema: modelSchema, predicate: groupedQueryPredicates) { result in
-                defer {
-                    sempahore.signal()
+            
+            do {
+                let models = try await withCheckedThrowingContinuation { continuation in
+                    storageAdapter.query(modelSchema: modelSchema, predicate: groupedQueryPredicates) { result in
+                        continuation.resume(with: result)
+                    }
                 }
-                switch result {
-                case .success(let models):
-                    queriedModels.append(contentsOf: models.map { model in
-                        (modelSchema.name, model)
-                    })
-                case .failure(let error):
-                    log.error("Failed to query \(modelSchema) on mutation event generation: \(error)")
-                }
+                queriedModels.append(contentsOf: models.map { model in
+                    (modelSchema.name, model)
+                })
+            } catch {
+                log.error("Failed to query \(modelSchema) on mutation event generation: \(error)")
             }
-            sempahore.wait()
         }
         return queriedModels
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/CascadeDeleteOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/CascadeDeleteOperationTests.swift
@@ -775,7 +775,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         }
 
         operation.syncIfNeededAndFinish(result)
-        await waitForExpectations(timeout: 10)
+        await waitForExpectations(timeout: 1)
         XCTAssertEqual(submittedEvents.count, 2)
         // The delete mutations should be synced in reverse order (children to parent)
         XCTAssertEqual(submittedEvents[0].modelName, CommentWithCompositeKey.modelName)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/CascadeDeleteOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/CascadeDeleteOperationTests.swift
@@ -58,15 +58,15 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
 
     // MARK: - Query and delete (No Sync)
 
-    func testWithId() {
+    func testWithId() async {
         let restaurant = Restaurant(restaurantName: "restaurant1")
-        guard case .success = saveModelSynchronous(model: restaurant) else {
+        guard case .success = await saveModelSynchronous(model: restaurant) else {
             XCTFail("Failed to save")
             return
         }
         let predicate: QueryPredicate = Restaurant.keys.id == restaurant.id
-        guard case .success(let queriedRestaurants) = queryModelSynchronous(modelType: Restaurant.self,
-                                                                            predicate: predicate) else {
+        guard case .success(let queriedRestaurants) = await queryModelSynchronous(modelType: Restaurant.self,
+                                                                                  predicate: predicate) else {
             XCTFail("Failed to query")
             return
         }
@@ -87,9 +87,9 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
         operation.start()
-        wait(for: [completed], timeout: 1)
-        guard case .success(let queriedRestaurants) = queryModelSynchronous(modelType: Restaurant.self,
-                                                                            predicate: predicate) else {
+        await waitForExpectations(timeout: 1)
+        guard case .success(let queriedRestaurants) = await queryModelSynchronous(modelType: Restaurant.self,
+                                                                                  predicate: predicate) else {
             XCTFail("Failed to query")
             return
         }
@@ -581,9 +581,9 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
 
     // MARK: - Internal testing
 
-    func testSingle() {
+    func testSingle() async {
         let restaurant = Restaurant(restaurantName: "restaurant1")
-        guard case .success = saveModelSynchronous(model: restaurant) else {
+        guard case .success = await saveModelSynchronous(model: restaurant) else {
             XCTFail("Failed to save")
             return
         }
@@ -594,7 +594,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
                                                modelSchema: Restaurant.schema,
                                                withIdentifier: identifier) { _ in }
 
-        let result = operation.queryAndDeleteTransaction()
+        let result = await operation.queryAndDeleteTransaction()
         switch result {
         case .success(let queryAndDeleteResult):
             XCTAssertEqual(queryAndDeleteResult.deletedModels.count, 1)
@@ -632,14 +632,14 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         wait(for: [receivedMutationEvent, expectedFailures, expectedSuccess], timeout: 1)
     }
 
-    func testDeleteWithAssociatedModels() {
+    func testDeleteWithAssociatedModels() async {
         let restaurant = Restaurant(restaurantName: "restaurant1")
         let lunchStandardMenu = Menu(name: "Standard", menuType: .lunch, restaurant: restaurant)
         let oysters = Dish(dishName: "Fried oysters", menu: lunchStandardMenu)
 
-        guard case .success = saveModelSynchronous(model: restaurant),
-            case .success = saveModelSynchronous(model: lunchStandardMenu),
-            case .success = saveModelSynchronous(model: oysters) else {
+        guard case .success = await saveModelSynchronous(model: restaurant),
+            case .success = await saveModelSynchronous(model: lunchStandardMenu),
+            case .success = await saveModelSynchronous(model: oysters) else {
                 XCTFail("Failed to save hierarchy")
                 return
         }
@@ -658,7 +658,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
 
-        let result = operation.queryAndDeleteTransaction()
+        let result = await operation.queryAndDeleteTransaction()
         switch result {
         case .success(let queryAndDeleteResult):
             XCTAssertEqual(queryAndDeleteResult.deletedModels.count, 1)
@@ -708,15 +708,15 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         XCTAssertEqual(submittedEvents[2].modelName, Restaurant.modelName)
     }
 
-    func testDeleteWithAssociatedModelsAndCompositePK() {
+    func testDeleteWithAssociatedModelsAndCompositePK() async {
         let post = PostWithCompositeKey(id: "post-id", title: "title")
         let comment = CommentWithCompositeKey(id: "comment-id", content: "comment-content", post: post)
 
-        if case .failure(let error) = saveModelSynchronous(model: post) {
+        if case .failure(let error) = await saveModelSynchronous(model: post) {
             XCTFail("Failed to save post with error \(error)")
         }
 
-        if case .failure(let error) = saveModelSynchronous(model: comment) {
+        if case .failure(let error) = await saveModelSynchronous(model: comment) {
             XCTFail("Failed to save comment with error \(error)")
         }
 
@@ -735,7 +735,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
 
-        let result = operation.queryAndDeleteTransaction()
+        let result = await operation.queryAndDeleteTransaction()
         switch result {
         case .success(let queryAndDeleteResult):
             XCTAssertEqual(queryAndDeleteResult.deletedModels.count, 1)
@@ -775,21 +775,21 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         }
 
         operation.syncIfNeededAndFinish(result)
-        wait(for: [completed, receivedMutationEvent, expectedFailures, expectedSuccess], timeout: 1)
+        await waitForExpectations(timeout: 10)
         XCTAssertEqual(submittedEvents.count, 2)
         // The delete mutations should be synced in reverse order (children to parent)
         XCTAssertEqual(submittedEvents[0].modelName, CommentWithCompositeKey.modelName)
         XCTAssertEqual(submittedEvents[1].modelName, PostWithCompositeKey.modelName)
     }
 
-    func testDeleteWithAssociatedModels_SingleFailure() {
+    func testDeleteWithAssociatedModels_SingleFailure() async {
         let restaurant = Restaurant(restaurantName: "restaurant1")
         let lunchStandardMenu = Menu(name: "Standard", menuType: .lunch, restaurant: restaurant)
         let oysters = Dish(dishName: "Fried oysters", menu: lunchStandardMenu)
 
-        guard case .success = saveModelSynchronous(model: restaurant),
-            case .success = saveModelSynchronous(model: lunchStandardMenu),
-            case .success = saveModelSynchronous(model: oysters) else {
+        guard case .success = await saveModelSynchronous(model: restaurant),
+            case .success = await saveModelSynchronous(model: lunchStandardMenu),
+            case .success = await saveModelSynchronous(model: oysters) else {
                 XCTFail("Failed to save hierarchy")
                 return
         }
@@ -808,7 +808,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
 
-        let result = operation.queryAndDeleteTransaction()
+        let result = await operation.queryAndDeleteTransaction()
         switch result {
         case .success(let queryAndDeleteResult):
             XCTAssertEqual(queryAndDeleteResult.deletedModels.count, 1)
@@ -849,7 +849,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         }
 
         operation.syncIfNeededAndFinish(result)
-        wait(for: [completed, receivedMutationEvent, expectedFailures, expectedSuccess], timeout: 1)
+        await waitForExpectations(timeout: 1)
         XCTAssertEqual(submittedEvents.count, 3)
         // The delete mutations should be synced in reverse order (children to parent)
         XCTAssertEqual(submittedEvents[0].modelName, Dish.modelName)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This started off by removing the DispatchSemaphore in CascadeDeleteOperation.queryAssociatedModels which then cacaded to a few other changes to make the calling code use async.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
