### PR TITLE
chore(datastore): remove model.identifier deprecated usage

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior+Combine.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior+Combine.swift
@@ -22,24 +22,6 @@ public extension DataStoreBaseBehavior {
         }.eraseToAnyPublisher()
     }
 
-    /// Deletes the model with the specified ID from the DataStore. If sync is enabled, this will delete the
-    /// model from the remote store as well.
-    ///
-    /// - Parameters:
-    ///   - modelType: The type of the model to delete
-    ///   - id: The ID of the model to delete
-    /// - Returns: A DataStorePublisher with the results of the operation
-    @available(*, deprecated, message: "Use delete(:withIdentifier:where:)")
-    func delete<M: Model>(
-        _ modelType: M.Type,
-        withId id: String,
-        where predicate: QueryPredicate? = nil
-    ) -> DataStorePublisher<Void> {
-        Future { promise in
-            self.delete(modelType, withId: id, where: predicate) { promise($0) }
-        }.eraseToAnyPublisher()
-    }
-
     /// Deletes the model with the specified identifier from the DataStore. If sync is enabled, this will delete the
     /// model from the remote store as well.
     ///

--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
@@ -80,19 +80,6 @@ extension DataStoreCategory: DataStoreBaseBehavior {
     }
 
     public func delete<M: Model>(_ modelType: M.Type,
-                                 withId id: String,
-                                 where predicate: QueryPredicate? = nil,
-                                 completion: @escaping DataStoreCallback<Void>) {
-        plugin.delete(modelType, withId: id, where: predicate, completion: completion)
-    }
-    
-    public func delete<M: Model>(_ modelType: M.Type,
-                                 withId id: String,
-                                 where predicate: QueryPredicate? = nil) async throws {
-        try await plugin.delete(modelType, withId: id, where: predicate)
-    }
-
-    public func delete<M: Model>(_ modelType: M.Type,
                                  withIdentifier id: String,
                                  where predicate: QueryPredicate? = nil,
                                  completion: @escaping DataStoreCallback<Void>) where M: ModelIdentifiable,

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -57,16 +57,6 @@ public protocol DataStoreBaseBehavior {
     func delete<M: Model>(_ model: M,
                           where predicate: QueryPredicate?) async throws
 
-    @available(*, deprecated, renamed: "delete(withIdentifier:where:completion:)")
-    func delete<M: Model>(_ modelType: M.Type,
-                          withId id: String,
-                          where predicate: QueryPredicate?,
-                          completion: @escaping DataStoreCallback<Void>)
-    @available(*, deprecated, renamed: "delete(withIdentifier:where:)")
-    func delete<M: Model>(_ modelType: M.Type,
-                          withId id: String,
-                          where predicate: QueryPredicate?) async throws
-
     func delete<M: Model>(_ modelType: M.Type,
                           withIdentifier id: String,
                           where predicate: QueryPredicate?,

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListProvider.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListProvider.swift
@@ -25,7 +25,7 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
         /// The associatedField represents the field to which the owner of the `List` is linked to.
         /// For example, if `Post.comments` is associated with `Comment.post` the `List<Comment>`
         /// of `Post` will have a reference to the `post` field in `Comment`.
-        case notLoaded(associatedId: Model.Identifier,
+        case notLoaded(associatedId: String,
                        associatedField: String)
 
         /// If the list is retrieved directly, this state holds the underlying data, nextToken used to create

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/AnyModel/AnyModelTester.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/AnyModel/AnyModelTester.swift
@@ -10,11 +10,11 @@ import AWSPluginsCore
 import Foundation
 
 struct AnyModelTester: Model {
-    let id: Identifier
+    let id: String
     let stringProperty: String
     let intProperty: Int
 
-    init(id: Identifier = "test-id", stringProperty: String, intProperty: Int) {
+    init(id: String = "test-id", stringProperty: String, intProperty: Int) {
         self.id = id
         self.stringProperty = stringProperty
         self.intProperty = intProperty

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -230,45 +230,6 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
 
     // MARK: - Delete
-
-    @available(*, deprecated, renamed: "delete(withIdentifier:where:completion:)")
-    public func delete<M: Model>(_ modelType: M.Type,
-                                 withId id: String,
-                                 where predicate: QueryPredicate? = nil,
-                                 completion: @escaping DataStoreCallback<Void>) {
-        delete(modelType, modelSchema: modelType.schema, withId: id, where: predicate, completion: completion)
-    }
-
-    @available(*, deprecated, renamed: "delete(withIdentifier:where:)")
-    public func delete<M: Model>(_ modelType: M.Type,
-                                 withId id: String,
-                                 where predicate: QueryPredicate? = nil) async throws {
-        try await delete(modelType, modelSchema: modelType.schema, withId: id, where: predicate)
-    }
-    
-    @available(*, deprecated, renamed: "delete(withIdentifier:where:completion:)")
-    public func delete<M: Model>(_ modelType: M.Type,
-                                 modelSchema: ModelSchema,
-                                 withId id: String,
-                                 where predicate: QueryPredicate? = nil,
-                                 completion: @escaping DataStoreCallback<Void>) {
-        initStorageEngineAndStartSync()
-        storageEngine.delete(modelType, modelSchema: modelSchema, withId: id, condition: predicate) { result in
-            self.onDeleteCompletion(result: result, modelSchema: modelSchema, completion: completion)
-        }
-    }
-
-    @available(*, deprecated, renamed: "delete(withIdentifier:where:)")
-    public func delete<M: Model>(_ modelType: M.Type,
-                                 modelSchema: ModelSchema,
-                                 withId id: String,
-                                 where predicate: QueryPredicate? = nil) async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            delete(modelType, modelSchema: modelSchema, withId: id, where: predicate) { result in
-                continuation.resume(with: result)
-            }
-        }
-    }
     
     public func delete<M: Model>(_ modelType: M.Type,
                                  withIdentifier identifier: String,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Core/DataStoreListProvider.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Core/DataStoreListProvider.swift
@@ -26,14 +26,14 @@ public class DataStoreListProvider<Element: Model>: ModelListProvider {
         /// The associatedField represents the field to which the owner of the `List` is linked to.
         /// For example, if `Post.comments` is associated with `Comment.post` the `List<Comment>`
         /// of `Post` will have a reference to the `post` field in `Comment`.
-        case notLoaded(associatedId: Model.Identifier, associatedField: String)
+        case notLoaded(associatedId: String, associatedField: String)
 
         case loaded([Element])
     }
 
     var loadedState: LoadedState
 
-    init(associatedId: Model.Identifier,
+    init(associatedId: String,
          associatedField: String) {
         self.loadedState = .notLoaded(associatedId: associatedId,
                                       associatedField: associatedField)

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/ModelStorageBehavior.swift
@@ -21,13 +21,6 @@ protocol ModelStorageBehavior {
                         condition: QueryPredicate?,
                         completion: @escaping DataStoreCallback<M>)
 
-    @available(*, deprecated, message: "Use delete(:modelSchema:withIdentifier:predicate:completion")
-    func delete<M: Model>(_ modelType: M.Type,
-                          modelSchema: ModelSchema,
-                          withId id: Model.Identifier,
-                          condition: QueryPredicate?,
-                          completion: @escaping DataStoreCallback<M?>)
-
     func delete<M: Model>(_ modelType: M.Type,
                           modelSchema: ModelSchema,
                           withIdentifier identifier: ModelIdentifierProtocol,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -211,24 +211,6 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
         }
     }
 
-    func delete<M: Model>(_ modelType: M.Type,
-                          modelSchema: ModelSchema,
-                          withId id: Model.Identifier,
-                          condition: QueryPredicate? = nil,
-                          completion: (DataStoreResult<M?>) -> Void) {
-        delete(untypedModelType: modelType,
-               modelSchema: modelSchema,
-               withId: id,
-               condition: condition) { result in
-            switch result {
-            case .success:
-                completion(.success(nil))
-            case .failure(let error):
-                completion(.failure(error))
-            }
-        }
-    }
-
     func delete<M>(_ modelType: M.Type,
                    modelSchema: ModelSchema,
                    withIdentifier identifier: ModelIdentifierProtocol,
@@ -245,18 +227,6 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
                 completion(.failure(error))
             }
         }
-    }
-
-    func delete(untypedModelType modelType: Model.Type,
-                modelSchema: ModelSchema,
-                withId id: Model.Identifier,
-                condition: QueryPredicate? = nil,
-                completion: DataStoreCallback<Void>) {
-        delete(untypedModelType: modelType,
-               modelSchema: modelSchema,
-               withIdentifier: DefaultModelIdentifier<AnyModel>.makeDefault(id: id),
-               condition: condition,
-               completion: completion)
     }
 
     func delete(untypedModelType modelType: Model.Type,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngineAdapter.swift
@@ -16,15 +16,9 @@ protocol StorageEngineAdapter: AnyObject, ModelStorageBehavior, ModelStorageErro
     // MARK: - Async APIs
     func save(untypedModel: Model, completion: @escaping DataStoreCallback<Model>)
 
-    func delete<M: Model>(_ modelType: M.Type,
-                          modelSchema: ModelSchema,
-                          withId id: Model.Identifier,
-                          condition: QueryPredicate?,
-                          completion: @escaping DataStoreCallback<M?>)
-
     func delete(untypedModelType modelType: Model.Type,
                 modelSchema: ModelSchema,
-                withId id: Model.Identifier,
+                withIdentifier identifier: ModelIdentifierProtocol,
                 condition: QueryPredicate?,
                 completion: DataStoreCallback<Void>)
 
@@ -82,20 +76,14 @@ extension StorageEngineAdapter {
         delete(modelType, modelSchema: modelType.schema, filter: predicate, completion: completion)
     }
 
-    func delete<M: Model>(_ modelType: M.Type,
-                          withId id: Model.Identifier,
-                          condition: QueryPredicate? = nil,
-                          completion: @escaping DataStoreCallback<M?>) {
-        delete(modelType, modelSchema: modelType.schema, withId: id, condition: condition, completion: completion)
-    }
 
     func delete(untypedModelType modelType: Model.Type,
-                withId id: Model.Identifier,
+                withIdentifier identifier: ModelIdentifierProtocol,
                 condition: QueryPredicate? = nil,
                 completion: DataStoreCallback<Void>) {
         delete(untypedModelType: modelType,
                modelSchema: modelType.schema,
-               withId: id,
+               withIdentifier: identifier,
                condition: condition,
                completion: completion)
     }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngineAdapter.swift
@@ -41,9 +41,9 @@ protocol StorageEngineAdapter: AnyObject, ModelStorageBehavior, ModelStorageErro
 
     func queryMutationSync(forAnyModel anyModel: AnyModel) throws -> MutationSync<AnyModel>?
 
-    func queryMutationSyncMetadata(for modelId: Model.Identifier, modelName: String) throws -> MutationSyncMetadata?
+    func queryMutationSyncMetadata(for modelId: String, modelName: String) throws -> MutationSyncMetadata?
 
-    func queryMutationSyncMetadata(for modelIds: [Model.Identifier], modelName: String) throws -> [MutationSyncMetadata]
+    func queryMutationSyncMetadata(for modelIds: [String], modelName: String) throws -> [MutationSyncMetadata]
 
     func queryModelSyncMetadata(for modelSchema: ModelSchema) throws -> ModelSyncMetadata?
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngineAdapter.swift
@@ -33,11 +33,6 @@ protocol StorageEngineAdapter: AnyObject, ModelStorageBehavior, ModelStorageErro
 
     // MARK: - Synchronous APIs
 
-    @available(*, deprecated, message: "Use exists(_:withIdentifier:predicate)")
-    func exists(_ modelSchema: ModelSchema,
-                withId id: Model.Identifier,
-                predicate: QueryPredicate?) throws -> Bool
-
     func exists(_ modelSchema: ModelSchema,
                 withIdentifier id: ModelIdentifierProtocol,
                 predicate: QueryPredicate?) throws -> Bool

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/Support/SortedList.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/Support/SortedList.swift
@@ -9,7 +9,7 @@ import Amplify
 
 class SortedList<ModelType: Model> {
     private(set) var sortedModels: [ModelType]
-    private(set) var modelIds: Set<Model.Identifier>
+    private(set) var modelIds: Set<String>
     private let sortInput: [QuerySortDescriptor]?
     private let modelSchema: ModelSchema
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
@@ -148,7 +148,10 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
                         for localEvent in localEvents {
                             group.addTask {
                                 try await withCheckedThrowingContinuation { continuation in
-                                    storageAdapter.delete(untypedModelType: MutationEvent.self, modelSchema: MutationEvent.schema, withId: localEvent.id, condition: nil) { result in
+                                    storageAdapter.delete(untypedModelType: MutationEvent.self,
+                                                          modelSchema: MutationEvent.schema,
+                                                          withIdentifier: localEvent.identifier(schema: MutationEvent.schema),
+                                                          condition: nil) { result in
                                         continuation.resume(with: result)
                                     }
                                 }
@@ -180,7 +183,7 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
                     .suffix(from: 1)
                     .forEach { storageAdapter.delete(MutationEvent.self,
                                                      modelSchema: MutationEvent.schema,
-                                                     withId: $0.id,
+                                                     withIdentifier: $0.identifier(schema: MutationEvent.schema),
                                                      condition: nil) { _ in } }
             }
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
@@ -304,7 +304,6 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
     private func saveDeleteMutation(remoteModel: MutationSync<AnyModel>) {
         log.verbose(#function)
         let modelName = remoteModel.model.modelName
-        let id = remoteModel.model.identifier
 
         guard let modelType = ModelRegistry.modelType(from: modelName) else {
             let error = DataStoreError.invalidModelName("Invalid Model \(modelName)")
@@ -318,9 +317,11 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
             return
         }
 
+        let identifier = remoteModel.model.identifier(schema: modelSchema)
+        
         storageAdapter.delete(untypedModelType: modelType,
                               modelSchema: modelSchema,
-                              withId: id,
+                              withIdentifier: identifier,
                               condition: nil) { response in
             switch response {
             case .failure(let dataStoreError):

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -348,7 +348,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
 
             storageAdapter.delete(untypedModelType: modelType,
                                   modelSchema: self.modelSchema,
-                                  withId: remoteModel.model.identifier,
+                                  withIdentifier: remoteModel.model.identifier(schema: self.modelSchema),
                                   condition: nil) { response in
                 switch response {
                 case .failure(let dataStoreError):

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -157,7 +157,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
         }
     }
 
-    func queryPendingMutations(forModelIds modelIds: [Model.Identifier]) -> Future<[MutationEvent], DataStoreError> {
+    func queryPendingMutations(forModelIds modelIds: [String]) -> Future<[MutationEvent], DataStoreError> {
         Future<[MutationEvent], DataStoreError> { promise in
             var result: Result<[MutationEvent], DataStoreError> = .failure(Self.unfulfilledDataStoreError())
             guard !self.isCancelled else {

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Support/MutationEvent+Query.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Support/MutationEvent+Query.swift
@@ -9,14 +9,14 @@ import Amplify
 import Dispatch
 
 extension MutationEvent {
-    static func pendingMutationEvents(for modelId: Model.Identifier,
+    static func pendingMutationEvents(for modelId: String,
                                       storageAdapter: StorageEngineAdapter,
                                       completion: @escaping DataStoreCallback<[MutationEvent]>) {
         
         pendingMutationEvents(for: [modelId], storageAdapter: storageAdapter, completion: completion)
     }
     
-    static func pendingMutationEvents(for modelIds: [Model.Identifier],
+    static func pendingMutationEvents(for modelIds: [String],
                                       storageAdapter: StorageEngineAdapter,
                                       completion: @escaping DataStoreCallback<[MutationEvent]>) {
         Task {

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreListProviderFunctionalTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreListProviderFunctionalTests.swift
@@ -40,7 +40,7 @@ class DataStoreListProviderFunctionalTests: BaseDataStoreTests {
 
     // MARK: - Helpers
 
-    func preparePost4DataForTest() -> Model.Identifier {
+    func preparePost4DataForTest() -> String {
         let post = Post4(title: "title")
         populateData([post])
         populateData([

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/ListTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/ListTests.swift
@@ -62,7 +62,7 @@ class ListTests: BaseDataStoreTests {
 
     // MARK: - Helpers
 
-    func preparePostDataForTest() -> Model.Identifier {
+    func preparePostDataForTest() -> String {
         let post = Post(title: "title", content: "content", createdAt: .now())
         populateData([post])
         populateData([

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
@@ -247,11 +247,15 @@ class SQLiteStorageEngineAdapterJsonTests: XCTestCase {
                     "createdAt": .string(createdAt)] as [String: JSONValue]
         let model = DynamicModel(values: post)
         let schema = ModelRegistry.modelSchema(from: "Post")!
+ 
         storageAdapter.save(model, modelSchema: schema) { insertResult in
             switch insertResult {
             case .success:
                 saveExpectation.fulfill()
-                self.storageAdapter.delete(DynamicModel.self, modelSchema: schema, withId: model.id) {
+                self.storageAdapter.delete(DynamicModel.self,
+                                           modelSchema: schema,
+                                           withIdentifier: model.identifier(schema: schema),
+                                           condition: nil) {
                     switch $0 {
                     case .success:
                         deleteExpectation.fulfill()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -367,7 +367,9 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             switch insertResult {
             case .success:
                 saveExpectation.fulfill()
-                self.storageAdapter.delete(Post.self, modelSchema: Post.schema, withId: post.id) {
+                self.storageAdapter.delete(untypedModelType: Post.self,
+                                           modelSchema: Post.schema,
+                                           withIdentifier: post.identifier(schema: Post.schema)) {
                     switch $0 {
                     case .success:
                         deleteExpectation.fulfill()
@@ -401,7 +403,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                 let predicate = postKeys.createdAt.gt(dateTestStart)
                 self.storageAdapter.delete(Post.self,
                                            modelSchema: Post.schema,
-                                           withId: post.id,
+                                           withIdentifier: post.identifier(schema: Post.schema),
                                            condition: predicate) { result in
                     switch result {
                     case .success:
@@ -436,7 +438,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                 let predicate = postKeys.createdAt.lt(dateTestStart)
                 self.storageAdapter.delete(Post.self,
                                            modelSchema: Post.schema,
-                                           withId: post.id,
+                                           withIdentifier: post.identifier(schema: Post.schema),
                                            condition: predicate) { result in
                     switch result {
                     case .success:

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -138,11 +138,6 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
         return []
     }
 
-    func exists(_ modelSchema: ModelSchema, withId id: Model.Identifier, predicate: QueryPredicate?) throws -> Bool {
-        XCTFail("Not expected to execute")
-        return true
-    }
-
     func exists(_ modelSchema: ModelSchema, withIdentifier id: ModelIdentifierProtocol, predicate: QueryPredicate?) throws -> Bool {
         XCTFail("Not expected to execute")
         return true
@@ -324,14 +319,6 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
                         condition where: QueryPredicate?,
                         completion: @escaping DataStoreCallback<M>) {
         XCTFail("Not expected to execute")
-    }
-
-    func delete<M: Model>(_ modelType: M.Type,
-                          modelSchema: ModelSchema,
-                          withId id: Model.Identifier,
-                          condition: QueryPredicate?,
-                          completion: DataStoreCallback<M?>) {
-        completion(.success(nil))
     }
 
     func delete<M: Model>(_ modelType: M.Type,

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -83,14 +83,6 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
 
     func delete<M: Model>(_ modelType: M.Type,
                           modelSchema: ModelSchema,
-                          withId id: Model.Identifier,
-                          condition: QueryPredicate? = nil,
-                          completion: DataStoreCallback<M?>) {
-        XCTFail("Not expected to execute")
-    }
-
-    func delete<M: Model>(_ modelType: M.Type,
-                          modelSchema: ModelSchema,
                           filter: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>) {
         XCTFail("Not expected to execute")
@@ -101,21 +93,21 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
                    condition: QueryPredicate?, completion: @escaping DataStoreCallback<M?>) where M: Model {
         XCTFail("Not expected to execute")
     }
-
+    
     func delete(untypedModelType modelType: Model.Type,
                 modelSchema: ModelSchema,
-                withId id: String,
-                condition: QueryPredicate? = nil,
-                completion: (Result<Void, DataStoreError>) -> Void) {
+                withIdentifier identifier: ModelIdentifierProtocol,
+                condition: QueryPredicate?,
+                completion: (DataStoreResult<Void>) -> Void) {
         if let responder = responders[.deleteUntypedModel] as? DeleteUntypedModelCompletionResponder {
-            let result = responder.callback((modelType, id))
+            let result = responder.callback((modelType, identifier.stringValue))
             completion(result)
             return
         }
-
+        
         return shouldReturnErrorOnDeleteMutation
-            ? completion(.failure(causedBy: DataStoreError.invalidModelName("DelMutate")))
-            : completion(.emptyResult)
+        ? completion(.failure(causedBy: DataStoreError.invalidModelName("DelMutate")))
+        : completion(.emptyResult)
     }
 
     func query(modelSchema: ModelSchema,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreCustomPrimaryKeyTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreCustomPrimaryKeyTests.swift
@@ -140,7 +140,8 @@ class DataStoreCustomPrimaryKeyTests: SyncEngineIntegrationTestBase {
             XCTFail("Listener not registered for hub")
             return
         }
-        _ = try await Amplify.DataStore.delete(CustomerOrder.self, withId: updatedCustomerOrder.id)
+
+        _ = try await Amplify.DataStore.delete(CustomerOrder.self, withIdentifier: updatedCustomerOrder.id)
         await waitForExpectations(timeout: networkTimeout)
         
         // query the customer order after deletion

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Models/CustomerOrder+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Models/CustomerOrder+Schema.swift
@@ -33,3 +33,8 @@ extension CustomerOrder {
     )
     }
 }
+
+extension CustomerOrder: ModelIdentifiable {
+    public typealias IdentifierFormat = ModelIdentifierFormat.Default
+    public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
@@ -54,8 +54,8 @@ class HubEventsIntegrationTestBase: XCTestCase {
 
     override func tearDown() async throws {
         print("Amplify reset")
-        storageAdapter.delete(untypedModelType: ModelSyncMetadata.self, withId: "Post") { _ in }
-        storageAdapter.delete(untypedModelType: ModelSyncMetadata.self, withId: "Comment") { _ in }
+        storageAdapter.delete(untypedModelType: ModelSyncMetadata.self, withIdentifier: ModelIdentifier<ModelSyncMetadata, ModelIdentifierFormat.Default>.makeDefault(id:"Post")) { _ in }
+        storageAdapter.delete(untypedModelType: ModelSyncMetadata.self, withIdentifier: ModelIdentifier<ModelSyncMetadata, ModelIdentifierFormat.Default>.makeDefault(id:"Comment")) { _ in }
         await Amplify.reset()
     }
 }

--- a/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryClientAPITests.swift
@@ -48,8 +48,8 @@ class TestModel: Model {
         return TestModel(id: UUID().uuidString)
     }
 
-    let id: Identifier
-    init(id: Identifier) {
+    let id: String
+    init(id: String) {
         self.id = id
     }
 }

--- a/AmplifyTests/CategoryTests/DataStore/Model/Collection/ArrayLiteralListProviderTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/Model/Collection/ArrayLiteralListProviderTests.swift
@@ -10,7 +10,7 @@ import Amplify
 
 class ArrayLiteralListProviderTests: XCTestCase {
     struct BasicModel: Model {
-        var id: Identifier
+        var id: String
     }
 
     func testLoadSuccess() throws {

--- a/AmplifyTests/CategoryTests/DataStore/Model/ListTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/Model/ListTests.swift
@@ -17,7 +17,7 @@ class ListTests: XCTestCase {
     }
 
     struct BasicModel: Model {
-        var id: Identifier
+        var id: String
     }
 
     class MockListDecoder: ModelListDecoder {


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Remove deprecated usages of `Model.Identifier`

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
