### PR TITLE
fix: make HubListenerTestUtilities.waitForListener async

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
@@ -23,7 +23,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
     ///    - The orchestrator starts up
     /// - Then:
     ///    - It performs a sync query for each registered model
-    func testInvokesCompletionCallback() throws {
+    func testInvokesCompletionCallback() async throws {
         ModelRegistry.reset()
         PostCommentModelRegistration().registerModels(registry: ModelRegistry.self)
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
@@ -62,7 +62,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
             syncQueriesStartedReceived.fulfill()
         }
 
-        guard try HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
+        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
             XCTFail("Listener not registered for hub")
             return
         }
@@ -96,7 +96,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
             syncCallbackReceived.fulfill()
         }
 
-        waitForExpectations(timeout: 1)
+        await waitForExpectations(timeout: 1)
         XCTAssertEqual(orchestrator.syncOperationQueue.maxConcurrentOperationCount, 1)
         Amplify.Hub.removeListener(hubListener)
         sink.cancel()
@@ -107,7 +107,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
     ///    - The orchestrator starts up
     /// - Then:
     ///    - Finish with an error for each sync query that fails.
-    func testFinishWithAPIError() throws {
+    func testFinishWithAPIError() async throws {
         ModelRegistry.reset()
         PostCommentModelRegistration().registerModels(registry: ModelRegistry.self)
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { request, listener in
@@ -153,7 +153,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
             syncQueriesStartedReceived.fulfill()
         }
 
-        guard try HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
+        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
             XCTFail("Listener not registered for hub")
             return
         }
@@ -195,7 +195,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
             syncCallbackReceived.fulfill()
         }
 
-        waitForExpectations(timeout: 1)
+        await waitForExpectations(timeout: 1)
         XCTAssertEqual(orchestrator.syncOperationQueue.maxConcurrentOperationCount, 1)
         Amplify.Hub.removeListener(hubListener)
         sink.cancel()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
@@ -68,7 +68,7 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
             }
         }
 
-        guard try HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
+        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
             XCTFail("Listener not registered for hub")
             return
         }
@@ -166,7 +166,7 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
             }
         }
 
-        guard try HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
+        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
             XCTFail("Listener not registered for hub")
             return
         }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
@@ -63,7 +63,7 @@ class RemoteSyncEngineTests: XCTestCase {
         remoteSyncEngineSink.cancel()
     }
 
-    func testFailureOnInitialSync() throws {
+    func testFailureOnInitialSync() async throws {
         let storageAdapterAvailable = expectation(description: "storageAdapterAvailable")
         let subscriptionsPaused = expectation(description: "subscriptionsPaused")
         let mutationsPaused = expectation(description: "mutationsPaused")
@@ -88,7 +88,7 @@ class RemoteSyncEngineTests: XCTestCase {
             subscriptionsEstablishedReceived.fulfill()
         }
 
-        guard try HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
+        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
             XCTFail("Listener not registered for hub")
             return
         }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
@@ -125,15 +125,7 @@ class RemoteSyncEngineTests: XCTestCase {
 
         remoteSyncEngine.start(api: apiPlugin, auth: nil)
 
-        wait(for: [storageAdapterAvailable,
-                   subscriptionsPaused,
-                   mutationsPaused,
-                   stateMutationsCleared,
-                   subscriptionsInitialized,
-                   subscriptionsEstablishedReceived,
-                   cleanedup,
-                   failureOnInitialSync,
-                   retryAdviceReceivedNetworkError], timeout: defaultAsyncWaitTimeout)
+        await waitForExpectations(timeout: defaultAsyncWaitTimeout)
         remoteSyncEngineSink.cancel()
         Amplify.Hub.removeListener(hubListener)
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
@@ -161,7 +161,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
                                                    eventName: HubPayload.EventName.DataStore.syncReceived) { _ in
             syncReceivedNotification.fulfill()
         }
-        guard try HubListenerTestUtilities.waitForListener(with: syncReceivedToken, timeout: 5.0) else {
+        guard try await HubListenerTestUtilities.waitForListener(with: syncReceivedToken, timeout: 5.0) else {
             XCTFail("Sync listener never registered")
             return
         }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/SyncEngineTestBase.swift
@@ -190,21 +190,22 @@ class SyncEngineTestBase: XCTestCase {
                 }
             }
         }
