### PR TITLE
feat(api): Add AsyncThrowingSequence API.subscribe

### DIFF
--- a/Amplify/Categories/API/ClientBehavior/APICategory+GraphQLBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategory+GraphQLBehavior.swift
@@ -39,7 +39,7 @@ extension APICategory: APICategoryGraphQLBehavior {
             plugin.subscribe(request: request, valueListener: valueListener, completionListener: completionListener)
     }
     
-    public func subscribe<R>(request: GraphQLRequest<R>) async throws -> GraphQLSubscriptionTask<R> {
-        try await plugin.subscribe(request: request)
+    public func subscribe<R>(request: GraphQLRequest<R>) -> AmplifyAsyncThrowingSequence<GraphQLSubscriptionEvent<R>> {
+        plugin.subscribe(request: request)
     }
 }

--- a/Amplify/Categories/API/ClientBehavior/APICategoryGraphQLBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategoryGraphQLBehavior.swift
@@ -49,6 +49,5 @@ public protocol APICategoryGraphQLBehavior: AnyObject {
                                  completionListener: GraphQLSubscriptionOperation<R>.ResultListener?)
         -> GraphQLSubscriptionOperation<R>
     
-    func subscribe<R: Decodable>(request: GraphQLRequest<R>) async throws ->
-        GraphQLSubscriptionTask<R>
+    func subscribe<R: Decodable>(request: GraphQLRequest<R>) -> AmplifyAsyncThrowingSequence<GraphQLSubscriptionEvent<R>>
 }

--- a/Amplify/Categories/API/Operation/GraphQLOperation.swift
+++ b/Amplify/Categories/API/Operation/GraphQLOperation.swift
@@ -15,7 +15,7 @@ open class GraphQLOperation<R: Decodable>: AmplifyOperation<
 /// GraphQL Subscription Operation
 open class GraphQLSubscriptionOperation<R: Decodable>: AmplifyInProcessReportingOperation<
     GraphQLOperationRequest<R>,
-    SubscriptionEvent<GraphQLResponse<R>>,
+    GraphQLSubscriptionEvent<R>,
     Void,
     APIError
 > { }
@@ -36,17 +36,3 @@ public extension GraphQLOperation {
 }
 
 public typealias GraphQLTask<R: Decodable> = GraphQLOperation<R>.TaskAdapter
-
-public extension GraphQLSubscriptionOperation {
-    typealias TaskAdapter = AmplifyInProcessReportingOperationTaskAdapter<Request, InProcess, Success, Failure>
-}
-
-public typealias GraphQLSubscriptionTask<R: Decodable> = GraphQLSubscriptionOperation<R>.TaskAdapter
-
-public extension GraphQLSubscriptionTask {
-    var subscription : AmplifyAsyncSequence<InProcess> {
-        get async {
-            await inProcess
-        }
-    }
-}

--- a/Amplify/Categories/API/Response/SubscriptionConnectionState.swift
+++ b/Amplify/Categories/API/Response/SubscriptionConnectionState.swift
@@ -17,3 +17,5 @@ public enum SubscriptionConnectionState {
     /// The subscription has been disconnected because of a lifecycle event or manual disconnect request
     case disconnected
 }
+
+extension SubscriptionConnectionState: Sendable { }

--- a/Amplify/Categories/API/Response/SubscriptionEvent.swift
+++ b/Amplify/Categories/API/Response/SubscriptionEvent.swift
@@ -6,10 +6,12 @@
 //
 
 /// Event for subscription
