### PR TITLE
chore(datastore): Fix deprecated .hasOne and .belongsTo APIs

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -251,7 +251,7 @@ public enum ModelFieldDefinition {
                       is: nullability,
                       isReadOnly: isReadOnly,
                       ofType: .model(type: type),
-                      association: .hasOne(associatedWith: associatedKey, targetName: targetName))
+                      association: .hasOne(associatedWith: associatedKey, targetNames: targetName.map { [$0] } ?? []))
     }
 
     public static func hasOne(_ key: CodingKey,
@@ -277,7 +277,7 @@ public enum ModelFieldDefinition {
                       is: nullability,
                       isReadOnly: isReadOnly,
                       ofType: .model(type: type),
-                      association: .belongsTo(associatedWith: associatedKey, targetName: targetName))
+                      association: .belongsTo(associatedWith: associatedKey, targetNames: targetName.map { [$0] } ?? []))
     }
 
     public static func belongsTo(_ key: CodingKey,

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/TestModelRegistration.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/TestModelRegistration.swift
@@ -80,7 +80,7 @@ struct TestJsonModelRegistration: AmplifyModelRegistration {
         let belongsTo = ModelField(name: "post",
                                    type: .model(name: "Post"),
                                    isRequired: true,
-                                   association: .belongsTo(associatedWith: nil, targetName: "postId"))
+                                   association: .belongsTo(associatedWith: nil, targetNames: ["postId"]))
         let commentSchema = ModelSchema(name: "Comment",
                                         listPluralName: "Comments",
                                         syncPluralName: "Comments",

--- a/AmplifyTests/CategoryTests/DataStore/ModelFieldAssociationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/ModelFieldAssociationTests.swift
@@ -17,7 +17,7 @@ class ModelFieldAssociationTests: XCTestCase {
     }
 
     func testBelongsToWithCodingKeys() {
-        let belongsTo = ModelAssociation.belongsTo(associatedWith: Comment.keys.post, targetName: "postID")
+        let belongsTo = ModelAssociation.belongsTo(associatedWith: Comment.keys.post, targetNames: ["postID"])
         guard case .belongsTo(let fieldName, let target) = belongsTo else {
             XCTFail("Should create belongsTo association")
             return
@@ -36,7 +36,7 @@ class ModelFieldAssociationTests: XCTestCase {
     }
 
     func testHasOneWithCodingKeys() {
-        let hasOne = ModelAssociation.hasOne(associatedWith: Comment.keys.post, targetName: nil)
+        let hasOne = ModelAssociation.hasOne(associatedWith: Comment.keys.post, targetNames: [])
         guard case .hasOne(let fieldName, let target) = hasOne else {
             XCTFail("Should create hasOne association")
             return
@@ -46,7 +46,7 @@ class ModelFieldAssociationTests: XCTestCase {
     }
 
     func testHasOneWithCodingKeysWithTargetName() {
-        let hasOne = ModelAssociation.hasOne(associatedWith: Comment.keys.post, targetName: "postID")
+        let hasOne = ModelAssociation.hasOne(associatedWith: Comment.keys.post, targetNames: ["postID"])
         guard case .hasOne(let fieldName, let target) = hasOne else {
             XCTFail("Should create hasOne association")
             return
@@ -66,7 +66,7 @@ class ModelFieldAssociationTests: XCTestCase {
     }
 
     func testModelFieldWithBelongsToAssociation() {
-        let belongsTo = ModelAssociation.belongsTo(associatedWith: nil, targetName: "commentPostId")
+        let belongsTo = ModelAssociation.belongsTo(associatedWith: nil, targetNames: ["commentPostId"])
         let field = ModelField.init(name: "post",
                                     type: .model(type: Post.self),
                                     association: belongsTo)
@@ -90,7 +90,7 @@ class ModelFieldAssociationTests: XCTestCase {
     }
 
     func testModelFieldWithHasOneAssociation() {
-        let hasOne = ModelAssociation.hasOne(associatedWith: Comment.keys.post, targetName: "postID")
+        let hasOne = ModelAssociation.hasOne(associatedWith: Comment.keys.post, targetNames: ["postID"])
         let field = ModelField.init(name: "comment",
                                     type: .model(type: Comment.self),
                                     association: hasOne)

--- a/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
@@ -102,10 +102,12 @@ class StorageCategoryConfigurationTests: XCTestCase {
 
     func testCanUseDefaultPluginIfOnlyOnePlugin() async throws {
         let plugin = MockStorageCategoryPlugin()
-        let methodInvokedOnDefaultPlugin = expectation(description: "test method invoked on default plugin")
+        let methodInvokedOnDefaultPlugin = asyncExpectation(description: "test method invoked on default plugin")
         plugin.listeners.append { message in
             if message == "downloadData" {
-                methodInvokedOnDefaultPlugin.fulfill()
+                Task {
+                    await methodInvokedOnDefaultPlugin.fulfill()
+                }
             }
         }
         try Amplify.add(plugin: plugin)


### PR DESCRIPTION
*Issue #, if available:* None 

*Description of changes:* Fix deprecated `.hasOne` and `.belongsTo` `ModelAssociation` APIs

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
