### PR TITLE
feat: add async List APIs for DataStore and API

### DIFF
--- a/Amplify/Categories/DataStore/Model/Collection/ArrayLiteralListProvider.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/ArrayLiteralListProvider.swift
@@ -25,6 +25,10 @@ public struct ArrayLiteralListProvider<Element: Model>: ModelListProvider {
     public func load(completion: @escaping (Result<[Element], CoreError>) -> Void) {
         completion(.success(elements))
     }
+    
+    public func load() async throws -> [Element] {
+        return elements
+    }
 
     public func hasNextPage() -> Bool {
         false
@@ -34,5 +38,11 @@ public struct ArrayLiteralListProvider<Element: Model>: ModelListProvider {
         completion(.failure(CoreError.clientValidation("No pagination on an array literal",
                                                        "Don't call this method",
                                                        nil)))
+    }
+    
+    public func getNextPage() async throws -> List<Element> {
+        throw CoreError.clientValidation("No pagination on an array literal",
+                                                       "Don't call this method",
+                                                       nil)
     }
 }

--- a/Amplify/Categories/DataStore/Model/Collection/List+LazyLoad.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+LazyLoad.swift
@@ -42,4 +42,15 @@ extension List {
             }
         }
     }
+    
+    public func fetch() async throws {
+        guard case .notLoaded = loadedState else {
+            return
+        }
+        do {
+            self.elements = try await listProvider.load()
+        } catch {
+            throw error
+        }
+    }
 }

--- a/Amplify/Categories/DataStore/Model/Collection/List+Pagination.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+Pagination.swift
@@ -38,4 +38,17 @@ extension List {
             completion(.failure(error))
         }
     }
+    
+    public func getNextPage() async throws -> List<Element> {
+        switch loadedState {
+        case .loaded:
+            return try await listProvider.getNextPage()
+        case .notLoaded:
+            let message = "Call `fetch` to lazy load the list before using this method."
+            let error: CoreError = .listOperation(message, "", nil)
+            Amplify.log.error(error: error)
+            assertionFailure(message)
+            throw error
+        }
+    }
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListProvider.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListProvider.swift
@@ -99,6 +99,15 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
             load(associatedId: associatedId, associatedField: associatedField, completion: completion)
         }
     }
+    
+    public func load() async throws -> [Element] {
+        switch loadedState {
+        case .loaded(let elements, _, _):
+            return elements
+        case .notLoaded(let associatedId, let associatedField):
+            return try await load(associatedId: associatedId, associatedField: associatedField)
+        }
+    }
 
     //// Internal `load` to perform the retrieval of the first page and storing it in memory
     func load(associatedId: String,
@@ -145,7 +154,50 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
             }
         }
     }
-
+    
+    func load(associatedId: String,
+              associatedField: String) async throws -> [Element] {
+        let predicate: QueryPredicate = field(associatedField) == associatedId
+        let filter = predicate.graphQLFilter(for: Element.schema)
+        let request = GraphQLRequest<JSONValue>.listQuery(responseType: JSONValue.self,
+                                                          modelSchema: Element.schema,
+                                                          filter: filter,
+                                                          limit: limit,
+                                                          apiName: apiName)
+        do {
+            let graphQLResponse = try await Amplify.API.query(request: request)
+            switch graphQLResponse {
+            case .success(let graphQLData):
+                guard let listResponse = try? AppSyncListResponse.initWithMetadata(type: Element.self,
+                                                                                   graphQLData: graphQLData,
+                                                                                   apiName: self.apiName) else {
+                    throw CoreError.listOperation("""
+                                            The AppSync response return successfully, but could not decode to
+                                            AWSAppSyncListResponse from: \(graphQLData)
+                                            """, "", nil)
+                }
+                
+                self.loadedState = .loaded(elements: listResponse.items,
+                                           nextToken: listResponse.nextToken,
+                                           filter: filter)
+                return listResponse.items
+            case .failure(let graphQLError):
+                Amplify.API.log.error(error: graphQLError)
+                throw CoreError.listOperation(
+                    "The AppSync response returned successfully with GraphQL errors.",
+                    "Check the underlying error for the failed GraphQL response.",
+                    graphQLError)
+            }
+        } catch let apiError as APIError {
+            Amplify.API.log.error(error: apiError)
+            throw CoreError.listOperation("The AppSync request failed",
+                                          "See underlying `APIError` for more details.",
+                                          apiError)
+        } catch {
+            throw error
+        }
+    }
+    
     public func hasNextPage() -> Bool {
         switch loadedState {
         case .loaded(_, let nextToken, _):
@@ -171,6 +223,22 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
         }
 
         getNextPage(nextToken: nextToken, filter: filter, completion: completion)
+    }
+    
+    public func getNextPage() async throws -> List<Element> {
+        guard case .loaded(_, let nextTokenOptional, let filter) = loadedState else {
+            throw CoreError.clientValidation("""
+                Make sure the underlying data is loaded by calling `load(completion)`, then only call this method when
+                `hasNextPage()` is true
+                """, "", nil)
+        }
+        guard let nextToken = nextTokenOptional else {
+            throw CoreError.clientValidation("There is no next page.",
+                                             "Only call `getNextPage()` when `hasNextPage()` is true.",
+                                             nil)
+        }
+
+        return try await getNextPage(nextToken: nextToken, filter: filter)
     }
 
     /// Internal `getNextPage` to retrieve the next page and return it as a new List object
