### PR TITLE
chore(datastore): fix ObserveQuery integ tests

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStoreObserveQueryOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStoreObserveQueryOperation.swift
@@ -404,7 +404,7 @@ public class AWSDataStoreObserveQueryOperation<M: Model>: AsynchronousOperation,
         passthroughPublisher.send(currentSnapshot)
         if log.logLevel >= .debug {
             let time = stopwatch.stop()
-            log.debug("Time to generate snapshot: \(time) seconds")
+            log.debug("Time to generate snapshot: \(time) seconds. isSynced: \(dispatchedModelSyncedEvent.get()), count: \(currentSnapshot.items.count)")
         }
     }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
@@ -59,6 +59,19 @@ class SyncEngineIntegrationTestBase: DataStoreTestBase {
         }
         wait(for: [stopped], timeout: 2)
     }
+    
+    func stopDataStore() async {
+        let stopped = expectation(description: "DataStore stopped")
+        Amplify.DataStore.stop { result in
+            switch result {
+            case .success:
+                stopped.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        await waitForExpectations(timeout: 2)
+    }
 
     func clearDataStore() {
         let cleared = expectation(description: "DataStore cleared")
@@ -71,6 +84,19 @@ class SyncEngineIntegrationTestBase: DataStoreTestBase {
             }
         }
         wait(for: [cleared], timeout: 2)
+    }
+    
+    func clearDataStore() async {
+        let cleared = expectation(description: "DataStore cleared")
+        Amplify.DataStore.clear { result in
+            switch result {
+            case .success:
+                cleared.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        await waitForExpectations(timeout: 2)
     }
 
     func startAmplify() throws {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix ObserveQuery integration tests

![image](https://user-images.githubusercontent.com/1365977/183689050-e0315366-9a24-4217-9dd0-ff2ec67b5f48.png)


*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
