### PR TITLE
chore(api): fix AWSdatStorePluginAuthCognitoTests to build successfully without errors

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthIntegrationTests+Support.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthIntegrationTests+Support.swift
@@ -11,16 +11,7 @@ import Amplify
 import DataStoreHostApp
 
 extension AWSDataStoreCategoryPluginAuthIntegrationTests {
-    func saveModel<T: Model>(_ model: T) {
-        let localSaveInvoked = expectation(description: "local model was saved")
-        Amplify.DataStore.save(model) { result in
-            switch result {
-            case .success(let todo):
-                localSaveInvoked.fulfill()
-            case .failure(let error):
-                XCTFail("Failed to save model \(error)")
-            }
-        }
-        wait(for: [localSaveInvoked], timeout: TestCommonConstants.networkTimeout)
+    func saveModel<T: Model>(_ model: T) async throws -> T{
+        return try await Amplify.DataStore.save(model)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthIntegrationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthIntegrationTests.swift
@@ -26,10 +26,10 @@ class AWSDataStoreCategoryPluginAuthIntegrationTests: AWSDataStoreAuthBaseTest {
     ///    - User signs in, retrieves tods, sync engine is started and reconciles local store with the ownerId
     ///    - The todo now it contains the ownerId
     func testUnauthenticatedSavesToLocalStoreIsReconciledWithCloudStoreAfterAuthentication() async throws {
-        setup(withModels: ModelsRegistration(), testType: .defaultAuthCognito)
+        try await setup(withModels: ModelsRegistration(), testType: .defaultAuthCognito)
         let savedLocalTodo = TodoExplicitOwnerField(content: "owner saved model")
-        saveModel(savedLocalTodo)
-        let queriedNoteOptional = queryModel(TodoExplicitOwnerField.self, byId: savedLocalTodo.id)
+        try await saveModel(savedLocalTodo)
+        let queriedNoteOptional = try await queryModel(TodoExplicitOwnerField.self, byId: savedLocalTodo.id)
         guard let model = queriedNoteOptional else {
             XCTFail("Failed to query local model")
             return
@@ -57,7 +57,7 @@ class AWSDataStoreCategoryPluginAuthIntegrationTests: AWSDataStoreAuthBaseTest {
             return
         }
 
-        signIn(user: user1)
+        try await signIn(user: user1)
 
         wait(for: [syncReceivedInvoked], timeout: TestCommonConstants.networkTimeout)
         Amplify.Hub.removeListener(syncReceivedListener)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthOwnerIntegrationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthOwnerIntegrationTests.swift
@@ -15,18 +15,18 @@ class AWSDataStoreCategoryPluginAuthOwnerIntegrationTests: AWSDataStoreAuthBaseT
     /// When: DataStore query/mutation operations are sent with CognitoUserPools
     /// Then: DataStore is successfully initialized, query returns a result,
     ///      mutation is processed for an authenticated users
-    func testImplicitCustomOwner() {
-        setup(withModels: CustomOwnerImplicitModelRegistration(),
+    func testImplicitCustomOwner() async throws {
+        try await setup(withModels: CustomOwnerImplicitModelRegistration(),
               testType: .defaultAuthCognito)
 
-        signIn(user: user1)
+        try await signIn(user: user1)
 
         let expectations = makeExpectations()
 
-        assertDataStoreReady(expectations)
+        try await assertDataStoreReady(expectations)
 
         // Query
-        assertQuerySuccess(modelType: TodoCustomOwnerImplicit.self,
+        try await assertQuerySuccess(modelType: TodoCustomOwnerImplicit.self,
                            expectations) { error in
             XCTFail("Error query \(error)")
         }
@@ -34,7 +34,7 @@ class AWSDataStoreCategoryPluginAuthOwnerIntegrationTests: AWSDataStoreAuthBaseT
         let todo = TodoCustomOwnerImplicit(title: "title")
 
         // Mutations
-        assertMutations(model: todo, expectations) { error in
+        try await assertMutations(model: todo, expectations) { error in
             XCTFail("Error mutation \(error)")
         }
 
@@ -45,18 +45,18 @@ class AWSDataStoreCategoryPluginAuthOwnerIntegrationTests: AWSDataStoreAuthBaseT
     /// When: DataStore query/mutation operations are sent with CognitoUserPools
     /// Then: DataStore is successfully initialized, query returns a result,
     ///      mutation is processed for an authenticated users
-    func testExplicitCustomOwner() {
-        setup(withModels: CustomOwnerExplicitModelRegistration(),
+    func testExplicitCustomOwner() async throws {
+        try await setup(withModels: CustomOwnerExplicitModelRegistration(),
               testType: .defaultAuthCognito)
 
-        signIn(user: user1)
+        try await signIn(user: user1)
 
         let expectations = makeExpectations()
 
-        assertDataStoreReady(expectations)
+        try await assertDataStoreReady(expectations)
 
         // Query
-        assertQuerySuccess(modelType: TodoCustomOwnerExplicit.self,
+        try await assertQuerySuccess(modelType: TodoCustomOwnerExplicit.self,
                            expectations) { error in
             XCTFail("Error query \(error)")
         }
@@ -64,7 +64,7 @@ class AWSDataStoreCategoryPluginAuthOwnerIntegrationTests: AWSDataStoreAuthBaseT
         let todo = TodoCustomOwnerExplicit(title: "title")
 
         // Mutations
-        assertMutations(model: todo, expectations) { error in
+        try await assertMutations(model: todo, expectations) { error in
             XCTFail("Error mutation \(error)")
         }
 
@@ -75,18 +75,18 @@ class AWSDataStoreCategoryPluginAuthOwnerIntegrationTests: AWSDataStoreAuthBaseT
     /// When: DataStore query/mutation operations are sent with CognitoUserPools
     /// Then: DataStore is successfully initialized, query returns a result,
     ///      mutation is processed for an authenticated users
-    func testExplicitOwner() {
-        setup(withModels: ExplicitOwnerModelRegistration(),
+    func testExplicitOwner() async throws {
+        try await setup(withModels: ExplicitOwnerModelRegistration(),
               testType: .defaultAuthCognito)
 
-        signIn(user: user1)
+        try await signIn(user: user1)
 
         let expectations = makeExpectations()
 
-        assertDataStoreReady(expectations)
+        try await assertDataStoreReady(expectations)
 
         // Query
-        assertQuerySuccess(modelType: TodoExplicitOwnerField.self,
+        try await assertQuerySuccess(modelType: TodoExplicitOwnerField.self,
                            expectations) { error in
             XCTFail("Error query \(error)")
         }
@@ -94,7 +94,7 @@ class AWSDataStoreCategoryPluginAuthOwnerIntegrationTests: AWSDataStoreAuthBaseT
         let todo = TodoExplicitOwnerField(content: "content")
 
         // Mutations
-        assertMutations(model: todo, expectations) { error in
+        try await assertMutations(model: todo, expectations) { error in
             XCTFail("Error mutation \(error)")
         }
 
@@ -105,18 +105,18 @@ class AWSDataStoreCategoryPluginAuthOwnerIntegrationTests: AWSDataStoreAuthBaseT
     /// When: DataStore query/mutation operations are sent with CognitoUserPools
     /// Then: DataStore is successfully initialized, query returns a result,
     ///      mutation is processed for an authenticated users
-    func testImplicitOwner() {
-        setup(withModels: ImplicitOwnerModelRegistration(),
+    func testImplicitOwner() async throws {
+        try await setup(withModels: ImplicitOwnerModelRegistration(),
               testType: .defaultAuthCognito)
 
-        signIn(user: user1)
+        try await signIn(user: user1)
 
         let expectations = makeExpectations()
 
-        assertDataStoreReady(expectations)
+        try await assertDataStoreReady(expectations)
 
         // Query
-        assertQuerySuccess(modelType: TodoImplicitOwnerField.self,
+        try await assertQuerySuccess(modelType: TodoImplicitOwnerField.self,
                            expectations) { error in
             XCTFail("Error query \(error)")
         }
@@ -124,7 +124,7 @@ class AWSDataStoreCategoryPluginAuthOwnerIntegrationTests: AWSDataStoreAuthBaseT
         let todo = TodoImplicitOwnerField(content: "content")
 
         // Mutations
-        assertMutations(model: todo, expectations) { error in
+        try await assertMutations(model: todo, expectations) { error in
             XCTFail("Error mutation \(error)")
         }
 
@@ -135,18 +135,18 @@ class AWSDataStoreCategoryPluginAuthOwnerIntegrationTests: AWSDataStoreAuthBaseT
     /// When: DataStore query/mutation operations are sent with CognitoUserPools
     /// Then: DataStore is successfully initialized, query returns a result,
     ///      mutation is processed for an authenticated users
-    func testAllowPrivate() {
-        setup(withModels: AllowPrivateModelRegistration(),
+    func testAllowPrivate() async throws {
+        try await setup(withModels: AllowPrivateModelRegistration(),
               testType: .defaultAuthCognito)
 
-        signIn(user: user1)
+        try await signIn(user: user1)
 
         let expectations = makeExpectations()
 
-        assertDataStoreReady(expectations)
+        try await assertDataStoreReady(expectations)
 
         // Query
-        assertQuerySuccess(modelType: TodoCognitoPrivate.self,
+        try await assertQuerySuccess(modelType: TodoCognitoPrivate.self,
                            expectations) { error in
             XCTFail("Error query \(error)")
         }
@@ -154,7 +154,7 @@ class AWSDataStoreCategoryPluginAuthOwnerIntegrationTests: AWSDataStoreAuthBaseT
         let todo = TodoCognitoPrivate(title: "title")
 
         // Mutations
-        assertMutations(model: todo, expectations) { error in
+        try await assertMutations(model: todo, expectations) { error in
             XCTFail("Error mutation \(error)")
         }
 


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
