### PR TITLE
feat(datastore): Add AsyncThrowingSequence Observe API

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -74,10 +74,10 @@ public protocol DataStoreBaseBehavior {
 }
 
 public protocol DataStoreSubscribeBehavior {
-    /// Returns a Publisher for model changes (create, updates, delete)
+    /// Returns an AmplifyAsyncThrowingSequence for model changes (create, updates, delete)
     /// - Parameter modelType: The model type to observe
-    func publisher<M: Model>(for modelType: M.Type) -> AnyPublisher<MutationEvent, DataStoreError>
-
+    func observe<M: Model>(_ modelType: M.Type) -> AmplifyAsyncThrowingSequence<MutationEvent>
+    
     /// Returns a Publisher for query snapshots.
     ///
     /// - Parameters:

--- a/Amplify/Categories/DataStore/Subscribe/DataStoreCategory+Subscribe.swift
+++ b/Amplify/Categories/DataStore/Subscribe/DataStoreCategory+Subscribe.swift
@@ -8,8 +8,8 @@
 import Combine
 
 extension DataStoreCategory: DataStoreSubscribeBehavior {
-    public func publisher<M: Model>(for modelType: M.Type) -> AnyPublisher<MutationEvent, DataStoreError> {
-        return plugin.publisher(for: modelType)
+    public func observe<M: Model>(_ modelType: M.Type) -> AmplifyAsyncThrowingSequence<MutationEvent> {
+        return plugin.observe(modelType)
     }
 
     public func observeQuery<M: Model>(for modelType: M.Type,

--- a/Amplify/Categories/DataStore/Subscribe/MutationEvent.swift
+++ b/Amplify/Categories/DataStore/Subscribe/MutationEvent.swift
@@ -95,3 +95,5 @@ public struct MutationEvent: Model {
         return typedModel
     }
 }
+
+extension MutationEvent: Sendable { }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
@@ -17,14 +17,15 @@ extension AWSDataStorePlugin: DataStoreSubscribeBehavior {
         return dataStorePublisher!.publisher
     }
 
-    public func publisher<M: Model>(for modelType: M.Type) -> AnyPublisher<MutationEvent, DataStoreError> {
-        return publisher(for: modelType.modelName)
-    }
-
     public func publisher(for modelName: ModelName) -> AnyPublisher<MutationEvent, DataStoreError> {
         return publisher.filter { $0.modelName == modelName }.eraseToAnyPublisher()
     }
 
+    public func observe<M: Model>(_ modelType: M.Type) -> AmplifyAsyncThrowingSequence<MutationEvent> {
+        let runner = ObserveTaskRunner(publisher: publisher(for: modelType.modelName))
+        return runner.sequence
+    }
+    
     public func observeQuery<M: Model>(for modelType: M.Type,
                                        where predicate: QueryPredicate? = nil,
                                        sort sortInput: QuerySortInput? = nil)

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStorePublisher.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStorePublisher.swift
@@ -39,3 +39,5 @@ protocol ModelSubcriptionBehavior {
 
     func sendFinished()
 }
+
+

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/ObserveTaskRunner.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/ObserveTaskRunner.swift
@@ -1,0 +1,51 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Combine
+
+struct ObserveRequest: AmplifyOperationRequest {
+    typealias Options = Any
+    var options: Any
+    init(options: Any = []) {
+        self.options = options
+    }
+}
+
+class ObserveTaskRunner: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel {
+    var request: ObserveRequest
+
+    typealias Request = ObserveRequest
+    typealias InProcess = MutationEvent
+
+    var publisher: AnyPublisher<MutationEvent, DataStoreError>
+    var sink: AnyCancellable?
+    var context = InternalTaskAsyncThrowingSequenceContext<MutationEvent>()
+    
+    private var running = false
+    
+    public init(request: ObserveRequest = .init(), publisher: AnyPublisher<MutationEvent, DataStoreError>) {
+        self.request = request
+        self.publisher = publisher
+    }
+    
+    func run() async throws {
+        guard !running else { return }
+        running = true
+        
+        self.sink = publisher.sink { completion in
+            switch completion {
+            case .finished:
+                self.finish()
+            case .failure(let error):
+                self.fail(error)
+            }
+        } receiveValue: { mutationEvent in
+            self.send(mutationEvent)
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/ObserveTaskRunner.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/ObserveTaskRunner.swift
@@ -24,7 +24,7 @@ class ObserveTaskRunner: InternalTaskRunner, InternalTaskAsyncThrowingSequence, 
 
     var publisher: AnyPublisher<MutationEvent, DataStoreError>
     var sink: AnyCancellable?
-    var context = InternalTaskAsyncThrowingSequenceContext<MutationEvent>()
+    var context = InternalTaskAsyncThrowingSequenceContext<InProcess>()
     
     private var running = false
     

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/ObserveTaskRunnerTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/ObserveTaskRunnerTests.swift
@@ -1,0 +1,60 @@
+//
+//  ObserveTaskRunnerTests.swift
+//  
+//
+//  Created by Law, Michael on 8/29/22.
+//
+
+import XCTest
+import Amplify
+@testable import AWSDataStorePlugin
+
+final class ObserveTaskRunnerTests: XCTestCase {
+
+    func testSuccess() async throws {
+        let dataStorePublisher = DataStorePublisher()
+        let runner = ObserveTaskRunner(publisher: dataStorePublisher.publisher)
+        let sequence = runner.sequence
+        
+        let started = asyncExpectation(description: "started")
+        let mutationEventReceived = asyncExpectation(description: "mutationEvent received",
+                                                     expectedFulfillmentCount: 5)
+        let mutationEventReceivedAfterCancel = asyncExpectation(description: "mutationEvent received", isInverted: true)
+        
+        let task = Task {
+            do {
+                await started.fulfill()
+                for try await mutationEvent in sequence {
+                    if mutationEvent.id == "id" {
+                        await mutationEventReceived.fulfill()
+                    } else {
+                        await mutationEventReceivedAfterCancel.fulfill()
+                    }
+                }
+            } catch {
+                XCTFail("Unexpected error \(error)")
+            }
+        }
+        await waitForExpectations([started], timeout: 10.0)
+        var mutationEvent = MutationEvent(id: "id",
+                                          modelId: "id",
+                                          modelName: "name",
+                                          json: "json",
+                                          mutationType: .create)
+        dataStorePublisher.send(input: mutationEvent)
+        dataStorePublisher.send(input: mutationEvent)
+        dataStorePublisher.send(input: mutationEvent)
+        dataStorePublisher.send(input: mutationEvent)
+        dataStorePublisher.send(input: mutationEvent)
+        await waitForExpectations([mutationEventReceived], timeout: 1.0)
+        
+        task.cancel()
+        mutationEvent = MutationEvent(id: "id2",
+                                      modelId: "id",
+                                      modelName: "name",
+                                      json: "json",
+                                      mutationType: .create)
+        dataStorePublisher.send(input: mutationEvent)
+        await waitForExpectations([mutationEventReceivedAfterCancel], timeout: 1.0)
+    }
+}

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -288,6 +288,10 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         return Result.Publisher(mutationEvent).eraseToAnyPublisher()
     }
 
+    func observe<M: Model>(_ modelType: M.Type) -> AmplifyAsyncThrowingSequence<MutationEvent> {
+        return AmplifyAsyncThrowingSequence(parent: nil)
+    }
+    
     public func observeQuery<M: Model>(for modelType: M.Type,
                                        where predicate: QueryPredicate? = nil,
                                        sort sortInput: QuerySortInput? = nil)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR replaces the previous `DataStore.publisher(for modelType:)` API with `DataStore.observe(_ modelType:)` with the new AmplifyAsyncThrowingSequence return type. We take this opportunity to align the naming with other platforms on the API name:

In JS
```javascript
const subscription = DataStore.observe(Post).subscribe(msg => {
  console.log(msg.model, msg.opType, msg.element);
});
```

In Android
```java
Amplify.DataStore.observe(Post.class,
    cancelable -> Log.i("MyAmplifyApp", "Observation began."),
    postChanged -> {
        Post post = postChanged.item();
        Log.i("MyAmplifyApp", "Post: " + post);
    },
    failure -> Log.e("MyAmplifyApp", "Observation failed.", failure),
    () -> Log.i("MyAmplifyApp", "Observation complete.")
);
```

In Flutter
```dart
stream = Amplify.DataStore.observe(Post.classType).listen(
    (event) {
      print('Received event of type ' + event.eventType.toString());
      print('Received post ' + event.item.toString());
    },
  );
```

And with this PR, in iOS
```swift
let task = Task {
    let mutationEvents = Amplify.DataStore.observe(Post.self)
    do {
        for try await mutationEvent in mutationEvents {
            print("\(mutationEvent)")
        }
    } catch {
        print("Unexpected error: \(error)")
    }
}
```

Ref: https://docs.amplify.aws/lib/datastore/real-time/q/platform/flutter/

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
