### PR TITLE
adds task cancellation to AsyncPassthroughSubject

### DIFF
--- a/Amplify/Core/Support/AsyncPassthroughSubject.swift
+++ b/Amplify/Core/Support/AsyncPassthroughSubject.swift
@@ -11,6 +11,10 @@ import Combine
 public struct AsyncPassthroughSubject<Success> {
     let task: Task<Success, Error>
 
+    public var isCancelled: Bool {
+        task.isCancelled
+    }
+
     public init(operation: @escaping @Sendable () async throws -> Success) {
         task = Task(operation: operation)
     }
@@ -28,7 +32,11 @@ public struct AsyncPassthroughSubject<Success> {
             }
         }
 
-        return subject.eraseToAnyPublisher()
+        return subject
+            .handleEvents(receiveCancel: {
+                task.cancel()
+            })
+            .eraseToAnyPublisher()
     }
 }
 #endif


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When a sink is cancelled on `AnyPublisher` it should cancel the task which is waiting on the value which would be sent to the `PassthroughSubject`.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
