### PR TITLE
feat(api): unnest return type

### DIFF
--- a/Amplify/Categories/API/ClientBehavior/APICategory+GraphQLBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategory+GraphQLBehavior.swift
@@ -15,6 +15,7 @@ extension APICategory: APICategoryGraphQLBehavior {
         plugin.query(request: request, listener: listener)
     }
 
+    @discardableResult
     public func query<R: Decodable>(request: GraphQLRequest<R>) async throws -> GraphQLTask<R>.Success {
         try await plugin.query(request: request)
     }
@@ -25,6 +26,7 @@ extension APICategory: APICategoryGraphQLBehavior {
         plugin.mutate(request: request, listener: listener)
     }
     
+    @discardableResult
     public func mutate<R: Decodable>(request: GraphQLRequest<R>) async throws -> GraphQLTask<R>.Success {
         try await plugin.mutate(request: request)
     }
@@ -36,6 +38,7 @@ extension APICategory: APICategoryGraphQLBehavior {
             plugin.subscribe(request: request, valueListener: valueListener, completionListener: completionListener)
     }
     
+    @discardableResult
     public func subscribe<R>(request: GraphQLRequest<R>) async throws -> GraphQLSubscriptionTask<R> {
         try await plugin.subscribe(request: request)
     }

--- a/Amplify/Categories/API/Error/APIError.swift
+++ b/Amplify/Categories/API/Error/APIError.swift
@@ -7,7 +7,10 @@
 
 import Foundation
 
