### PR TITLE
Makes AsyncStream conform to Sendable when Element is Sendable

### DIFF
--- a/Amplify/Core/Support/AmplifyTask+OperationTaskAdapters.swift
+++ b/Amplify/Core/Support/AmplifyTask+OperationTaskAdapters.swift
@@ -58,7 +58,7 @@ public class AmplifyOperationTaskAdapter<Request: AmplifyOperationRequest, Succe
     }
 }
 
-public class AmplifyInProcessReportingOperationTaskAdapter<Request: AmplifyOperationRequest, InProcess, Success, Failure: AmplifyError>: AmplifyInProcessTask {
+public class AmplifyInProcessReportingOperationTaskAdapter<Request: AmplifyOperationRequest, InProcess: Sendable, Success, Failure: AmplifyError>: AmplifyInProcessTask {
     let operation: AmplifyInProcessReportingOperation<Request, InProcess, Success, Failure>
     let childTask: ChildTask<InProcess, Success, Failure>
     var resultToken: UnsubscribeToken? = nil

--- a/Amplify/Core/Support/AmplifyTask.swift
+++ b/Amplify/Core/Support/AmplifyTask.swift
@@ -27,7 +27,7 @@ public protocol AmplifyTask {
 }
 
 public protocol AmplifyInProcessReportingTask {
-    associatedtype InProcess
+    associatedtype InProcess: Sendable
 
     var inProcess: AsyncChannel<InProcess> { get async }
 

--- a/Amplify/Core/Support/AsyncStream+Sendable.swift
+++ b/Amplify/Core/Support/AsyncStream+Sendable.swift
@@ -1,0 +1,13 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+#if swift(<5.6)
+extension AsyncStream: @unchecked Sendable where Element: Sendable { }
+extension AsyncThrowingStream: @unchecked Sendable where Element: Sendable { }
+#endif

--- a/Amplify/Core/Support/ChildTask.swift
+++ b/Amplify/Core/Support/ChildTask.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Takes a Parent Operation which conforms to Cancellable so that if the
 /// Child Task is cancelled it will also cancel the parent.
-actor ChildTask<InProcess, Success, Failure: Error>: BufferingSequence {
+actor ChildTask<InProcess: Sendable, Success, Failure: Error>: BufferingSequence {
     typealias Element = InProcess
     let parent: Cancellable
     var inProcessChannel: AsyncChannel<InProcess>? = nil

--- a/Amplify/Core/Support/Progress+Sendable.swift
+++ b/Amplify/Core/Support/Progress+Sendable.swift
@@ -1,0 +1,10 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Progress: @unchecked Sendable {}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This will only apply to older Swift compilers so that this code builds with Xcode 13.2.1. The code below is what declares the `@unchecked Sendable` conformance which is added in the next version of Swift.

```swift
#if swift(<5.6)
extension AsyncStream: @unchecked Sendable where Element: Sendable { }
extension AsyncThrowingStream: @unchecked Sendable where Element: Sendable { }
#endif
```

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