@@ -208,6 +276,36 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
                                                    "See underlying `APIError` for more details.",
                                                    apiError)))
             }
+        }
+    }
+    
+    func getNextPage(nextToken: String,
+                     filter: [String: Any]?) async throws -> List<Element> {
+        let request = GraphQLRequest<List<Element>>.listQuery(responseType: List<Element>.self,
+                                                              modelSchema: Element.schema,
+                                                              filter: filter,
+                                                              limit: limit,
+                                                              nextToken: nextToken,
+                                                              apiName: apiName)
+        do {
+            let graphQLResponse = try await Amplify.API.query(request: request)
+            switch graphQLResponse {
+            case .success(let nextPageList):
+                _ = try await nextPageList.fetch()
+                return nextPageList
+            case .failure(let graphQLError):
+                Amplify.API.log.error(error: graphQLError)
+                throw CoreError.listOperation("""
+                    The AppSync request was processed by the service, but the response contained GraphQL errors.
+                    """, "Check the underlying error for the failed GraphQL response.", graphQLError)
+            }
+        } catch let apiError as APIError {
+            Amplify.API.log.error(error: apiError)
+            throw CoreError.listOperation("The AppSync request failed",
+                                          "See underlying `APIError` for more details.",
+                                          apiError)
+        } catch {
+            throw error
         }
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/ListTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/ListTests.swift
@@ -16,7 +16,7 @@ class ListTests: XCTestCase {
         ModelListDecoderRegistry.registerDecoder(AppSyncListDecoder.self)
     }
 
-    func testDecodeToResponseTypeList() throws {
+    func testDecodeToResponseTypeList() async throws {
         let request = GraphQLRequest<List<Comment4>>(document: "",
                                                      responseType: List<Comment4>.self,
                                                      decodePath: "listComments")
@@ -37,11 +37,7 @@ class ListTests: XCTestCase {
         ]
 
         let result = try decoder.decodeToResponseType(graphQLData)
-        let fetchCompleted = expectation(description: "Fetch completed")
-        result.fetch { _ in
-            XCTAssertEqual(result.count, 2)
-            fetchCompleted.fulfill()
-        }
-        wait(for: [fetchCompleted], timeout: 1)
+        try await result.fetch()
+        XCTAssertEqual(result.count, 2)
     }
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Core/DataStoreListProvider.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Core/DataStoreListProvider.swift
@@ -72,6 +72,28 @@ public class DataStoreListProvider<Element: Model>: ModelListProvider {
             }
         }
     }
