### PR TITLE
fix(Storage): Various bug fixes

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3Adapter.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3Adapter.swift
@@ -34,7 +34,7 @@ class AWSS3Adapter: AWSS3Behavior {
         Task {
             let input = DeleteObjectInput(bucket: request.bucket, key: request.key)
             do {
-                _ = try await awsS3.deleteObject(input: input)
+                _ = try await awsS3.deleteObject(input: input, config: config)
                 completion(.success(()))
             } catch {
                 completion(.failure(StorageError(error: error)))

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3Adapter.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3Adapter.swift
@@ -48,11 +48,15 @@ class AWSS3Adapter: AWSS3Behavior {
     ///   - completion: handle which return a result with list of items
     func listObjectsV2(_ request: AWSS3ListObjectsV2Request, completion: @escaping (Result<StorageListResult, StorageError>) -> Void) {
         Task {
+            var finalPrefix: String?
+            if let prefix = request.prefix {
+                finalPrefix = prefix + (request.path ?? "")
+            }
             let input = ListObjectsV2Input(bucket: request.bucket,
                                            continuationToken: request.continuationToken,
                                            delimiter: request.delimiter,
                                            maxKeys: request.maxKeys,
-                                           prefix: request.prefix,
+                                           prefix: finalPrefix,
                                            startAfter: request.startAfter)
             do {
                 let response = try await awsS3.listObjectsV2(input: input)

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3ListObjectsV2Request.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3ListObjectsV2Request.swift
@@ -16,6 +16,7 @@ import AWSClientRuntime
 struct AWSS3ListObjectsV2Request {
     let bucket: String
     let prefix: String?
+    let path: String?
     let continuationToken: String?
     let delimiter: String?
     let maxKeys: Int
@@ -23,12 +24,14 @@ struct AWSS3ListObjectsV2Request {
 
     init(bucket: String,
          prefix: String? = nil,
+         path: String? = nil,
          continuationToken: String? = nil,
          delimiter: String? = nil,
          maxKeys: Int = 1_000,
          startAfter: String? = nil) {
         self.bucket = bucket
         self.prefix = prefix
+        self.path = path
         self.continuationToken = continuationToken
         self.delimiter = delimiter
         self.maxKeys = maxKeys

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3PreSignedURLBuilderBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3PreSignedURLBuilderBehavior.swift
@@ -26,12 +26,12 @@ protocol AWSS3PreSignedURLBuilderBehavior {
 
 extension AWSS3PreSignedURLBuilderBehavior {
 
-    func getPreSignedURL(key: String, signingOperation: AWSS3SigningOperation) async throws -> URL {
-        try await getPreSignedURL(key: key, signingOperation: signingOperation, expires: nil)
+    func getPreSignedURL(key: String, signingOperation: AWSS3SigningOperation, expires: Int64? = nil) async throws -> URL {
+        try await getPreSignedURL(key: key, signingOperation: signingOperation, expires: expires)
     }
 
-    func getPreSignedURL(key: String) async throws -> URL {
-        try await getPreSignedURL(key: key, signingOperation: .getObject, expires: nil)
+    func getPreSignedURL(key: String, expires: Int64? = nil) async throws -> URL {
+        try await getPreSignedURL(key: key, signingOperation: .getObject, expires: expires)
     }
 
 }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/S3Client+deleteObject.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/S3Client+deleteObject.swift
@@ -1,0 +1,51 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import AWSClientRuntime
+import AWSS3
+import ClientRuntime
+
+extension S3Client {
+    public func deleteObject(input: DeleteObjectInput, config: AWSClientRuntime.AWSClientConfiguration) async throws -> DeleteObjectOutputResponse
+    {
+        let client = ClientRuntime.SdkHttpClient(engine: config.httpClientEngine, config: config.httpClientConfiguration)
+        let encoder = ClientRuntime.XMLEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let decoder = ClientRuntime.XMLDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        decoder.trimValueWhitespaces = false
+        decoder.removeWhitespaceElements = true
+        let serviceName = "S3"
+        let context = ClientRuntime.HttpContextBuilder()
+                      .withEncoder(value: encoder)
+                      .withDecoder(value: decoder)
+                      .withMethod(value: .delete)
+                      .withServiceName(value: serviceName)
+                      .withOperation(value: "deleteObject")
+                      .withIdempotencyTokenGenerator(value: config.idempotencyTokenGenerator)
+                      .withLogger(value: config.logger)
+                      .withCredentialsProvider(value: config.credentialsProvider)
+                      .withRegion(value: config.region)
+                      .withSigningName(value: "s3")
+                      .withSigningRegion(value: config.signingRegion)
+        var operation = ClientRuntime.OperationStack<DeleteObjectInput, DeleteObjectOutputResponse, DeleteObjectOutputError>(id: "deleteObject")
+        operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<DeleteObjectInput, DeleteObjectOutputResponse, DeleteObjectOutputError>())
+        operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<DeleteObjectInput, DeleteObjectOutputResponse>())
+        operation.buildStep.intercept(position: .before, middleware: AWSClientRuntime.EndpointResolverMiddleware<DeleteObjectOutputResponse, DeleteObjectOutputError>(endpointResolver: config.endpointResolver, serviceId: serviceName))
+        let apiMetadata = AWSClientRuntime.APIMetadata(serviceId: serviceName, version: "1.0")
+        operation.buildStep.intercept(position: .before, middleware: AWSClientRuntime.UserAgentMiddleware(metadata: AWSClientRuntime.AWSUserAgentMetadata.fromEnv(apiMetadata: apiMetadata, frameworkMetadata: config.frameworkMetadata)))
+        operation.serializeStep.intercept(position: .after, middleware: ClientRuntime.HeaderMiddleware<DeleteObjectInput, DeleteObjectOutputResponse>())
+        operation.serializeStep.intercept(position: .after, middleware: ClientRuntime.QueryItemMiddleware<DeleteObjectInput, DeleteObjectOutputResponse>())
+        operation.finalizeStep.intercept(position: .after, middleware: AWSClientRuntime.RetryerMiddleware<DeleteObjectOutputResponse, DeleteObjectOutputError>(retryer: config.retryer))
+        let sigv4Config = AWSClientRuntime.SigV4Config(signedBodyHeader: .contentSha256, unsignedBody: false)
+        operation.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.SigV4Middleware<DeleteObjectOutputResponse, DeleteObjectOutputError>(config: sigv4Config))
+        operation.deserializeStep.intercept(position: .before, middleware: ClientRuntime.LoggerMiddleware<DeleteObjectOutputResponse, DeleteObjectOutputError>(clientLogMode: config.clientLogMode))
+        operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware<DeleteObjectOutputResponse, DeleteObjectOutputError>())
+        let result = try await operation.handleMiddleware(context: context.build(), input: input, next: client.getHandler())
+        return result
+    }
+}

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+GetPreSignedURLBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+GetPreSignedURLBehavior.swift
@@ -16,7 +16,8 @@ extension AWSS3StorageService {
                          onEvent: @escaping StorageServiceGetPreSignedURLEventHandler) {
         Task {
             do {
-                onEvent(.completed(try await preSignedURLBuilder.getPreSignedURL(key: serviceKey)))
+                onEvent(.completed(try await preSignedURLBuilder.getPreSignedURL(key: serviceKey,
+                                                                                 expires: Int64(expires))))
             } catch {
                 onEvent(.failed(StorageError.unknown("Failed to get pre-signed URL", nil)))
             }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+ListBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+ListBehavior.swift
@@ -13,8 +13,7 @@ extension AWSS3StorageService {
     func list(prefix: String,
               path: String?,
               onEvent: @escaping StorageServiceListEventHandler) {
-        let finalPrefix = prefix + (path ?? "")
-        let request = AWSS3ListObjectsV2Request(bucket: bucket, prefix: finalPrefix)
+        let request = AWSS3ListObjectsV2Request(bucket: bucket, prefix: prefix, path: path)
         awsS3.listObjectsV2(request) { result in
             switch result {
             case .success(let list):

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/FileSystem.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/FileSystem.swift
@@ -175,7 +175,7 @@ class FileSystem {
     }
 
     func moveFile(from sourceFileURL: URL, to destinationURL: URL) throws {
-        guard FileManager.default.fileExists(atPath: destinationURL.path) else {
+        guard !FileManager.default.fileExists(atPath: destinationURL.path) else {
             throw Failure.fatalError(errorDescription: "File already exists at destination: \(destinationURL.path)")
         }
         try FileManager.default.moveItem(atPath: sourceFileURL.path, toPath: destinationURL.path)


### PR DESCRIPTION
*Description of changes:*
Fixing the following Storage issues:

**Download**
- Attempting to download to a file always fails with "file already exists". Caused by a missing `!` in a validation.
- `.httpStatusError` is returned instead of `.keyNotFound` and `accessDenied` when applicable. Fixed by implementing a check for these status codes in `StorageTransferResponse.responseError`.

**List**
- Setting a `path` value in its options results in said value being removed from each `item.key` that is returned. 
  E.g. if you provide the full path for a given item, the item will have an empty key. If you provide the folder, each `item.key` will not include the folder.
  Fixed by adding a `path` attribute to the `AWSS3ListObjectsV2Request` instead of concatenating everything into its `prefix`.

**GetURL**
- Setting an `expires` value in its options does nothing, the URL does not expire. Fixed by propagating the `expires` argument instead of `nil`.

**Remove**
- Doesn't work on protected nor private buckets. This was caused due to the Swift SDK setting `useDoubleURIEncode: false` when creating the `SigV4Config` struct. 
   Fixed with a local extension that creates the right struct.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
