### PR TITLE
Revises AsyncChannel to conform to behavior of Apple's implementation

### DIFF
--- a/Amplify/Core/Support/AsyncThrowingChannel.swift
+++ b/Amplify/Core/Support/AsyncThrowingChannel.swift
@@ -10,39 +10,45 @@ import Foundation
 public actor AsyncThrowingChannel<Element: Sendable, Failure: Error>: AsyncSequence {
     public struct Iterator: AsyncIteratorProtocol, Sendable {
         private let channel: AsyncThrowingChannel<Element, Failure>
+        private var active = true
 
         public init(_ channel: AsyncThrowingChannel<Element, Failure>) {
             self.channel = channel
         }
 
         public mutating func next() async throws -> Element? {
-            try Task.checkCancellation()
-            return try await channel.next()
+            guard active else {
+                return nil
+            }
+            do {
+                let value: Element? = try await withTaskCancellationHandler { [channel] in
+                    Task {
+                        await channel.cancel()
+                    }
+                } operation: {
+                    try await channel.next()
+                }
+
+                if let value = value {
+                    return value
+                } else {
+                    active = false
+                    return nil
+                }
+            } catch {
+                active = false
+                throw error
+            }
         }
     }
 
-    public enum InternalFailure: Error {
-        case cannotSendAfterTerminated
-    }
-    public typealias ChannelContinuation = CheckedContinuation<Element?, Error>
+    typealias NextContinuation = CheckedContinuation<Element?, Error>
+    typealias SendContinuation = CheckedContinuation<Void, Never>
 
-    private var continuations: [ChannelContinuation] = []
     private var elements: [Element] = []
-    private var cancelled: Bool = false
+    private var nexts: [NextContinuation] = []
+    private var sends: [SendContinuation] = []
     private var terminated: Bool = false
-    private var error: Error? = nil
-
-    private var hasNext: Bool {
-        !continuations.isEmpty && !elements.isEmpty
-    }
-
-    private var canFail: Bool {
-        error != nil && !continuations.isEmpty
-    }
-
-    private var canTerminate: Bool {
-        terminated && elements.isEmpty && !continuations.isEmpty
-    }
 
     init() {
     }
@@ -52,75 +58,76 @@ public actor AsyncThrowingChannel<Element: Sendable, Failure: Error>: AsyncSeque
     }
 
     public func next() async throws -> Element? {
-        if cancelled {
-            throw CancellationError()
-        }
-        return try await withCheckedThrowingContinuation { (continuation: ChannelContinuation) in
-            continuations.append(continuation)
+        try await withCheckedThrowingContinuation { (continuation: NextContinuation) in
+            nexts.append(continuation)
             processNext()
         }
     }
 
-    public func send(_ element: Element) throws {
-        if Task.isCancelled {
-            cancelled = true
-            processNext()
-            throw CancellationError()
+    func send(_ element: Element) async {
+        await withTaskCancellationHandler {
+            Task {
+                await terminateAll()
+            }
+        } operation: {
+            await withCheckedContinuation { (continuation: SendContinuation) in
+                elements.append(element)
+                sends.append(continuation)
+                processNext()
+            }
         }
-        guard !terminated else {
-            throw InternalFailure.cannotSendAfterTerminated
-        }
-        elements.append(element)
-        processNext()
     }
 
-    public func fail(_ error: Error) where Failure == Error {
-        self.error = error
-        processNext()
-    }
-
-    public func finish() {
+    func terminateAll(error: Failure? = nil) {
         terminated = true
-        processNext()
+        while !sends.isEmpty {
+            let send = sends.removeFirst()
+            send.resume(returning: ())
+        }
+        while !nexts.isEmpty {
+            let next = nexts.removeFirst()
+            if let error = error {
+                next.resume(throwing: error)
+            } else {
+                next.resume(returning: nil)
+            }
+        }
+    }
+
+    func fail(_ error: Error) where Failure == Error {
+        terminateAll(error: error)
+    }
+
+    func finish() {
+        terminateAll()
+    }
+
+    func cancel() {
+        terminateAll()
     }
 
     private func processNext() {
-        if cancelled && !continuations.isEmpty {
-            let continuation = continuations.removeFirst()
-            assert(continuations.isEmpty)
-            continuation.resume(throwing: CancellationError())
+        if terminated && !nexts.isEmpty {
+            let next = nexts.removeFirst()
+            next.resume(returning: nil)
             return
         }
 
-        if canFail {
-            let continuation = continuations.removeFirst()
-            assert(continuations.isEmpty)
-            assert(elements.isEmpty)
-            assert(error != nil)
-            if let error = error {
-                continuation.resume(throwing: error)
-                return
-            }
-        }
-
-        if canTerminate {
-            let continuation = continuations.removeFirst()
-            assert(continuations.isEmpty)
-            assert(elements.isEmpty)
-            continuation.resume(returning: nil)
+        guard !elements.isEmpty,
+              !sends.isEmpty,
+              !nexts.isEmpty else {
             return
         }
 
-        guard hasNext else {
-            return
-        }
-
-        assert(!continuations.isEmpty)
         assert(!elements.isEmpty)
+        assert(!nexts.isEmpty)
+        assert(!sends.isEmpty)
 
-        let continuation = continuations.removeFirst()
         let element = elements.removeFirst()
+        let send = sends.removeFirst()
+        let next = nexts.removeFirst()
 
-        continuation.resume(returning: element)
+        next.resume(returning: element)
+        send.resume(returning: ())
     }
 }

--- a/AmplifyTests/CoreTests/AsyncChannelTests.swift
+++ b/AmplifyTests/CoreTests/AsyncChannelTests.swift
@@ -9,10 +9,10 @@ import XCTest
 @testable import Amplify
 
 final class AsyncChannelTests: XCTestCase {
-#if swift(>=5.7)
-    let isSwiftCompatible = true
+#if os(macOS)
+    let isMacOS = true
 #else
-    let isSwiftCompatible = false
+    let isMacOS = false
 #endif
 
     enum Failure: Error {
@@ -138,7 +138,7 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testChannelCancelled() async throws {
-        try XCTSkipIf(!isSwiftCompatible)
+        try XCTSkipIf(!isMacOS)
         let channel = AsyncChannel<String>()
         let ready = expectation(description: "ready")
         let task: Task<String?, Never> = Task {
@@ -153,7 +153,7 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testThrowingChannelCancelled() async throws {
-        try XCTSkipIf(!isSwiftCompatible)
+        try XCTSkipIf(!isMacOS)
         let channel = AsyncThrowingChannel<String, Error>()
         let ready = expectation(description: "ready")
         let task: Task<String?, Error> = Task {
@@ -168,7 +168,7 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testChannelCancelledOnSend() async throws {
-        try XCTSkipIf(!isSwiftCompatible)
+        try XCTSkipIf(!isMacOS)
         let channel = AsyncChannel<Int>()
         let notYetDone = expectation(description: "not yet done")
         notYetDone.isInverted = true
@@ -184,7 +184,7 @@ final class AsyncChannelTests: XCTestCase {
     }
 
     func testThrowingChannelCancelledOnSend() async throws {
-        try XCTSkipIf(!isSwiftCompatible)
+        try XCTSkipIf(!isMacOS)
         let channel = AsyncThrowingChannel<Int, Error>()
         let notYetDone = expectation(description: "not yet done")
         notYetDone.isInverted = true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Task cancellation must be handled on the send and next sides of the channel. The send should also suspend until a next continuation is matched to it. This causes back pressure. Tests pass on macOS but fail with iOS which also happens with the unit tests in Apple's package. The way these tests work will have to be revised due to difficulties with unit testing Swift Concurrency.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
