### PR TITLE
feat(api): Add Async APIs

### DIFF
--- a/Amplify/Categories/API/ClientBehavior/APICategory+GraphQLBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategory+GraphQLBehavior.swift
@@ -6,7 +6,7 @@
 //
 
 extension APICategory: APICategoryGraphQLBehavior {
-
+    
     // MARK: - Request-based GraphQL operations
 
     @discardableResult
@@ -15,10 +15,18 @@ extension APICategory: APICategoryGraphQLBehavior {
         plugin.query(request: request, listener: listener)
     }
 
+    public func query<R: Decodable>(request: GraphQLRequest<R>) async throws -> GraphQLTask<R>.Success {
+        try await plugin.query(request: request)
+    }
+
     @discardableResult
     public func mutate<R: Decodable>(request: GraphQLRequest<R>,
                                      listener: GraphQLOperation<R>.ResultListener?) -> GraphQLOperation<R> {
         plugin.mutate(request: request, listener: listener)
+    }
+    
+    public func mutate<R: Decodable>(request: GraphQLRequest<R>) async throws -> GraphQLTask<R>.Success {
+        try await plugin.mutate(request: request)
     }
 
     public func subscribe<R>(request: GraphQLRequest<R>,
@@ -26,5 +34,9 @@ extension APICategory: APICategoryGraphQLBehavior {
                              completionListener: GraphQLSubscriptionOperation<R>.ResultListener?)
         -> GraphQLSubscriptionOperation<R> {
             plugin.subscribe(request: request, valueListener: valueListener, completionListener: completionListener)
+    }
+    
+    public func subscribe<R>(request: GraphQLRequest<R>) async throws -> GraphQLSubscriptionTask<R> {
+        try await plugin.subscribe(request: request)
     }
 }

--- a/Amplify/Categories/API/ClientBehavior/APICategory+RESTBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategory+RESTBehavior.swift
@@ -8,33 +8,58 @@
 import Foundation
 
 extension APICategory: APICategoryRESTBehavior {
+    
     @discardableResult
     public func get(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation {
         plugin.get(request: request, listener: listener)
+    }
+    
+    public func get(request: RESTRequest) async throws -> RESTTask.Success {
+        try await plugin.get(request: request)
     }
 
     @discardableResult
     public func put(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation {
         plugin.put(request: request, listener: listener)
     }
+    
+    public func put(request: RESTRequest) async throws -> RESTTask.Success {
+        try await plugin.put(request: request)
+    }
 
     @discardableResult
     public func post(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation {
         plugin.post(request: request, listener: listener)
+    }
+    
+    public func post(request: RESTRequest) async throws -> RESTTask.Success {
+        try await plugin.post(request: request)
     }
 
     @discardableResult
     public func delete(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation {
         plugin.delete(request: request, listener: listener)
     }
+    
+    public func delete(request: RESTRequest) async throws -> RESTTask.Success {
+        try await plugin.delete(request: request)
+    }
 
     @discardableResult
     public func head(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation {
         plugin.head(request: request, listener: listener)
     }
+    
+    public func head(request: RESTRequest) async throws -> RESTTask.Success {
+        try await plugin.head(request: request)
+    }
 
     @discardableResult
     public func patch(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation {
         plugin.patch(request: request, listener: listener)
+    }
+    
+    public func patch(request: RESTRequest) async throws -> RESTTask.Success {
+        try await plugin.patch(request: request)
     }
 }

--- a/Amplify/Categories/API/ClientBehavior/APICategoryGraphQLBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategoryGraphQLBehavior.swift
@@ -20,7 +20,9 @@ public protocol APICategoryGraphQLBehavior: AnyObject {
     @discardableResult
     func query<R: Decodable>(request: GraphQLRequest<R>,
                              listener: GraphQLOperation<R>.ResultListener?) -> GraphQLOperation<R>
-
+    
+    func query<R: Decodable>(request: GraphQLRequest<R>) async throws -> GraphQLTask<R>.Success
+    
     /// Perform a GraphQL mutate operation against a previously configured API. This operation
     /// will be asynchronous, with the callback accessible both locally and via the Hub.
     ///
@@ -31,6 +33,8 @@ public protocol APICategoryGraphQLBehavior: AnyObject {
     @discardableResult
     func mutate<R: Decodable>(request: GraphQLRequest<R>,
                               listener: GraphQLOperation<R>.ResultListener?) -> GraphQLOperation<R>
+    
+    func mutate<R: Decodable>(request: GraphQLRequest<R>) async throws -> GraphQLTask<R>.Success
 
     /// Perform a GraphQL subscribe operation against a previously configured API. This operation
     /// will be asychronous, with the callback accessible both locally and via the Hub.
@@ -44,4 +48,7 @@ public protocol APICategoryGraphQLBehavior: AnyObject {
                                  valueListener: GraphQLSubscriptionOperation<R>.InProcessListener?,
                                  completionListener: GraphQLSubscriptionOperation<R>.ResultListener?)
         -> GraphQLSubscriptionOperation<R>
+    
+    func subscribe<R: Decodable>(request: GraphQLRequest<R>) async throws ->
+        GraphQLSubscriptionTask<R>
 }

--- a/Amplify/Categories/API/ClientBehavior/APICategoryRESTBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategoryRESTBehavior.swift
@@ -16,6 +16,8 @@ public protocol APICategoryRESTBehavior {
     /// - Returns: An operation that can be observed for its value
     @discardableResult
     func get(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation
+    
+    func get(request: RESTRequest) async throws -> RESTTask.Success
 
     /// Perform an HTTP PUT operation
     ///
@@ -23,6 +25,8 @@ public protocol APICategoryRESTBehavior {
     /// - Returns: An operation that can be observed for its value
     @discardableResult
     func put(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation
+    
+    func put(request: RESTRequest) async throws -> RESTTask.Success
 
     /// Perform an HTTP POST operation
     ///
@@ -31,6 +35,8 @@ public protocol APICategoryRESTBehavior {
     @discardableResult
     func post(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation
 
+    func post(request: RESTRequest) async throws -> RESTTask.Success
+    
     /// Perform an HTTP DELETE operation
     ///
     /// - Parameter request: Contains information such as path, query parameters, body.
@@ -38,12 +44,16 @@ public protocol APICategoryRESTBehavior {
     @discardableResult
     func delete(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation
 
+    func delete(request: RESTRequest) async throws -> RESTTask.Success
+    
     /// Perform an HTTP HEAD operation
     ///
     /// - Parameter request: Contains information such as path, query parameters, body.
     /// - Returns: An operation that can be observed for its value
     @discardableResult
     func head(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation
+    
+    func head(request: RESTRequest) async throws -> RESTTask.Success
 
     /// Perform an HTTP PATCH operation
     ///
@@ -51,4 +61,6 @@ public protocol APICategoryRESTBehavior {
     /// - Returns: An operation that can be observed for its value
     @discardableResult
     func patch(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation
+    
+    func patch(request: RESTRequest) async throws -> RESTTask.Success
 }

--- a/Amplify/Categories/API/Operation/GraphQLOperation.swift
+++ b/Amplify/Categories/API/Operation/GraphQLOperation.swift
@@ -30,3 +30,23 @@ public extension HubPayload.EventName.API {
     /// eventName for HubPayloads emitted by this operation
     static let subscribe = "API.subscribe"
 }
+
+public extension GraphQLOperation {
+    typealias TaskAdapter = AmplifyOperation<Request, Success, Failure>
+}
+
+public typealias GraphQLTask<R: Decodable> = GraphQLOperation<R>.TaskAdapter
+
+ public extension GraphQLSubscriptionOperation {
+     typealias TaskAdapter = AmplifyInProcessReportingOperationTaskAdapter<Request, InProcess, Success, Failure>
+ }
+
+ public typealias GraphQLSubscriptionTask<R: Decodable> = GraphQLSubscriptionOperation<R>.TaskAdapter
+
+public extension GraphQLSubscriptionTask {
+    var subscription : AsyncChannel<InProcess> {
+        get async {
+            await inProcess
+        }
+    }
+}

--- a/Amplify/Categories/API/Operation/GraphQLOperation.swift
+++ b/Amplify/Categories/API/Operation/GraphQLOperation.swift
@@ -32,16 +32,16 @@ public extension HubPayload.EventName.API {
 }
 
 public extension GraphQLOperation {
-    typealias TaskAdapter = AmplifyOperation<Request, Success, Failure>
+    typealias TaskAdapter = AmplifyOperationTaskAdapter<Request, Success, Failure>
 }
 
 public typealias GraphQLTask<R: Decodable> = GraphQLOperation<R>.TaskAdapter
 
- public extension GraphQLSubscriptionOperation {
-     typealias TaskAdapter = AmplifyInProcessReportingOperationTaskAdapter<Request, InProcess, Success, Failure>
- }
+public extension GraphQLSubscriptionOperation {
+    typealias TaskAdapter = AmplifyInProcessReportingOperationTaskAdapter<Request, InProcess, Success, Failure>
+}
 
- public typealias GraphQLSubscriptionTask<R: Decodable> = GraphQLSubscriptionOperation<R>.TaskAdapter
+public typealias GraphQLSubscriptionTask<R: Decodable> = GraphQLSubscriptionOperation<R>.TaskAdapter
 
 public extension GraphQLSubscriptionTask {
     var subscription : AsyncChannel<InProcess> {

--- a/Amplify/Categories/API/Operation/RESTOperation.swift
+++ b/Amplify/Categories/API/Operation/RESTOperation.swift
@@ -31,3 +31,9 @@ public extension HubPayload.EventName.API {
     /// eventName for HubPayloads emitted by this operation
     static let head = "API.head"
 }
+
+public extension RESTOperation {
+    typealias TaskAdapter = AmplifyOperationTaskAdapter<Request, Success, Failure>
+}
+
+public typealias RESTTask = RESTOperation.TaskAdapter

--- a/Amplify/Core/Support/AmplifyTask.swift
+++ b/Amplify/Core/Support/AmplifyTask.swift
@@ -45,3 +45,4 @@ public extension AmplifyInProcessReportingTask where InProcess == Progress {
         }
     }
 }
+

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin+GraphQLBehavior.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin+GraphQLBehavior.swift
@@ -19,6 +19,17 @@ public extension AWSAPIPlugin {
         queue.addOperation(operation)
         return operation
     }
+    
+    func query<R: Decodable>(request: GraphQLRequest<R>) async throws -> GraphQLTask<R>.Success {
+        let operation = AWSGraphQLOperation(request: request.toOperationRequest(operationType: .query),
+                                            session: session,
+                                            mapper: mapper,
+                                            pluginConfig: pluginConfig,
+                                            resultListener: nil)
+        let task = AmplifyOperationTaskAdapter(operation: operation)
+        queue.addOperation(operation)
+        return try await task.value
+    }
 
     func mutate<R: Decodable>(request: GraphQLRequest<R>,
                               listener: GraphQLOperation<R>.ResultListener?) -> GraphQLOperation<R> {
@@ -29,6 +40,17 @@ public extension AWSAPIPlugin {
                                             resultListener: listener)
         queue.addOperation(operation)
         return operation
+    }
+    
+    func mutate<R: Decodable>(request: GraphQLRequest<R>) async throws -> GraphQLTask<R>.Success {
+        let operation = AWSGraphQLOperation(request: request.toOperationRequest(operationType: .mutation),
+                                            session: session,
+                                            mapper: mapper,
+                                            pluginConfig: pluginConfig,
+                                            resultListener: nil)
+        let task = AmplifyOperationTaskAdapter(operation: operation)
+        queue.addOperation(operation)
+        return try await task.value
     }
 
     func subscribe<R>(
@@ -46,5 +68,19 @@ public extension AWSAPIPlugin {
                 resultListener: completionListener)
             queue.addOperation(operation)
             return operation
+    }
+    
+    func subscribe<R>(request: GraphQLRequest<R>) async throws -> GraphQLSubscriptionTask<R> {
+        let operation = AWSGraphQLSubscriptionOperation(
+            request: request.toOperationRequest(operationType: .subscription),
+            pluginConfig: pluginConfig,
+            subscriptionConnectionFactory: subscriptionConnectionFactory,
+            authService: authService,
+            apiAuthProviderFactory: authProviderFactory,
+            inProcessListener: nil,
+            resultListener: nil)
+        let task = AmplifyInProcessReportingOperationTaskAdapter(operation: operation)
+        queue.addOperation(operation)
+        return task
     }
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin+RESTBehavior.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin+RESTBehavior.swift
@@ -23,6 +23,21 @@ public extension AWSAPIPlugin {
         queue.addOperation(operation)
         return operation
     }
+    
+    func get(request: RESTRequest) async throws -> RESTTask.Success {
+        let operationRequest = RESTOperationRequest(request: request,
+                                                    operationType: .get)
+
+        let operation = AWSRESTOperation(request: operationRequest,
+                                         session: session,
+                                         mapper: mapper,
+                                         pluginConfig: pluginConfig,
+                                         resultListener: nil)
+
+        let task = AmplifyOperationTaskAdapter(operation: operation)
+        queue.addOperation(operation)
+        return try await task.value
+    }
 
     func put(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation {
         let operationRequest = RESTOperationRequest(request: request,
@@ -36,6 +51,21 @@ public extension AWSAPIPlugin {
 
         queue.addOperation(operation)
         return operation
+    }
+    
+    func put(request: RESTRequest) async throws -> RESTTask.Success {
+        let operationRequest = RESTOperationRequest(request: request,
+                                                    operationType: .put)
+
+        let operation = AWSRESTOperation(request: operationRequest,
+                                         session: session,
+                                         mapper: mapper,
+                                         pluginConfig: pluginConfig,
+                                         resultListener: nil)
+
+        let task = AmplifyOperationTaskAdapter(operation: operation)
+        queue.addOperation(operation)
+        return try await task.value
     }
 
     func post(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation {
@@ -51,6 +81,21 @@ public extension AWSAPIPlugin {
         queue.addOperation(operation)
         return operation
     }
+    
+    func post(request: RESTRequest) async throws -> RESTTask.Success {
+        let operationRequest = RESTOperationRequest(request: request,
+                                                    operationType: .post)
+
+        let operation = AWSRESTOperation(request: operationRequest,
+                                         session: session,
+                                         mapper: mapper,
+                                         pluginConfig: pluginConfig,
+                                         resultListener: nil)
+
+        let task = AmplifyOperationTaskAdapter(operation: operation)
+        queue.addOperation(operation)
+        return try await task.value
+    }
 
     func patch(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation {
         let operationRequest = RESTOperationRequest(request: request, operationType: .patch)
@@ -63,6 +108,20 @@ public extension AWSAPIPlugin {
 
         queue.addOperation(operation)
         return operation
+    }
+    
+    func patch(request: RESTRequest) async throws -> RESTTask.Success {
+        let operationRequest = RESTOperationRequest(request: request, operationType: .patch)
+
+        let operation = AWSRESTOperation(request: operationRequest,
+                                         session: session,
+                                         mapper: mapper,
+                                         pluginConfig: pluginConfig,
+                                         resultListener: nil)
+
+        let task = AmplifyOperationTaskAdapter(operation: operation)
+        queue.addOperation(operation)
+        return try await task.value
     }
 
     func delete(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation {
@@ -78,6 +137,21 @@ public extension AWSAPIPlugin {
         queue.addOperation(operation)
         return operation
     }
+    
+    func delete(request: RESTRequest) async throws -> RESTTask.Success {
+        let operationRequest = RESTOperationRequest(request: request,
+                                                    operationType: .delete)
+
+        let operation = AWSRESTOperation(request: operationRequest,
+                                         session: session,
+                                         mapper: mapper,
+                                         pluginConfig: pluginConfig,
+                                         resultListener: nil)
+
+        let task = AmplifyOperationTaskAdapter(operation: operation)
+        queue.addOperation(operation)
+        return try await task.value
+    }
 
     func head(request: RESTRequest, listener: RESTOperation.ResultListener?) -> RESTOperation {
         let operationRequest = RESTOperationRequest(request: request,
@@ -91,5 +165,20 @@ public extension AWSAPIPlugin {
 
         queue.addOperation(operation)
         return operation
+    }
+    
+    func head(request: RESTRequest) async throws -> RESTTask.Success {
+        let operationRequest = RESTOperationRequest(request: request,
+                                                    operationType: .head)
+
+        let operation = AWSRESTOperation(request: operationRequest,
+                                         session: session,
+                                         mapper: mapper,
+                                         pluginConfig: pluginConfig,
+                                         resultListener: nil)
+
+        let task = AmplifyOperationTaskAdapter(operation: operation)
+        queue.addOperation(operation)
+        return try await task.value
     }
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionOperation.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionOperation.swift
@@ -51,8 +51,8 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
             }
         }
 
-        super.cancel()
         dispatch(result: .successfulVoid)
+        super.cancel()
         finish()
     }
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		21E73E7128898D7900D7DB7E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E73E7028898D7900D7DB7E /* ContentView.swift */; };
 		21E73E7328898D7A00D7DB7E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 21E73E7228898D7A00D7DB7E /* Assets.xcassets */; };
 		21E73E7628898D7A00D7DB7E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 21E73E7528898D7A00D7DB7E /* Preview Assets.xcassets */; };
+		21EE281428AD33A7003FBCE2 /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EE281328AD33A7003FBCE2 /* AsyncExpectation.swift */; };
 		395906B628AC4AC8004B96B1 /* RESTWithIAMIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698BC728899BC8004BD994 /* RESTWithIAMIntegrationTests.swift */; };
 		395906B928AC4C3A004B96B1 /* TestConfigHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395906B828AC4C3A004B96B1 /* TestConfigHelper.swift */; };
 		395906CA28AC6468004B96B1 /* RESTWithUserPoolIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698BCE28899BCF004BD994 /* RESTWithUserPoolIntegrationTests.swift */; };
@@ -260,6 +261,7 @@
 		21E73E7028898D7900D7DB7E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		21E73E7228898D7A00D7DB7E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		21E73E7528898D7A00D7DB7E /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		21EE281328AD33A7003FBCE2 /* AsyncExpectation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncExpectation.swift; sourceTree = "<group>"; };
 		395906AC28AC4A16004B96B1 /* AWSAPIPluginRESTIAMTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSAPIPluginRESTIAMTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		395906B828AC4C3A004B96B1 /* TestConfigHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConfigHelper.swift; sourceTree = "<group>"; };
 		395906C028AC63A9004B96B1 /* AWSAPIPluginRESTUserPoolTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSAPIPluginRESTUserPoolTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -339,6 +341,7 @@
 			isa = PBXGroup;
 			children = (
 				21262523289ABB0C003788E3 /* TestConfigHelper.swift */,
+				21EE281328AD33A7003FBCE2 /* AsyncExpectation.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -1099,6 +1102,7 @@
 				21262731289ABFEB003788E3 /* ScalarContainer+Schema.swift in Sources */,
 				21262752289ABFEB003788E3 /* Project1.swift in Sources */,
 				2126273A289ABFEB003788E3 /* Team1+Schema.swift in Sources */,
+				21EE281428AD33A7003FBCE2 /* AsyncExpectation.swift in Sources */,
 				21262749289ABFEB003788E3 /* AmplifyModels.swift in Sources */,
 				21262735289ABFEB003788E3 /* User5.swift in Sources */,
 				21698AB72889996A004BD994 /* GraphQLConnectionScenario1Tests.swift in Sources */,

--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		213DBC8128A6C4FB00B30280 /* TestConfigHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213DBC8028A6C4FB00B30280 /* TestConfigHelper.swift */; };
 		213DBC8528A6CE9800B30280 /* GraphQLWithLambdaAuthIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698BA328899B3F004BD994 /* GraphQLWithLambdaAuthIntegrationTests.swift */; };
 		213DBC8728A6CEDD00B30280 /* Todo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213DBC8628A6CEDD00B30280 /* Todo.swift */; };
+		213DBC8928A700E000B30280 /* SubscriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213DBC8828A700E000B30280 /* SubscriptionView.swift */; };
 		21698AA328899921004BD994 /* Todo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698A9F28899921004BD994 /* Todo.swift */; };
 		21698AB72889996A004BD994 /* GraphQLConnectionScenario1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698AA82889996A004BD994 /* GraphQLConnectionScenario1Tests.swift */; };
 		21698AB92889996A004BD994 /* GraphQLConnectionScenario3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698AAA2889996A004BD994 /* GraphQLConnectionScenario3Tests.swift */; };
@@ -216,6 +217,7 @@
 		213DBC7528A6C47000B30280 /* AWSAPIPluginGraphQLLambdaAuthTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSAPIPluginGraphQLLambdaAuthTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		213DBC8028A6C4FB00B30280 /* TestConfigHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConfigHelper.swift; sourceTree = "<group>"; };
 		213DBC8628A6CEDD00B30280 /* Todo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Todo.swift; sourceTree = "<group>"; };
+		213DBC8828A700E000B30280 /* SubscriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionView.swift; sourceTree = "<group>"; };
 		21698A7B28899804004BD994 /* AWSAPIPluginFunctionalTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSAPIPluginFunctionalTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		21698A9528899818004BD994 /* AWSAPIPluginIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSAPIPluginIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		21698A9F28899921004BD994 /* Todo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Todo.swift; sourceTree = "<group>"; };
@@ -540,6 +542,7 @@
 				21E73E7028898D7900D7DB7E /* ContentView.swift */,
 				21E73E7228898D7A00D7DB7E /* Assets.xcassets */,
 				21E73E7428898D7A00D7DB7E /* Preview Content */,
+				213DBC8828A700E000B30280 /* SubscriptionView.swift */,
 			);
 			path = APIHostApp;
 			sourceTree = "<group>";
@@ -1128,6 +1131,7 @@
 				21E73E7128898D7900D7DB7E /* ContentView.swift in Sources */,
 				21698C082889B173004BD994 /* TestExtensions.swift in Sources */,
 				21698C092889B173004BD994 /* TestCommonConstants.swift in Sources */,
+				213DBC8928A700E000B30280 /* SubscriptionView.swift in Sources */,
 				21E73E6F28898D7900D7DB7E /* APIHostAppApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp/SubscriptionView.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp/SubscriptionView.swift
@@ -1,0 +1,118 @@
+//
+//  SubscriptionView.swift
+//  APIHostApp
+//
+//  Created by Law, Michael on 8/12/22.
+//
+
+import SwiftUI
+import AWSAPIPlugin
+import AWSPluginsCore
+import Amplify
+
+public extension AsyncSequence {
+    func forEach(_ block: (Element) async throws -> Void) async rethrows {
+        for try await element in self {
+            try await block(element)
+        }
+    }
+}
+
+class SubscriptionViewModel: ObservableObject {
+    
+    @Published var todos = [Todo]()
+    let apiPlugin = AWSAPIPlugin()
+
+    func subscribe() async {
+        do {
+            let task = try await apiPlugin.subscribe(request: .subscription(of: Todo.self, type: .onCreate))
+            await task.subscription.forEach { subscriptionEvent in
+                await self.processSubscription(subscriptionEvent)
+            }
+                    
+        } catch {
+            print("Failed to subscribe error: \(error)")
+        }
+    }
+    
+    func processSubscription(_ subscriptionEvent: GraphQLSubscriptionTask<Todo>.InProcess) async {
+        switch subscriptionEvent {
+        case .connection(let subscriptionConnectionState):
+            print("Subscription connect state is \(subscriptionConnectionState)")
+        case .data(let result):
+            switch result {
+            case .success(let createdTodo):
+                print("Successfully got todo from subscription: \(createdTodo)")
+                await storeTodo(createdTodo)
+            case .failure(let error):
+                print("Got failed result with \(error.errorDescription)")
+            }
+        }
+    }
+    
+    @MainActor
+    func storeTodo(_ todo: Todo) async {
+        self.todos.append(todo)
+    }
+}
+struct SubscriptionView: View {
+    @StateObject var vm = SubscriptionViewModel()
+    
+    var body: some View {
+        if #available(iOS 15.0, *) {
+            VStack {
+                
+            }.task { await vm.subscribe() }
+            
+        } else {
+            // Fallback on earlier versions
+            Text("task is on iOS 15.0")
+        }
+        
+    }
+    
+}
+
+struct SubscriptionView_Previews: PreviewProvider {
+    static var previews: some View {
+        SubscriptionView()
+    }
+}
+
+public struct Todo: Model {
+    public let id: String
+    public var name: String
+    public var description: String?
+
+    public init(id: String = UUID().uuidString,
+                name: String,
+                description: String? = nil) {
+        self.id = id
+        self.name = name
+        self.description = description
+    }
+}
+
+extension Todo {
+  // MARK: - CodingKeys
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case name
+    case description
+  }
+
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema
+
+  public static let schema = defineSchema { model in
+    let todo = Todo.keys
+
+    model.listPluralName = "Todos"
+    model.syncPluralName = "Todos"
+
+    model.fields(
+      .id(),
+      .field(todo.name, is: .required, ofType: .string),
+      .field(todo.description, is: .optional, ofType: .string))
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/Base/AsyncExpectation.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/Base/AsyncExpectation.swift
@@ -1,0 +1,130 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+import Amplify
+
+public actor AsyncExpectation {
+    enum State {
+        case pending
+        case fulfilled
+        case timedOut
+    }
+    public typealias AsyncExpectationContinuation = CheckedContinuation<Void, Error>
+    public let expectationDescription: String
+    public let isInverted: Bool
+    public let expectedFulfillmentCount: Int
+
+    private var fulfillmentCount: Int = 0
+    private var continuation: AsyncExpectationContinuation?
+    private var state: State = .pending
+
+    public init(description: String,
+                isInverted: Bool = false,
+                expectedFulfillmentCount: Int = 1) {
+        expectationDescription = description
+        self.isInverted = isInverted
+        self.expectedFulfillmentCount = expectedFulfillmentCount
+    }
+
+    public static func expectation(description: String,
+                                   isInverted: Bool = false,
+                                   expectedFulfillmentCount: Int = 1) -> AsyncExpectation {
+        AsyncExpectation(description: description,
+                         isInverted: isInverted,
+                         expectedFulfillmentCount: expectedFulfillmentCount)
+    }
+
+    public func fulfill(file: StaticString = #filePath, line: UInt = #line) {
+        guard state != .fulfilled else { return }
+
+        guard !isInverted else {
+            XCTFail("Inverted expectation fulfilled: \(expectationDescription)", file: file, line: line)
+            finish()
+            return
+        }
+
+        fulfillmentCount += 1
+        if fulfillmentCount == expectedFulfillmentCount {
+            state = .fulfilled
+            finish()
+        }
+    }
+
+    @MainActor
+    public static func waitForExpectations(_ expectations: [AsyncExpectation],
+                                           timeout: Double = 1.0,
+                                           file: StaticString = #filePath,
+                                           line: UInt = #line) async throws {
+        guard !expectations.isEmpty else { return }
+
+        // check if all expectations are already satisfied and skip sleeping
+        var count = 0
+        for exp in expectations {
+            if await exp.state == .fulfilled {
+                count += 1
+            }
+        }
+        if count == expectations.count {
+            return
+        }
+
+        let timeoutTask = Task {
+            try await Task.sleep(seconds: timeout)
+            for exp in expectations {
+                await exp.timeOut(file: file, line: line)
+            }
+        }
+
+        await withThrowingTaskGroup(of: Void.self) { group in
+            for exp in expectations {
+                group.addTask {
+                    try await exp.wait()
+                }
+            }
+        }
+
+        timeoutTask.cancel()
+    }
+
+    private func wait() async throws {
+        try await withTaskCancellationHandler(handler: {
+            Task {
+                await cancel()
+            }
+        }, operation: {
+            if state == .fulfilled {
+                return
+            } else {
+                return try await withCheckedThrowingContinuation { (continuation: AsyncExpectationContinuation) in
+                    self.continuation = continuation
+                }
+            }
+        })
+    }
+
+    private func timeOut(file: StaticString = #filePath,
+                         line: UInt = #line) async {
+        if state != .fulfilled && !isInverted {
+            state = .timedOut
+            XCTFail("Expectation timed out: \(expectationDescription)", file: file, line: line)
+        }
+        finish()
+    }
+
+    private func cancel() {
+        continuation?.resume(throwing: CancellationError())
+        continuation = nil
+    }
+
+    private func finish() {
+        continuation?.resume(returning: ())
+        continuation = nil
+    }
+
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+Subscribe.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+Subscribe.swift
@@ -12,87 +12,17 @@ import XCTest
 
 extension GraphQLConnectionScenario3Tests {
 
-    func testOnCreatePostSubscriptionWithModel() {
-        let connectedInvoked = expectation(description: "Connection established")
-        let disconnectedInvoked = expectation(description: "Connection disconnected")
-        let completedInvoked = expectation(description: "Completed invoked")
-        let progressInvoked = expectation(description: "progress invoked")
-        progressInvoked.expectedFulfillmentCount = 2
-        let uuid = UUID().uuidString
-        let uuid2 = UUID().uuidString
-        let testMethodName = String("\(#function)".dropLast(2))
-        let title = testMethodName + "Title"
-
-        let operation = Amplify.API.subscribe(
-            request: .subscription(of: Post3.self, type: .onCreate),
-            valueListener: { event in
-                switch event {
-                case .connection(let state):
-                    switch state {
-                    case .connecting:
-                        break
-                    case .connected:
-                        connectedInvoked.fulfill()
-                    case .disconnected:
-                        disconnectedInvoked.fulfill()
-                    }
-                case .data(let result):
-                    switch result {
-                    case .success(let post):
-                        if post.id == uuid || post.id == uuid2 {
-                            progressInvoked.fulfill()
-                        }
-                    case .failure(let error):
-                        XCTFail("\(error)")
-                    }
-                }
-
-        },
-            completionListener: { event in
-                switch event {
-                case .failure(let error):
-                    XCTFail("Unexpected .failed event: \(error)")
-                case .success:
-                    completedInvoked.fulfill()
-                }
-        })
-
-        XCTAssertNotNil(operation)
-        wait(for: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
-
-        guard createPost(id: uuid, title: title) != nil else {
-            XCTFail("Failed to create post")
-            return
-        }
-
-        guard createPost(id: uuid2, title: title) != nil else {
-            XCTFail("Failed to create post")
-            return
-        }
-
-        wait(for: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
-        operation.cancel()
-        wait(for: [disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
-        XCTAssertTrue(operation.isFinished)
-    }
-
-    func testOnCreatePostSubscriptionWithModel2() async throws {
+    func testOnCreatePostSubscriptionWithModel() async throws {
         let connectedInvoked = AsyncExpectation(description: "Connection established")
-        let disconnectedInvoked = AsyncExpectation(description: "Connection disconnected")
-        let completedInvoked = AsyncExpectation(description: "Completed invoked")
         let progressInvoked = AsyncExpectation(description: "progress invoked", expectedFulfillmentCount: 2)
         let uuid = UUID().uuidString
         let uuid2 = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
-        print("1")
         let task = try await Amplify.API.subscribe(request: .subscription(of: Post3.self, type: .onCreate))
-        print("2")
         let subscription = await task.subscription
-        print("3")
         Task {
             for await subscriptionEvent in subscription {
-                print("Got subscriptionEvent \(subscriptionEvent)")
                 switch subscriptionEvent {
                 case .connection(let state):
                     switch state {
@@ -101,7 +31,7 @@ extension GraphQLConnectionScenario3Tests {
                     case .connected:
                         await connectedInvoked.fulfill()
                     case .disconnected:
-                        await disconnectedInvoked.fulfill()
+                        break
                     }
                 case .data(let result):
                     switch result {
@@ -116,82 +46,55 @@ extension GraphQLConnectionScenario3Tests {
                 }
             }
         }
-        Task {
-            try await task.value
-            print("12")
-            await completedInvoked.fulfill()
-        }
         
-        print("5")
-        //let completion: Void = try await task.value
         XCTAssertNotNil(task)
         try await AsyncExpectation.waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
-        print("6")
         let post = Post3(id: uuid, title: title)
-        let createdPost = try await Amplify.API.mutate(request: .create(post))
-        print("7")
+        _ = try await Amplify.API.mutate(request: .create(post))
         let post2 = Post3(id: uuid2, title: title)
-        let createdPost2 = try await Amplify.API.mutate(request: .create(post2))
-        print("8")
+        _ = try await Amplify.API.mutate(request: .create(post2))
 
         try await AsyncExpectation.waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
-        print("9")
         await task.cancel()
-        print("10")
-        //try await AsyncExpectation.waitForExpectations([disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
-        print("11")
     }
     
-    func testOnUpdatePostSubscriptionWithModel() {
-        let connectedInvoked = expectation(description: "Connection established")
-        let disconnectedInvoked = expectation(description: "Connection disconnected")
-        let completedInvoked = expectation(description: "Completed invoked")
-        let progressInvoked = expectation(description: "progress invoked")
+    func testOnUpdatePostSubscriptionWithModel() async throws {
+        let connectingInvoked = AsyncExpectation(description: "Connection connecting")
+        let connectedInvoked = AsyncExpectation(description: "Connection established")
+        let progressInvoked = AsyncExpectation(description: "progress invoked")
 
-        let operation = Amplify.API.subscribe(
-            request: .subscription(of: Post3.self, type: .onUpdate),
-            valueListener: { event in
-                switch event {
+        let task = try await Amplify.API.subscribe(request: .subscription(of: Post3.self, type: .onUpdate))
+        let subscription = await task.subscription
+        Task {
+            for await subscriptionEvent in subscription {
+                switch subscriptionEvent {
                 case .connection(let state):
                     switch state {
                     case .connecting:
-                        break
+                        await connectingInvoked.fulfill()
                     case .connected:
-                        connectedInvoked.fulfill()
+                        await connectedInvoked.fulfill()
                     case .disconnected:
-                        disconnectedInvoked.fulfill()
+                        break
                     }
                 case .data:
-                    progressInvoked.fulfill()
+                    await progressInvoked.fulfill()
                 }
-        },
-            completionListener: { event in
-                switch event {
-                case .failure(let error):
-                    XCTFail("Unexpected .failed event: \(error)")
-                case .success:
-                    completedInvoked.fulfill()
-                }
-        })
-        XCTAssertNotNil(operation)
-        wait(for: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+            }
+        }
+                                 
+        try await AsyncExpectation.waitForExpectations([connectingInvoked, connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
+        let post = Post3(id: uuid, title: title)
+        _ = try await Amplify.API.mutate(request: .create(post))
+        _ = try await Amplify.API.mutate(request: .update(post))
 
-        guard let createdPost = createPost(id: uuid, title: title) else {
-            XCTFail("Failed to create post")
-            return
-        }
-        guard mutatePost(post: createdPost) != nil else {
-            XCTFail("Failed to update post")
-            return
-        }
+        try await AsyncExpectation.waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
 
-        wait(for: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
-        operation.cancel()
-        wait(for: [disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
-        XCTAssertTrue(operation.isFinished)
+        await task.cancel()
     }
 
     func testOnDeletePostSubscriptionWithModel() {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+Subscribe.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+Subscribe.swift
@@ -76,6 +76,72 @@ extension GraphQLConnectionScenario3Tests {
         XCTAssertTrue(operation.isFinished)
     }
 
+    func testOnCreatePostSubscriptionWithModel2() async throws {
+        let connectedInvoked = AsyncExpectation(description: "Connection established")
+        let disconnectedInvoked = AsyncExpectation(description: "Connection disconnected")
+        let completedInvoked = AsyncExpectation(description: "Completed invoked")
+        let progressInvoked = AsyncExpectation(description: "progress invoked", expectedFulfillmentCount: 2)
+        let uuid = UUID().uuidString
+        let uuid2 = UUID().uuidString
+        let testMethodName = String("\(#function)".dropLast(2))
+        let title = testMethodName + "Title"
+        print("1")
+        let task = try await Amplify.API.subscribe(request: .subscription(of: Post3.self, type: .onCreate))
+        print("2")
+        let subscription = await task.subscription
+        print("3")
+        Task {
+            for await subscriptionEvent in subscription {
+                print("Got subscriptionEvent \(subscriptionEvent)")
+                switch subscriptionEvent {
+                case .connection(let state):
+                    switch state {
+                    case .connecting:
+                        break
+                    case .connected:
+                        await connectedInvoked.fulfill()
+                    case .disconnected:
+                        await disconnectedInvoked.fulfill()
+                    }
+                case .data(let result):
+                    switch result {
+                    case .success(let post):
+                        if post.id == uuid || post.id == uuid2 {
+                            
+                            await progressInvoked.fulfill()
+                        }
+                    case .failure(let error):
+                        XCTFail("\(error)")
+                    }
+                }
+            }
+        }
+        Task {
+            try await task.value
+            print("12")
+            await completedInvoked.fulfill()
+        }
+        
+        print("5")
+        //let completion: Void = try await task.value
+        XCTAssertNotNil(task)
+        try await AsyncExpectation.waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        print("6")
+        let post = Post3(id: uuid, title: title)
+        let createdPost = try await Amplify.API.mutate(request: .create(post))
+        print("7")
+        let post2 = Post3(id: uuid2, title: title)
+        let createdPost2 = try await Amplify.API.mutate(request: .create(post2))
+        print("8")
+
+        try await AsyncExpectation.waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        print("9")
+        await task.cancel()
+        print("10")
+        //try await AsyncExpectation.waitForExpectations([disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
+        print("11")
+    }
+    
     func testOnUpdatePostSubscriptionWithModel() {
         let connectedInvoked = expectation(description: "Connection established")
         let disconnectedInvoked = expectation(description: "Connection disconnected")

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
@@ -83,6 +83,7 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
                                      document: testDocument,
                                      variables: nil,
                                      responseType: JSONValue.self)
+
         let receivedValueConnecting = expectation(description: "Received value for connecting")
 
         var valueListener: GraphQLSubscriptionOperation<JSONValue>.InProcessListener = { value in
@@ -90,9 +91,10 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
             case .connection(let state):
                 switch state {
                 case .connecting:
+                    print("1/3 Subscription is connecting")
                     receivedValueConnecting.fulfill()
                 case .disconnected:
-                    XCTFail("Unexpected value on value listener: \(state)")
+                    break
                 default:
                     XCTFail("Unexpected value on value listener: \(state)")
                 }
@@ -108,20 +110,21 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
             valueListener: valueListener,
             completionListener: completionListener
         )
-        await waitForExpectations(timeout: 1)
-
+        await waitForExpectations(timeout: 5)
+        
         let receivedCompletion = expectation(description: "Received completion")
         let receivedFailure = expectation(description: "Received failure")
         receivedFailure.isInverted = true
         let receivedValueDisconnected = expectation(description: "Received value for disconnected")
         
-        valueListener = { value in
+        _ = operation.subscribe { value in
             switch value {
             case .connection(let state):
                 switch state {
                 case .connecting:
                     XCTFail("Unexpected value on value listener: \(state)")
                 case .disconnected:
+                    print("2/3 Subscription is disconnected")
                     receivedValueDisconnected.fulfill()
                 default:
                     XCTFail("Unexpected value on value listener: \(state)")
@@ -130,20 +133,21 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
                 XCTFail("Unexpected value on on value listener: \(value)")
             }
         }
-
-        completionListener = { result in
+        _ = operation.subscribe { result in
             switch result {
             case .failure:
                 receivedFailure.fulfill()
             case .success:
+                print("3/3 Subscription is completed successfully")
                 receivedCompletion.fulfill()
             }
         }
+        
         operation.cancel()
         XCTAssert(operation.isCancelled)
-        await waitForExpectations(timeout: 1)
+        await waitForExpectations(timeout: 5)
     }
-
+    
     func testFailureOnConnection() async {
         let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _ in
             throw APIError.invalidConfiguration("something went wrong", "", nil)
@@ -204,9 +208,8 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
                                      document: testDocument,
                                      variables: nil,
                                      responseType: JSONValue.self)
-        let receivedCompletion = expectation(description: "Received completion")
-        let receivedFailure = expectation(description: "Received failure")
-        receivedFailure.isInverted = true
+        
+        
         let receivedValue = expectation(description: "Received value for connecting")
         receivedValue.assertForOverFulfill = false
 
@@ -214,7 +217,17 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
             receivedValue.fulfill()
         }
 
-        let completionListener: GraphQLSubscriptionOperation<JSONValue>.ResultListener = { result in
+        let operation = apiPlugin.subscribe(
+            request: request,
+            valueListener: valueListener,
+            completionListener: nil
+        )
+        await waitForExpectations(timeout: 5)
+        let receivedFailure = expectation(description: "Received failure")
+        receivedFailure.isInverted = true
+        let receivedCompletion = expectation(description: "Received completion")
+        
+        _ = operation.subscribe { result in
             switch result {
             case .failure:
                 receivedFailure.fulfill()
@@ -222,15 +235,9 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
                 receivedCompletion.fulfill()
             }
         }
-
-        let operation = apiPlugin.subscribe(
-            request: request,
-            valueListener: valueListener,
-            completionListener: completionListener
-        )
-        wait(for: [connectionCreation], timeout: 0.3)
+        
         operation.cancel()
         XCTAssert(operation.isCancelled)
-        await waitForExpectations(timeout: 0.3)
+        await waitForExpectations(timeout: 5)
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
@@ -86,7 +86,7 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
 
         let receivedValueConnecting = expectation(description: "Received value for connecting")
 
-        var valueListener: GraphQLSubscriptionOperation<JSONValue>.InProcessListener = { value in
+        let valueListener: GraphQLSubscriptionOperation<JSONValue>.InProcessListener = { value in
             switch value {
             case .connection(let state):
                 switch state {
@@ -103,7 +103,7 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
             }
         }
 
-        var completionListener: GraphQLSubscriptionOperation<JSONValue>.ResultListener = { _ in }
+        let completionListener: GraphQLSubscriptionOperation<JSONValue>.ResultListener = { _ in }
 
         let operation = apiPlugin.subscribe(
             request: request,
@@ -117,7 +117,7 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
         receivedFailure.isInverted = true
         let receivedValueDisconnected = expectation(description: "Received value for disconnected")
         
-        _ = operation.subscribe { value in
+        _ = operation.subscribe(inProcessListener: { value in
             switch value {
             case .connection(let state):
                 switch state {
@@ -132,8 +132,8 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
             default:
                 XCTFail("Unexpected value on on value listener: \(value)")
             }
-        }
-        _ = operation.subscribe { result in
+        })
+        _ = operation.subscribe(resultListener: { result in
             switch result {
             case .failure:
                 receivedFailure.fulfill()
@@ -141,7 +141,7 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
                 print("3/3 Subscription is completed successfully")
                 receivedCompletion.fulfill()
             }
-        }
+        })
         
         operation.cancel()
         XCTAssert(operation.isCancelled)
@@ -227,14 +227,14 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
         receivedFailure.isInverted = true
         let receivedCompletion = expectation(description: "Received completion")
         
-        _ = operation.subscribe { result in
+        _ = operation.subscribe(resultListener: { result in
             switch result {
             case .failure:
                 receivedFailure.fulfill()
             case .success:
                 receivedCompletion.fulfill()
             }
-        }
+        })
         
         operation.cancel()
         XCTAssert(operation.isCancelled)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update the AWSAPIPlugin APIs to based on **Adds AmplifyTask and Task Adapter for Operations** [PR 2128](https://github.com/aws-amplify/amplify-ios/pull/2128)

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
