### PR TITLE
fix: improve hub reset() compatibility with swift concurrency

### DIFF
--- a/Amplify/DefaultPlugins/AWSHubPlugin/AWSHubPlugin.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/AWSHubPlugin.swift
@@ -42,7 +42,7 @@ final public class AWSHubPlugin: HubCategoryPlugin {
 
     /// Removes listeners and empties the message queue
     public func reset() async {
-        dispatcher.destroy()
+        await dispatcher.destroy()
     }
 
     public func dispatch(to channel: HubChannel, payload: HubPayload) {


### PR DESCRIPTION
*Description of changes:*
fix: improve hub reset() compatibility with swift concurrency

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
