### PR TITLE
fix(datastore): fix crash in OutgoingMutationQueue

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/AWSDataStorePlugin.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AWSDataStorePlugin.xcscheme
@@ -37,11 +37,6 @@
                BlueprintName = "AWSDataStoreCategoryPluginTests"
                ReferencedContainer = "container:">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "OutgoingMutationQueueNetworkTests/testLastMutationSentWhenNoNetwork()">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/CascadeDeleteOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/CascadeDeleteOperation.swift
@@ -458,7 +458,6 @@ public class CascadeDeleteOperation<M: Model>: AsynchronousOperation {
         }
     }
 
-    @available(iOS 13.0, *)
     private func submitToSyncEngine(mutationEvent: MutationEvent,
                                     syncEngine: RemoteSyncEngineBehavior,
                                     completion: @escaping DataStoreCallback<MutationEvent>) {

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/CascadeDeleteOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/CascadeDeleteOperation.swift
@@ -462,23 +462,7 @@ public class CascadeDeleteOperation<M: Model>: AsynchronousOperation {
     private func submitToSyncEngine(mutationEvent: MutationEvent,
                                     syncEngine: RemoteSyncEngineBehavior,
                                     completion: @escaping DataStoreCallback<MutationEvent>) {
-        let mutationQueueSink = AtomicValue<AnyCancellable?>(initialValue: nil)
-        mutationQueueSink.set(syncEngine
-            .submit(mutationEvent)
-            .sink(
-                receiveCompletion: { futureCompletion in
-                    switch futureCompletion {
-                    case .failure(let error):
-                        completion(.failure(causedBy: error))
-                    case .finished:
-                        self.log.verbose("\(#function) Received successful completion")
-                    }
-                    mutationQueueSink.get()?.cancel()
-                    mutationQueueSink.set(nil)
-                }, receiveValue: { mutationEvent in
-                    self.log.verbose("\(#function) saved mutation event: \(mutationEvent)")
-                    completion(.success(mutationEvent))
-                }))
+        syncEngine.submit(mutationEvent, completion: completion)
     }
 }
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
@@ -356,24 +356,9 @@ final class StorageEngine: StorageEngineBehavior {
     private func submitToSyncEngine(mutationEvent: MutationEvent,
                                     syncEngine: RemoteSyncEngineBehavior,
                                     completion: @escaping DataStoreCallback<MutationEvent>) {
-        var mutationQueueSink: AnyCancellable?
-        mutationQueueSink = syncEngine
-            .submit(mutationEvent)
-            .sink(
-                receiveCompletion: { futureCompletion in
-                    switch futureCompletion {
-                    case .failure(let error):
-                        completion(.failure(causedBy: error))
-                    case .finished:
-                        self.log.verbose("\(#function) Received successful completion")
-                    }
-                    mutationQueueSink?.cancel()
-                    mutationQueueSink = nil
-
-                }, receiveValue: { mutationEvent in
-                    self.log.verbose("\(#function) saved mutation event: \(mutationEvent)")
-                    completion(.success(mutationEvent))
-                })
+        Task {
+            syncEngine.submit(mutationEvent, completion: completion)
+        }
     }
 
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/MutationEvent/MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/MutationEvent/MutationEventIngester.swift
@@ -10,5 +10,5 @@ import Combine
 
 /// Ingests MutationEvents from and writes them to the MutationEvent persistent store
 protocol MutationEventIngester: AnyObject {
-    func submit(mutationEvent: MutationEvent) -> Future<MutationEvent, DataStoreError>
+    func submit(mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>)->Void)
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
@@ -238,8 +238,8 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         }
     }
 
