### PR TITLE
chore: update integration test runners to use macOS 12

### DIFF
--- a/.github/workflows/integ_test_api.yml
+++ b/.github/workflows/integ_test_api.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   prepare-for-test:
-    runs-on: macos-latest
+    runs-on: macos-12
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -31,7 +31,7 @@ jobs:
   api-functional-test:
       continue-on-error: true
       needs: prepare-for-test
-      runs-on: macos-latest
+      runs-on: macos-12
       environment: IntegrationTest
       steps:
         - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -59,7 +59,7 @@ jobs:
     if: ${{ false }}
     continue-on-error: true
     needs: prepare-for-test
-    runs-on: macos-latest
+    runs-on: macos-12
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/integ_test_datastore.yml
+++ b/.github/workflows/integ_test_datastore.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   prepare-for-test:
-    runs-on: macos-latest
+    runs-on: macos-12
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -31,7 +31,7 @@ jobs:
   datastore-integration-test:
     continue-on-error: true
     needs: prepare-for-test
-    runs-on: macos-latest
+    runs-on: macos-12
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/release_kickoff.yml
+++ b/.github/workflows/release_kickoff.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   release:
     name: Release
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b


### PR DESCRIPTION
*Description of changes:*
update integration test runners to use macOS 12

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
