### PR TITLE
fix: AuthProvider.getLatestAuthToken (dev-preview rename)

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify.xcscheme
@@ -9,14 +9,28 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "Amplify"
                BuildableName = "Amplify"
                BlueprintName = "Amplify"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AmplifyTests"
+               BuildableName = "AmplifyTests"
+               BlueprintName = "AmplifyTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>

--- a/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
+++ b/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
@@ -27,7 +27,7 @@ open class APIAuthProviderFactory {
 public protocol AmplifyAuthTokenProvider {
     typealias AuthToken = String
 
-    func getUserPoolAccessToken() async throws -> String
+    func getLatestAuthToken() async throws -> String
 }
 
 /// Amplify OIDC Auth Provider

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
@@ -17,7 +17,7 @@ class AuthTokenProviderWrapper: AuthTokenProvider {
         self.wrappedAuthTokenProvider = tokenAuthProvider
     }
     
-    func getUserPoolAccessToken() async throws -> String {
-        try await wrappedAuthTokenProvider.getUserPoolAccessToken()
+    func getLatestAuthToken() async throws -> String {
+        try await wrappedAuthTokenProvider.getLatestAuthToken()
     }
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenURLRequestInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenURLRequestInterceptor.swift
@@ -36,7 +36,7 @@ struct AuthTokenURLRequestInterceptor: URLRequestInterceptor {
         
         let token: String
         do {
-            token = try await authTokenProvider.getUserPoolAccessToken()
+            token = try await authTokenProvider.getLatestAuthToken()
         } catch {
             throw APIError.operationError("Failed to retrieve authorization token.", "", error)
         }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptor.swift
@@ -72,7 +72,7 @@ class AuthenticationTokenAuthInterceptor: AuthInterceptorAsync {
     }
 
     private func getAuthToken() async -> AmplifyAuthTokenProvider.AuthToken? {
-        try? await authTokenProvider.getUserPoolAccessToken()
+        try? await authTokenProvider.getLatestAuthToken()
     }
 }
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/OIDCAuthProviderWrapper.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/OIDCAuthProviderWrapper.swift
@@ -18,6 +18,6 @@ class OIDCAuthProviderWrapper: OIDCAuthProviderAsync {
     }
 
     func getLatestAuthToken() async throws -> String {
-        try await authTokenProvider.getUserPoolAccessToken()
+        try await authTokenProvider.getLatestAuthToken()
     }
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift
@@ -18,6 +18,6 @@ class AWSOIDCAuthProvider: OIDCAuthProviderAsync {
     }
 
     func getLatestAuthToken() async throws -> String {
-        try await authService.getUserPoolAccessToken()
+        try await authService.getLatestAuthToken()
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginIntegrationTests/GraphQL/GraphQLWithLambdaAuthIntegrationTests/GraphQLWithLambdaAuthIntegrationTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginIntegrationTests/GraphQL/GraphQLWithLambdaAuthIntegrationTests/GraphQLWithLambdaAuthIntegrationTests.swift
@@ -238,7 +238,7 @@ class GraphQLWithLambdaAuthIntegrationTests: XCTestCase {
 
 // MARK: - API Auth provider
 private class CustomTokenProvider: AmplifyFunctionAuthProvider {
-    func getUserPoolAccessToken() async throws -> String {
+    func getLatestAuthToken() async throws -> String {
         return "custom-lambda-token"
     }
     

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -125,7 +125,7 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
 
     struct MockTokenProvider: AuthTokenProvider {
         
-        func getUserPoolAccessToken() async throws -> String {
+        func getLatestAuthToken() async throws -> String {
             "token"
         }
     }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -34,7 +34,7 @@ extension AuthTokenURLRequestInterceptorTests {
     class MockTokenProvider: AuthTokenProvider {
         let authorizationToken = "authorizationToken"
         
-        func getUserPoolAccessToken() async throws -> String {
+        func getLatestAuthToken() async throws -> String {
             authorizationToken
         }
     }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptorTests.swift
@@ -36,7 +36,7 @@ class AuthenticationTokenAuthInterceptorTests: XCTestCase {
 private class TestAuthTokenProvider: AmplifyAuthTokenProvider {
     let authToken = "token"
     
-    func getUserPoolAccessToken() async throws -> String {
+    func getLatestAuthToken() async throws -> String {
         authToken
     }
 }
@@ -45,7 +45,7 @@ private class TestFailingAuthTokenProvider: AmplifyAuthTokenProvider {
     
     let authToken = "token"
     
-    func getUserPoolAccessToken() async throws -> String {
+    func getLatestAuthToken() async throws -> String {
         throw "Token error"
     }
 }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPluginTests/Mocks/MockAWSAuthService.swift
@@ -44,7 +44,7 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
         completion(.success(identityId ?? "IdentityId"))
     }
     
-    public func getUserPoolAccessToken() async throws -> String {
+    public func getLatestAuthToken() async throws -> String {
         ""
     }
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -82,7 +82,7 @@ public class AWSAuthService: AWSAuthServiceBehavior {
     }
     
     /// Retrieves the Cognito token from the AuthCognitoTokensProvider
-    public func getUserPoolAccessToken() async throws -> String {
+    public func getLatestAuthToken() async throws -> String {
         try await withCheckedThrowingContinuation { continuation in
             Amplify.Auth.fetchAuthSession { [weak self] event in
                 switch event {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -20,5 +20,5 @@ public protocol AWSAuthServiceBehavior: AnyObject {
     func getIdentityID(completion: @escaping (Result<String, AuthError>) -> Void)
     
     /// Retrieves the token from the Auth token provider
-    func getUserPoolAccessToken() async throws -> String
+    func getLatestAuthToken() async throws -> String
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift
@@ -9,7 +9,7 @@ import Foundation
 import Amplify
 
 public protocol AuthTokenProvider {
-    func getUserPoolAccessToken() async throws -> String
+    func getLatestAuthToken() async throws -> String
 }
 
 public struct BasicUserPoolTokenProvider: AuthTokenProvider {
@@ -20,7 +20,7 @@ public struct BasicUserPoolTokenProvider: AuthTokenProvider {
         self.authService = authService
     }
     
-    public func getUserPoolAccessToken() async throws -> String {
-        try await authService.getUserPoolAccessToken()
+    public func getLatestAuthToken() async throws -> String {
+        try await authService.getLatestAuthToken()
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -46,7 +46,7 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
         completion(.success(identityId ?? "IdentityId"))
     }
     
-    public func getUserPoolAccessToken() async throws -> String {
+    public func getLatestAuthToken() async throws -> String {
         if let error = getTokenError {
             throw error
         } else {

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine+AuthModeStrategyDelegate.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine+AuthModeStrategyDelegate.swift
@@ -17,10 +17,10 @@ extension RemoteSyncEngine: AuthModeStrategyDelegate {
            let oidcAuthProvider = authProviderFactory.apiAuthProviderFactory().oidcAuthProvider() {
             
             // if OIDC is used as authentication provider
-            // use `getUserPoolAccessToken`
+            // use `getLatestAuthToken`
             var isLoggedInWithOIDC = false
             do {
-                _ = try await oidcAuthProvider.getUserPoolAccessToken()
+                _ = try await oidcAuthProvider.getLatestAuthToken()
                 isLoggedInWithOIDC = true
             } catch {
                 isLoggedInWithOIDC = false

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -202,7 +202,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
         let request: GraphQLRequest<Payload>
         if modelSchema.hasAuthenticationRules,
             let _ = auth,
-            let tokenString = try? await awsAuthService.getUserPoolAccessToken(),
+            let tokenString = try? await awsAuthService.getLatestAuthToken(),
             case .success(let claims) = awsAuthService.getTokenClaims(tokenString: tokenString) {
             request = GraphQLRequest<Payload>.subscription(to: modelSchema,
                                                            subscriptionType: subscriptionType,
@@ -210,7 +210,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
                                                            authType: authType)
         } else if modelSchema.hasAuthenticationRules,
             let oidcAuthProvider = hasOIDCAuthProviderAvailable(api: api),
-            let tokenString = try? await oidcAuthProvider.getUserPoolAccessToken(),
+            let tokenString = try? await oidcAuthProvider.getLatestAuthToken(),
             case .success(let claims) = awsAuthService.getTokenClaims(tokenString: tokenString) {
             request = GraphQLRequest<Payload>.subscription(to: modelSchema,
                                                            subscriptionType: subscriptionType,

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -296,7 +296,7 @@ class MockAPIAuthProviderFactory: APIAuthProviderFactory {
 class MockOIDCAuthProvider: AmplifyOIDCAuthProvider {
     var result: Result<AuthToken, Error>?
     
-    func getUserPoolAccessToken() async throws -> String {
+    func getLatestAuthToken() async throws -> String {
         if case let .success(token) = result {
             return token
         } else {
@@ -308,7 +308,7 @@ class MockOIDCAuthProvider: AmplifyOIDCAuthProvider {
 class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
     var result: Result<AuthToken, Error>?
     
-    func getUserPoolAccessToken() async throws -> String {
+    func getLatestAuthToken() async throws -> String {
         if case let .success(token) = result {
             return token
         } else {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Renaming getUserPoolAccessToken() to getLatestAuthToken()

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
