### PR TITLE
chore(datastore): fix LocalSubscriptionTests 

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionTests.swift
@@ -99,13 +99,13 @@ class LocalSubscriptionTests: XCTestCase {
     /// - Then:
     ///    - I receive notifications for updates to that model
     func testObserve() async throws {
-        let receivedMutationEvent = expectation(description: "Received mutation event")
+        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
 
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await _ in mutationEvents {
-                    receivedMutationEvent.fulfill()
+                    await receivedMutationEvent.fulfill()
                 }
             } catch {
                 XCTFail("Unexpected error: \(error)")
@@ -122,7 +122,7 @@ class LocalSubscriptionTests: XCTestCase {
                          comments: [])
 
         _ = try await Amplify.DataStore.save(model)
-        wait(for: [receivedMutationEvent], timeout: 1.0)
+        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
         subscription.cancel()
     }
 
@@ -132,14 +132,14 @@ class LocalSubscriptionTests: XCTestCase {
     /// - Then:
     ///    - I am notified of `create` mutations
     func testCreate() async throws {
-        let receivedMutationEvent = expectation(description: "Received mutation event")
+        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
 
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await mutationEvent in mutationEvents {
                     if mutationEvent.mutationType == MutationEvent.MutationType.create.rawValue {
-                        receivedMutationEvent.fulfill()
+                        await receivedMutationEvent.fulfill()
                     }
                 }
             } catch {
@@ -157,7 +157,7 @@ class LocalSubscriptionTests: XCTestCase {
                          comments: [])
 
         _ = try await Amplify.DataStore.save(model)
-        wait(for: [receivedMutationEvent], timeout: 1.0)
+        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
 
         subscription.cancel()
     }
@@ -185,13 +185,13 @@ class LocalSubscriptionTests: XCTestCase {
         newModel.content = newContent
         newModel.updatedAt = .now()
 
-        let receivedMutationEvent = expectation(description: "Received mutation event")
+        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
 
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await _ in mutationEvents {
-                    receivedMutationEvent.fulfill()
+                    await receivedMutationEvent.fulfill()
                 }
             } catch {
                 XCTFail("Unexpected error: \(error)")
@@ -200,7 +200,7 @@ class LocalSubscriptionTests: XCTestCase {
         
         _ = try await Amplify.DataStore.save(newModel)
 
-        wait(for: [receivedMutationEvent], timeout: 1.0)
+        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
 
         subscription.cancel()
     }
@@ -211,14 +211,14 @@ class LocalSubscriptionTests: XCTestCase {
     /// - Then:
     ///    - I am notified of `delete` mutations
     func testDelete() async throws {
-        let receivedMutationEvent = expectation(description: "Received mutation event")
+        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
 
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await mutationEvent in mutationEvents {
                     if mutationEvent.mutationType == MutationEvent.MutationType.delete.rawValue {
-                        receivedMutationEvent.fulfill()
+                        await receivedMutationEvent.fulfill()
                     }
                 }
             } catch {
@@ -232,7 +232,7 @@ class LocalSubscriptionTests: XCTestCase {
 
         _ = try await Amplify.DataStore.save(model)
         _ = try await Amplify.DataStore.delete(model)
-        wait(for: [receivedMutationEvent], timeout: 1.0)
+        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
 
         subscription.cancel()
     }


### PR DESCRIPTION
*Issue #, if available:*
Tests for `LocalSubscriptionTests.swift` were failing
*Description of changes:*
small fix of `LocalSubscriptionTests.swift` to `async` so that all the tests successfully run.
<img width="418" alt="Screen Shot 2022-09-11 at 3 38 25 PM" src="https://user-images.githubusercontent.com/107574718/189551856-b8846fc6-f22f-4c0c-9429-e4de523608b2.png">


*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
