### PR TITLE
chore(AmplifyTestCommon): Adding helper methods to facilitate waiting for …

### DIFF
--- a/AmplifyTestCommon/Helpers/XCTestCase+AsyncTesting.swift
+++ b/AmplifyTestCommon/Helpers/XCTestCase+AsyncTesting.swift
@@ -1,0 +1,118 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import AmplifyAsyncTesting
+import XCTest
+
+extension XCTestCase {
+
+    /// Waits for the execution of a given async code, using a given async expectation,
+    /// and returns its result  or `nil` if it threw an error.
+    ///
+    /// This method will automatically call the expectation's `fulfill()` method when the async
+    /// code finishes, either successfully or with error.
+    ///
+    /// - Parameters:
+    ///   - expectation: The async expectation that will be fulfilled once the code in `action` completes.
+    ///   - timeout: How long to wait for `action` to complete. Defaults to `TestCommonConstants.networkTimeout`.
+    ///   - action: Closure containing async code.
+    ///   
+    /// - Returns:The result of successfuly running `action`, or `nil` if it threw an error.
+    @discardableResult
+    func wait<T>(with expectation: AsyncExpectation,
+                 timeout: TimeInterval = TestCommonConstants.networkTimeout,
+                 action: @escaping () async throws -> T) async -> T? {
+        let task = Task { () -> T? in
+            defer {
+                Task {
+                    await expectation.fulfill()
+                }
+            }
+            do {
+                return try await action()
+            } catch {
+                if !(error is CancellationError) {
+                    XCTFail("Failed with \(error)")
+                }
+                return nil
+            }
+        }
+        await waitForExpectations([expectation], timeout: timeout)
+        task.cancel()
+        return await task.value
+    }
+
+    /// Waits for the execution of a given async code and returns its result or `nil` if it threw an error.
+    ///
+    /// - Parameters:
+    ///   - name: The name that will be used to create the async expectation that will be fulfilled once the code in `action` completes.
+    ///   - timeout: How long to wait for `action` to complete. Defaults to `TestCommonConstants.networkTimeout`.
+    ///   - action: Closure containing async code.
+    ///
+    /// - Returns:The result of successfuly running `action`, or `nil` if it threw an error.
+    @discardableResult
+    func wait<T>(name: String,
+                 timeout: TimeInterval = TestCommonConstants.networkTimeout,
+                 action: @escaping () async throws -> T) async -> T? {
+        let expectation = asyncExpectation(description: name)
+        return await wait(with: expectation, timeout: timeout, action: action)
+    }
+
+    /// Waits for an error during the execution of a given async code, using a given async expectation,
+    /// and returns said error or `nil` if it run successfully.
+    ///
+    /// This method will automatically call the expectation's `fulfill()` method when the async
+    /// code finishes, either successfully or with error.
+    ///
+    /// - Parameters:
+    ///   - expectation: The async expectation that will be fulfilled once the code in `action` completes.
+    ///   - timeout: How long to wait for `action` to complete. Defaults to `TestCommonConstants.networkTimeout`.
+    ///   - action: Closure containing async code.
+    ///
+    /// - Returns:The error thrown during the execution of `action`, or `nil` if it run successfully.
+    @discardableResult
+    func waitError<T>(with expectation: AsyncExpectation,
+                      timeout: TimeInterval = TestCommonConstants.networkTimeout,
+                      action: @escaping () async throws -> T) async -> Error? {
+        let task = Task { () -> Error? in
+            defer {
+                Task { await expectation.fulfill() }
+            }
+            do {
+                let result = try await action()
+                XCTFail("Should not have completed, got \(result)")
+                return nil
+            } catch {
+                if error is CancellationError {
+                    return nil
+                }
+                return error
+            }
+        }
+        await waitForExpectations([expectation], timeout: timeout)
+        task.cancel()
+        return await task.value
+    }
+
+    /// Waits for an error during the execution of a given async code and returns said error
+    /// or `nil` if it run successfully.
+    ///
+    ///
+    /// - Parameters:
+    ///   - expectation: The async expectation that will be fulfilled once the code in `action` completes.
+    ///   - timeout: How long to wait for `action` to complete. Defaults to `TestCommonConstants.networkTimeout`.
+    ///   - action: Closure containing async code.
+    ///
+    /// - Returns:The error thrown during the execution of `action`, or `nil` if it run successfully.
+    @discardableResult
+    func waitError<T>(name: String,
+                      timeout: TimeInterval = TestCommonConstants.networkTimeout,
+                      action: @escaping () async throws -> T) async -> Error? {
+        let expectation = asyncExpectation(description: name)
+        return await waitError(with: expectation, timeout: timeout, action: action)
+    }
+}


### PR DESCRIPTION
*Description of changes:*

While migrating some integration tests to the new async APIs and to use the new `AsyncExpectation`, and I noticed that **A LOT** of tests ended up with this code block:

```swift
    let successExpectation = asyncExpectation("Call succeeds")
    Task { 
        do {
            try await Amplify.X.Y() // Call some Amplify async API
            await successExpectation.fulfill()
            // All good 👍
        } catch {
            XCTFail("Oh no 🫢! Anyway...")
        }
    }
    await waitForExpectations([anExpectation], timeout: aTimeout)
```
or its error equivalent:
```swift
    let errorExpectation = asyncExpectation("Error is thrown")
    Task { 
        do {
            try await Amplify.X.Y() // Call some Amplify async API
            XCTFail("Oh no 🫢! Anyway...")
        } catch {
            await errorExpectation.fulfill()
           // All good 👍
        }
    }
    await waitForExpectations([anExpectation], timeout: aTimeout)
```

This is done because the new `async` Amplify APIs _might_ never complete or take a very long time to do so, which would effectively block the execution of the remaining tests. 
To prevent this, we wrap them in a `Task` and just wait for a given amount of time for it to be over, otherwise we fail the expectation _(See [AsyncTesting](https://github.com/brennanMKE/AsyncTesting) for more information about it)_.

-----

To make things easier, I went ahead and created some convenience methods that just wraps all that into:

```swift
    let successExpectation = asyncExpectation("Call succeeds")
    await wait(with: successExpectation, timeout: aTimeout) {
        try await Amplify.X.Y() // Call some Amplify async API
    }
```
or
```swift
    let errorExpectation = asyncExpectation("Error is thrown")
    await waitError(with: errorExpectation, timeout: aTimeout) {
        try await Amplify.X.Y() // Call some Amplify async API
    }
```

And you can also get the actual result or error from them as well:
```swift
    let successExpectation = asyncExpectation("Call succeeds")
    let result = await wait(with: expectation, timeout: aTimeout) {
        return try await Amplify.X.Y() // Call some Amplify async API
    }
    XCTAssertNotNil(result) 
    // and so on...
```

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