-    func submit(_ mutationEvent: MutationEvent) -> Future<MutationEvent, DataStoreError> {
-        return mutationEventIngester.submit(mutationEvent: mutationEvent)
+    func submit(_ mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>)->Void) {
+        mutationEventIngester.submit(mutationEvent: mutationEvent, completion: completion)
     }
 
     // MARK: - Startup sequence

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngineBehavior.swift
@@ -46,7 +46,7 @@ protocol RemoteSyncEngineBehavior: AnyObject {
 
     /// Submits a new mutation for synchronization to the remote API. The response will be handled by the appropriate
     /// reconciliation queue
-    func submit(_ mutationEvent: MutationEvent) -> Future<MutationEvent, DataStoreError>
+    func submit(_ mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>)->Void)
 
     var publisher: AnyPublisher<RemoteSyncEngineEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/CascadeDeleteOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/CascadeDeleteOperationTests.swift
@@ -313,14 +313,14 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
 
     // MARK: - Query and delete (With Sync)
 
-    func testWithId_WithSync() {
+    func testWithId_WithSync() async {
         let restaurant = Restaurant(restaurantName: "restaurant1")
-        guard case .success = saveModelSynchronous(model: restaurant) else {
+        guard case .success = await saveModelSynchronous(model: restaurant) else {
             XCTFail("Failed to save")
             return
         }
         let predicate: QueryPredicate = Restaurant.keys.id == restaurant.id
-        guard case .success(let queriedRestaurants) = queryModelSynchronous(modelType: Restaurant.self,
+        guard case .success(let queriedRestaurants) = await queryModelSynchronous(modelType: Restaurant.self,
                                                                             predicate: predicate) else {
             XCTFail("Failed to query")
             return
@@ -334,21 +334,14 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         let expectedSuccess = expectation(description: "Simulated success on mutation event submitted to sync engine")
         expectedSuccess.expectedFulfillmentCount = 1
 
-        syncEngine.setCallbackOnSubmit(callback: { _ in
+        syncEngine.setCallbackOnSubmit { submittedMutationEvent, completion in
             receivedMutationEvent.fulfill()
-        })
-
-        syncEngine.setReturnOnSubmit { submittedMutationEvent in
             if submittedMutationEvent.modelId == restaurant.id {
                 expectedSuccess.fulfill()
-                return Future<MutationEvent, DataStoreError> { promise in
-                    promise(.success(submittedMutationEvent))
-                }
-            }
-
-            expectedFailures.fulfill()
-            return Future<MutationEvent, DataStoreError> { promise in
-                promise(.failure(.internalOperation("mockError", "", nil)))
+                completion(.success(submittedMutationEvent))
+            } else {
+                expectedFailures.fulfill()
+                completion(.failure(.internalOperation("mockError", "", nil)))
             }
         }
 
@@ -368,8 +361,8 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
         operation.start()
-        wait(for: [completed, receivedMutationEvent, expectedFailures, expectedSuccess], timeout: 1)
-        guard case .success(let queriedRestaurants) = queryModelSynchronous(modelType: Restaurant.self,
+        await waitForExpectations(timeout: 1)
+        guard case .success(let queriedRestaurants) = await queryModelSynchronous(modelType: Restaurant.self,
                                                                             predicate: predicate) else {
             XCTFail("Failed to query")
             return
@@ -377,18 +370,18 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         XCTAssertEqual(queriedRestaurants.count, 0)
     }
 
-    func testWithIdentifier_WithSync() {
+    func testWithIdentifier_WithSync() async {
         let modelId = "model-id"
         let modelDob = Temporal.DateTime.now()
         let model = ModelCompositePk(id: modelId, dob: modelDob, name: "name")
 
-        guard case .success = saveModelSynchronous(model: model) else {
+        guard case .success = await saveModelSynchronous(model: model) else {
             XCTFail("Failed to save")
             return
         }
         let predicate: QueryPredicate = ModelCompositePk.keys.id == modelId
             && ModelCompositePk.keys.dob == modelDob
-        guard case .success(let queriedModels) = queryModelSynchronous(modelType: ModelCompositePk.self,
+        guard case .success(let queriedModels) = await queryModelSynchronous(modelType: ModelCompositePk.self,
                                                                             predicate: predicate) else {
             XCTFail("Failed to query")
             return
@@ -402,21 +395,14 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         let expectedSuccess = expectation(description: "Simulated success on mutation event submitted to sync engine")
         expectedSuccess.expectedFulfillmentCount = 1
 
-        syncEngine.setCallbackOnSubmit(callback: { _ in
+        syncEngine.setCallbackOnSubmit { submittedMutationEvent, completion in
             receivedMutationEvent.fulfill()
-        })
-
-        syncEngine.setReturnOnSubmit { submittedMutationEvent in
             if submittedMutationEvent.modelId == model.identifier {
                 expectedSuccess.fulfill()
-                return Future<MutationEvent, DataStoreError> { promise in
-                    promise(.success(submittedMutationEvent))
-                }
-            }
-
-            expectedFailures.fulfill()
-            return Future<MutationEvent, DataStoreError> { promise in
-                promise(.failure(.internalOperation("mockError", "", nil)))
+                completion(.success(submittedMutationEvent))
+            } else {
+                expectedFailures.fulfill()
+                completion(.failure(.internalOperation("mockError", "", nil)))
             }
         }
 
@@ -436,8 +422,8 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
         operation.start()
-        wait(for: [completed, receivedMutationEvent, expectedFailures, expectedSuccess], timeout: 1)
-        guard case .success(let queriedModels) = queryModelSynchronous(modelType: ModelCompositePk.self,
+        await waitForExpectations(timeout: 1)
+        guard case .success(let queriedModels) = await queryModelSynchronous(modelType: ModelCompositePk.self,
                                                                             predicate: predicate) else {
             XCTFail("Failed to query")
             return
@@ -469,21 +455,14 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         let expectedSuccess = expectation(description: "Simulated success on mutation event submitted to sync engine")
         expectedSuccess.expectedFulfillmentCount = 1
 
-        syncEngine.setCallbackOnSubmit(callback: { _ in
+        syncEngine.setCallbackOnSubmit { submittedMutationEvent, completion in
             receivedMutationEvent.fulfill()
-        })
-
-        syncEngine.setReturnOnSubmit { submittedMutationEvent in
             if submittedMutationEvent.modelId == restaurant.id {
                 expectedSuccess.fulfill()
-                return Future<MutationEvent, DataStoreError> { promise in
-                    promise(.success(submittedMutationEvent))
-                }
-            }
-
-            expectedFailures.fulfill()
-            return Future<MutationEvent, DataStoreError> { promise in
-                promise(.failure(.internalOperation("mockError", "", nil)))
+                completion(.success(submittedMutationEvent))
+            } else {
+                expectedFailures.fulfill()
+                completion(.failure(.internalOperation("mockError", "", nil)))
             }
         }
 
@@ -536,21 +515,15 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         let expectedSuccess = expectation(description: "Simulated success on mutation event submitted to sync engine")
         expectedSuccess.expectedFulfillmentCount = 1
 
-        syncEngine.setCallbackOnSubmit(callback: { _ in
+        
+        syncEngine.setCallbackOnSubmit { submittedMutationEvent, completion in
             receivedMutationEvent.fulfill()
-        })
-
-        syncEngine.setReturnOnSubmit { submittedMutationEvent in
             if submittedMutationEvent.modelId == restaurant.id {
                 expectedSuccess.fulfill()
-                return Future<MutationEvent, DataStoreError> { promise in
-                    promise(.success(submittedMutationEvent))
-                }
-            }
-
-            expectedFailures.fulfill()
-            return Future<MutationEvent, DataStoreError> { promise in
-                promise(.failure(.internalOperation("mockError", "", nil)))
+                completion(.success(submittedMutationEvent))
+            } else {
+                expectedFailures.fulfill()
+                completion(.failure(.internalOperation("mockError", "", nil)))
             }
         }
 
@@ -610,21 +583,14 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         let expectedSuccess = expectation(description: "Simulated success on mutation event submitted to sync engine")
         expectedSuccess.expectedFulfillmentCount = 1
 
-        syncEngine.setCallbackOnSubmit(callback: { _ in
+        syncEngine.setCallbackOnSubmit { submittedMutationEvent, completion in
             receivedMutationEvent.fulfill()
-        })
-
-        syncEngine.setReturnOnSubmit { submittedMutationEvent in
             if submittedMutationEvent.modelId == restaurant.id {
                 expectedSuccess.fulfill()
-                return Future<MutationEvent, DataStoreError> { promise in
-                    promise(.success(submittedMutationEvent))
-                }
-            }
-
-            expectedFailures.fulfill()
-            return Future<MutationEvent, DataStoreError> { promise in
-                promise(.failure(.internalOperation("mockError", "", nil)))
+                completion(.success(submittedMutationEvent))
+            } else {
+                expectedFailures.fulfill()
+                completion(.failure(.internalOperation("mockError", "", nil)))
             }
         }
 
@@ -678,24 +644,18 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         expectedSuccess.expectedFulfillmentCount = 3
 
         var submittedEvents = [MutationEvent]()
-        syncEngine.setCallbackOnSubmit(callback: { mutationEvent in
-            submittedEvents.append(mutationEvent)
+        
+        syncEngine.setCallbackOnSubmit { submittedMutationEvent, completion in
+            submittedEvents.append(submittedMutationEvent)
             receivedMutationEvent.fulfill()
-        })
-
-        syncEngine.setReturnOnSubmit { submittedMutationEvent in
             if submittedMutationEvent.modelId == restaurant.id ||
                 submittedMutationEvent.modelId == lunchStandardMenu.id ||
                 submittedMutationEvent.modelId == oysters.id {
                 expectedSuccess.fulfill()
-                return Future<MutationEvent, DataStoreError> { promise in
-                    promise(.success(submittedMutationEvent))
-                }
-            }
-
-            expectedFailures.fulfill()
-            return Future<MutationEvent, DataStoreError> { promise in
-                promise(.failure(.internalOperation("mockError", "", nil)))
+                completion(.success(submittedMutationEvent))
+            } else {
+                expectedFailures.fulfill()
+                completion(.failure(.internalOperation("mockError", "", nil)))
             }
         }
 
@@ -754,23 +714,17 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         expectedSuccess.expectedFulfillmentCount = 2
 
         var submittedEvents = [MutationEvent]()
-        syncEngine.setCallbackOnSubmit(callback: { mutationEvent in
-            submittedEvents.append(mutationEvent)
+        
+        syncEngine.setCallbackOnSubmit { submittedMutationEvent, completion in
+            submittedEvents.append(submittedMutationEvent)
             receivedMutationEvent.fulfill()
-        })
-
-        syncEngine.setReturnOnSubmit { submittedMutationEvent in
             if submittedMutationEvent.modelId == post.identifier ||
                 submittedMutationEvent.modelId == comment.identifier {
                 expectedSuccess.fulfill()
-                return Future<MutationEvent, DataStoreError> { promise in
-                    promise(.success(submittedMutationEvent))
-                }
-            }
-
-            expectedFailures.fulfill()
-            return Future<MutationEvent, DataStoreError> { promise in
-                promise(.failure(.internalOperation("mockError", "", nil)))
+                completion(.success(submittedMutationEvent))
+            } else {
+                expectedFailures.fulfill()
+                completion(.failure(.internalOperation("mockError", "", nil)))
             }
         }
 
@@ -828,23 +782,17 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         expectedSuccess.expectedFulfillmentCount = 2
 
         var submittedEvents = [MutationEvent]()
-        syncEngine.setCallbackOnSubmit(callback: { mutationEvent in
-            submittedEvents.append(mutationEvent)
+        
+        syncEngine.setCallbackOnSubmit { submittedMutationEvent, completion in
+            submittedEvents.append(submittedMutationEvent)
             receivedMutationEvent.fulfill()
-        })
-
-        syncEngine.setReturnOnSubmit { submittedMutationEvent in
             if submittedMutationEvent.modelId == restaurant.id ||
                 submittedMutationEvent.modelId == oysters.id {
                 expectedSuccess.fulfill()
-                return Future<MutationEvent, DataStoreError> { promise in
-                    promise(.success(submittedMutationEvent))
-                }
-            }
-            // fail on `submittedMutationEvent.modelId == lunchStandardMenu.id`
-            expectedFailures.fulfill()
-            return Future<MutationEvent, DataStoreError> { promise in
-                promise(.failure(.internalOperation("mockError", "", nil)))
+                completion(.success(submittedMutationEvent))
+            } else {
+                expectedFailures.fulfill()
+                completion(.failure(.internalOperation("mockError", "", nil)))
             }
         }
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsDelete.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsDelete.swift
@@ -157,9 +157,11 @@ class StorageEngineTestsDelete: StorageEngineTestsBase {
         }
 
         let mutationEventOnProject = expectation(description: "Mutation Events submitted to sync engine")
-        syncEngine.setCallbackOnSubmit(callback: { _ in
+        syncEngine.setCallbackOnSubmit{ submittedMutationEvent, completion in
             mutationEventOnProject.fulfill()
-        })
+            completion(.success(submittedMutationEvent))
+        }
+
         let project = Project.keys
         guard case .success = deleteModelSynchronousOrFailOtherwise(modelType: Project.self,
                                                                     withId: projectA.id,

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsHasMany.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsHasMany.swift
@@ -102,9 +102,10 @@ class StorageEngineTestsHasMany: StorageEngineTestsBase {
 
         let receivedMutationEvent = expectation(description: "Mutation Events submitted to sync engine")
         receivedMutationEvent.expectedFulfillmentCount = 6
-        syncEngine.setCallbackOnSubmit(callback: { _ in
+        syncEngine.setCallbackOnSubmit{ submittedMutationEvent, completion in
             receivedMutationEvent.fulfill()
-        })
+            completion(.success(submittedMutationEvent))
+        }
         guard case .success = deleteModelSynchronousOrFailOtherwise(modelType: Restaurant.self,
                                                                     withId: dreamRestaurant.id) else {
             XCTFail("Failed to delete restaurant")
@@ -193,9 +194,10 @@ class StorageEngineTestsHasMany: StorageEngineTestsBase {
         // Delete Top level of restaurant
         let receivedMutationEvent = expectation(description: "Mutation Events submitted to sync engine")
         receivedMutationEvent.expectedFulfillmentCount = numberOfMenus + numberOfDishes + 1
-        syncEngine.setCallbackOnSubmit(callback: { _ in
+        syncEngine.setCallbackOnSubmit{ submittedMutationEvent, completion in
             receivedMutationEvent.fulfill()
-        })
+            completion(.success(submittedMutationEvent))
+        }
         guard case .success = deleteModelSynchronousOrFailOtherwise(modelType: Restaurant.self,
                                                                     withId: restaurant1.id,
                                                                     timeout: 100) else {
@@ -226,22 +228,20 @@ class StorageEngineTestsHasMany: StorageEngineTestsBase {
         let expectedSuccess = expectation(description: "Simulated success on mutation event submitted to sync engine")
         expectedSuccess.expectedFulfillmentCount = 1
 
-        syncEngine.setCallbackOnSubmit(callback: { _ in
+        syncEngine.setCallbackOnSubmit{ submittedMutationEvent, completion in
             receivedMutationEvent.fulfill()
-        })
+            completion(.success(submittedMutationEvent))
+        }
 
-        syncEngine.setReturnOnSubmit { submittedMutationEvent in
+        syncEngine.setCallbackOnSubmit{ submittedMutationEvent, completion in
+            receivedMutationEvent.fulfill()
             if submittedMutationEvent.modelId == lunchStandardMenu.id ||
                 submittedMutationEvent.modelId == oysters.id {
                 expectedFailures.fulfill()
-                return Future<MutationEvent, DataStoreError> { promise in
-                    promise(.failure(.internalOperation("mockError", "", nil)))
-                }
+                completion(.failure(.internalOperation("mockError", "", nil)))
             }
             expectedSuccess.fulfill()
-            return Future<MutationEvent, DataStoreError> { promise in
-                promise(.success(submittedMutationEvent))
-            }
+            completion(.success(submittedMutationEvent))
         }
 
         guard case .failure(let error) = deleteModelSynchronousOrFailOtherwise(modelType: Restaurant.self,

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsHasMany.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsHasMany.swift
@@ -230,18 +230,14 @@ class StorageEngineTestsHasMany: StorageEngineTestsBase {
 
         syncEngine.setCallbackOnSubmit{ submittedMutationEvent, completion in
             receivedMutationEvent.fulfill()
-            completion(.success(submittedMutationEvent))
-        }
-
-        syncEngine.setCallbackOnSubmit{ submittedMutationEvent, completion in
-            receivedMutationEvent.fulfill()
             if submittedMutationEvent.modelId == lunchStandardMenu.id ||
                 submittedMutationEvent.modelId == oysters.id {
                 expectedFailures.fulfill()
                 completion(.failure(.internalOperation("mockError", "", nil)))
+            } else {
+                expectedSuccess.fulfill()
+                completion(.success(submittedMutationEvent))
             }
-            expectedSuccess.fulfill()
-            completion(.success(submittedMutationEvent))
         }
 
         guard case .failure(let error) = deleteModelSynchronousOrFailOtherwise(modelType: Restaurant.self,
@@ -252,5 +248,4 @@ class StorageEngineTestsHasMany: StorageEngineTestsBase {
         wait(for: [receivedMutationEvent, expectedFailures, expectedSuccess], timeout: defaultTimeout)
         XCTAssertEqual(error.errorDescription, "mockError")
     }
-
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsHasOne.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsHasOne.swift
@@ -101,9 +101,10 @@ class StorageEngineTestsHasOne: StorageEngineTestsBase {
         }
 
         let mutationEventOnProject = expectation(description: "Mutation Events submitted to sync engine")
-        syncEngine.setCallbackOnSubmit(callback: { _ in
+        syncEngine.setCallbackOnSubmit{ submittedMutationEvent, completion in
             mutationEventOnProject.fulfill()
-        })
+            completion(.success(submittedMutationEvent))
+        }
         guard case .success = deleteModelSynchronousOrFailOtherwise(modelType: Project.self,
                                                                     withId: projectA.id) else {
             XCTFail("Failed to delete projectA")

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsManyToMany.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsManyToMany.swift
@@ -94,9 +94,10 @@ class StorageEngineTestsManyToMany: StorageEngineTestsBase {
         let mutationEvents = expectation(description: "Mutation Events submitted to sync engine")
         mutationEvents.expectedFulfillmentCount = 2
 
-        syncEngine.setCallbackOnSubmit(callback: { _ in
+        syncEngine.setCallbackOnSubmit{ submittedMutationEvent, completion in
             mutationEvents.fulfill()
-        })
+            completion(.success(submittedMutationEvent))
+        }
         guard case .success = deleteModelSynchronousOrFailOtherwise(modelType: M2MPost.self,
                                                                     withId: post1.id) else {
             XCTFail("Failed to delete post1")
@@ -150,9 +151,10 @@ class StorageEngineTestsManyToMany: StorageEngineTestsBase {
         let mutationEvents = expectation(description: "Mutation Events submitted to sync engine")
         mutationEvents.expectedFulfillmentCount = 2
 
-        syncEngine.setCallbackOnSubmit(callback: { _ in
+        syncEngine.setCallbackOnSubmit{ submittedMutationEvent, completion in
             mutationEvents.fulfill()
-        })
+            completion(.success(submittedMutationEvent))
+        }
         guard case .success = deleteModelSynchronousOrFailOtherwise(modelType: M2MUser.self,
                                                                     withId: user1.id) else {
             XCTFail("Failed to delete post1")

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
@@ -126,7 +126,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
             }
         }
 
-        await waitForExpectations(timeout: 0.1)
+        await waitForExpectations(timeout: 0.2)
 
         // Set the responder to reject the mutation. Make sure to push a retry advice before sending
         // a new mutation.
@@ -155,7 +155,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
                 savedUpdate1.fulfill()
             }
         }
-        await waitForExpectations(timeout: 0.1)
+        await waitForExpectations(timeout: 0.2)
 
         // At this point, the MutationEvent table (the backing store for the outgoing mutation
         // queue) has only a record for the interim update. It is marked as `inProcess: true`,
@@ -181,7 +181,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
 
         // Assert that DataStore has pushed the no-network event. This isn't strictly necessary for
         // correct operation of the queue.
-        await waitForExpectations(timeout: 0.1)
+        await waitForExpectations(timeout: 0.2)
 
         // At this point, the MutationEvent table has only a record for update1. It is marked as
         // `inProcess: false`, because the mutation queue has been fully cancelled by the cleanup
@@ -204,7 +204,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
                 savedUpdate2.fulfill()
             }
         }
-        await waitForExpectations(timeout: 0.1)
+        await waitForExpectations(timeout: 0.2)
 
         // At this point, the MutationEvent table has only a record for update2. It is marked as
         // `inProcess: false`, because the mutation queue has been fully cancelled.
@@ -223,7 +223,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
                 savedFinalUpdate.fulfill()
             }
         }
-        await waitForExpectations(timeout: 0.1)
+        await waitForExpectations(timeout: 0.2)
 
         let syncStarted = expectation(description: "syncStarted")
         setUpSyncStartedListener(

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
@@ -126,7 +126,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
             }
         }
 
-        await waitForExpectations(timeout: 0.2)
+        await waitForExpectations(timeout: 1.0)
 
         // Set the responder to reject the mutation. Make sure to push a retry advice before sending
         // a new mutation.
@@ -155,7 +155,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
                 savedUpdate1.fulfill()
             }
         }
-        await waitForExpectations(timeout: 0.2)
+        await waitForExpectations(timeout: 1.0)
 
         // At this point, the MutationEvent table (the backing store for the outgoing mutation
         // queue) has only a record for the interim update. It is marked as `inProcess: true`,
@@ -181,7 +181,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
 
         // Assert that DataStore has pushed the no-network event. This isn't strictly necessary for
         // correct operation of the queue.
-        await waitForExpectations(timeout: 0.2)
+        await waitForExpectations(timeout: 1.0)
 
         // At this point, the MutationEvent table has only a record for update1. It is marked as
         // `inProcess: false`, because the mutation queue has been fully cancelled by the cleanup
@@ -204,7 +204,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
                 savedUpdate2.fulfill()
             }
         }
-        await waitForExpectations(timeout: 0.2)
+        await waitForExpectations(timeout: 1.0)
 
         // At this point, the MutationEvent table has only a record for update2. It is marked as
         // `inProcess: false`, because the mutation queue has been fully cancelled.
@@ -223,7 +223,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
                 savedFinalUpdate.fulfill()
             }
         }
-        await waitForExpectations(timeout: 0.2)
+        await waitForExpectations(timeout: 1.0)
 
         let syncStarted = expectation(description: "syncStarted")
         setUpSyncStartedListener(

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockRemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockRemoteSyncEngine.swift
@@ -15,6 +15,15 @@ import Combine
 
 typealias OnSubmitCallBack = (MutationEvent) -> Void
 class MockRemoteSyncEngine: RemoteSyncEngineBehavior {
+    func submit(_ mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>) -> Void) {
+        if let callback = callbackOnSubmit {
+            callback(mutationEvent)
+        }
+//        if let returnOnSubmit = self.returnOnSubmit {
+//            return returnOnSubmit(mutationEvent)
+//        }
+        completion(.success(mutationEvent))
+    }
 
     let remoteSyncTopicPublisher: PassthroughSubject<RemoteSyncEngineEvent, DataStoreError>
     var callbackOnSubmit: OnSubmitCallBack?


### PR DESCRIPTION
*Description of changes:*
fix(datastore): fix crash in OutgoingMutationQueue

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