-public enum APIGraphQLError<ResponseType: Decodable> {
+public enum APIGraphQLError2 {
+    case partial(GraphQLData: Decodable, [GraphQLError])
+}
+public enum APIGraphQLError {
 
     // Maybe name this something else
     case apiError(APIError)
@@ -18,8 +21,8 @@ public enum APIGraphQLError<ResponseType: Decodable> {
     /// A partially-successful response. The `ResponseType` associated value will contain as much of the payload as the
     /// service was able to fulfill, and the errors will be an array of GraphQLError that contain service-specific error
     /// messages.
-    case partial(ResponseType, [GraphQLError])
-
+    case partial(data: Decodable, errors: [GraphQLError])
+    
     /// A successful, or partially-successful response from the server that could not be transformed into the specified
     /// response type. The RawGraphQLResponse contains the entire response from the service, including data and errors.
     case transformationError(RawGraphQLResponse, APIError)

--- a/Amplify/Categories/API/Operation/GraphQLOperation.swift
+++ b/Amplify/Categories/API/Operation/GraphQLOperation.swift
@@ -8,8 +8,8 @@
 /// GraphQL Operation
 open class GraphQLOperation<R: Decodable>: AmplifyOperation<
     GraphQLOperationRequest<R>,
-    GraphQLResponse<R>,
-    APIError
+    R,
+    APIGraphQLError<R>
 > { }
 
 /// GraphQL Subscription Operation

--- a/Amplify/Categories/API/Operation/GraphQLOperation.swift
+++ b/Amplify/Categories/API/Operation/GraphQLOperation.swift
@@ -9,7 +9,7 @@
 open class GraphQLOperation<R: Decodable>: AmplifyOperation<
     GraphQLOperationRequest<R>,
     R,
-    APIGraphQLError<R>
+    APIGraphQLError
 > { }
 
 /// GraphQL Subscription Operation

--- a/Amplify/Categories/DataStore/Model/Collection/List+LazyLoad.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+LazyLoad.swift
@@ -26,23 +26,6 @@ extension List {
     ///
     /// If you have directly created this list object (for example, by calling `List(elements:)`) then the collection
     /// has already been initialized and calling this method will have no effect.
-    public func fetch(_ completion: @escaping (Result<Void, CoreError>) -> Void) {
-        guard case .notLoaded = loadedState else {
-            completion(.successfulVoid)
-            return
-        }
-
-        listProvider.load { result in
-            switch result {
-            case .success(let elements):
-                self.elements = elements
-                completion(.success(()))
-            case .failure(let coreError):
-                completion(.failure(coreError))
-            }
-        }
-    }
-    
     public func fetch() async throws {
         guard case .notLoaded = loadedState else {
             return

--- a/Amplify/Categories/DataStore/Model/Collection/List+Pagination.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+Pagination.swift
@@ -26,19 +26,6 @@ extension List {
 
     /// Retrieve the next page as a new in-memory List object. Calling `getNextPage(completion:)` will load the
     /// underlying elements of the receiver from the data source if not yet loaded before
-    public func getNextPage(completion: @escaping (Result<List<Element>, CoreError>) -> Void) {
-        switch loadedState {
-        case .loaded:
-            listProvider.getNextPage(completion: completion)
-        case .notLoaded:
-            let message = "Call `fetch` to lazy load the list before using this method."
-            let error: CoreError = .listOperation(message, "", nil)
-            Amplify.log.error(error: error)
-            assertionFailure(message)
-            completion(.failure(error))
-        }
-    }
-    
     public func getNextPage() async throws -> List<Element> {
         switch loadedState {
         case .loaded:

--- a/Amplify/Categories/DataStore/Model/Internal/ModelListProvider.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelListProvider.swift
@@ -37,8 +37,6 @@ public protocol ModelListProvider {
     func getState() -> ModelListProviderState<Element>
     
     ///  Retrieve the array of `Element` from the data source asychronously.
-    func load(completion: @escaping (Result<[Element], CoreError>) -> Void)
-    
     func load() async throws -> [Element]
 
     /// Check if there is subsequent data to retrieve. This method always returns false if the underlying provider is
@@ -46,10 +44,6 @@ public protocol ModelListProvider {
     /// If true, the next page can be retrieved using `getNextPage(completion:)`.
     func hasNextPage() -> Bool
 
-    /// Asynchronously retrieve the next page as a new in-memory List object. Returns a failure if there
-    /// is no next page of results. You can validate whether the list has another page with `hasNextPage()`.
-    func getNextPage(completion: @escaping (Result<List<Element>, CoreError>) -> Void)
- 
     func getNextPage() async throws -> List<Element>
 }
 
@@ -58,30 +52,23 @@ public protocol ModelListProvider {
 /// application making any change to these `public` types should be backward compatible, otherwise it will be a breaking
 /// change.
 public struct AnyModelListProvider<Element: Model>: ModelListProvider {
+    
     private let getStateClosure: () -> ModelListProviderState<Element>
-    private let loadWithCompletionClosure: (@escaping (Result<[Element], CoreError>) -> Void) -> Void
     private let loadAsync: () async throws -> [Element]
     private let hasNextPageClosure: () -> Bool
-    private let getNextPageClosure: (@escaping (Result<List<Element>, CoreError>) -> Void) -> Void
     private let getNextPageAsync: () async throws -> List<Element>
 
     public init<Provider: ModelListProvider>(
         provider: Provider
     ) where Provider.Element == Self.Element {
         self.getStateClosure = provider.getState
-        self.loadWithCompletionClosure = provider.load(completion:)
         self.loadAsync = provider.load
         self.hasNextPageClosure = provider.hasNextPage
-        self.getNextPageClosure = provider.getNextPage(completion:)
         self.getNextPageAsync = provider.getNextPage
     }
 
     public func getState() -> ModelListProviderState<Element> {
         getStateClosure()
-    }
-    
-    public func load(completion: @escaping (Result<[Element], CoreError>) -> Void) {
-        loadWithCompletionClosure(completion)
     }
     
     public func load() async throws -> [Element] {
@@ -90,10 +77,6 @@ public struct AnyModelListProvider<Element: Model>: ModelListProvider {
 
     public func hasNextPage() -> Bool {
         hasNextPageClosure()
-    }
-
-    public func getNextPage(completion: @escaping (Result<List<Element>, CoreError>) -> Void) {
-        getNextPageClosure(completion)
     }
     
     public func getNextPage() async throws -> List<Element> {

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListProvider.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListProvider.swift
@@ -288,17 +288,14 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
                                                               nextToken: nextToken,
                                                               apiName: apiName)
         do {
-            let graphQLResponse = try await Amplify.API.query(request: request)
-            switch graphQLResponse {
-            case .success(let nextPageList):
-                _ = try await nextPageList.fetch()
-                return nextPageList
-            case .failure(let graphQLError):
-                Amplify.API.log.error(error: graphQLError)
-                throw CoreError.listOperation("""
-                    The AppSync request was processed by the service, but the response contained GraphQL errors.
-                    """, "Check the underlying error for the failed GraphQL response.", graphQLError)
-            }
+            let nextPageList = try await Amplify.API.query(request: request)
+            _ = try await nextPageList.fetch()
+            return nextPageList
+        } catch let apiGraphQLError as APIGraphQLError<List<Element>> {
+            Amplify.API.log.error(error: apiGraphQLError)
+            throw CoreError.listOperation("""
+                The AppSync request was processed by the service, but the response contained GraphQL errors.
+                """, "Check the underlying error for the failed GraphQL response.", apiGraphQLError)
         } catch let apiError as APIError {
             Amplify.API.log.error(error: apiError)
             throw CoreError.listOperation("The AppSync request failed",
@@ -307,5 +304,31 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
         } catch {
             throw error
         }
+        
+        // example 1 - not feasible right now
+//        do {
+//
+//        } catch let apiGraphQLError as APIGraphQLError<List<Element>> {
+//
+//        } catch let apiError as APIError {
+//
+//        }
+//
+//        // example 2 -
+//        do {
+//
+//        } catch let apiGraphQLError as APIGraphQLError<List<Element>> {
+//            switch apiGraphQLError {
+//            case .apiError(let apiError):
+//                break
+////                switch apiError {
+////                case .invalidURL:
+////
+////                }
+//            case .error:
+//            case .partial:
+//            case .unknown:
+//            }
+//        }
     }
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLOperation+APIOperation.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLOperation+APIOperation.swift
@@ -31,7 +31,7 @@ extension AWSGraphQLOperation: APIOperation {
             finish()
             return
         } catch {
-            dispatch(result: .failure(APIGraphQLError<R>.unknown("", "", error)))
+            dispatch(result: .failure(APIGraphQLError.unknown("", "", error)))
             finish()
             return
         }
@@ -68,16 +68,16 @@ extension AWSGraphQLOperation: APIOperation {
             case .failure(let error):
                 switch error {
                 case .error(let errors):
-                    let apiGraphQLError = APIGraphQLError<R>.error(errors)
+                    let apiGraphQLError = APIGraphQLError.error(errors)
                     dispatch(result: .failure(apiGraphQLError))
                 case .partial(let responseType, let errors):
-                    let apiGraphQLError = APIGraphQLError<R>.partial(responseType, errors)
+                    let apiGraphQLError = APIGraphQLError.partial(data: responseType, errors: errors)
                     dispatch(result: .failure(apiGraphQLError))
                 case .transformationError(let response, let apiError):
-                    let apiGraphQLError = APIGraphQLError<R>.transformationError(response, apiError)
+                    let apiGraphQLError = APIGraphQLError.transformationError(response, apiError)
                     dispatch(result: .failure(apiGraphQLError))
                 case .unknown(let error, let recovery, let underlyingError):
-                    let apiGraphQLError = APIGraphQLError<R>.unknown(error, recovery, underlyingError)
+                    let apiGraphQLError = APIGraphQLError.unknown(error, recovery, underlyingError)
                     dispatch(result: .failure(apiGraphQLError))
                 }
             }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

What we would like to achieve in this PR is to improve the DX of APIPlugin's GraphQL APIs. Currently, the return type is a `Result<ResponseType, GraphQLResponse<ResponseType>>`, where the Success is the response type that was indicated in the request and the Failure case is a 4 case enum of transformationError(RawResponse, error), partial(Data, [GraphQLError]), error([GraphQLError]), and unknown(underlyingError).

Developers that want to handle errors in this API have to do the following:
```swift
do {
   let result= try wait Amplify.API.mutate(request: .create(model))
   switch result {
   case .success(let responseType):
   case .failure(let graphQLResponseError):
     switch graphQLResponseError {
       case .partial:
       case .error:
       case .transformationError:
       case .unknown:
     }
   }
} catch let apiError as APIError {
   // APIError has a bunch of cases related to API network failures of course, like `.network`, `.operation`, `.unknown`, `.invalidConfig` etc.
  // switch on this with ~7 enum cases
}
```

Optimal DX
```swift
do {
   let responseType = try wait Amplify.API.mutate(request: .create(model))
} catch let error as APIGraphQLError {
   // APIError has a bunch of cases related to API network failures of course, like `.network`, `.operation`, `.unknown`, `.invalidConfig` etc.
  // switch on this with ~7 enum cases
   switch error {
       case .partial(let responseType, let errors)
       case .graphQLErrors(let graphQLErrors): // renamed from `error([GraphQLError])`
       case .transformationError:
       case .unknown:
       case .network:
       case .operation:
       case .invalidConfig:
   }
}
```

Alternative DX

```swift
do {
   let responseType = try wait Amplify.API.mutate(request: .create(model))
} catch let graphQLResponseError as GraphQLResponseError {
  switch graphQLResponseError {
       case .partial:
       case .error:
       case .transformationError:
       case .unknown:
     }
} catch let apiError as APIError {
   // APIError has a bunch of cases related to API network failures of course, like `.network`, `.operation`, `.unknown`, `.invalidConfig` etc.
  // switch on this with ~7 enum cases
}
```


### Compare this to Android, JS, and Flutter's


<details>
<summary>Flutter (https://docs.amplify.aws/lib/graphqlapi/mutate-data/q/platform/flutter/)</summary>

```
Future<void> createTodo() async {
  try {
    final todo = Todo(name: 'my first todo', description: 'todo description');
    final request = ModelMutations.create(todo);
    final response = await Amplify.API.mutate(request: request).response;

    final createdTodo = response.data;
    if (createdTodo == null) {
      safePrint('errors: ${response.errors}');
      return;
    }
    safePrint('Mutation result: ${createdTodo.name}');
  } on c catch (e) {
    safePrint('Mutation failed: $e');
  }
}
```

</details>

Flutter has `response.data` and catches ApiException


<details>
<summary>Android</summary>

```

Todo todo = Todo.builder()
    .name("My todo")
    .build();

Amplify.API.mutate(ModelMutation.create(todo),
    response -> Log.i("MyAmplifyApp", "Todo with id: " + response.getData().getId()),
    error -> Log.e("MyAmplifyApp", "Create failed", error)
);
```
</details>

Android has `response.getData()` and returns an error that can also be cast to an Exception.

<details>
<summary>JS</summary>

```
import { API } from "aws-amplify";
import * as mutations from './graphql/mutations';

const todoDetails = {
  name: 'Todo 1',
  description: 'Learn AWS AppSync'
};

const newTodo = await API.graphql({ query: mutations.createTodo, variables: {input: todoDetails}});

```

</details>

JS returns the item as the return type of the async API, ie. `const newTodo = await ..`. Error handling is unclear from looking at the docs



*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
