### PR TITLE
Add custom network preferences for AWSCognitoAuthPlugin

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -98,7 +98,18 @@ extension AWSCognitoAuthPlugin {
         }
         let region = (regionString as NSString).aws_regionTypeValue()
         let anonymousCredentialProvider = AWSAnonymousCredentialsProvider()
-        return AmplifyAWSServiceConfiguration(region: region, credentialsProvider: anonymousCredentialProvider)
+        let service = AmplifyAWSServiceConfiguration(region: region, credentialsProvider: anonymousCredentialProvider)
+        setUserPreferencesForService(service: service)
+        return service
+    }
+    
+    func setUserPreferencesForService(service: AmplifyAWSServiceConfiguration) {
+        guard let networkPreferences = networkPreferences else {
+            return
+        }
+        service.maxRetryCount = networkPreferences.maxRetryCount
+        service.timeoutIntervalForRequest = networkPreferences.timeoutIntervalForRequest
+        service.timeoutIntervalForResource = networkPreferences.timeoutIntervalForResource
     }
 
     func userPoolServiceConfiguration(from authConfiguration: JSONValue) throws -> AmplifyAWSServiceConfiguration? {
@@ -109,11 +120,14 @@ extension AWSCognitoAuthPlugin {
         }
         let region = (regionString as NSString).aws_regionTypeValue()
 
+        let service: AmplifyAWSServiceConfiguration
         if  let endpoint = try resolveCognitoOverrideEndpoint(using: authConfiguration, region: region) {
-            return AmplifyAWSServiceConfiguration(region: region, endpoint: endpoint)
+            service = AmplifyAWSServiceConfiguration(region: region, endpoint: endpoint)
         } else {
-            return AmplifyAWSServiceConfiguration(region: region)
+            service = AmplifyAWSServiceConfiguration(region: region)
         }
+        setUserPreferencesForService(service: service)
+        return service
     }
 
     func resolveCognitoOverrideEndpoint(

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
@@ -44,6 +44,9 @@ final public class AWSCognitoAuthPlugin: AuthCategoryPlugin {
     public var key: PluginKey {
         return "awsCognitoAuthPlugin"
     }
+    
+    /// The user network preferences for timeout and retry
+    let networkPreferences: AWSCognitoNetworkPreferences?
 
     public func getEscapeHatch() -> AWSCognitoAuthService {
         if let internalAuthorizationProvider = authorizationProvider as? AuthorizationProviderAdapter,
@@ -55,6 +58,11 @@ final public class AWSCognitoAuthPlugin: AuthCategoryPlugin {
 
     /// Instantiates an instance of the AWSCognitoAuthPlugin.
     public init() {
+        self.networkPreferences = nil
+    }
+    
+    public init(networkPreferences: AWSCognitoNetworkPreferences) {
+        self.networkPreferences = networkPreferences
     }
 }
 

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
@@ -61,6 +61,9 @@ final public class AWSCognitoAuthPlugin: AuthCategoryPlugin {
         self.networkPreferences = nil
     }
     
+    /// Instantiates an instance of the AWSCognitoAuthPlugin with custom network preferences
+    /// - Parameters:
+    ///   - networkPreferences: network preferences
     public init(networkPreferences: AWSCognitoNetworkPreferences) {
         self.networkPreferences = networkPreferences
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/AWSCognitoNetworkPreferences.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/AWSCognitoNetworkPreferences.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct AWSCognitoNetworkPreferences {
     
-    /// The timeout interval to use when waiting for additional data.
+    /// The maximum number of retries for failed requests. The value needs to be between 0 and 10 inclusive. If set to higher than 10, it becomes 10.
     public let maxRetryCount: UInt32
     
     /// The timeout interval to use when waiting for additional data.

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/AWSCognitoNetworkPreferences.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/AWSCognitoNetworkPreferences.swift
@@ -17,4 +17,12 @@ public struct AWSCognitoNetworkPreferences {
     
     /// The maximum amount of time that a resource request should be allowed to take.
     public let timeoutIntervalForResource: Double
+    
+    public init(maxRetryCount: UInt32,
+                timeoutIntervalForRequest: Double,
+                timeoutIntervalForResource: Double) {
+        self.maxRetryCount = maxRetryCount
+        self.timeoutIntervalForRequest = timeoutIntervalForRequest
+        self.timeoutIntervalForResource = timeoutIntervalForResource
+    }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/AWSCognitoNetworkPreferences.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/AWSCognitoNetworkPreferences.swift
@@ -1,0 +1,20 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public struct AWSCognitoNetworkPreferences {
+    
+    /// The timeout interval to use when waiting for additional data.
+    public let maxRetryCount: UInt32
+    
+    /// The timeout interval to use when waiting for additional data.
+    public let timeoutIntervalForRequest: Double
+    
+    /// The maximum amount of time that a resource request should be allowed to take.
+    public let timeoutIntervalForResource: Double
+}


### PR DESCRIPTION
*Issue https://github.com/aws-amplify/amplify-ios/issues/1060

*Description of changes:*
Add a new constructor to AWSCognitoAuthPlugin with network preferences for custom timeout and retry. 

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
<del> - [  ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
