### PR TITLE
fix(datastore): make startAmplify async in SyncEngineTestBase

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/SyncEngineTestBase.swift
@@ -174,12 +174,9 @@ class SyncEngineTestBase: XCTestCase {
     }
 
     /// Starts amplify by invoking `Amplify.configure(amplifyConfig)`
-    func startAmplify() throws {
+    func startAmplify() async throws {
         try Amplify.configure(amplifyConfig)
-        Task {
-            try await Amplify.DataStore.start()
-        }
-        // Amplify.DataStore.start(completion: {_ in})
+        try await Amplify.DataStore.start()
     }
     
     /// Starts amplify by invoking `Amplify.configure(amplifyConfig)`, and waits to receive a `syncStarted` Hub message
@@ -200,7 +197,9 @@ class SyncEngineTestBase: XCTestCase {
                 return
             }
 
-            try startAmplify()
+            Task {
+                try await startAmplify()
+            }
         } catch {
             Amplify.Hub.removeListener(token)
             completion(.failure(error))


### PR DESCRIPTION
*Description of changes:*
make startAmplify async in SyncEngineTestBase

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
