### PR TITLE
Fixes build failure due to use of private initializer in DeviceInfo

### DIFF
--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Endpoint/EndpointInformation.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Endpoint/EndpointInformation.swift
@@ -28,6 +28,6 @@ extension DeviceInfo: EndpointInformation {
 
 extension EndpointInformation where Self == DeviceInfo {
     static var current: EndpointInformation {
-        DeviceInfo()
+        DeviceInfo.current
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Uses `current` property which is public.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
