### PR TITLE
fix: deprecate callback GraphQL APIs with APICategoryGraphQLBehaviorExtended

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify.xcscheme
@@ -56,6 +56,9 @@
                <Test
                   Identifier = "DataStoreCategoryConfigurationTests/testPreconditionFailureInvokingWithMultiplePlugins()">
                </Test>
+               <Test
+                  Identifier = "StorageCategoryConfigurationTests">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/Amplify/Categories/API/ClientBehavior/APICategory+GraphQLBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategory+GraphQLBehavior.swift
@@ -8,35 +8,12 @@
 extension APICategory: APICategoryGraphQLBehavior {
     
     // MARK: - Request-based GraphQL operations
-
-    @available(*, deprecated, renamed: "query(request:)")
-    @discardableResult
-    public func query<R: Decodable>(request: GraphQLRequest<R>,
-                                    listener: GraphQLOperation<R>.ResultListener?) -> GraphQLOperation<R> {
-        plugin.query(request: request, listener: listener)
-    }
-
     public func query<R: Decodable>(request: GraphQLRequest<R>) async throws -> GraphQLTask<R>.Success {
         try await plugin.query(request: request)
-    }
-
-    @available(*, deprecated, renamed: "mutate(request:)")
-    @discardableResult
-    public func mutate<R: Decodable>(request: GraphQLRequest<R>,
-                                     listener: GraphQLOperation<R>.ResultListener?) -> GraphQLOperation<R> {
-        plugin.mutate(request: request, listener: listener)
     }
     
     public func mutate<R: Decodable>(request: GraphQLRequest<R>) async throws -> GraphQLTask<R>.Success {
         try await plugin.mutate(request: request)
-    }
-
-    @available(*, deprecated, renamed: "subscribe(request:)")
-    public func subscribe<R>(request: GraphQLRequest<R>,
-                             valueListener: GraphQLSubscriptionOperation<R>.InProcessListener?,
-                             completionListener: GraphQLSubscriptionOperation<R>.ResultListener?)
-        -> GraphQLSubscriptionOperation<R> {
-            plugin.subscribe(request: request, valueListener: valueListener, completionListener: completionListener)
     }
     
     public func subscribe<R>(request: GraphQLRequest<R>) -> AmplifyAsyncThrowingSequence<GraphQLSubscriptionEvent<R>> {

--- a/Amplify/Categories/API/ClientBehavior/APICategoryGraphQLBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategoryGraphQLBehavior.swift
@@ -17,10 +17,6 @@ public protocol APICategoryGraphQLBehavior: AnyObject {
     ///   - request: The GraphQL request containing apiName, document, variables, and responseType
     ///   - listener: The event listener for the operation
     /// - Returns: The AmplifyOperation being enqueued
-    @discardableResult
-    func query<R: Decodable>(request: GraphQLRequest<R>,
-                             listener: GraphQLOperation<R>.ResultListener?) -> GraphQLOperation<R>
-                             
     func query<R: Decodable>(request: GraphQLRequest<R>) async throws -> GraphQLTask<R>.Success
     
     /// Perform a GraphQL mutate operation against a previously configured API. This operation
@@ -30,10 +26,6 @@ public protocol APICategoryGraphQLBehavior: AnyObject {
     ///   - request: The GraphQL request containing apiName, document, variables, and responseType
     ///   - listener: The event listener for the operation
     /// - Returns: The AmplifyOperation being enqueued
-    @discardableResult
-    func mutate<R: Decodable>(request: GraphQLRequest<R>,
-                              listener: GraphQLOperation<R>.ResultListener?) -> GraphQLOperation<R>
-
     func mutate<R: Decodable>(request: GraphQLRequest<R>) async throws -> GraphQLTask<R>.Success
 
     /// Perform a GraphQL subscribe operation against a previously configured API. This operation
@@ -43,11 +35,6 @@ public protocol APICategoryGraphQLBehavior: AnyObject {
     ///   - request: The GraphQL request containing apiName, document, variables, and responseType
     ///   - valueListener: Invoked when the GraphQL subscription receives a new value from the service
     ///   - completionListener: Invoked when the subscription has terminated
-    /// - Returns: The AmplifyInProcessReportingOperation being enqueued
-    func subscribe<R: Decodable>(request: GraphQLRequest<R>,
-                                 valueListener: GraphQLSubscriptionOperation<R>.InProcessListener?,
-                                 completionListener: GraphQLSubscriptionOperation<R>.ResultListener?)
-        -> GraphQLSubscriptionOperation<R>
-    
+    /// - Returns: The AmplifyInProcessReportingOperation being enqueued    
     func subscribe<R: Decodable>(request: GraphQLRequest<R>) -> AmplifyAsyncThrowingSequence<GraphQLSubscriptionEvent<R>>
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin.swift
@@ -9,7 +9,7 @@ import Amplify
 import AWSPluginsCore
 import Foundation
 
-final public class AWSAPIPlugin: NSObject, APICategoryPlugin, AWSAPIAuthInformation {
+final public class AWSAPIPlugin: NSObject, APICategoryPlugin, APICategoryGraphQLBehaviorExtended, AWSAPIAuthInformation {
     /// The unique key of the plugin within the API category.
     public var key: PluginKey {
         return "awsAPIPlugin"

--- a/AmplifyPlugins/Core/AWSPluginsCore/API/APICategoryGraphQLBehaviorExtended.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/API/APICategoryGraphQLBehaviorExtended.swift
@@ -10,7 +10,7 @@ import Amplify
 
 /// Extending the existing `APICategoryGraphQLBehavior` to include callback based APIs.
 ///
-/// This exists to allow DataSore to continue to use the `APICategoryGraphQLCallbackBehavior` APIs without exposing
+/// This exists to allow DataStore to continue to use the `APICategoryGraphQLCallbackBehavior` APIs without exposing
 /// them publicly from Amplify in `APICategoryGraphQLBehavior`. Eventually, the goal is for DataStore to use the
 /// Async APIs, at which point, this protocol can be completely removed. Introducing this protocol allows Amplify to
 /// to fully deprecate the callback based APIs, while allowing DataStore a gradual migration path forward in moving

--- a/AmplifyPlugins/Core/AWSPluginsCore/API/APICategoryGraphQLBehaviorExtended.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/API/APICategoryGraphQLBehaviorExtended.swift
@@ -1,0 +1,41 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Amplify
+
+/// Extending the existing `APICategoryGraphQLBehavior` to include callback based APIs.
+///
+/// This exists to allow DataSore to continue to use the `APICategoryGraphQLCallbackBehavior` APIs without exposing
+/// them publicly from Amplify in `APICategoryGraphQLBehavior`. Eventually, the goal is for DataStore to use the
+/// Async APIs, at which point, this protocol can be completely removed. Introducing this protocol allows Amplify to
+/// to fully deprecate the callback based APIs, while allowing DataStore a gradual migration path forward in moving
+/// away from APIPlugin's callback APIs to the Async APIs.
+/// See https://github.com/aws-amplify/amplify-ios/issues/2252 for more details
+///
+/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+///   by host applications. The behavior of this may change without warning.
+public protocol APICategoryGraphQLBehaviorExtended:
+    APICategoryGraphQLCallbackBehavior, APICategoryGraphQLBehavior, AnyObject { }
+
+/// Listener callback based APIs
+///
+/// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
+///   by host applications. The behavior of this may change without warning.
+public protocol APICategoryGraphQLCallbackBehavior {
+    @discardableResult
+    func query<R: Decodable>(request: GraphQLRequest<R>,
+                             listener: GraphQLOperation<R>.ResultListener?) -> GraphQLOperation<R>
+    @discardableResult
+    func mutate<R: Decodable>(request: GraphQLRequest<R>,
+                              listener: GraphQLOperation<R>.ResultListener?) -> GraphQLOperation<R>
+    
+    func subscribe<R: Decodable>(request: GraphQLRequest<R>,
+                                 valueListener: GraphQLSubscriptionOperation<R>.InProcessListener?,
+                                 completionListener: GraphQLSubscriptionOperation<R>.ResultListener?)
+        -> GraphQLSubscriptionOperation<R>
+}

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine+SyncRequirement.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine+SyncRequirement.swift
@@ -19,11 +19,17 @@ extension StorageEngine {
                                                "Ensure the API category has been setup and configured for your project", nil)))
             return
         }
-
+        guard let apiGraphQL = api as? APICategoryGraphQLBehaviorExtended else {
+            log.info("Unable to find GraphQL API plugin for syncEngine. syncEngine will not be started")
+            completion(.failure(.configuration("Unable to find suitable GraphQL API plugin for syncEngine. syncEngine will not be started",
+                                               "Ensure the API category has been setup and configured for your project", nil)))
+            return
+        }
+        
         let authPluginRequired = StorageEngine.requiresAuthPlugin(api)
 
         guard authPluginRequired else {
-            syncEngine?.start(api: api, auth: nil)
+            syncEngine?.start(api: apiGraphQL, auth: nil)
             completion(.successfulVoid)
             return
         }
@@ -34,7 +40,7 @@ extension StorageEngine {
                                                "Ensure the Auth category has been setup and configured for your project", nil)))
             return
         }
-        syncEngine?.start(api: api, auth: auth)
+        syncEngine?.start(api: apiGraphQL, auth: auth)
         completion(.successfulVoid)
     }
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -13,7 +13,7 @@ import Foundation
 final class InitialSyncOperation: AsynchronousOperation {
     typealias SyncQueryResult = PaginatedList<AnyModel>
 
-    private weak var api: APICategoryGraphQLBehavior?
+    private weak var api: APICategoryGraphQLBehaviorExtended?
     private weak var reconciliationQueue: IncomingEventReconciliationQueue?
     private weak var storageAdapter: StorageEngineAdapter?
     private let dataStoreConfiguration: DataStoreConfiguration
@@ -36,7 +36,7 @@ final class InitialSyncOperation: AsynchronousOperation {
     }
 
     init(modelSchema: ModelSchema,
-         api: APICategoryGraphQLBehavior?,
+         api: APICategoryGraphQLBehaviorExtended?,
          reconciliationQueue: IncomingEventReconciliationQueue?,
          storageAdapter: StorageEngineAdapter?,
          dataStoreConfiguration: DataStoreConfiguration,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
@@ -19,7 +19,7 @@ protocol InitialSyncOrchestrator {
 typealias InitialSyncOrchestratorFactory =
     (DataStoreConfiguration,
      AuthModeStrategy,
-    APICategoryGraphQLBehavior?,
+     APICategoryGraphQLBehaviorExtended?,
     IncomingEventReconciliationQueue?,
     StorageEngineAdapter?) -> InitialSyncOrchestrator
 
@@ -30,7 +30,7 @@ final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
     private var initialSyncOperationSinks: [String: AnyCancellable]
 
     private let dataStoreConfiguration: DataStoreConfiguration
-    private weak var api: APICategoryGraphQLBehavior?
+    private weak var api: APICategoryGraphQLBehaviorExtended?
     private weak var reconciliationQueue: IncomingEventReconciliationQueue?
     private weak var storageAdapter: StorageEngineAdapter?
     private let authModeStrategy: AuthModeStrategy
@@ -52,7 +52,7 @@ final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
 
     init(dataStoreConfiguration: DataStoreConfiguration,
          authModeStrategy: AuthModeStrategy,
-         api: APICategoryGraphQLBehavior?,
+         api: APICategoryGraphQLBehaviorExtended?,
          reconciliationQueue: IncomingEventReconciliationQueue?,
          storageAdapter: StorageEngineAdapter?) {
         self.initialSyncOperationSinks = [:]

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Action.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Action.swift
@@ -6,6 +6,7 @@
 //
 
 import Amplify
+import AWSPluginsCore
 import Combine
 
 extension OutgoingMutationQueue {
@@ -14,7 +15,7 @@ extension OutgoingMutationQueue {
     enum Action {
         // Startup/config actions
         case initialized
-        case receivedStart(APICategoryGraphQLBehavior, MutationEventPublisher, IncomingEventReconciliationQueue?)
+        case receivedStart(APICategoryGraphQLBehaviorExtended, MutationEventPublisher, IncomingEventReconciliationQueue?)
         case receivedSubscription
 
         // Event loop

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+State.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+State.swift
@@ -6,6 +6,7 @@
 //
 
 import Amplify
+import AWSPluginsCore
 import Combine
 
 extension OutgoingMutationQueue {
@@ -15,7 +16,7 @@ extension OutgoingMutationQueue {
         // Startup/config states
         case notInitialized
         case stopped
-        case starting(APICategoryGraphQLBehavior, MutationEventPublisher, IncomingEventReconciliationQueue?)
+        case starting(APICategoryGraphQLBehaviorExtended, MutationEventPublisher, IncomingEventReconciliationQueue?)
 
         // Event loop
         case requestingEvent

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -13,7 +13,7 @@ import AWSPluginsCore
 /// Submits outgoing mutation events to the provisioned API
 protocol OutgoingMutationQueueBehavior: AnyObject {
     func stopSyncingToCloud(_ completion: @escaping BasicClosure)
-    func startSyncingToCloud(api: APICategoryGraphQLBehavior,
+    func startSyncingToCloud(api: APICategoryGraphQLBehaviorExtended,
                              mutationEventPublisher: MutationEventPublisher,
                              reconciliationQueue: IncomingEventReconciliationQueue?)
     var publisher: AnyPublisher<MutationEvent, Never> { get }
@@ -32,7 +32,7 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
         target: DispatchQueue.global()
     )
 
-    private weak var api: APICategoryGraphQLBehavior?
+    private weak var api: APICategoryGraphQLBehaviorExtended?
     private weak var reconciliationQueue: IncomingEventReconciliationQueue?
 
     private var subscription: Subscription?
@@ -85,7 +85,7 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
 
     // MARK: - Public API
 
-    func startSyncingToCloud(api: APICategoryGraphQLBehavior,
+    func startSyncingToCloud(api: APICategoryGraphQLBehaviorExtended,
                              mutationEventPublisher: MutationEventPublisher,
                              reconciliationQueue: IncomingEventReconciliationQueue?) {
         log.verbose(#function)
@@ -131,7 +131,7 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
     /// Responder method for `starting`. Starts the operation queue and subscribes to
     /// the publisher. After subscribing to the publisher, return actions:
     /// - receivedSubscription
-    private func doStart(api: APICategoryGraphQLBehavior,
+    private func doStart(api: APICategoryGraphQLBehaviorExtended,
                          mutationEventPublisher: MutationEventPublisher,
                          reconciliationQueue: IncomingEventReconciliationQueue?) {
         log.verbose(#function)
@@ -220,7 +220,7 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
 
     private func processSyncMutationToCloudResult(_ result: GraphQLOperation<MutationSync<AnyModel>>.OperationResult,
                                                   mutationEvent: MutationEvent,
-                                                  api: APICategoryGraphQLBehavior) {
+                                                  api: APICategoryGraphQLBehaviorExtended) {
         if case let .success(graphQLResponse) = result {
             if case let .success(graphQLResult) = graphQLResponse {
                 processSuccessEvent(mutationEvent,
@@ -268,7 +268,7 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
     }
 
     private func processMutationErrorFromCloud(mutationEvent: MutationEvent,
-                                               api: APICategoryGraphQLBehavior,
+                                               api: APICategoryGraphQLBehaviorExtended,
                                                apiError: APIError?,
                                                graphQLResponseError: GraphQLResponseError<MutationSync<AnyModel>>?) {
         if let apiError = apiError, apiError.isOperationCancelledError {

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
@@ -26,11 +26,11 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
     private let apiError: APIError?
     private let completion: (Result<MutationEvent?, Error>) -> Void
     private var mutationOperation: AtomicValue<GraphQLOperation<MutationSync<AnyModel>>?>
-    private weak var api: APICategoryGraphQLBehavior?
+    private weak var api: APICategoryGraphQLBehaviorExtended?
 
     init(dataStoreConfiguration: DataStoreConfiguration,
          mutationEvent: MutationEvent,
-         api: APICategoryGraphQLBehavior,
+         api: APICategoryGraphQLBehaviorExtended,
          storageAdapter: StorageEngineAdapter,
          graphQLResponseError: GraphQLResponseError<MutationSync<AnyModel>>? = nil,
          apiError: APIError? = nil,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
@@ -17,7 +17,7 @@ class SyncMutationToCloudOperation: AsynchronousOperation {
 
     typealias MutationSyncCloudResult = GraphQLOperation<MutationSync<AnyModel>>.OperationResult
 
-    private weak var api: APICategoryGraphQLBehavior?
+    private weak var api: APICategoryGraphQLBehaviorExtended?
     private let mutationEvent: MutationEvent
     private let completion: GraphQLOperation<MutationSync<AnyModel>>.ResultListener
     private let requestRetryablePolicy: RequestRetryablePolicy
@@ -31,7 +31,7 @@ class SyncMutationToCloudOperation: AsynchronousOperation {
     private var authTypesIterator: AWSAuthorizationTypeIterator?
 
     init(mutationEvent: MutationEvent,
-         api: APICategoryGraphQLBehavior,
+         api: APICategoryGraphQLBehaviorExtended,
          authModeStrategy: AuthModeStrategy,
          networkReachabilityPublisher: AnyPublisher<ReachabilityUpdate, Never>? = nil,
          currentAttemptNumber: Int = 1,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine+Action.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine+Action.swift
@@ -6,6 +6,7 @@
 //
 
 import Amplify
+import AWSPluginsCore
 import Combine
 
 extension RemoteSyncEngine {
@@ -17,10 +18,10 @@ extension RemoteSyncEngine {
 
         case pausedSubscriptions
         case pausedMutationQueue(StorageEngineAdapter)
-        case clearedStateOutgoingMutations(APICategoryGraphQLBehavior, StorageEngineAdapter)
+        case clearedStateOutgoingMutations(APICategoryGraphQLBehaviorExtended, StorageEngineAdapter)
         case initializedSubscriptions
         case performedInitialSync
-        case activatedCloudSubscriptions(APICategoryGraphQLBehavior, MutationEventPublisher, IncomingEventReconciliationQueue?)
+        case activatedCloudSubscriptions(APICategoryGraphQLBehaviorExtended, MutationEventPublisher, IncomingEventReconciliationQueue?)
         case activatedMutationQueue
         case notifiedSyncStarted
         case cleanedUp(AmplifyError)

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine+State.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine+State.swift
@@ -6,6 +6,7 @@
 //
 
 import Amplify
+import AWSPluginsCore
 import Combine
 
 extension RemoteSyncEngine {
@@ -17,10 +18,10 @@ extension RemoteSyncEngine {
         case pausingSubscriptions
         case pausingMutationQueue
         case clearingStateOutgoingMutations(StorageEngineAdapter)
-        case initializingSubscriptions(APICategoryGraphQLBehavior, StorageEngineAdapter)
+        case initializingSubscriptions(APICategoryGraphQLBehaviorExtended, StorageEngineAdapter)
         case performingInitialSync
         case activatingCloudSubscriptions
-        case activatingMutationQueue(APICategoryGraphQLBehavior, MutationEventPublisher, IncomingEventReconciliationQueue?)
+        case activatingMutationQueue(APICategoryGraphQLBehaviorExtended, MutationEventPublisher, IncomingEventReconciliationQueue?)
         case notifyingSyncStarted
 
         case syncEngineActive

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
@@ -20,7 +20,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     private var authModeStrategy: AuthModeStrategy
 
     // Assigned at `start`
-    weak var api: APICategoryGraphQLBehavior?
+    weak var api: APICategoryGraphQLBehaviorExtended?
     weak var auth: AuthCategoryBehavior?
 
     // Assigned and released inside `performInitialQueries`, but we maintain a reference so we can `reset`
@@ -196,7 +196,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     }
     // swiftlint:enable cyclomatic_complexity
 
-    func start(api: APICategoryGraphQLBehavior = Amplify.API, auth: AuthCategoryBehavior? = Amplify.Auth) {
+    func start(api: APICategoryGraphQLBehaviorExtended, auth: AuthCategoryBehavior?) {
         guard storageAdapter != nil else {
             log.error(error: DataStoreError.nilStorageAdapter())
             remoteSyncTopicPublisher.send(completion: .failure(DataStoreError.nilStorageAdapter()))
@@ -272,7 +272,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         }
     }
     
-    private func initializeSubscriptions(api: APICategoryGraphQLBehavior,
+    private func initializeSubscriptions(api: APICategoryGraphQLBehaviorExtended,
                                          storageAdapter: StorageEngineAdapter) async {
         log.debug(#function)
         let syncableModelSchemas = ModelRegistry.modelSchemas.filter { $0.isSyncable }
@@ -354,7 +354,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         reconciliationQueue.start()
     }
 
-    private func startMutationQueue(api: APICategoryGraphQLBehavior,
+    private func startMutationQueue(api: APICategoryGraphQLBehaviorExtended,
                                     mutationEventPublisher: MutationEventPublisher,
                                     reconciliationQueue: IncomingEventReconciliationQueue?) {
         log.debug(#function)

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngineBehavior.swift
@@ -6,6 +6,7 @@
 //
 
 import Amplify
+import AWSPluginsCore
 import Combine
 
 enum RemoteSyncEngineEvent {
@@ -40,7 +41,7 @@ protocol RemoteSyncEngineBehavior: AnyObject {
     ///    the updates in the Datastore
     /// 1. Mutation processor drains messages off the queue in serial and sends to the service, invoking
     ///    any local callbacks on error if necessary
-    func start(api: APICategoryGraphQLBehavior, auth: AuthCategoryBehavior?)
+    func start(api: APICategoryGraphQLBehaviorExtended, auth: AuthCategoryBehavior?)
 
     func stop(completion: @escaping DataStoreCallback<Void>)
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -13,7 +13,7 @@ import Foundation
 // Used for testing:
 typealias IncomingEventReconciliationQueueFactory =
     ([ModelSchema],
-    APICategoryGraphQLBehavior,
+    APICategoryGraphQLBehaviorExtended,
     StorageEngineAdapter,
     [DataStoreSyncExpression],
     AuthCategoryBehavior?,
@@ -41,7 +41,7 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
     }
 
     init(modelSchemas: [ModelSchema],
-         api: APICategoryGraphQLBehavior,
+         api: APICategoryGraphQLBehaviorExtended,
          storageAdapter: StorageEngineAdapter,
          syncExpressions: [DataStoreSyncExpression],
          auth: AuthCategoryBehavior? = nil,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -23,7 +23,7 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
     }
 
     init(modelSchema: ModelSchema,
-         api: APICategoryGraphQLBehavior,
+         api: APICategoryGraphQLBehaviorExtended,
          modelPredicate: QueryPredicate?,
          auth: AuthCategoryBehavior?,
          authModeStrategy: AuthModeStrategy) async {

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -47,7 +47,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
     private let modelName: ModelName
 
     init(modelSchema: ModelSchema,
-         api: APICategoryGraphQLBehavior,
+         api: APICategoryGraphQLBehaviorExtended,
          modelPredicate: QueryPredicate?,
          auth: AuthCategoryBehavior?,
          authModeStrategy: AuthModeStrategy,
@@ -195,7 +195,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
 
     static func makeAPIRequest(for modelSchema: ModelSchema,
                                subscriptionType: GraphQLSubscriptionType,
-                               api: APICategoryGraphQLBehavior,
+                               api: APICategoryGraphQLBehaviorExtended,
                                auth: AuthCategoryBehavior?,
                                authType: AWSAuthorizationType?,
                                awsAuthService: AWSAuthServiceBehavior) async -> GraphQLRequest<Payload> {
@@ -225,7 +225,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
         return request
     }
 
-    static func hasOIDCAuthProviderAvailable(api: APICategoryGraphQLBehavior) -> AmplifyOIDCAuthProvider? {
+    static func hasOIDCAuthProviderAvailable(api: APICategoryGraphQLBehaviorExtended) -> AmplifyOIDCAuthProvider? {
         if let apiPlugin = api as? APICategoryAuthProviderFactoryBehavior,
             let oidcAuthProvider = apiPlugin.apiAuthProviderFactory().oidcAuthProvider() {
             return oidcAuthProvider
@@ -282,7 +282,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
 extension IncomingAsyncSubscriptionEventPublisher {
     static func apiRequestFactoryFor(for modelSchema: ModelSchema,
                                      subscriptionType: GraphQLSubscriptionType,
-                                     api: APICategoryGraphQLBehavior,
+                                     api: APICategoryGraphQLBehaviorExtended,
                                      auth: AuthCategoryBehavior?,
                                      awsAuthService: AWSAuthServiceBehavior,
                                      authTypeProvider: AWSAuthorizationTypeIterator) -> RetryableGraphQLOperation<Payload>.RequestFactory {

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -14,7 +14,7 @@ import Foundation
 typealias ModelReconciliationQueueFactory = (
     ModelSchema,
     StorageEngineAdapter,
-    APICategoryGraphQLBehavior,
+    APICategoryGraphQLBehaviorExtended,
     ReconcileAndSaveOperationQueue,
     QueryPredicate?,
     AuthCategoryBehavior?,
@@ -78,7 +78,7 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
 
     init(modelSchema: ModelSchema,
          storageAdapter: StorageEngineAdapter?,
-         api: APICategoryGraphQLBehavior,
+         api: APICategoryGraphQLBehaviorExtended,
          reconcileAndSaveQueue: ReconcileAndSaveOperationQueue,
          modelPredicate: QueryPredicate?,
          auth: AuthCategoryBehavior?,

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
@@ -57,7 +57,7 @@ class RemoteSyncEngineTests: XCTestCase {
             XCTFail("We should not expect the sync engine not to continue")
         })
 
-        remoteSyncEngine.start()
+        remoteSyncEngine.start(api: MockAPICategoryPlugin(), auth: nil)
 
         wait(for: [failureOnStorageAdapter], timeout: defaultAsyncWaitTimeout)
         remoteSyncEngineSink.cancel()
@@ -123,7 +123,7 @@ class RemoteSyncEngineTests: XCTestCase {
         MockAWSInitialSyncOrchestrator.setResponseOnSync(result: .failure(
             DataStoreError.internalOperation("forceError", "none", URLError(.notConnectedToInternet))))
 
-        remoteSyncEngine.start(api: apiPlugin)
+        remoteSyncEngine.start(api: apiPlugin, auth: nil)
 
         wait(for: [storageAdapterAvailable,
                    subscriptionsPaused,
@@ -183,7 +183,7 @@ class RemoteSyncEngineTests: XCTestCase {
                 }
             })
 
-        remoteSyncEngine.start(api: apiPlugin)
+        remoteSyncEngine.start(api: apiPlugin, auth: nil)
 
         wait(for: [storageAdapterAvailable,
                    subscriptionsPaused,
@@ -254,7 +254,7 @@ class RemoteSyncEngineTests: XCTestCase {
                 }
             })
 
-        remoteSyncEngine.start(api: apiPlugin)
+        remoteSyncEngine.start(api: apiPlugin, auth: nil)
 
         wait(for: [storageAdapterAvailable,
                    subscriptionsPaused,
@@ -331,7 +331,7 @@ class RemoteSyncEngineTests: XCTestCase {
                 }
             })
 
-        remoteSyncEngine.start(api: apiPlugin)
+        remoteSyncEngine.start(api: apiPlugin, auth: nil)
 
         wait(for: [storageAdapterAvailable,
                    subscriptionsPaused,

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockOutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockOutgoingMutationQueue.swift
@@ -17,7 +17,7 @@ class MockOutgoingMutationQueue: OutgoingMutationQueueBehavior {
         completion()
     }
 
-    func startSyncingToCloud(api: APICategoryGraphQLBehavior,
+    func startSyncingToCloud(api: APICategoryGraphQLBehaviorExtended,
                              mutationEventPublisher: MutationEventPublisher,
                              reconciliationQueue: IncomingEventReconciliationQueue?) {
         // no-op

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockRemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockRemoteSyncEngine.swift
@@ -35,7 +35,7 @@ class MockRemoteSyncEngine: RemoteSyncEngineBehavior {
     init() {
         self.remoteSyncTopicPublisher = PassthroughSubject<RemoteSyncEngineEvent, DataStoreError>()
     }
-    func start(api: APICategoryGraphQLBehavior, auth: AuthCategoryBehavior?) {
+    func start(api: APICategoryGraphQLBehaviorExtended, auth: AuthCategoryBehavior?) {
 
     }
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/NoOpMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/NoOpMutationQueue.swift
@@ -7,6 +7,7 @@
 
 @testable import Amplify
 @testable import AWSDataStorePlugin
+import AWSPluginsCore
 import Combine
 
 /// A mutation queue that takes no action on either pause or start, to let these unit tests operate on the
@@ -16,7 +17,7 @@ class NoOpMutationQueue: OutgoingMutationQueueBehavior {
         completion()
     }
 
-    func startSyncingToCloud(api: APICategoryGraphQLBehavior,
+    func startSyncingToCloud(api: APICategoryGraphQLBehaviorExtended,
                              mutationEventPublisher: MutationEventPublisher,
                              reconciliationQueue: IncomingEventReconciliationQueue?) {
         // do nothing

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/SubscriptionEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/SubscriptionEndToEndTests.swift
@@ -40,7 +40,10 @@ class SubscriptionEndToEndTests: SyncEngineIntegrationTestBase {
         let originalContent = "Original content from SubscriptionTests at \(Date())"
         let updatedContent = "UPDATED CONTENT from SubscriptionTests at \(Date())"
 
-        let createReceived = expectation(description: "createReceived")
+        let createReceived = asyncExpectation(description: "createReceived")
+        let updateReceived = asyncExpectation(description: "updateReceived")
+        let deleteReceived = asyncExpectation(description: "deleteReceived")
+
         var hubListener = Amplify.Hub.listen(to: .dataStore,
                                              eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
             guard let mutationEvent = payload.data as? MutationEvent else {
@@ -53,11 +56,11 @@ class SubscriptionEndToEndTests: SyncEngineIntegrationTestBase {
             }
             switch mutationEvent.mutationType {
             case GraphQLMutationType.create.rawValue:
-                createReceived.fulfill()
+                Task { await createReceived.fulfill() }
             case GraphQLMutationType.update.rawValue:
-                break
+                Task { await updateReceived.fulfill() }
             case GraphQLMutationType.delete.rawValue:
-                break
+                Task { await deleteReceived.fulfill() }
             default:
                 break
             }
@@ -67,8 +70,10 @@ class SubscriptionEndToEndTests: SyncEngineIntegrationTestBase {
             return
         }
 
+        // Act: send create mutation
         try await sendCreateRequest(withId: id, content: originalContent)
-        await waitForExpectations(timeout: networkTimeout)
+        await waitForExpectations([createReceived], timeout: networkTimeout)
+        // Assert
         let createSyncData = await getMutationSync(forPostWithId: id)
         XCTAssertNotNil(createSyncData)
         let createdPost = createSyncData?.model.instance as? Post
@@ -77,34 +82,10 @@ class SubscriptionEndToEndTests: SyncEngineIntegrationTestBase {
         XCTAssertEqual(createSyncData?.syncMetadata.version, 1)
         XCTAssertEqual(createSyncData?.syncMetadata.deleted, false)
         
-        let updateReceived = expectation(description: "updateReceived")
-        hubListener = Amplify.Hub.listen(to: .dataStore,
-                                             eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
-            guard let mutationEvent = payload.data as? MutationEvent else {
-                XCTFail("Can't cast payload as mutation event")
-                return
-            }
-            guard mutationEvent.modelId == id else {
-                print("Received unrelated mutation, skipping \(mutationEvent)")
-                return
-            }
-            switch mutationEvent.mutationType {
-            case GraphQLMutationType.create.rawValue:
-                break
-            case GraphQLMutationType.update.rawValue:
-                updateReceived.fulfill()
-            case GraphQLMutationType.delete.rawValue:
-                break
-            default:
-                break
-            }
-        }
-        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
-            XCTFail("Listener not registered for hub")
-            return
-        }
+        // Act: send update mutation
         try await sendUpdateRequest(forId: id, content: updatedContent, version: 1)
-        await waitForExpectations(timeout: networkTimeout)
+        await waitForExpectations([updateReceived], timeout: networkTimeout)
+        // Assert
         let updateSyncData = await getMutationSync(forPostWithId: id)
         XCTAssertNotNil(updateSyncData)
         let updatedPost = updateSyncData?.model.instance as? Post
@@ -112,37 +93,11 @@ class SubscriptionEndToEndTests: SyncEngineIntegrationTestBase {
         XCTAssertEqual(updatedPost?.content, updatedContent)
         XCTAssertEqual(updateSyncData?.syncMetadata.version, 2)
         XCTAssertEqual(updateSyncData?.syncMetadata.deleted, false)
-
-        let deleteReceived = expectation(description: "deleteReceived")
-
-        hubListener = Amplify.Hub.listen(to: .dataStore,
-                                             eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
-            guard let mutationEvent = payload.data as? MutationEvent else {
-                XCTFail("Can't cast payload as mutation event")
-                return
-            }
-            guard mutationEvent.modelId == id else {
-                print("Received unrelated mutation, skipping \(mutationEvent)")
-                return
-            }
-            switch mutationEvent.mutationType {
-            case GraphQLMutationType.create.rawValue:
-                break
-            case GraphQLMutationType.update.rawValue:
-                break
-            case GraphQLMutationType.delete.rawValue:
-                deleteReceived.fulfill()
-            default:
-                break
-            }
-        }
-        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
-            XCTFail("Listener not registered for hub")
-            return
-        }
         
+        // Act: send delete mutation
         try await sendDeleteRequest(forId: id, version: 2)
-        await waitForExpectations(timeout: networkTimeout)
+        await waitForExpectations([deleteReceived], timeout: networkTimeout)
+        // Assert
         let deleteSyncData = await getMutationSync(forPostWithId: id)
         XCTAssertNil(deleteSyncData)
     }

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -6,12 +6,14 @@
 //
 
 import Amplify
+import AWSPluginsCore
 import Combine
 import Foundation
 
 class MockAPICategoryPlugin: MessageReporter,
                              APICategoryPlugin,
-                             APICategoryReachabilityBehavior {
+                             APICategoryReachabilityBehavior,
+                             APICategoryGraphQLBehaviorExtended {
 
     var authProviderFactory: APIAuthProviderFactory?
 


### PR DESCRIPTION
*Issue #, if available:*
Related https://github.com/aws-amplify/amplify-ios/issues/2252

*Description of changes:*
To provide a path forward in removing the APIPlugin's callback APIs, they have been moved from Amplify over to AWSPluginsCore in this PR. This way, a developer does not have access to the APIs through Amplify.API, while DataStore and if other consumers really want, can cast the plugin to APICategoryGraphQLBehaviorExtended to get the GraphQL callback based APIs. APICategoryGraphQLBehaviorExtended and APICategoryGraphQLCallbackBehavior has been marked with a warning on that it has to be public but is not meant for public use, and can change without a major version bump.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
