### PR TITLE
chore(api): fix GraphQLModelBasedTests to async

### DIFF
--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
@@ -12,76 +12,63 @@ import XCTest
 
 // swiftlint:disable type_body_length
 class GraphQLModelBasedTests: XCTestCase {
-
+    
     static let amplifyConfiguration = "testconfiguration/GraphQLModelBasedTests-amplifyconfiguration"
-
+    
     final public class PostCommentModelRegistration: AmplifyModelRegistration {
         public func registerModels(registry: ModelRegistry.Type) {
             ModelRegistry.register(modelType: Post.self)
             ModelRegistry.register(modelType: Comment.self)
         }
-
+        
         public let version: String = "1"
     }
-
+    
     
     override func setUp() async throws {
         await Amplify.reset()
         Amplify.Logging.logLevel = .verbose
         let plugin = AWSAPIPlugin(modelRegistration: PostCommentModelRegistration())
-
+        
         do {
             try Amplify.add(plugin: plugin)
-
+            
             let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(
                 forResource: GraphQLModelBasedTests.amplifyConfiguration)
             try Amplify.configure(amplifyConfig)
-
+            
             ModelRegistry.register(modelType: Comment.self)
             ModelRegistry.register(modelType: Post.self)
-
+            
         } catch {
             XCTFail("Error during setup: \(error)")
         }
     }
-
+    
     override func tearDown() async throws {
         await Amplify.reset()
     }
-
-    func testQuerySinglePostWithModel() {
+    
+    func testQuerySinglePostWithModel() async throws {
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
-        guard let post = createPost(id: uuid, title: title) else {
-            XCTFail("Failed to set up test")
+        let post = Post(id: uuid, title: title, content: "content", createdAt: .now())
+        _ = try await Amplify.API.mutate(request: .create(post))
+        let graphQLResponse = try await Amplify.API.query(request: .get(Post.self, byId: uuid))
+        guard case .success(let data) = graphQLResponse else {
+            XCTFail("Missing successful response")
             return
         }
-
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-        _ = Amplify.API.query(request: .get(Post.self, byId: uuid)) { event in
-            switch event {
-            case .success(let graphQLResponse):
-                guard case let .success(data) = graphQLResponse else {
-                    XCTFail("Missing successful response")
-                    return
-                }
-                guard let resultPost = data else {
-                    XCTFail("Missing post from query")
-                    return
-                }
-
-                XCTAssertEqual(resultPost.id, post.id)
-                XCTAssertEqual(resultPost.title, title)
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("Unexpected .failed event: \(error)")
-            }
+        guard let resultPost = data else {
+            XCTFail("Missing post from query")
+            return
         }
-
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
+        
+        XCTAssertEqual(resultPost.id, post.id)
+        XCTAssertEqual(resultPost.title, title)
     }
-
+    
     /// Test custom GraphQLRequest with nested list deserializes to generated Post Model
     ///
     /// - Given: A post containing a single comment
@@ -90,114 +77,90 @@ class GraphQLModelBasedTests: XCTestCase {
     /// - Then:
     ///    - The resulting post object contains the list of comments
     ///
-    func testCustomQueryPostWithComments() {
+    func testCustomQueryPostWithComments() async throws {
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
-        guard let post = createPost(id: uuid, title: title) else {
-            XCTFail("Failed to set up test")
-            return
-        }
-        guard createComment(content: "content", post: post) != nil else {
-            XCTFail("Failed to create comment with post")
-            return
-        }
-
-        let requestInvokedSuccessfully = expectation(description: "request completed")
+        let post = Post(id: uuid, title: title, content: "content", createdAt: .now())
+        _ = try await Amplify.API.mutate(request: .create(post))
+        let comment = Comment(content: "commentContent",
+                              createdAt: .now(),
+                              post: post)
+        _ = try await Amplify.API.mutate(request: .create(comment))
+        
         let document = """
-        query getPost($id: ID!) {
-          getPost(id: $id){
+    query getPost($id: ID!) {
+      getPost(id: $id){
+        id
+        title
+        content
+        createdAt
+        updatedAt
+        draft
+        rating
+        status
+        comments {
+          items {
             id
-            title
             content
             createdAt
             updatedAt
-            draft
-            rating
-            status
-            comments {
-              items {
-                id
-                content
-                createdAt
-                updatedAt
-                post {
-                  id
-                  title
-                  content
-                  createdAt
-                  updatedAt
-                  draft
-                  rating
-                  status
-                }
-              }
-              nextToken
+            post {
+              id
+              title
+              content
+              createdAt
+              updatedAt
+              draft
+              rating
+              status
             }
           }
+          nextToken
         }
-        """
+      }
+    }
+    """
         let graphQLRequest = GraphQLRequest(document: document,
                                             variables: ["id": uuid],
                                             responseType: Post?.self,
                                             decodePath: "getPost")
-        _ = Amplify.API.query(request: graphQLRequest) { event in
-            switch event {
-            case .success(let graphQLResponse):
-                guard case let .success(data) = graphQLResponse else {
-                    XCTFail("Missing successful response")
-                    return
-                }
-                guard let resultPost = data else {
-                    XCTFail("Missing post from query")
-                    return
-                }
-
-                XCTAssertEqual(resultPost.id, post.id)
-                XCTAssertEqual(resultPost.title, title)
-                guard let comments = resultPost.comments else {
-                    XCTFail("Missing comments from post")
-                    return
-                }
-                XCTAssertEqual(comments.count, 1)
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("Unexpected .failed event: \(error)")
-            }
+        let graphQLResponse = try await Amplify.API.query(request: graphQLRequest)
+        guard case .success(let data) = graphQLResponse else {
+            XCTFail("Missing successful response")
+            return
         }
-
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
+        guard let resultPost = data else {
+            XCTFail("Missing post from query")
+            return
+        }
+        
+        XCTAssertEqual(resultPost.id, post.id)
+        XCTAssertEqual(resultPost.title, title)
+        guard let comments = resultPost.comments else {
+            XCTFail("Missing comments from post")
+            return
+        }
+        XCTAssertEqual(comments.count, 1)
     }
-
-    func testListQueryWithModel() {
+    
+    func testListQueryWithModel() async throws {
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
-        guard createPost(id: uuid, title: title) != nil else {
-            XCTFail("Failed to ensure at least one Post to be retrieved on the listQuery")
+        let post = Post(id: uuid, title: title, content: "content", createdAt: .now())
+        _ = try await Amplify.API.mutate(request: .create(post))
+        
+        let graphQLResponse = try await Amplify.API.query(request: .list(Post.self))
+        //            case .success(let graphQLResponse):
+        guard case .success(let posts) = graphQLResponse else {
+            XCTFail("Missing successful response")
             return
         }
-
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-
-        _ = Amplify.API.query(request: .list(Post.self)) { event in
-            switch event {
-            case .success(let graphQLResponse):
-                guard case let .success(posts) = graphQLResponse else {
-                    XCTFail("Missing successful response")
-                    return
-                }
-                XCTAssertTrue(!posts.isEmpty)
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("Unexpected .failed event: \(error)")
-            }
-        }
-
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
+        XCTAssertTrue(!posts.isEmpty)
     }
-
-    func testListQueryWithPredicate() {
+    
+    func testListQueryWithPredicate() async throws {
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let uniqueTitle = testMethodName + uuid + "Title"
@@ -207,174 +170,101 @@ class GraphQLModelBasedTests: XCTestCase {
                                createdAt: .now(),
                                draft: true,
                                rating: 12.3)
-        guard createPost(post: createdPost) != nil else {
-            XCTFail("Failed to ensure at least one Post to be retrieved on the listQuery")
-            return
-        }
-
-        let requestInvokedSuccessfully = expectation(description: "request completed")
+        _ = try await Amplify.API.mutate(request: .create(createdPost))
         let post = Post.keys
         let predicate = post.id == uuid &&
-            post.title == uniqueTitle &&
-            post.content == "content" &&
-            post.createdAt == createdPost.createdAt &&
-            post.rating == 12.3 &&
-            post.draft == true
-
-        _ = Amplify.API.query(request: .list(Post.self, where: predicate)) { event in
-            switch event {
-            case .success(let graphQLResponse):
-                guard case let .success(posts) = graphQLResponse else {
-                    XCTFail("Missing successful response")
-                    return
-                }
-                XCTAssertEqual(posts.count, 1)
-                guard let singlePost = posts.first else {
-                    XCTFail("Should only have a single post with the unique title")
-                    return
-                }
-                XCTAssertEqual(singlePost.id, uuid)
-                XCTAssertEqual(singlePost.title, uniqueTitle)
-                XCTAssertEqual(singlePost.content, "content")
-                XCTAssertEqual(singlePost.createdAt.iso8601String, createdPost.createdAt.iso8601String)
-                XCTAssertEqual(singlePost.rating, 12.3)
-                XCTAssertEqual(singlePost.draft, true)
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("Unexpected .failed event: \(error)")
-            }
+        post.title == uniqueTitle &&
+        post.content == "content" &&
+        post.createdAt == createdPost.createdAt &&
+        post.rating == 12.3 &&
+        post.draft == true
+        
+        let graphQLResponse = try await Amplify.API.query(request: .list(Post.self, where: predicate))
+        guard case .success(let posts) = graphQLResponse else {
+            XCTFail("Missing successful response")
+            return
         }
-
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
+        XCTAssertEqual(posts.count, 1)
+        guard let singlePost = posts.first else {
+            XCTFail("Should only have a single post with the unique title")
+            return
+        }
+        XCTAssertEqual(singlePost.id, uuid)
+        XCTAssertEqual(singlePost.title, uniqueTitle)
+        XCTAssertEqual(singlePost.content, "content")
+        XCTAssertEqual(singlePost.createdAt.iso8601String, createdPost.createdAt.iso8601String)
+        XCTAssertEqual(singlePost.rating, 12.3)
+        XCTAssertEqual(singlePost.draft, true)
     }
-
-    func testCreatPostWithModel() {
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-
+    
+    func testCreatPostWithModel() async throws {
         let post = Post(title: "title", content: "content", createdAt: .now())
-        _ = Amplify.API.mutate(request: .create(post)) { event in
-            switch event {
-            case .success(let data):
-                switch data {
-                case .success(let post):
-                    XCTAssertEqual(post.title, "title")
-                    requestInvokedSuccessfully.fulfill()
-                case .failure(let error):
-                    XCTFail("Unexpected response with error \(error)")
-                }
-            case .failure(let error):
-                XCTFail("\(error)")
-            }
+        let createdPostResult = try await Amplify.API.mutate(request: .create(post))
+        guard case .success(let resultedPost) = createdPostResult else {
+            XCTFail("Error creating a Post")
+            return
         }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
+        XCTAssertEqual(resultedPost.title, "title")
     }
-
-    func testCreateCommentWithModel() {
+    
+    func testCreateCommentWithModel() async throws {
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
-        guard let createdPost = createPost(id: uuid, title: title) else {
-            XCTFail("Failed to create a Post.")
-            return
-        }
-
-        let requestInvokedSuccessfully = expectation(description: "request completed")
+        let post = Post(id: uuid, title: title, content: "content", createdAt: .now())
+        _ = try await Amplify.API.mutate(request: .create(post))
         let comment = Comment(content: "commentContent",
                               createdAt: .now(),
-                              post: createdPost)
-        _ = Amplify.API.mutate(request: .create(comment)) { event in
-            switch event {
-            case .success(let data):
-                switch data {
-                case .success(let comment):
-                    XCTAssertEqual(comment.content, "commentContent")
-                    XCTAssertNotNil(comment.post)
-                    XCTAssertEqual(comment.post?.id, uuid)
-                    requestInvokedSuccessfully.fulfill()
-                case .failure(let error):
-                    XCTFail("Unexpected response with error \(error)")
-                }
-            case .failure(let error):
-                XCTFail("\(error)")
-            }
+                              post: post)
+        let createdCommentResult = try await Amplify.API.mutate(request: .create(comment))
+        guard case .success(let resultComment) = createdCommentResult else {
+            XCTFail("Error creating a Comment")
+            return
         }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
+        XCTAssertEqual(resultComment.content, "commentContent")
+        XCTAssertNotNil(resultComment.post)
     }
-
-    func testDeletePostWithModel() {
+    
+    func testDeletePostWithModel() async throws {
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
-        guard let post = createPost(id: uuid, title: title) else {
-            XCTFail("Failed to ensure at least one Post to be retrieved on the listQuery")
+        let post = Post(id: uuid, title: title, content: "content", createdAt: .now())
+        _ = try await Amplify.API.mutate(request: .create(post))
+        let deletedPostResult = try await Amplify.API.mutate(request: .delete(post))
+        guard case .success(let deletedPost) = deletedPostResult else {
+            XCTFail("Error deleting the Post \(deletedPostResult)")
             return
         }
-
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-
-        _ = Amplify.API.mutate(request: .delete(post)) { event in
-            switch event {
-            case .success(let data):
-                switch data {
-                case .success(let post):
-                    XCTAssertEqual(post.title, title)
-                case .failure(let error):
-                    XCTFail("\(error)")
-                }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("\(error)")
+        XCTAssertEqual(deletedPost.title, title)
+        let getPostAfterDeleteCompleted = try await Amplify.API.query(request: .get(Post.self, byId: post.id))
+        switch getPostAfterDeleteCompleted {
+        case .success(let queriedDeletedPostOptional):
+            guard queriedDeletedPostOptional == nil else {
+                XCTFail("Should be nil after deletion")
+                return
             }
+        case .failure(let response):
+            XCTFail("Failed with: \(response)")
         }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
-
-        let queryComplete = expectation(description: "query complete")
-
-        _ = Amplify.API.query(request: .get(Post.self, byId: uuid)) { event in
-            switch event {
-            case .success(let graphQLResponse):
-                guard case let .success(post) = graphQLResponse else {
-                    XCTFail("Missing successful response")
-                    return
-                }
-                XCTAssertNil(post)
-                queryComplete.fulfill()
-            case .failure(let error):
-                XCTFail("Unexpected .failed event: \(error)")
-            }
-        }
-
-        wait(for: [queryComplete], timeout: TestCommonConstants.networkTimeout)
     }
-
-    func testUpdatePostWithModel() {
+    
+    func testUpdatePostWithModel() async throws {
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
-        guard let post = createPost(id: uuid, title: title) else {
-            XCTFail("Failed to ensure at least one Post to be retrieved on the listQuery")
-            return
-        }
+        let post = Post(id: uuid, title: title, content: "content", createdAt: .now())
+        _ = try await Amplify.API.mutate(request: .create(post))
         let updatedTitle = title + "Updated"
         let updatedPost = Post(id: uuid, title: updatedTitle, content: post.content, createdAt: post.createdAt)
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-        _ = Amplify.API.mutate(request: .update(updatedPost)) { event in
-            switch event {
-            case .success(let data):
-                switch data {
-                case .success(let post):
-                    XCTAssertEqual(post.title, updatedTitle)
-                case .failure(let error):
-                    XCTFail("\(error)")
-                }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("\(error)")
-            }
+        let updatedPostOptional = try await Amplify.API.mutate(request: .update(updatedPost))
+        guard case .success(let updatedPosts) = updatedPostOptional else {
+            XCTFail("Error Updating the Post \(updatedPostOptional)")
+            return
         }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
+        XCTAssertEqual(updatedPosts.title, updatedTitle)
     }
-
+    
     func testOnCreatePostSubscriptionWithModel() async throws {
         let connectedInvoked = AsyncExpectation(description: "Connection established")
         let progressInvoked = AsyncExpectation(description: "progress invoked", expectedFulfillmentCount: 2)
@@ -414,17 +304,17 @@ class GraphQLModelBasedTests: XCTestCase {
         
         let post = Post(id: uuid, title: title, content: "content", createdAt: .now())
         _ = try await Amplify.API.mutate(request: .create(post))
-        let post2 = Post(id: uuid, title: title, content: "content", createdAt: .now())
+        let post2 = Post(id: uuid2, title: title, content: "content", createdAt: .now())
         _ = try await Amplify.API.mutate(request: .create(post2))
         try await AsyncExpectation.waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
         await task.cancel()
     }
-
+    
     func testOnUpdatePostSubscriptionWithModel() async throws {
         let connectingInvoked = AsyncExpectation(description: "Connection connecting")
         let connectedInvoked = AsyncExpectation(description: "Connection established")
         let progressInvoked = AsyncExpectation(description: "progress invoked")
-
+        
         let task = try await Amplify.API.subscribe(request: .subscription(of: Post.self, type: .onUpdate))
         let subscription = await task.subscription
         Task {
@@ -444,7 +334,7 @@ class GraphQLModelBasedTests: XCTestCase {
                 }
             }
         }
-                                 
+        
         try await AsyncExpectation.waitForExpectations([connectingInvoked, connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         
         let uuid = UUID().uuidString
@@ -453,116 +343,94 @@ class GraphQLModelBasedTests: XCTestCase {
         let post = Post(id: uuid, title: title, content: "content", createdAt: .now())
         _ = try await Amplify.API.mutate(request: .create(post))
         _ = try await Amplify.API.mutate(request: .update(post))
-
+        
         try await AsyncExpectation.waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
-
+        
         await task.cancel()
     }
-
-    func testOnDeletePostSubscriptionWithModel() {
-        let connectedInvoked = expectation(description: "Connection established")
-        let disconnectedInvoked = expectation(description: "Connection disconnected")
-        let completedInvoked = expectation(description: "Completed invoked")
-        let progressInvoked = expectation(description: "progress invoked")
-
-        let operation = Amplify.API.subscribe(
-            request: .subscription(of: Post.self, type: .onDelete),
-            valueListener: { event in
-                switch event {
+    func testOnDeletePostSubscriptionWithModel() async throws {
+        let connectingInvoked = AsyncExpectation(description: "Connection connecting")
+        let connectedInvoked = AsyncExpectation(description: "Connection established")
+        let progressInvoked = AsyncExpectation(description: "progress invoked")
+        
+        let task = try await Amplify.API.subscribe(request: .subscription(of: Post.self, type: .onDelete))
+        let subscription = await task.subscription
+        Task {
+            for await subscriptionEvent in subscription {
+                switch subscriptionEvent {
                 case .connection(let state):
                     switch state {
                     case .connecting:
-                        break
+                        await connectingInvoked.fulfill()
                     case .connected:
-                        connectedInvoked.fulfill()
+                        await connectedInvoked.fulfill()
                     case .disconnected:
-                        disconnectedInvoked.fulfill()
+                        break
                     }
                 case .data:
-                    progressInvoked.fulfill()
+                    await progressInvoked.fulfill()
                 }
-        },
-            completionListener: { event in
-                switch event {
-                case .failure(let error):
-                    XCTFail("Unexpected .failed event: \(error)")
-                case .success:
-                    completedInvoked.fulfill()
-                }
-        })
-        XCTAssertNotNil(operation)
-        wait(for: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+            }
+        }
+        
+        try await AsyncExpectation.waitForExpectations([connectingInvoked, connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
-
-        guard let post = createPost(id: uuid, title: title) else {
-            XCTFail("Failed to create post")
-            return
-        }
-
-        guard deletePost(post: post) != nil else {
-            XCTFail("Failed to update post")
-            return
-        }
-
-        wait(for: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
-        operation.cancel()
-        wait(for: [disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
-        XCTAssertTrue(operation.isFinished)
+        let post = Post(id: uuid, title: title, content: "content", createdAt: .now())
+        _ = try await Amplify.API.mutate(request: .create(post))
+        _ = try await Amplify.API.mutate(request: .delete(post))
+        
+        try await AsyncExpectation.waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        
+        await task.cancel()
     }
-
-    func testOnCreateCommentSubscriptionWithModel() {
-        let connectedInvoked = expectation(description: "Connection established")
-        let disconnectedInvoked = expectation(description: "Connection disconnected")
-        let completedInvoked = expectation(description: "Completed invoked")
-        let progressInvoked = expectation(description: "progress invoked")
-
-        let operation = Amplify.API.subscribe(
-            request: .subscription(of: Comment.self, type: .onCreate),
-            valueListener: { event in
-                switch event {
+    
+    func testOnCreateCommentSubscriptionWithModel() async throws {
+        let connectedInvoked = AsyncExpectation(description: "Connection established")
+        let progressInvoked = AsyncExpectation(description: "progress invoked", expectedFulfillmentCount: 2)
+        let uuid = UUID().uuidString
+        let uuid2 = UUID().uuidString
+        let testMethodName = String("\(#function)".dropLast(2))
+        let title = testMethodName + "Title"
+        let task = try await Amplify.API.subscribe(request: .subscription(of: Comment.self, type: .onCreate))
+        let subscription = await task.subscription
+        Task {
+            for await subscriptionEvent in subscription {
+                switch subscriptionEvent {
                 case .connection(let state):
                     switch state {
                     case .connecting:
                         break
                     case .connected:
-                        connectedInvoked.fulfill()
+                        await connectedInvoked.fulfill()
                     case .disconnected:
-                        disconnectedInvoked.fulfill()
+                        break
                     }
-                case .data:
-                    progressInvoked.fulfill()
+                case .data(let result):
+                    switch result {
+                    case .success(let comment):
+                        if comment.id == uuid || comment.id == uuid2 {
+                            await progressInvoked.fulfill()
+                        }
+                    case .failure(let error):
+                        XCTFail("\(error)")
+                    }
                 }
-        },
-            completionListener: { event in
-                switch event {
-                case .failure(let error):
-                    XCTFail("Unexpected .failed event: \(error)")
-                case .success:
-                    completedInvoked.fulfill()
-                }
-        })
-        XCTAssertNotNil(operation)
-        wait(for: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
-        let uuid = UUID().uuidString
-        let testMethodName = String("\(#function)".dropLast(2))
-        let title = testMethodName + "Title"
-
-        guard let createdPost = createPost(id: uuid, title: title) else {
-            XCTFail("Failed to create post")
-            return
+            }
         }
-
-        guard createComment(content: "content", post: createdPost) != nil else {
-            XCTFail("Failed to create comment with post")
-            return
-        }
-
-        wait(for: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
-        operation.cancel()
-        wait(for: [disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
-        XCTAssertTrue(operation.isFinished)
+        
+        XCTAssertNotNil(task)
+        try await AsyncExpectation.waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        let post = Post(id: uuid, title: title, content: "content", createdAt: .now())
+        _ = try await Amplify.API.mutate(request: .create(post))
+        let comment = Comment(id: uuid, content: "content", createdAt: .now(), post: post)
+        _ = try await Amplify.API.mutate(request: .create(comment))
+        let comment2 = Comment(id: uuid2, content: "content", createdAt: .now(), post: post)
+        _ = try await Amplify.API.mutate(request: .create(comment2))
+        try await AsyncExpectation.waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await task.cancel()
     }
 
     // MARK: Helpers

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
@@ -348,6 +348,7 @@ class GraphQLModelBasedTests: XCTestCase {
         
         await task.cancel()
     }
+    
     func testOnDeletePostSubscriptionWithModel() async throws {
         let connectingInvoked = AsyncExpectation(description: "Connection connecting")
         let connectedInvoked = AsyncExpectation(description: "Connection established")

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/README.md
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/README.md
@@ -34,7 +34,7 @@ enum PostStatus {
     PUBLISHED
 }
 
-type Post @model {
+type Post @model @auth(rules: [{ allow: public }]) {
     id: ID!
     title: String!
     content: String!
@@ -46,7 +46,7 @@ type Post @model {
     comments: [Comment] @connection(name: "PostComment")
 }
 
-type Comment @model {
+type Comment @model @auth(rules: [{ allow: public }]) {
     id: ID!
     content: String!
     createdAt: AWSDateTime!
@@ -56,39 +56,39 @@ type Comment @model {
 ## These are examples from https://docs.amplify.aws/cli/graphql-transformer/connection
 
 # 1 - Project has a single optional Team
-type Project1 @model {
+type Project1 @model @auth(rules: [{ allow: public }]) {
   id: ID!
   name: String
   team: Team1 @connection
 }
 
-type Team1 @model {
+type Team1 @model @auth(rules: [{ allow: public }]) {
   id: ID!
   name: String!
 }
 
-# 2 - Project with explicit field for team’s id
-type Project2 @model {
+# 2 - Project with explicit field for team's id
+type Project2 @model @auth(rules: [{ allow: public }]) {
   id: ID!
   name: String
   teamID: ID!
   team: Team2 @connection(fields: ["teamID"])
 }
 
-type Team2 @model {
+type Team2 @model @auth(rules: [{ allow: public }]) {
   id: ID!
   name: String!
 }
 
 # 3 - Post Comment - keyName reference key directive
 
-type Post3 @model {
+type Post3 @model @auth(rules: [{ allow: public }]) {
   id: ID!
   title: String!
   comments: [Comment3] @connection(keyName: "byPost3", fields: ["id"])
 }
 
-type Comment3 @model
+type Comment3 @model @auth(rules: [{ allow: public }])
   @key(name: "byPost3", fields: ["postID", "content"]) {
   id: ID!
   postID: ID!
@@ -97,13 +97,13 @@ type Comment3 @model
 
 # 4 - Post Comment bi-directional belongs to
 
-type Post4 @model {
+type Post4 @model @auth(rules: [{ allow: public }]) {
   id: ID!
   title: String!
   comments: [Comment4] @connection(keyName: "byPost4", fields: ["id"])
 }
 
-type Comment4 @model
+type Comment4 @model @auth(rules: [{ allow: public }])
   @key(name: "byPost4", fields: ["postID", "content"]) {
   id: ID!
   postID: ID!
@@ -113,15 +113,14 @@ type Comment4 @model
 
 # 5 Many to Many
 
-type Post5 @model {
+type Post5 @model @auth(rules: [{ allow: public }]) {
   id: ID!
   title: String!
   editors: [PostEditor5] @connection(keyName: "byPost5", fields: ["id"])
 }
 
 # Create a join model
-type PostEditor5
-  @model
+type PostEditor5 @model @auth(rules: [{ allow: public }])
   @key(name: "byPost5", fields: ["postID", "editorID"])
   @key(name: "byEditor5", fields: ["editorID", "postID"]) {
   id: ID!
@@ -131,7 +130,7 @@ type PostEditor5
   editor: User5! @connection(fields: ["editorID"])
 }
 
-type User5 @model {
+type User5 @model @auth(rules: [{ allow: public }]) {
   id: ID!
   username: String!
   posts: [PostEditor5] @connection(keyName: "byEditor5", fields: ["id"])
@@ -142,13 +141,14 @@ type User5 @model {
 # > Choose a schema template: `One-to-many relationship (e.g., “Blogs” with “Posts” and “Comments”)`
 
 # 6 - Blog Post Comment
-type Blog6 @model {
+type Blog6 @model @auth(rules: [{ allow: public }]) {
   id: ID!
   name: String!
   posts: [Post6] @connection(keyName: "byBlog", fields: ["id"])
 }
 
-type Post6 @model @key(name: "byBlog", fields: ["blogID"]) {
+type Post6 @model @auth(rules: [{ allow: public }])
+@key(name: "byBlog", fields: ["blogID"]) {
   id: ID!
   title: String!
   blogID: ID!
@@ -156,7 +156,8 @@ type Post6 @model @key(name: "byBlog", fields: ["blogID"]) {
   comments: [Comment6] @connection(keyName: "byPost", fields: ["id"])
 }
 
-type Comment6 @model @key(name: "byPost", fields: ["postID", "content"]) {
+type Comment6 @model @auth(rules: [{ allow: public }])
+@key(name: "byPost", fields: ["postID", "content"]) {
   id: ID!
   postID: ID!
   post: Post6 @connection(fields: ["postID"])
@@ -165,7 +166,7 @@ type Comment6 @model @key(name: "byPost", fields: ["postID", "content"]) {
 
 # Scalars, Lists, Enums
 
-type ScalarContainer @model {
+type ScalarContainer @model @auth(rules: [{ allow: public }]) {
    id: ID!
    myString: String
    myInt: Int
@@ -182,7 +183,7 @@ type ScalarContainer @model {
    myIPAddress: AWSIPAddress
 }
 
-type ListIntContainer @model {
+type ListIntContainer @model @auth(rules: [{ allow: public }]) {
   id: ID!
   test: Int!
   nullableInt: Int
@@ -192,7 +193,7 @@ type ListIntContainer @model {
   nullableIntNullableList: [Int]
 }
 
-type ListStringContainer @model {
+type ListStringContainer @model @auth(rules: [{ allow: public }]) {
   id: ID!
   test: String!
   nullableString: String
@@ -202,7 +203,7 @@ type ListStringContainer @model {
   nullableStringNullableList: [String]
 }
 
-type EnumTestModel @model {
+type EnumTestModel @model @auth(rules: [{ allow: public }]) {
   id: ID!
   enumVal: TestEnum!
   nullableEnumVal: TestEnum
@@ -217,7 +218,7 @@ enum TestEnum {
   VALUE_TWO
 }
 
-type NestedTypeTestModel @model {
+type NestedTypeTestModel @model @auth(rules: [{ allow: public }]){
   id: ID!
   nestedVal: Nested!
   nullableNestedVal: Nested
@@ -235,5 +236,11 @@ type Nested {
 ```
 
 3.  `amplify push`
+? Do you want to generate code for your newly created GraphQL API (Y/n) `N`
 
 4. Copy `amplifyconfiguration.json` over as `GraphQLModelBasedTests-amplifyconfiguration.json` to `~/.aws-amplify/amplify-ios/testconfiguration/`
+
+```
+cp amplifyconfiguration.json ~/.aws-amplify/amplify-ios/testconfiguration/GraphQLModelBasedTests-amplifyconfiguration.json
+```
+You can now run the tests!

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/README.md
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/README.md
@@ -34,7 +34,7 @@ enum PostStatus {
     PUBLISHED
 }
 
-type Post @model @auth(rules: [{ allow: public }]) {
+type Post @model {
     id: ID!
     title: String!
     content: String!
@@ -46,7 +46,7 @@ type Post @model @auth(rules: [{ allow: public }]) {
     comments: [Comment] @connection(name: "PostComment")
 }
 
-type Comment @model @auth(rules: [{ allow: public }]) {
+type Comment @model {
     id: ID!
     content: String!
     createdAt: AWSDateTime!
@@ -56,39 +56,39 @@ type Comment @model @auth(rules: [{ allow: public }]) {
 ## These are examples from https://docs.amplify.aws/cli/graphql-transformer/connection
 
 # 1 - Project has a single optional Team
-type Project1 @model @auth(rules: [{ allow: public }]) {
+type Project1 @model {
   id: ID!
   name: String
   team: Team1 @connection
 }
 
-type Team1 @model @auth(rules: [{ allow: public }]) {
+type Team1 @model {
   id: ID!
   name: String!
 }
 
 # 2 - Project with explicit field for team's id
-type Project2 @model @auth(rules: [{ allow: public }]) {
+type Project2 @model {
   id: ID!
   name: String
   teamID: ID!
   team: Team2 @connection(fields: ["teamID"])
 }
 
-type Team2 @model @auth(rules: [{ allow: public }]) {
+type Team2 @model {
   id: ID!
   name: String!
 }
 
 # 3 - Post Comment - keyName reference key directive
 
-type Post3 @model @auth(rules: [{ allow: public }]) {
+type Post3 @model {
   id: ID!
   title: String!
   comments: [Comment3] @connection(keyName: "byPost3", fields: ["id"])
 }
 
-type Comment3 @model @auth(rules: [{ allow: public }])
+type Comment3 @model
   @key(name: "byPost3", fields: ["postID", "content"]) {
   id: ID!
   postID: ID!
@@ -97,13 +97,13 @@ type Comment3 @model @auth(rules: [{ allow: public }])
 
 # 4 - Post Comment bi-directional belongs to
 
-type Post4 @model @auth(rules: [{ allow: public }]) {
+type Post4 @model {
   id: ID!
   title: String!
   comments: [Comment4] @connection(keyName: "byPost4", fields: ["id"])
 }
 
-type Comment4 @model @auth(rules: [{ allow: public }])
+type Comment4 @model
   @key(name: "byPost4", fields: ["postID", "content"]) {
   id: ID!
   postID: ID!
@@ -113,14 +113,14 @@ type Comment4 @model @auth(rules: [{ allow: public }])
 
 # 5 Many to Many
 
-type Post5 @model @auth(rules: [{ allow: public }]) {
+type Post5 @model {
   id: ID!
   title: String!
   editors: [PostEditor5] @connection(keyName: "byPost5", fields: ["id"])
 }
 
 # Create a join model
-type PostEditor5 @model @auth(rules: [{ allow: public }])
+type PostEditor5 @model
   @key(name: "byPost5", fields: ["postID", "editorID"])
   @key(name: "byEditor5", fields: ["editorID", "postID"]) {
   id: ID!
@@ -130,7 +130,7 @@ type PostEditor5 @model @auth(rules: [{ allow: public }])
   editor: User5! @connection(fields: ["editorID"])
 }
 
-type User5 @model @auth(rules: [{ allow: public }]) {
+type User5 @model {
   id: ID!
   username: String!
   posts: [PostEditor5] @connection(keyName: "byEditor5", fields: ["id"])
@@ -141,13 +141,13 @@ type User5 @model @auth(rules: [{ allow: public }]) {
 # > Choose a schema template: `One-to-many relationship (e.g., “Blogs” with “Posts” and “Comments”)`
 
 # 6 - Blog Post Comment
-type Blog6 @model @auth(rules: [{ allow: public }]) {
+type Blog6 @model {
   id: ID!
   name: String!
   posts: [Post6] @connection(keyName: "byBlog", fields: ["id"])
 }
 
-type Post6 @model @auth(rules: [{ allow: public }])
+type Post6 @model
 @key(name: "byBlog", fields: ["blogID"]) {
   id: ID!
   title: String!
@@ -156,7 +156,7 @@ type Post6 @model @auth(rules: [{ allow: public }])
   comments: [Comment6] @connection(keyName: "byPost", fields: ["id"])
 }
 
-type Comment6 @model @auth(rules: [{ allow: public }])
+type Comment6 @model
 @key(name: "byPost", fields: ["postID", "content"]) {
   id: ID!
   postID: ID!
@@ -166,7 +166,7 @@ type Comment6 @model @auth(rules: [{ allow: public }])
 
 # Scalars, Lists, Enums
 
-type ScalarContainer @model @auth(rules: [{ allow: public }]) {
+type ScalarContainer @model {
    id: ID!
    myString: String
    myInt: Int
@@ -183,7 +183,7 @@ type ScalarContainer @model @auth(rules: [{ allow: public }]) {
    myIPAddress: AWSIPAddress
 }
 
-type ListIntContainer @model @auth(rules: [{ allow: public }]) {
+type ListIntContainer @model {
   id: ID!
   test: Int!
   nullableInt: Int
@@ -193,7 +193,7 @@ type ListIntContainer @model @auth(rules: [{ allow: public }]) {
   nullableIntNullableList: [Int]
 }
 
-type ListStringContainer @model @auth(rules: [{ allow: public }]) {
+type ListStringContainer @model {
   id: ID!
   test: String!
   nullableString: String
@@ -203,7 +203,7 @@ type ListStringContainer @model @auth(rules: [{ allow: public }]) {
   nullableStringNullableList: [String]
 }
 
-type EnumTestModel @model @auth(rules: [{ allow: public }]) {
+type EnumTestModel @model {
   id: ID!
   enumVal: TestEnum!
   nullableEnumVal: TestEnum
@@ -218,7 +218,7 @@ enum TestEnum {
   VALUE_TWO
 }
 
-type NestedTypeTestModel @model @auth(rules: [{ allow: public }]){
+type NestedTypeTestModel @model {
   id: ID!
   nestedVal: Nested!
   nullableNestedVal: Nested

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/README.md
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/README.md
@@ -120,8 +120,7 @@ type Post5 @model {
 }
 
 # Create a join model
-type PostEditor5 @model
-  @key(name: "byPost5", fields: ["postID", "editorID"])
+type PostEditor5 @model @key(name: "byPost5", fields: ["postID", "editorID"])
   @key(name: "byEditor5", fields: ["editorID", "postID"]) {
   id: ID!
   postID: ID!
@@ -147,8 +146,7 @@ type Blog6 @model {
   posts: [Post6] @connection(keyName: "byBlog", fields: ["id"])
 }
 
-type Post6 @model
-@key(name: "byBlog", fields: ["blogID"]) {
+type Post6 @model @key(name: "byBlog", fields: ["blogID"]) {
   id: ID!
   title: String!
   blogID: ID!
@@ -156,8 +154,7 @@ type Post6 @model
   comments: [Comment6] @connection(keyName: "byPost", fields: ["id"])
 }
 
-type Comment6 @model
-@key(name: "byPost", fields: ["postID", "content"]) {
+type Comment6 @model @key(name: "byPost", fields: ["postID", "content"]) {
   id: ID!
   postID: ID!
   post: Post6 @connection(fields: ["postID"])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed `GraphQLModelBasedTests.swift` from old apis to new async apis except for a test `testConcurrentSubscriptions()` 
<img width="516" alt="Screen Shot 2022-08-24 at 12 06 06 AM" src="https://user-images.githubusercontent.com/107574718/186353934-0bf5d496-0349-4a86-af28-1aef3115d5b7.png">

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