+    
+    public func load() async throws -> [Element] {
+        switch loadedState {
+        case .loaded(let elements):
+            return elements
+        case .notLoaded(let associatedId, let associatedField):
+            let predicate: QueryPredicate = field(associatedField) == associatedId
+            do {
+                let elements = try await Amplify.DataStore.query(Element.self, where: predicate)
+                self.loadedState = .loaded(elements)
+                return elements
+            } catch let error as DataStoreError {
+                Amplify.DataStore.log.error(error: error)
+                throw CoreError.listOperation("Failed to Query DataStore.",
+                                              "See underlying DataStoreError for more details.",
+                                              error)
+            } catch {
+                throw error
+                
+            }
+        }
+    }
 
     public func hasNextPage() -> Bool {
         false
@@ -81,5 +103,11 @@ public class DataStoreListProvider<Element: Model>: ModelListProvider {
         completion(.failure(CoreError.clientValidation("There is no next page.",
                                                        "Only call `getNextPage()` when `hasNextPage()` is true.",
                                                        nil)))
+    }
+    
+    public func getNextPage() async throws -> List<Element> {
+        throw CoreError.clientValidation("There is no next page.",
+                                         "Only call `getNextPage()` when `hasNextPage()` is true.",
+                                         nil)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
@@ -306,7 +306,7 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
             }
         }
         _ = try await setUpLocalStore(numberOfPosts: 15)