-
-        do {
-            Task {
+        
+        
+        Task {
             guard try await HubListenerTestUtilities.waitForListener(with: token, timeout: 5.0) else {
                 XCTFail("Never registered listener for sync started")
                 return
             }
-
             
+            do {
                 try await startAmplify()
+            } catch {
+                Amplify.Hub.removeListener(token)
+                completion(.failure(error))
             }
-        } catch {
-            Amplify.Hub.removeListener(token)
-            completion(.failure(error))
         }
+        
     }
 
     /// Starts amplify by invoking `Amplify.configure(amplifyConfig)`, and waits to receive a `syncStarted` Hub message

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/SyncEngineTestBase.swift
@@ -192,12 +192,13 @@ class SyncEngineTestBase: XCTestCase {
         }
 
         do {
-            guard try HubListenerTestUtilities.waitForListener(with: token, timeout: 5.0) else {
+            Task {
+            guard try await HubListenerTestUtilities.waitForListener(with: token, timeout: 5.0) else {
                 XCTFail("Never registered listener for sync started")
                 return
             }
 
-            Task {
+            
                 try await startAmplify()
             }
         } catch {

--- a/AmplifyTestCommon/Helpers/HubListenerTestUtilities.swift
+++ b/AmplifyTestCommon/Helpers/HubListenerTestUtilities.swift
@@ -21,7 +21,7 @@ struct HubListenerTestUtilities {
                                 plugin: HubCategoryPlugin? = nil,
                                 timeout: TimeInterval,
                                 file: StaticString = #file,
-                                line: UInt = #line) throws -> Bool {
+                                line: UInt = #line) async throws -> Bool {
 
         let plugin = try plugin ?? Amplify.Hub.getPlugin(for: AWSHubPlugin.key)
 
@@ -37,7 +37,8 @@ struct HubListenerTestUtilities {
                 hasListener = true
                 break
             }
-            Thread.sleep(forTimeInterval: 0.01)
+            try? await Task.sleep(seconds: 0.01)
+//            Thread.sleep(forTimeInterval: 0.01)
         }
 
         return hasListener

--- a/AmplifyTestCommon/Helpers/HubListenerTestUtilities.swift
+++ b/AmplifyTestCommon/Helpers/HubListenerTestUtilities.swift
@@ -38,7 +38,6 @@ struct HubListenerTestUtilities {
                 break
             }
             try? await Task.sleep(seconds: 0.01)
-//            Thread.sleep(forTimeInterval: 0.01)
         }
 
         return hasListener

--- a/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
@@ -32,7 +32,7 @@ class AmplifyOperationHubTests: XCTestCase {
     /// Given: An AmplifyOperation
     /// When: I invoke Hub.listen(to: operation)
     /// Then: I am notified of events for that operation, in the operation event listener format
-    func testlistenerViaListenToOperation() throws {
+    func testlistenerViaListenToOperation() async throws {
         let options = StorageListRequest.Options(pluginOptions: ["pluginDelay": 0.5])
         let request = StorageListRequest(options: options)
 
@@ -44,11 +44,11 @@ class AmplifyOperationHubTests: XCTestCase {
             listenerWasInvoked.fulfill()
         }
 
-        try waitForToken(token)
+        try await waitForToken(token)
 
         operation.doMockDispatch()
 
-        waitForExpectations(timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
     }
 
     /// Given: A configured system
@@ -101,10 +101,10 @@ class AmplifyOperationHubTests: XCTestCase {
 
     // Convenience to let tests wait for a listener to be registered. Instead of returning a bool, simply throws if the
     // listener is not registered
-    private func waitForToken(_ token: UnsubscribeToken) throws {
+    private func waitForToken(_ token: UnsubscribeToken) async throws {
         // swiftlint:disable:next force_cast
         let hubPlugin = try Amplify.Hub.getPlugin(for: AWSHubPlugin.key) as! AWSHubPlugin
-        guard try HubListenerTestUtilities.waitForListener(with: token, plugin: hubPlugin, timeout: 1.0) else {
+        guard try await HubListenerTestUtilities.waitForListener(with: token, plugin: hubPlugin, timeout: 1.0) else {
             throw "Listener not registered"
         }
     }

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginConcurrencyTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginConcurrencyTests.swift
@@ -68,9 +68,11 @@ class DefaultHubPluginConcurrencyTests: XCTestCase {
                 messagesReceived.append(messageReceived)
             }
         }
+        
+        let capturedChannels = channels
 
         DispatchQueue.concurrentPerform(iterations: channels.count) { iteration in
-            let channel = channels[iteration]
+            let channel = capturedChannels[iteration]
             for messageIteration in 0 ..< messagesExpectedPerListener {
                 let payload = HubPayload(eventName: "Message \(messageIteration), channel \(channel)")
                 plugin.dispatch(to: channel, payload: payload)

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginConcurrencyTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginConcurrencyTests.swift
@@ -38,7 +38,7 @@ class DefaultHubPluginConcurrencyTests: XCTestCase {
     /// - ...to multiple channels
     /// - ...to multiple subscribers
     /// Then: All messages are delivered, to the correct listeners
-    func testConcurrentMessageDelivery() throws {
+    func testConcurrentMessageDelivery() async throws {
         let channelCount = 10
         let listenersPerChannel = 50
         let messagesExpectedPerListener = 10
@@ -61,7 +61,7 @@ class DefaultHubPluginConcurrencyTests: XCTestCase {
                     messageReceived.fulfill()
                 }
 
-                guard try HubListenerTestUtilities.waitForListener(with: token, plugin: plugin, timeout: 1.0) else {
+                guard try await HubListenerTestUtilities.waitForListener(with: token, plugin: plugin, timeout: 1.0) else {
                     XCTFail("Listener \(listenerIteration) on channel \(channel) not registered")
                     return
                 }

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginCustomChannelTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginCustomChannelTests.swift
@@ -37,27 +37,27 @@ class DefaultHubPluginCustomChannelTests: XCTestCase {
     /// Given: A listener to a custom channel
     /// When: A message is dispatched to that custom channel
     /// Then: The listener is invoked
-    func testMessageReceivedOnCustomChannel() throws {
+    func testMessageReceivedOnCustomChannel() async throws {
         let eventReceived = expectation(description: "Event received")
 
         let listener = plugin.listen(to: .custom("CustomChannel1"), isIncluded: nil) { _ in
             eventReceived.fulfill()
         }
 
-        guard try HubListenerTestUtilities.waitForListener(with: listener, plugin: plugin, timeout: 0.5) else {
+        guard try await HubListenerTestUtilities.waitForListener(with: listener, plugin: plugin, timeout: 0.5) else {
             XCTFail("listener1 not registered")
             return
         }
 
         plugin.dispatch(to: .custom("CustomChannel1"), payload: HubPayload(eventName: "TEST_EVENT"))
 
-        waitForExpectations(timeout: 0.5)
+        await waitForExpectations(timeout: 0.5)
     }
 
     /// Given: A listener to a custom channel
     /// When: A message is dispatched to a different custom channel
     /// Then: The listener is not invoked
-    func testMessageNotReceivedOnDifferentCustomChannel() throws {
+    func testMessageNotReceivedOnDifferentCustomChannel() async throws {
         let eventReceived = expectation(description: "Event received")
         eventReceived.isInverted = true
 
@@ -65,20 +65,20 @@ class DefaultHubPluginCustomChannelTests: XCTestCase {
             eventReceived.fulfill()
         }
 
-        guard try HubListenerTestUtilities.waitForListener(with: listener, plugin: plugin, timeout: 0.5) else {
+        guard try await HubListenerTestUtilities.waitForListener(with: listener, plugin: plugin, timeout: 0.5) else {
             XCTFail("listener1 not registered")
             return
         }
 
         plugin.dispatch(to: .custom("CustomChannel2"), payload: HubPayload(eventName: "TEST_EVENT"))
 
-        waitForExpectations(timeout: 0.5)
+        await waitForExpectations(timeout: 0.5)
     }
 
     /// Given: Multiple listeners to a custom channel
     /// When: A message is dispatched to that custom channel
     /// Then: All listeners are invoked
-    func testMultipleSubscribersOnCustomChannel() throws {
+    func testMultipleSubscribersOnCustomChannel() async throws {
         let listener1Invoked = expectation(description: "Listener 1 invoked")
         let listener2Invoked = expectation(description: "Listener 2 invoked")
 
@@ -86,7 +86,7 @@ class DefaultHubPluginCustomChannelTests: XCTestCase {
             listener1Invoked.fulfill()
         }
 
-        guard try HubListenerTestUtilities.waitForListener(with: listener1, plugin: plugin, timeout: 0.5) else {
+        guard try await HubListenerTestUtilities.waitForListener(with: listener1, plugin: plugin, timeout: 0.5) else {
             XCTFail("listener1 not registered")
             return
         }
@@ -95,14 +95,14 @@ class DefaultHubPluginCustomChannelTests: XCTestCase {
             listener2Invoked.fulfill()
         }
 
-        guard try HubListenerTestUtilities.waitForListener(with: listener2, plugin: plugin, timeout: 0.5) else {
+        guard try await HubListenerTestUtilities.waitForListener(with: listener2, plugin: plugin, timeout: 0.5) else {
             XCTFail("listener2 not registered")
             return
         }
 
         plugin.dispatch(to: .custom("CustomChannel1"), payload: HubPayload(eventName: "TEST_EVENT"))
 
-        waitForExpectations(timeout: 0.5)
+        await waitForExpectations(timeout: 0.5)
     }
 
 }

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginTests.swift
@@ -57,13 +57,13 @@ class DefaultHubPluginTests: XCTestCase {
     /// Given: The default Hub plugin
     /// When: I invoke listen(to:eventName:)
     /// Then: I receive messages with that event name
-    func testDefaultPluginListenEventName() throws {
+    func testDefaultPluginListenEventName() async throws {
         let expectedMessageReceived = expectation(description: "Message was received as expected")
         let unsubscribeToken = plugin.listen(to: .storage, eventName: "TEST_EVENT") { _ in
             expectedMessageReceived.fulfill()
         }
 
-        guard try HubListenerTestUtilities.waitForListener(with: unsubscribeToken, plugin: plugin, timeout: 0.5) else {
+        guard try await HubListenerTestUtilities.waitForListener(with: unsubscribeToken, plugin: plugin, timeout: 0.5) else {
             XCTFail("Token with \(unsubscribeToken.id) was not registered")
             return
         }
@@ -75,7 +75,7 @@ class DefaultHubPluginTests: XCTestCase {
     /// Given: The default Hub plugin with a registered listener
     /// When: I dispatch a message
     /// Then: My listener is invoked with the message
-    func testDefaultPluginDispatches() throws {
+    func testDefaultPluginDispatches() async throws {
         let messageReceived = expectation(description: "Message was received")
 
         // We have other tests for multiple message delivery, and since await Amplify.reset() is known to leave in-process
@@ -86,19 +86,19 @@ class DefaultHubPluginTests: XCTestCase {
             messageReceived.fulfill()
         }
 
-        guard try HubListenerTestUtilities.waitForListener(with: token, plugin: plugin, timeout: 0.5) else {
+        guard try await HubListenerTestUtilities.waitForListener(with: token, plugin: plugin, timeout: 0.5) else {
             XCTFail("Token with \(token.id) was not registered")
             return
         }
 
         plugin.dispatch(to: .storage, payload: HubPayload(eventName: "TEST_EVENT"))
-        waitForExpectations(timeout: 0.5)
+        await waitForExpectations(timeout: 0.5)
     }
 
     /// Given: A subscription token from a previous call to the default Hub plugin's `listen` method
     /// When: I invoke removeListener()
     /// Then: My listener is removed, and I receive no more events
-    func testDefaultPluginRemoveListener() throws {
+    func testDefaultPluginRemoveListener() async throws {
         let expectedMessageReceived = expectation(description: "Message was received as expected")
         let unexpectedMessageReceived = expectation(description: "Message was received after removing listener")
         unexpectedMessageReceived.isInverted = true
@@ -118,7 +118,7 @@ class DefaultHubPluginTests: XCTestCase {
             }
         }
 
-        guard try HubListenerTestUtilities.waitForListener(with: unsubscribeToken,
+        guard try await HubListenerTestUtilities.waitForListener(with: unsubscribeToken,
                                                               plugin: plugin,
                                                               timeout: 0.5) else {
             XCTFail("Token with \(unsubscribeToken.id) was not registered")
@@ -130,7 +130,7 @@ class DefaultHubPluginTests: XCTestCase {
 
         plugin.removeListener(unsubscribeToken)
 
-        isStillRegistered.set(
+        await isStillRegistered.set(
             try HubListenerTestUtilities.waitForListener(with: unsubscribeToken,
                                                          plugin: plugin,
                                                          timeout: 0.5)


### PR DESCRIPTION
*Description of changes:*
make HubListenerTestUtilities.waitForListener async

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
