### PR TITLE
fix(datastore): observeQuery snapshot on .modelSynced event 

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStoreObserveQueryOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStoreObserveQueryOperation.swift
@@ -144,7 +144,7 @@ class ObserveQueryTaskRunner<M: Model>: InternalTaskRunner, InternalTaskAsyncThr
             }
             
             if let readyEventSink = readyEventSink {
-                        readyEventSink.cancel()
+                readyEventSink.cancel()
             }
         }
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionTests.swift
@@ -99,13 +99,13 @@ class LocalSubscriptionTests: XCTestCase {
     /// - Then:
     ///    - I receive notifications for updates to that model
     func testObserve() async throws {
-        let receivedMutationEvent = expectation(description: "Received mutation event")
+        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
 
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await _ in mutationEvents {
-                    receivedMutationEvent.fulfill()
+                    await receivedMutationEvent.fulfill()
                 }
             } catch {
                 XCTFail("Unexpected error: \(error)")
@@ -122,7 +122,7 @@ class LocalSubscriptionTests: XCTestCase {
                          comments: [])
 
         _ = try await Amplify.DataStore.save(model)
-        wait(for: [receivedMutationEvent], timeout: 1.0)
+        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
         subscription.cancel()
     }
 
@@ -132,14 +132,14 @@ class LocalSubscriptionTests: XCTestCase {
     /// - Then:
     ///    - I am notified of `create` mutations
     func testCreate() async throws {
-        let receivedMutationEvent = expectation(description: "Received mutation event")
+        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
 
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await mutationEvent in mutationEvents {
                     if mutationEvent.mutationType == MutationEvent.MutationType.create.rawValue {
-                        receivedMutationEvent.fulfill()
+                        await receivedMutationEvent.fulfill()
                     }
                 }
             } catch {
@@ -157,7 +157,7 @@ class LocalSubscriptionTests: XCTestCase {
                          comments: [])
 
         _ = try await Amplify.DataStore.save(model)
-        wait(for: [receivedMutationEvent], timeout: 1.0)
+        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
 
         subscription.cancel()
     }
@@ -185,13 +185,13 @@ class LocalSubscriptionTests: XCTestCase {
         newModel.content = newContent
         newModel.updatedAt = .now()
 
-        let receivedMutationEvent = expectation(description: "Received mutation event")
+        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
 
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await _ in mutationEvents {
-                    receivedMutationEvent.fulfill()
+                    await receivedMutationEvent.fulfill()
                 }
             } catch {
                 XCTFail("Unexpected error: \(error)")
@@ -200,7 +200,7 @@ class LocalSubscriptionTests: XCTestCase {
         
         _ = try await Amplify.DataStore.save(newModel)
 
-        wait(for: [receivedMutationEvent], timeout: 1.0)
+        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
 
         subscription.cancel()
     }
@@ -211,14 +211,14 @@ class LocalSubscriptionTests: XCTestCase {
     /// - Then:
     ///    - I am notified of `delete` mutations
     func testDelete() async throws {
-        let receivedMutationEvent = expectation(description: "Received mutation event")
+        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
 
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await mutationEvent in mutationEvents {
                     if mutationEvent.mutationType == MutationEvent.MutationType.delete.rawValue {
-                        receivedMutationEvent.fulfill()
+                        await receivedMutationEvent.fulfill()
                     }
                 }
             } catch {
@@ -232,7 +232,7 @@ class LocalSubscriptionTests: XCTestCase {
 
         _ = try await Amplify.DataStore.save(model)
         _ = try await Amplify.DataStore.delete(model)
-        wait(for: [receivedMutationEvent], timeout: 1.0)
+        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
 
         subscription.cancel()
     }


### PR DESCRIPTION
*Issue #, if available:*
#1759
*Description of changes:*
(reference taken from #2105)
Datastore observeQuery is an API that produces streamlines of data snapshots along with its' syncState.
While producing data snapshots and syncing to the cloud, the `isSynced` value remains `false` and is toggled to `true` when the syncing process is complete. But there can be potential loss of snapshots in the toggle from the last snapshot during the sync and the first snapshot after the sync as there can be lot of items being changed at that point after toggle. And the snapshot to be produced after the sync is delayed as it waits for any new changes. 
The fix is to listen on datastore .modelSynced where Items observed will be returned in a single snapshot on isSynced toggled from `false` to `true`. The operation will internally listen to `.modelSynced` event from the `Hub`, thus emitting required snapshots on toggle fixing the issue #1759

Also wrote a small test case covering a test case where storageEngine returns two Posts in a single snapshot.
*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