-public enum SubscriptionEvent<T> {
+public enum GraphQLSubscriptionEvent<T: Decodable> {
     /// The subscription's connection state has changed.
     case connection(SubscriptionConnectionState)
 
     /// The subscription received data.
-    case data(T)
+    case data(GraphQLResponse<T>)
 }
+
+extension GraphQLSubscriptionEvent: Sendable { }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin+GraphQLBehavior.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin+GraphQLBehavior.swift
@@ -70,17 +70,13 @@ public extension AWSAPIPlugin {
             return operation
     }
     
-    func subscribe<R>(request: GraphQLRequest<R>) async throws -> GraphQLSubscriptionTask<R> {
-        let operation = AWSGraphQLSubscriptionOperation(
-            request: request.toOperationRequest(operationType: .subscription),
-            pluginConfig: pluginConfig,
-            subscriptionConnectionFactory: subscriptionConnectionFactory,
-            authService: authService,
-            apiAuthProviderFactory: authProviderFactory,
-            inProcessListener: nil,
-            resultListener: nil)
-        let task = AmplifyInProcessReportingOperationTaskAdapter(operation: operation)
-        queue.addOperation(operation)
-        return task
+    func subscribe<R>(request: GraphQLRequest<R>) -> AmplifyAsyncThrowingSequence<GraphQLSubscriptionEvent<R>> {
+        let request = request.toOperationRequest(operationType: .subscription)
+        let runner = AWSGraphQLSubscriptionTaskRunner(request: request,
+                                                      pluginConfig: pluginConfig,
+                                                      subscriptionConnectionFactory: subscriptionConnectionFactory,
+                                                      authService: authService,
+                                                      apiAuthProviderFactory: authProviderFactory)
+        return runner.sequence
     }
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
@@ -10,6 +10,177 @@ import Foundation
 import AWSPluginsCore
 import AppSyncRealTimeClient
 
+public class AWSGraphQLSubscriptionTaskRunner<R: Decodable>: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel {
+    public typealias Request = GraphQLOperationRequest<R>
+    public typealias InProcess = GraphQLSubscriptionEvent<R>
+
+    public var request: GraphQLOperationRequest<R>
+    public var context = InternalTaskAsyncThrowingSequenceContext<GraphQLSubscriptionEvent<R>>()
+    
+    let pluginConfig: AWSAPICategoryPluginConfiguration
+    let subscriptionConnectionFactory: SubscriptionConnectionFactory
+    let authService: AWSAuthServiceBehavior
+    var apiAuthProviderFactory: APIAuthProviderFactory
+    
+    var subscriptionConnection: SubscriptionConnection?
+    var subscriptionItem: SubscriptionItem?
+    private var running = false
+
+    private let subscriptionQueue = DispatchQueue(label: "AWSGraphQLSubscriptionOperation.subscriptionQueue")
+    
+    init(request: Request,
+         pluginConfig: AWSAPICategoryPluginConfiguration,
+         subscriptionConnectionFactory: SubscriptionConnectionFactory,
+         authService: AWSAuthServiceBehavior,
+         apiAuthProviderFactory: APIAuthProviderFactory) {
+        self.request = request
+        self.pluginConfig = pluginConfig
+        self.subscriptionConnectionFactory = subscriptionConnectionFactory
+        self.authService = authService
+        self.apiAuthProviderFactory = apiAuthProviderFactory
+    }
+    
+    public func cancel() {
+        subscriptionQueue.sync {
+            if let subscriptionItem = subscriptionItem, let subscriptionConnection = subscriptionConnection {
+                subscriptionConnection.unsubscribe(item: subscriptionItem)
+                let subscriptionEvent = GraphQLSubscriptionEvent<R>.connection(.disconnected)
+                send(subscriptionEvent)
+            }
+        }
+    }
+    
+    public func run() async throws {
+        guard !running else { return }
+        running = true
+
+        // Validate the request
+        do {
+            try request.validate()
+        } catch let error as APIError {
+            fail(error)
+            return
+        } catch {
+            fail(APIError.unknown("Could not validate request", "", nil))
+            finish()
+            return
+        }
+
+        // Retrieve endpoint configuration
+        let endpointConfig: AWSAPICategoryPluginConfiguration.EndpointConfig
+        do {
+            endpointConfig = try pluginConfig.endpoints.getConfig(for: request.apiName, endpointType: .graphQL)
+        } catch let error as APIError {
+            fail(error)
+            return
+        } catch {
+            fail(APIError.unknown("Could not get endpoint configuration", "", nil))
+            return
+        }
+
+        // Retrieve request plugin option and
+        // auth type in case of a multi-auth setup
+        let pluginOptions = request.options.pluginOptions as? AWSPluginOptions
+
+        // Retrieve the subscription connection
+        subscriptionQueue.sync {
+            do {
+                subscriptionConnection = try subscriptionConnectionFactory
+                    .getOrCreateConnection(for: endpointConfig,
+                                              authService: authService,
+                                              authType: pluginOptions?.authType,
+                                              apiAuthProviderFactory: apiAuthProviderFactory)
+            } catch {
+                let error = APIError.operationError("Unable to get connection for api \(endpointConfig.name)", "", error)
+                fail(error)
+                return
+            }
+
+            // Create subscription
+
+            subscriptionItem = subscriptionConnection?.subscribe(requestString: request.document,
+                                                                 variables: request.variables,
+                                                                 eventHandler: { [weak self] event, _ in
+                self?.onAsyncSubscriptionEvent(event: event)
+            })
+        }
+    }
+    
+    // MARK: - Subscription callbacks
+    
+    private func onAsyncSubscriptionEvent(event: SubscriptionItemEvent) {
+        switch event {
+        case .connection(let subscriptionConnectionEvent):
+            onSubscriptionEvent(subscriptionConnectionEvent)
+        case .data(let data):
+            onGraphQLResponseData(data)
+        case .failed(let error):
+            onSubscriptionFailure(error)
+        }
+    }
+
+    private func onSubscriptionEvent(_ subscriptionConnectionEvent: SubscriptionConnectionEvent) {
+        switch subscriptionConnectionEvent {
+        case .connecting:
+            let subscriptionEvent = GraphQLSubscriptionEvent<R>.connection(.connecting)
+            send(subscriptionEvent)
+        case .connected:
+            let subscriptionEvent = GraphQLSubscriptionEvent<R>.connection(.connected)
+            send(subscriptionEvent)
+        case .disconnected:
+            let subscriptionEvent = GraphQLSubscriptionEvent<R>.connection(.disconnected)
+            send(subscriptionEvent)
+            finish()
+        }
+    }
+
+    private func onSubscriptionConnectionState(_ subscriptionConnectionState: SubscriptionConnectionState) {
+        let subscriptionEvent = GraphQLSubscriptionEvent<R>.connection(subscriptionConnectionState)
+        send(subscriptionEvent)
+
+        if case .disconnected = subscriptionConnectionState {
+            finish()
+        }
+    }
+
+    private func onGraphQLResponseData(_ graphQLResponseData: Data) {
+        do {
+            let graphQLResponseDecoder = GraphQLResponseDecoder(request: request, response: graphQLResponseData)
+            let graphQLResponse = try graphQLResponseDecoder.decodeToGraphQLResponse()
+            send(.data(graphQLResponse))
+        } catch let error as APIError {
+            fail(error)
+        } catch {
+            // TODO: Verify with the team that terminating a subscription after failing to decode/cast one
+            // payload is the right thing to do. Another option would be to propagate a GraphQL error, but
+            // leave the subscription alive.
+            
+            fail(APIError.operationError("Failed to deserialize", "", error))
+        }
+    }
+
+    private func onSubscriptionFailure(_ error: Error) {
+        var errorDescription = "Subscription item event failed with error"
+        if case let ConnectionProviderError.subscription(_, payload) = error,
+           let errors = payload?["errors"] as? AppSyncJSONValue,
+           let graphQLErrors = try? GraphQLErrorDecoder.decodeAppSyncErrors(errors) {
+
+            if graphQLErrors.hasUnauthorizedError() {
+                errorDescription += ": \(APIError.UnauthorizedMessageString)"
+            }
+
+            let graphQLResponseError = GraphQLResponseError<R>.error(graphQLErrors)
+            fail(APIError.operationError(errorDescription, "", graphQLResponseError))
+            return
+        } else if case ConnectionProviderError.unauthorized = error {
+            errorDescription += ": \(APIError.UnauthorizedMessageString)"
+        }
+
+        fail(APIError.operationError(errorDescription, "", error))
+    }
+}
+
+// TODO: Remove this code, it has replaced been with AWSGraphQLSubscriptionTaskRunner above.
 final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscriptionOperation<R> {
 
     let pluginConfig: AWSAPICategoryPluginConfiguration
@@ -46,7 +217,7 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
         subscriptionQueue.sync {
             if let subscriptionItem = subscriptionItem, let subscriptionConnection = subscriptionConnection {
                 subscriptionConnection.unsubscribe(item: subscriptionItem)
-                let subscriptionEvent = SubscriptionEvent<GraphQLResponse<R>>.connection(.disconnected)
+                let subscriptionEvent = GraphQLSubscriptionEvent<R>.connection(.disconnected)
                 dispatchInProcess(data: subscriptionEvent)
             }
         }
@@ -118,6 +289,8 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
         }
     }
 
+    // MARK: - Subscription callbacks
+    
     private func onAsyncSubscriptionEvent(event: SubscriptionItemEvent) {
         switch event {
         case .connection(let subscriptionConnectionEvent):
@@ -132,13 +305,13 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
     private func onSubscriptionEvent(_ subscriptionConnectionEvent: SubscriptionConnectionEvent) {
         switch subscriptionConnectionEvent {
         case .connecting:
-            let subscriptionEvent = SubscriptionEvent<GraphQLResponse<R>>.connection(.connecting)
+            let subscriptionEvent = GraphQLSubscriptionEvent<R>.connection(.connecting)
             dispatchInProcess(data: subscriptionEvent)
         case .connected:
-            let subscriptionEvent = SubscriptionEvent<GraphQLResponse<R>>.connection(.connected)
+            let subscriptionEvent = GraphQLSubscriptionEvent<R>.connection(.connected)
             dispatchInProcess(data: subscriptionEvent)
         case .disconnected:
-            let subscriptionEvent = SubscriptionEvent<GraphQLResponse<R>>.connection(.disconnected)
+            let subscriptionEvent = GraphQLSubscriptionEvent<R>.connection(.disconnected)
             dispatchInProcess(data: subscriptionEvent)
             dispatch(result: .successfulVoid)
             finish()
@@ -146,7 +319,7 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
     }
 
     private func onSubscriptionConnectionState(_ subscriptionConnectionState: SubscriptionConnectionState) {
-        let subscriptionEvent = SubscriptionEvent<GraphQLResponse<R>>.connection(subscriptionConnectionState)
+        let subscriptionEvent = GraphQLSubscriptionEvent<R>.connection(subscriptionConnectionState)
         dispatchInProcess(data: subscriptionEvent)
 
         if case .disconnected = subscriptionConnectionState {

--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp/SubscriptionView.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp/SubscriptionView.swift
@@ -25,8 +25,8 @@ class SubscriptionViewModel: ObservableObject {
 
     func subscribe() async {
         do {
-            let task = try await apiPlugin.subscribe(request: .subscription(of: Todo.self, type: .onCreate))
-            await task.subscription.forEach { subscriptionEvent in
+            let subscription = apiPlugin.subscribe(request: .subscription(of: Todo.self, type: .onCreate))
+            try await subscription.forEach { subscriptionEvent in
                 await self.processSubscription(subscriptionEvent)
             }
                     
@@ -35,7 +35,7 @@ class SubscriptionViewModel: ObservableObject {
         }
     }
     
-    func processSubscription(_ subscriptionEvent: GraphQLSubscriptionTask<Todo>.InProcess) async {
+    func processSubscription(_ subscriptionEvent: GraphQLSubscriptionEvent<Todo>) async {
         switch subscriptionEvent {
         case .connection(let subscriptionConnectionState):
             print("Subscription connect state is \(subscriptionConnectionState)")

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+Subscribe.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+Subscribe.swift
@@ -20,35 +20,37 @@ extension GraphQLConnectionScenario3Tests {
         let uuid2 = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
-        let task = try await Amplify.API.subscribe(request: .subscription(of: Post3.self, type: .onCreate))
-        let subscription = await task.subscription
+        let subscription = Amplify.API.subscribe(request: .subscription(of: Post3.self, type: .onCreate))
         Task {
-            for await subscriptionEvent in subscription {
-                switch subscriptionEvent {
-                case .connection(let state):
-                    switch state {
-                    case .connecting:
-                        break
-                    case .connected:
-                        await connectedInvoked.fulfill()
-                    case .disconnected:
-                        break
-                    }
-                case .data(let result):
-                    switch result {
-                    case .success(let post):
-                        if post.id == uuid || post.id == uuid2 {
-                            
-                            await progressInvoked.fulfill()
+            do {
+                for try await subscriptionEvent in subscription {
+                    switch subscriptionEvent {
+                    case .connection(let state):
+                        switch state {
+                        case .connecting:
+                            break
+                        case .connected:
+                            await connectedInvoked.fulfill()
+                        case .disconnected:
+                            break
                         }
-                    case .failure(let error):
-                        XCTFail("\(error)")
+                    case .data(let result):
+                        switch result {
+                        case .success(let post):
+                            if post.id == uuid || post.id == uuid2 {
+                                
+                                await progressInvoked.fulfill()
+                            }
+                        case .failure(let error):
+                            XCTFail("\(error)")
+                        }
                     }
                 }
+            } catch {
+                XCTFail("Unexpected subscription failure")
             }
         }
         
-        XCTAssertNotNil(task)
         await waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         let post = Post3(id: uuid, title: title)
         _ = try await Amplify.API.mutate(request: .create(post))
@@ -63,23 +65,26 @@ extension GraphQLConnectionScenario3Tests {
         let connectedInvoked = AsyncExpectation(description: "Connection established")
         let progressInvoked = AsyncExpectation(description: "progress invoked")
 
-        let task = try await Amplify.API.subscribe(request: .subscription(of: Post3.self, type: .onUpdate))
-        let subscription = await task.subscription
+        let subscription = Amplify.API.subscribe(request: .subscription(of: Post3.self, type: .onUpdate))
         Task {
-            for await subscriptionEvent in subscription {
-                switch subscriptionEvent {
-                case .connection(let state):
-                    switch state {
-                    case .connecting:
-                        await connectingInvoked.fulfill()
-                    case .connected:
-                        await connectedInvoked.fulfill()
-                    case .disconnected:
-                        break
+            do {
+                for try await subscriptionEvent in subscription {
+                    switch subscriptionEvent {
+                    case .connection(let state):
+                        switch state {
+                        case .connecting:
+                            await connectingInvoked.fulfill()
+                        case .connected:
+                            await connectedInvoked.fulfill()
+                        case .disconnected:
+                            break
+                        }
+                    case .data:
+                        await progressInvoked.fulfill()
                     }
-                case .data:
-                    await progressInvoked.fulfill()
                 }
+            } catch {
+                XCTFail("Unexpected subscription failure")
             }
         }
                                  
@@ -93,8 +98,6 @@ extension GraphQLConnectionScenario3Tests {
         _ = try await Amplify.API.mutate(request: .update(post))
 
         await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
-
-        await task.cancel()
     }
     
     func testOnDeletePostSubscriptionWithModel() async throws {
@@ -102,23 +105,26 @@ extension GraphQLConnectionScenario3Tests {
         let connectedInvoked = AsyncExpectation(description: "Connection established")
         let progressInvoked = AsyncExpectation(description: "progress invoked")
         
-        let task = try await Amplify.API.subscribe(request: .subscription(of: Post3.self, type: .onDelete))
-        let subscription = await task.subscription
+        let subscription = Amplify.API.subscribe(request: .subscription(of: Post3.self, type: .onDelete))
         Task {
-            for await subscriptionEvent in subscription {
-                switch subscriptionEvent {
-                case .connection(let state):
-                    switch state {
-                    case .connecting:
-                        await connectingInvoked.fulfill()
-                    case .connected:
-                        await connectedInvoked.fulfill()
-                    case .disconnected:
-                        break
+            do {
+                for try await subscriptionEvent in subscription {
+                    switch subscriptionEvent {
+                    case .connection(let state):
+                        switch state {
+                        case .connecting:
+                            await connectingInvoked.fulfill()
+                        case .connected:
+                            await connectedInvoked.fulfill()
+                        case .disconnected:
+                            break
+                        }
+                    case .data:
+                        await progressInvoked.fulfill()
                     }
-                case .data:
-                    await progressInvoked.fulfill()
                 }
+            } catch {
+                XCTFail("Unexpected subscription failure")
             }
         }
         await waitForExpectations([connectingInvoked, connectedInvoked], timeout: TestCommonConstants.networkTimeout)
@@ -137,33 +143,34 @@ extension GraphQLConnectionScenario3Tests {
         }
 
         await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
-        await task.cancel()
     }
 
     func testOnCreateCommentSubscriptionWithModel() async throws {
         let connectingInvoked = AsyncExpectation(description: "Connection connecting")
         let connectedInvoked = AsyncExpectation(description: "Connection established")
         let progressInvoked = AsyncExpectation(description: "progress invoked")
-        let task = try await Amplify.API.subscribe(request: .subscription(of: Comment3.self, type: .onCreate))
-        let subscription = await task.subscription
+        let subscription = Amplify.API.subscribe(request: .subscription(of: Comment3.self, type: .onCreate))
         Task {
-            for await subscriptionEvent in subscription {
-                switch subscriptionEvent {
-                case .connection(let state):
-                    switch state {
-                    case .connecting:
-                        await connectingInvoked.fulfill()
-                    case .connected:
-                        await connectedInvoked.fulfill()
-                    case .disconnected:
-                        break
+            do {
+                for try await subscriptionEvent in subscription {
+                    switch subscriptionEvent {
+                    case .connection(let state):
+                        switch state {
+                        case .connecting:
+                            await connectingInvoked.fulfill()
+                        case .connected:
+                            await connectedInvoked.fulfill()
+                        case .disconnected:
+                            break
+                        }
+                    case .data:
+                        await progressInvoked.fulfill()
                     }
-                case .data:
-                    await progressInvoked.fulfill()
                 }
+            } catch {
+                XCTFail("Unexpected subscription failure")
             }
         }
-        XCTAssertNotNil(task)
         await waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
@@ -180,7 +187,5 @@ extension GraphQLConnectionScenario3Tests {
         }
 
         await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
-        await task.cancel()
-
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario6Tests.swift
@@ -62,7 +62,7 @@ class GraphQLConnectionScenario6Tests: XCTestCase {
     func testGetBlogThenFetchPostsThenFetchComments() async throws {
         guard let blog = try await createBlog(name: "name"),
               let post1 = try await createPost(title: "title", blog: blog),
-              let post2 = try await createPost(title: "title", blog: blog),
+              try await createPost(title: "title", blog: blog) != nil,
               let comment1post1 = try await createComment(post: post1, content: "content"),
               let comment2post1 = try await createComment(post: post1, content: "content") else {
             XCTFail("Could not create blog, posts, and comments")

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
@@ -445,9 +445,9 @@ class GraphQLModelBasedTests: XCTestCase {
         return try await createPost(post: post)
     }
 
-    func createComment(content: String, post: Post) -> Comment? {
+    func createComment(content: String, post: Post) async throws -> Comment? {
         let comment = Comment(content: content, createdAt: .now(), post: post)
-        return createComment(comment: comment)
+        return try await createComment(comment: comment)
     }
 
     func createPost(post: Post) async throws -> Post? {
@@ -460,70 +460,33 @@ class GraphQLModelBasedTests: XCTestCase {
         }
     }
 
-    func createComment(comment: Comment) -> Comment? {
-        var result: Comment?
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-
-        _ = Amplify.API.mutate(request: .create(comment)) { event in
-            switch event {
-            case .success(let data):
-                switch data {
-                case .success(let comment):
-                    result = comment
-                default:
-                    XCTFail("Could not get data back")
-                }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("\(error)")
-            }
+    func createComment(comment: Comment) async throws -> Comment? {
+        let data = try await Amplify.API.mutate(request: .create(comment))
+        switch data {
+        case .success(let comment):
+            return comment
+        case .failure(let error):
+            throw error
         }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
-        return result
     }
 
-    func mutatePost(_ post: Post, expect: XCTestExpectation? = nil) -> Post? {
-        var result: Post?
-        let requestInvokedSuccessfully = expect ?? expectation(description: "request completed")
-        _ = Amplify.API.mutate(request: .update(post)) { event in
-            switch event {
-            case .success(let data):
-                switch data {
-                case .success(let post):
-                    result = post
-                default:
-                    XCTFail("Could not get data back")
-                }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("\(error)")
-            }
+    func mutatePost(_ post: Post) async throws -> Post {
+        let data = try await Amplify.API.mutate(request: .update(post))
+        switch data {
+        case .success(let post):
+            return post
+        case .failure(let error):
+            throw error
         }
-        if expect == nil {
-            wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
-        }
-        return result
     }
 
-    func deletePost(post: Post) -> Post? {
-        var result: Post?
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-
-        _ = Amplify.API.mutate(request: .delete(post)) { event in
-            switch event {
-            case .success(let data):
-                switch data {
-                case .success(let post):
-                    result = post
-                default:
-                    XCTFail("Could not get data back")
-                }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("\(error)")
-            }
+    func deletePost(post: Post) async throws -> Post {
+        let data = try await Amplify.API.mutate(request: .delete(post))
+        switch data {
+        case .success(let post):
+            return post
+        case .failure(let error):
+            throw error
         }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
-        return result
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
@@ -272,34 +272,36 @@ class GraphQLModelBasedTests: XCTestCase {
         let uuid2 = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
-        let task = try await Amplify.API.subscribe(request: .subscription(of: Post.self, type: .onCreate))
-        let subscription = await task.subscription
+        let subscription = Amplify.API.subscribe(request: .subscription(of: Post.self, type: .onCreate))
         Task {
-            for await subscriptionEvent in subscription {
-                switch subscriptionEvent {
-                case .connection(let state):
-                    switch state {
-                    case .connecting:
-                        break
-                    case .connected:
-                        await connectedInvoked.fulfill()
-                    case .disconnected:
-                        break
-                    }
-                case .data(let result):
-                    switch result {
-                    case .success(let post):
-                        if post.id == uuid || post.id == uuid2 {
-                            await progressInvoked.fulfill()
+            do {
+                for try await subscriptionEvent in subscription {
+                    switch subscriptionEvent {
+                    case .connection(let state):
+                        switch state {
+                        case .connecting:
+                            break
+                        case .connected:
+                            await connectedInvoked.fulfill()
+                        case .disconnected:
+                            break
                         }
-                    case .failure(let error):
-                        XCTFail("\(error)")
+                    case .data(let result):
+                        switch result {
+                        case .success(let post):
+                            if post.id == uuid || post.id == uuid2 {
+                                await progressInvoked.fulfill()
+                            }
+                        case .failure(let error):
+                            XCTFail("\(error)")
+                        }
                     }
                 }
+            } catch {
+                XCTFail("Unexpected subscription failure")
             }
         }
         
-        XCTAssertNotNil(task)
         await waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         
         let post = Post(id: uuid, title: title, content: "content", createdAt: .now())
@@ -307,7 +309,6 @@ class GraphQLModelBasedTests: XCTestCase {
         let post2 = Post(id: uuid2, title: title, content: "content", createdAt: .now())
         _ = try await Amplify.API.mutate(request: .create(post2))
         await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
-        await task.cancel()
     }
     
     func testOnUpdatePostSubscriptionWithModel() async throws {
@@ -315,23 +316,26 @@ class GraphQLModelBasedTests: XCTestCase {
         let connectedInvoked = AsyncExpectation(description: "Connection established")
         let progressInvoked = AsyncExpectation(description: "progress invoked")
         
-        let task = try await Amplify.API.subscribe(request: .subscription(of: Post.self, type: .onUpdate))
-        let subscription = await task.subscription
+        let subscription = Amplify.API.subscribe(request: .subscription(of: Post.self, type: .onUpdate))
         Task {
-            for await subscriptionEvent in subscription {
-                switch subscriptionEvent {
-                case .connection(let state):
-                    switch state {
-                    case .connecting:
-                        await connectingInvoked.fulfill()
-                    case .connected:
-                        await connectedInvoked.fulfill()
-                    case .disconnected:
-                        break
+            do {
+                for try await subscriptionEvent in subscription {
+                    switch subscriptionEvent {
+                    case .connection(let state):
+                        switch state {
+                        case .connecting:
+                            await connectingInvoked.fulfill()
+                        case .connected:
+                            await connectedInvoked.fulfill()
+                        case .disconnected:
+                            break
+                        }
+                    case .data:
+                        await progressInvoked.fulfill()
                     }
-                case .data:
-                    await progressInvoked.fulfill()
                 }
+            } catch {
+                XCTFail("Unexpected subscription failure")
             }
         }
         
@@ -345,8 +349,6 @@ class GraphQLModelBasedTests: XCTestCase {
         _ = try await Amplify.API.mutate(request: .update(post))
         
         await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
-        
-        await task.cancel()
     }
     
     func testOnDeletePostSubscriptionWithModel() async throws {
@@ -354,23 +356,26 @@ class GraphQLModelBasedTests: XCTestCase {
         let connectedInvoked = AsyncExpectation(description: "Connection established")
         let progressInvoked = AsyncExpectation(description: "progress invoked")
         
-        let task = try await Amplify.API.subscribe(request: .subscription(of: Post.self, type: .onDelete))
-        let subscription = await task.subscription
+        let subscription = Amplify.API.subscribe(request: .subscription(of: Post.self, type: .onDelete))
         Task {
-            for await subscriptionEvent in subscription {
-                switch subscriptionEvent {
-                case .connection(let state):
-                    switch state {
-                    case .connecting:
-                        await connectingInvoked.fulfill()
-                    case .connected:
-                        await connectedInvoked.fulfill()
-                    case .disconnected:
-                        break
+            do {
+                for try await subscriptionEvent in subscription {
+                    switch subscriptionEvent {
+                    case .connection(let state):
+                        switch state {
+                        case .connecting:
+                            await connectingInvoked.fulfill()
+                        case .connected:
+                            await connectedInvoked.fulfill()
+                        case .disconnected:
+                            break
+                        }
+                    case .data:
+                        await progressInvoked.fulfill()
                     }
-                case .data:
-                    await progressInvoked.fulfill()
                 }
+            } catch {
+                XCTFail("Unexpected subscription failure")
             }
         }
         
@@ -384,8 +389,6 @@ class GraphQLModelBasedTests: XCTestCase {
         _ = try await Amplify.API.mutate(request: .delete(post))
         
         await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
-        
-        await task.cancel()
     }
     
     func testOnCreateCommentSubscriptionWithModel() async throws {
@@ -395,34 +398,36 @@ class GraphQLModelBasedTests: XCTestCase {
         let uuid2 = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
-        let task = try await Amplify.API.subscribe(request: .subscription(of: Comment.self, type: .onCreate))
-        let subscription = await task.subscription
+        let subscription = Amplify.API.subscribe(request: .subscription(of: Comment.self, type: .onCreate))
         Task {
-            for await subscriptionEvent in subscription {
-                switch subscriptionEvent {
-                case .connection(let state):
-                    switch state {
-                    case .connecting:
-                        break
-                    case .connected:
-                        await connectedInvoked.fulfill()
-                    case .disconnected:
-                        break
-                    }
-                case .data(let result):
-                    switch result {
-                    case .success(let comment):
-                        if comment.id == uuid || comment.id == uuid2 {
-                            await progressInvoked.fulfill()
+            do {
+                for try await subscriptionEvent in subscription {
+                    switch subscriptionEvent {
+                    case .connection(let state):
+                        switch state {
+                        case .connecting:
+                            break
+                        case .connected:
+                            await connectedInvoked.fulfill()
+                        case .disconnected:
+                            break
                         }
-                    case .failure(let error):
-                        XCTFail("\(error)")
+                    case .data(let result):
+                        switch result {
+                        case .success(let comment):
+                            if comment.id == uuid || comment.id == uuid2 {
+                                await progressInvoked.fulfill()
+                            }
+                        case .failure(let error):
+                            XCTFail("\(error)")
+                        }
                     }
                 }
+            } catch {
+                XCTFail("Unexpected subscription failure")
             }
         }
         
-        XCTAssertNotNil(task)
         await waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         let post = Post(id: uuid, title: title, content: "content", createdAt: .now())
         _ = try await Amplify.API.mutate(request: .create(post))
@@ -431,14 +436,13 @@ class GraphQLModelBasedTests: XCTestCase {
         let comment2 = Comment(id: uuid2, content: "content", createdAt: .now(), post: post)
         _ = try await Amplify.API.mutate(request: .create(comment2))
         await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
-        await task.cancel()
     }
 
     // MARK: Helpers
 
-    func createPost(id: String, title: String, expect: XCTestExpectation? = nil) -> Post? {
+    func createPost(id: String, title: String) async throws -> Post? {
         let post = Post(id: id, title: title, content: "content", createdAt: .now())
-        return createPost(post: post, expect: expect)
+        return try await createPost(post: post)
     }
 
     func createComment(content: String, post: Post) -> Comment? {
@@ -446,30 +450,14 @@ class GraphQLModelBasedTests: XCTestCase {
         return createComment(comment: comment)
     }
 
-    func createPost(post: Post, expect: XCTestExpectation? = nil) -> Post? {
-        var result: Post? = post
-        
-        let requestInvokedSuccessfully = expect ?? expectation(description: "request completed")
-
-        _ = Amplify.API.mutate(request: .create(post)) { event in
-            switch event {
-            case .success(let data):
-                switch data {
-                case .success(let post):
-                    result = post
-                default:
-                    XCTFail("Create Post was not successful: \(data)")
-                }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("\(error)")
-            }
+    func createPost(post: Post) async throws -> Post? {
+        let data = try await Amplify.API.mutate(request: .create(post))
+        switch data {
+        case .success(let post):
+            return post
+        case .failure(let error):
+            throw error
         }
-        if expect == nil {
-            wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
-        }
-        
-        return result
     }
 
     func createComment(comment: Comment) -> Comment? {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionTaskRunnerCancelTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionTaskRunnerCancelTests.swift
@@ -1,0 +1,189 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@testable import Amplify
+@testable import AWSAPIPlugin
+@testable import AmplifyTestCommon
+@testable import AppSyncRealTimeClient
+@testable import AWSPluginsCore
+@testable import AWSPluginsTestCommon
+
+// swiftlint:disable:next type_name
+class AWSGraphQLSubscriptionTaskRunnerCancelTests: XCTestCase {
+    var apiPlugin: AWSAPIPlugin!
+    var authService: MockAWSAuthService!
+    var pluginConfig: AWSAPICategoryPluginConfiguration!
+
+    let apiName = "apiName"
+    let baseURL = URL(fileURLWithPath: "path")
+    let region = "us-east-1"
+
+    let testDocument = "query { getTodo { id name description }}"
+    let testVariables = ["id": 123]
+
+    let testBody = Data()
+    let testPath = "testPath"
+
+    func setUp(subscriptionConnectionFactory: SubscriptionConnectionFactory) async {
+        apiPlugin = AWSAPIPlugin()
+
+        let authService = MockAWSAuthService()
+        self.authService = authService
+
+        do {
+            let endpointConfig = [apiName: try AWSAPICategoryPluginConfiguration.EndpointConfig(
+                name: apiName,
+                baseURL: baseURL,
+                region: region,
+                authorizationType: AWSAuthorizationType.none,
+                endpointType: .graphQL,
+                apiAuthProviderFactory: APIAuthProviderFactory())]
+            let pluginConfig = AWSAPICategoryPluginConfiguration(endpoints: endpointConfig)
+            self.pluginConfig = pluginConfig
+
+            let dependencies = AWSAPIPlugin.ConfigurationDependencies(
+                pluginConfig: pluginConfig,
+                authService: authService,
+                subscriptionConnectionFactory: subscriptionConnectionFactory,
+                logLevel: .error
+            )
+            apiPlugin.configure(using: dependencies)
+        } catch {
+            XCTFail("Failed to create endpoint config")
+        }
+
+        await Amplify.reset()
+        let config = AmplifyConfiguration()
+        do {
+            try Amplify.configure(config)
+        } catch {
+            XCTFail("Error setting up Amplify: \(error)")
+        }
+    }
+    
+    func testCancelSendsCompletion() async {
+        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _ in
+            return MockSubscriptionConnection(onSubscribe: { (_, _, eventHandler) -> SubscriptionItem in
+                let item = SubscriptionItem(requestString: "", variables: nil, eventHandler: { _, _ in
+                })
+                eventHandler(.connection(.connecting), item)
+                return item
+            }, onUnsubscribe: {_ in
+            })
+        })
+        await setUp(subscriptionConnectionFactory: mockSubscriptionConnectionFactory)
+
+        let request = GraphQLRequest(apiName: apiName,
+                                     document: testDocument,
+                                     variables: nil,
+                                     responseType: JSONValue.self)
+
+        let receivedValueConnecting = asyncExpectation(description: "Received value for connecting")
+        let receivedValueDisconnected = asyncExpectation(description: "Received value for disconnected")
+        let receivedCompletion = asyncExpectation(description: "Received completion")
+        let receivedFailure = asyncExpectation(description: "Received failure", isInverted: true)
+        let subscriptionEvents = apiPlugin.subscribe(request: request)
+        Task {
+            do {
+                for try await subscriptionEvent in subscriptionEvents {
+                    switch subscriptionEvent {
+                    case .connection(let state):
+                        switch state {
+                        case .connecting:
+                            await receivedValueConnecting.fulfill()
+                        case .disconnected:
+                            await receivedValueDisconnected.fulfill()
+                        default:
+                            XCTFail("Unexpected value on value listener: \(state)")
+                        }
+                    default:
+                        XCTFail("Unexpected value on on value listener: \(subscriptionEvent)")
+                    }
+                }
+                await receivedCompletion.fulfill()
+            } catch {
+                await receivedFailure.fulfill()
+            }
+        }
+        await waitForExpectations([receivedValueConnecting])
+        subscriptionEvents.cancel()
+        await waitForExpectations([receivedValueDisconnected, receivedCompletion, receivedFailure])
+    }
+    
+    func testFailureOnConnection() async {
+        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _ in
+            throw APIError.invalidConfiguration("something went wrong", "", nil)
+        })
+
+        await setUp(subscriptionConnectionFactory: mockSubscriptionConnectionFactory)
+
+        let request = GraphQLRequest(apiName: apiName,
+                                     document: testDocument,
+                                     variables: nil,
+                                     responseType: JSONValue.self)
+
+        let receivedCompletion = asyncExpectation(description: "Received completion", isInverted: true)
+        let receivedFailure = asyncExpectation(description: "Received failure")
+        let receivedValue = asyncExpectation(description: "Received value for connecting", isInverted: true)
+
+        let subscriptionEvents = apiPlugin.subscribe(request: request)
+        Task {
+            do {
+                for try await _ in subscriptionEvents {
+                    await receivedValue.fulfill()
+                }
+                await receivedCompletion.fulfill()
+            } catch {
+                await receivedFailure.fulfill()
+            }
+        }
+        
+        await waitForExpectations([receivedValue, receivedFailure, receivedCompletion], timeout: 0.3)
+    }
+
+    func testCallingCancelWhileCreatingConnectionShouldCallCompletionListener() async {
+        let connectionCreation = asyncExpectation(description: "connection factory called")
+        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _ in
+            Task { await connectionCreation.fulfill() }
+            return MockSubscriptionConnection(onSubscribe: { (_, _, eventHandler) -> SubscriptionItem in
+                let item = SubscriptionItem(requestString: "", variables: nil, eventHandler: { _, _ in
+                })
+                eventHandler(.connection(.connecting), item)
+                return item
+            }, onUnsubscribe: {_ in
+            })
+        })
+
+        await setUp(subscriptionConnectionFactory: mockSubscriptionConnectionFactory)
+
+        let request = GraphQLRequest(apiName: apiName,
+                                     document: testDocument,
+                                     variables: nil,
+                                     responseType: JSONValue.self)
+        
+        let receivedValue = asyncExpectation(description: "Received value for connecting", expectedFulfillmentCount: 1)
+        let receivedFailure = asyncExpectation(description: "Received failure", isInverted: true)
+        let receivedCompletion = asyncExpectation(description: "Received completion")
+        
+        let subscriptionEvents = apiPlugin.subscribe(request: request)
+        Task {
+            do {
+                for try await _ in subscriptionEvents {
+                    await receivedValue.fulfill()
+                }
+                await receivedCompletion.fulfill()
+            } catch {
+                await receivedFailure.fulfill()
+            }
+        }
+        await waitForExpectations([receivedValue, connectionCreation], timeout: 5)
+        subscriptionEvents.cancel()
+        await waitForExpectations([receivedFailure, receivedCompletion], timeout: 5)
+    }
+}

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTaskTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTaskTests.swift
@@ -11,7 +11,7 @@ import XCTest
 import Amplify
 @testable import AmplifyTestCommon
 @testable import AWSAPIPlugin
-
+import AmplifyAsyncTesting
 import AppSyncRealTimeClient
 
 class GraphQLSubscribeTasksTests: OperationTestBase {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTaskTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTaskTests.swift
@@ -11,13 +11,11 @@ import XCTest
 import Amplify
 @testable import AmplifyTestCommon
 @testable import AWSAPIPlugin
-import AmplifyAsyncTesting
+
 import AppSyncRealTimeClient
 
-class GraphQLSubscribeCombineTests: OperationTestBase {
+class GraphQLSubscribeTasksTests: OperationTestBase {
 
-    var sink: AnyCancellable?
-    
     // Setup expectations
     var onSubscribeInvoked: AsyncExpectation!
     var receivedCompletionSuccess: AsyncExpectation!
@@ -244,36 +242,36 @@ class GraphQLSubscribeCombineTests: OperationTestBase {
             responseType: JSONValue.self
         )
         let subscription = apiPlugin.subscribe(request: request)
-        sink = Amplify.Publisher.create(subscription).sink { completion in
-            switch completion {
-            case .failure:
-                Task { await self.receivedCompletionFailure.fulfill() }
-            case .finished:
-                Task { await self.receivedCompletionSuccess.fulfill() }
-            }
-        } receiveValue: { subscriptionEvent in
-            switch subscriptionEvent {
-            case .connection(let connectionState):
-                switch connectionState {
-                case .connecting:
-                    Task { await self.receivedStateValueConnecting.fulfill() }
-                case .connected:
-                    Task { await self.receivedStateValueConnected.fulfill() }
-                case .disconnected:
-                    Task { await self.receivedStateValueDisconnected.fulfill() }
-                }
-            case .data(let result):
-                switch result {
-                case .success(let actualValue):
-                    if let expectedValue = expectedValue {
-                        XCTAssertEqual(actualValue, expectedValue)
+        Task {
+            do {
+                for try await subscriptionEvent in subscription {
+                    switch subscriptionEvent {
+                    case .connection(let connectionState):
+                        switch connectionState {
+                        case .connecting:
+                            await self.receivedStateValueConnecting.fulfill()
+                        case .connected:
+                            await self.receivedStateValueConnected.fulfill()
+                        case .disconnected:
+                            await self.receivedStateValueDisconnected.fulfill()
+                        }
+                    case .data(let result):
+                        switch result {
+                        case .success(let actualValue):
+                            if let expectedValue = expectedValue {
+                                XCTAssertEqual(actualValue, expectedValue)
+                            }
+                            await self.receivedDataValueSuccess.fulfill()
+                        case .failure:
+                            await self.receivedDataValueError.fulfill()
+                        }
                     }
-                    Task { await self.receivedDataValueSuccess.fulfill() }
-                case .failure:
-                    Task { await self.receivedDataValueError.fulfill() }
                 }
+                
+                await self.receivedCompletionSuccess.fulfill()
+            } catch {
+                await self.receivedCompletionFailure.fulfill()
             }
         }
     }
-
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -20,7 +20,7 @@ import Foundation
 /// incoming successful events onto a `Publisher`, that queue processors can subscribe to.
 final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
     typealias Payload = MutationSync<AnyModel>
-    typealias Event = SubscriptionEvent<GraphQLResponse<Payload>>
+    typealias Event = GraphQLSubscriptionEvent<Payload>
 
     private var onCreateOperation: RetryableGraphQLSubscriptionOperation<Payload>?
     private var onCreateValueListener: GraphQLSubscriptionOperation<Payload>.InProcessListener?

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
@@ -57,7 +57,7 @@ final class IncomingAsyncSubscriptionEventToAnyModelMapper: Subscriber, AmplifyC
 
     // MARK: - Event processing
 
-    private func dispose(of subscriptionEvent: SubscriptionEvent<GraphQLResponse<Payload>>) {
+    private func dispose(of subscriptionEvent: GraphQLSubscriptionEvent<Payload>) {
         log.verbose("dispose(of subscriptionEvent): \(subscriptionEvent)")
         switch subscriptionEvent {
         case .connection(let connectionState):

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -146,7 +146,7 @@ class MockAPICategoryPlugin: MessageReporter,
             return operation
     }
 
-    func subscribe<R: Decodable>(request: GraphQLRequest<R>) async throws -> GraphQLSubscriptionTask<R> {
+    func subscribe<R: Decodable>(request: GraphQLRequest<R>) -> AmplifyAsyncThrowingSequence<GraphQLSubscriptionEvent<R>> {
         notify(
                 """
                 subscribe(request:listener:) document: \(request.document); \
@@ -161,9 +161,9 @@ class MockAPICategoryPlugin: MessageReporter,
                                                  variables: request.variables,
                                                  responseType: request.responseType,
                                                  options: requestOptions)
-        let operation = MockSubscriptionGraphQLOperation(request: request, responseType: request.responseType)
-        let taskAdapter = AmplifyInProcessReportingOperationTaskAdapter(operation: operation)
-        return taskAdapter
+        
+        let taskRunner = MockAWSGraphQLSubscriptionTaskRunner(request: request)
+        return taskRunner.sequence
     }
     
     public func reachabilityPublisher(for apiName: String?) -> AnyPublisher<ReachabilityUpdate, Never>? {
@@ -430,4 +430,20 @@ class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
             return "token"
         }
     }
+}
+
+class MockAWSGraphQLSubscriptionTaskRunner<R: Decodable>: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel {
+    
+    public typealias Request = GraphQLOperationRequest<R>
+    public typealias InProcess = GraphQLSubscriptionEvent<R>
+    public var request: GraphQLOperationRequest<R>
+    public var context = InternalTaskAsyncThrowingSequenceContext<GraphQLSubscriptionEvent<R>>()
+    func run() async throws {
+        
+    }
+    
+    init(request: GraphQLOperationRequest<R>) {
+        self.request = request
+    }
+    
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR introduces the AsyncThrowingSequence version of API.subscribe.
```swift
func subscribe<R>(request: GraphQLRequest<R>) -> AmplifyAsyncThrowingSequence<GraphQLSubscriptionEvent<R>>
```

 I also took the opportunity to rename the subscription event that is received from `SubscriptionEvent<GraphQLResponse<T>>` to `GraphQLSubscriptionEvent<T>`. A subscription event is always going to be a GraphQLResponse on the `data` case, so there's no need for a nested generic. 

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
