### PR TITLE
fix(api): SubscriptionOperation dispatch completion event before super.cancel

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionOperation.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionOperation.swift
@@ -51,8 +51,8 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
             }
         }
 
-        super.cancel()
         dispatch(result: .successfulVoid)
+        super.cancel()
         finish()
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
AmplifyOperation's cancel() unsubscribes the result listener in a recent change. The implementation of the AWSGraphQLSubscriptionOperation's cancel() dispatches a successful completion event on "cancel" as part of the behavior of the lifecycle of a subscription. If it operation gets cancelled, the caller gets an inprocess event of "disconnected" followed by a result event of successful Void. The code change changes the sequence performed during cancel() by calling `dispatch(result: successfulVoid)` before calling `super.cancel()`


*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
