### PR TITLE
Revises AsyncSequence support to cover optional parent cancellation

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
@@ -320,8 +320,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      enableThreadSanitizer = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
@@ -320,7 +320,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Amplify/Categories/API/Operation/GraphQLOperation.swift
+++ b/Amplify/Categories/API/Operation/GraphQLOperation.swift
@@ -44,7 +44,7 @@ public extension GraphQLSubscriptionOperation {
 public typealias GraphQLSubscriptionTask<R: Decodable> = GraphQLSubscriptionOperation<R>.TaskAdapter
 
 public extension GraphQLSubscriptionTask {
-    var subscription : AmplifySequence<InProcess> {
+    var subscription : AmplifyAsyncSequence<InProcess> {
         get async {
             await inProcess
         }

--- a/Amplify/Core/Support/AmplifyAsyncSequence.swift
+++ b/Amplify/Core/Support/AmplifyAsyncSequence.swift
@@ -1,11 +1,21 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 import Foundation
 
-public struct AmplifySequence<Element: Sendable>: AsyncSequence {
+public struct AmplifyAsyncSequence<Element: Sendable>: AsyncSequence, Cancellable {
     public typealias Iterator = AsyncStream<Element>.Iterator
     private var asyncStream: AsyncStream<Element>! = nil
     private var continuation: AsyncStream<Element>.Continuation! = nil
+    private var parent: Cancellable? = nil
 
-    public init(bufferingPolicy: AsyncStream<Element>.Continuation.BufferingPolicy = .unbounded) {
+    public init(parent: Cancellable? = nil,
+                bufferingPolicy: AsyncStream<Element>.Continuation.BufferingPolicy = .unbounded) {
+        self.parent = parent
         asyncStream = AsyncStream<Element>(Element.self, bufferingPolicy: bufferingPolicy) { continuation in
             self.continuation = continuation
         }
@@ -21,5 +31,10 @@ public struct AmplifySequence<Element: Sendable>: AsyncSequence {
 
     public func finish() {
         continuation.finish()
+    }
+
+    public func cancel() {
+        finish()
+        parent?.cancel()
     }
 }

--- a/Amplify/Core/Support/AmplifyTask+OperationTaskAdapters.swift
+++ b/Amplify/Core/Support/AmplifyTask+OperationTaskAdapters.swift
@@ -86,7 +86,7 @@ public class AmplifyInProcessReportingOperationTaskAdapter<Request: AmplifyOpera
         }
     }
 
-    public var inProcess: AmplifySequence<InProcess> {
+    public var inProcess: AmplifyAsyncSequence<InProcess> {
         get async {
             await childTask.inProcess
         }

--- a/Amplify/Core/Support/AmplifyTask.swift
+++ b/Amplify/Core/Support/AmplifyTask.swift
@@ -29,7 +29,7 @@ public protocol AmplifyTask {
 public protocol AmplifyInProcessReportingTask {
     associatedtype InProcess
 
-    var inProcess: AmplifySequence<InProcess> { get async }
+    var inProcess: AmplifyAsyncSequence<InProcess> { get async }
 
 #if canImport(Combine)
     var inProcessPublisher: AnyPublisher<InProcess, Never> { get }
@@ -39,10 +39,9 @@ public protocol AmplifyInProcessReportingTask {
 public typealias AmplifyInProcessTask = AmplifyTask & AmplifyInProcessReportingTask
 
 public extension AmplifyInProcessReportingTask where InProcess == Progress {
-    var progress : AmplifySequence<InProcess> {
+    var progress : AmplifyAsyncSequence<InProcess> {
         get async {
             await inProcess
         }
     }
 }
-

--- a/Amplify/Core/Support/ChildTask.swift
+++ b/Amplify/Core/Support/ChildTask.swift
@@ -12,17 +12,17 @@ import Foundation
 actor ChildTask<InProcess, Success, Failure: Error>: BufferingSequence {
     typealias Element = InProcess
     let parent: Cancellable
-    var inProcessChannel: AmplifySequence<InProcess>? = nil
+    var inProcessChannel: AmplifyAsyncSequence<InProcess>? = nil
     var valueContinuations: [CheckedContinuation<Success, Error>] = []
     var storedResult: Result<Success, Failure>? = nil
     var isCancelled = false
 
-    var inProcess: AmplifySequence<InProcess> {
-        let channel: AmplifySequence<InProcess>
+    var inProcess: AmplifyAsyncSequence<InProcess> {
+        let channel: AmplifyAsyncSequence<InProcess>
         if let inProcessChannel = inProcessChannel {
             channel = inProcessChannel
         } else {
-            channel = AmplifySequence<InProcess>(bufferingPolicy: bufferingPolicy)
+            channel = AmplifyAsyncSequence<InProcess>(bufferingPolicy: bufferingPolicy)
             inProcessChannel = channel
         }
 


### PR DESCRIPTION
* renames AmplifySequence to AmplifyAsyncSequence
* adds optional parent which is Cancellable
* conforms AmplifyAsyncSequence to Cancellable
* adds new unit tests to cover new behavior
* tests run 100 times each pass without any tsan violations

*Issue #, if available:*

*Description of changes:*

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