-        wait(for: [allSnapshotsReceived], timeout: 100)
+        await waitForExpectations(timeout: 100)
         XCTAssertTrue(snapshotCount >= 2)
         sink.cancel()
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreListProviderFunctionalTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreListProviderFunctionalTests.swift
@@ -14,28 +14,19 @@ import XCTest
 
 class DataStoreListProviderFunctionalTests: BaseDataStoreTests {
 
-    func testDataStoreListProviderWithAssociationDataShouldLoadWithCompletion() {
+    func testDataStoreListProviderWithAssociationDataShouldLoad() async throws {
         let postId = preparePost4DataForTest()
         let provider = DataStoreListProvider<Comment4>(associatedId: postId, associatedField: "post")
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
             return
         }
-        let loadComplete = expectation(description: "Load completed")
-        provider.load { result in
-            switch result {
-            case .success(let results):
-                guard case .loaded = provider.loadedState else {
-                    XCTFail("Should be loaded")
-                    return
-                }
-                XCTAssertEqual(results.count, 2)
-                loadComplete.fulfill()
-            case .failure(let error):
-                XCTFail("\(error)")
-            }
+        let results = try await provider.load()
+        guard case .loaded = provider.loadedState else {
+            XCTFail("Should be loaded")
+            return
         }
-        wait(for: [loadComplete], timeout: 1)
+        XCTAssertEqual(results.count, 2)
     }
 
     // MARK: - Helpers

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -114,6 +114,17 @@ class MockAPICategoryPlugin: MessageReporter,
     func query<R: Decodable>(request: GraphQLRequest<R>) async throws -> GraphQLTask<R>.Success {
         notify("query(request:listener:) request: \(request)")
 
+        if let responder = responders[.queryRequestResponse] as? QueryRequestResponder<R> {
+            
+            let result = responder.callback(request)
+            switch result {
+            case .success(let response):
+                return response
+            case .failure(let error):
+                throw error
+            }
+        }
+        
         let requestOptions = GraphQLOperationRequest<R>.Options(pluginOptions: nil)
         let request = GraphQLOperationRequest<R>(apiName: request.apiName,
                                                  operationType: .query,

--- a/AmplifyTestCommon/Mocks/MockAPIResponders.swift
+++ b/AmplifyTestCommon/Mocks/MockAPIResponders.swift
@@ -10,6 +10,7 @@ import Amplify
 extension MockAPICategoryPlugin {
     enum ResponderKeys {
         case queryRequestListener
+        case queryRequestResponse
         case subscribeRequestListener
         case mutateRequestListener
     }
@@ -18,6 +19,11 @@ extension MockAPICategoryPlugin {
 typealias QueryRequestListenerResponder<R: Decodable> = MockResponder<
     (GraphQLRequest<R>, GraphQLOperation<R>.ResultListener?),
     GraphQLOperation<R>?
+>
+
+typealias QueryRequestResponder<R: Decodable> = MockResponder<
+    GraphQLRequest<R>,
+    GraphQLOperation<R>.OperationResult
 >
 
 typealias MutateRequestListenerResponder<R: Decodable> = MockResponder<

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -89,11 +89,11 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         notify("queryByPredicate")
 
         if let responder = responders[.queryModelsListener] as? QueryModelsResponder<M> {
-            if let callback = responder.callback((modelType: modelType,
+            if let result = responder.callback((modelType: modelType,
                                                   where: predicate,
                                                   sort: sortInput,
                                                   paginate: paginationInput)) {
-                completion(callback)
+                completion(result)
             }
         }
     }
@@ -103,6 +103,21 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
                          sort sortInput: QuerySortInput?,
                          paginate paginationInput: QueryPaginationInput?) async throws -> [M] {
         notify("queryByPredicate")
+        
+        if let responder = responders[.queryModelsListener] as? QueryModelsResponder<M> {
+            if let result = responder.callback((modelType: modelType,
+                                                  where: predicate,
+                                                  sort: sortInput,
+                                                  paginate: paginationInput)) {
+                switch result {
+                case .success(let models):
+                    return models
+                case .failure(let error):
+                    throw error
+                }
+            }
+        }
+        
         return []
     }
 

--- a/AmplifyTests/CategoryTests/DataStore/Model/Collection/ArrayLiteralListProviderTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/Model/Collection/ArrayLiteralListProviderTests.swift
@@ -42,6 +42,13 @@ class ArrayLiteralListProviderTests: XCTestCase {
 
         wait(for: [loadComplete], timeout: 1)
     }
+    
+    func testLoadAsync() async throws {
+        let provider = ArrayLiteralListProvider(elements: [BasicModel(id: "id")])
+        let elements = try await provider.load()
+        XCTAssertEqual(elements.count, 1)
+        XCTAssertEqual(elements[0].id, "id")
+    }
 
     func testHasNextPageFalse() {
         let provider = ArrayLiteralListProvider(elements: [BasicModel(id: "id")])
@@ -65,5 +72,17 @@ class ArrayLiteralListProviderTests: XCTestCase {
         }
 
         wait(for: [getNextPageComplete], timeout: 1)
+    }
+    
+    func testGetNextPageAsync() async {
+        let provider = ArrayLiteralListProvider(elements: [BasicModel(id: "id")])
+        do {
+            _ = try await provider.getNextPage()
+            XCTFail("Should have failed")
+        } catch CoreError.clientValidation {
+            print("(Expected) Error is CoreError.clientValidation")
+        } catch {
+            XCTFail("Should have been core error")
+        }
     }
 }

--- a/AmplifyTests/CategoryTests/DataStore/Model/ListTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/Model/ListTests.swift
@@ -78,6 +78,16 @@ class ListTests: XCTestCase {
                 completion(.success(elements))
             }
         }
+        
+        public func load() async throws -> [Element] {
+            if let error = error {
+                throw error
+            } else if let error = errorOnLoad {
+                throw error
+            } else {
+                return elements
+            }
+        }
 
         public func hasNextPage() -> Bool {
             return nextPage != nil
@@ -90,6 +100,18 @@ class ListTests: XCTestCase {
                 completion(.failure(error))
             } else if let nextPage = nextPage {
                 completion(.success(nextPage))
+            } else {
+                fatalError("Mock not implemented")
+            }
+        }
+        
+        public func getNextPage() async throws -> List<Element> {
+            if let error = error {
+                throw error
+            } else if let error = errorOnNextPage {
+                throw error
+            } else if let nextPage = nextPage {
+                return nextPage
             } else {
                 fatalError("Mock not implemented")
             }
@@ -199,7 +221,7 @@ class ListTests: XCTestCase {
         wait(for: [fetchCompleted], timeout: 1)
     }
 
-    func testLoadFailure() {
+    func testLoadFailure() async throws {
         let mockListProvider = MockListProvider<BasicModel>(
             errorOnLoad: .listOperation("", "", DataStoreError.internalOperation("", "", nil)))
             .eraseToAnyModelListProvider()
@@ -208,16 +230,12 @@ class ListTests: XCTestCase {
             XCTFail("Should not be loaded")
             return
         }
-        let fetchCompleted = expectation(description: "Fetch completed")
-        list.fetch { result in
-            switch result {
-            case .success:
-                XCTFail("Expected to fail on load")
-            case .failure:
-                fetchCompleted.fulfill()
-            }
+        do {
+            _ = try await list.fetch()
+            XCTFail("Should have caught error")
+        } catch {
+            print("Error \(error)")
         }
-        wait(for: [fetchCompleted], timeout: 1)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is based on the async APIs for APIPlugin (https://github.com/aws-amplify/amplify-ios/pull/2140) and async APIs for DataStore. This PR adds the `async` versions of the APIs for List such as `fetch`, `load`, `getNextPage`. 

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
