### PR TITLE
fix(Storage): Adding support for pausing, resuming and cancelling multipart uploads

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
@@ -114,7 +114,7 @@ class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
             // tell the session the upload part has started
             self.session?.handle(uploadPartEvent: .started(partNumber: partNumber, taskIdentifier: uploadTask.taskIdentifier))
 
-            uploadTask.resume()
+            subTask.resume()
         }
 
         let partialFileResultHandler: (Result<URL, Error>) -> Void = { [weak self] result in

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadSession.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadSession.swift
@@ -181,6 +181,7 @@ class StorageMultipartUploadSession {
 
     func startUpload() {
         do {
+            transferTask.notify(progress: Progress(totalUnitCount: 0))
             let reference = StorageTaskReference(transferTask)
             onEvent(.initiated(reference))
             try client.createMultipartUpload()
@@ -260,6 +261,7 @@ class StorageMultipartUploadSession {
 
                 if let uploadId = multipartUpload.uploadId {
                     try client.completeMultipartUpload(uploadId: uploadId)
+                    transferTask.complete()
                 } else {
                     fatalError("Invalid state")
                 }
@@ -304,7 +306,7 @@ class StorageMultipartUploadSession {
                     // the next call does async work
                     let subTask = createSubTask(partNumber: partNumber)
                     try client.uploadPart(partNumber: partNumber, multipartUpload: multipartUpload, subTask: subTask)
-
+                    transferTask.addSubTask(subTask)
                     lastNumber = partNumber
                 }
             }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageTransferTask.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageTransferTask.swift
@@ -175,7 +175,7 @@ class StorageTransferTask {
         logger.debug("Cancelling storage transfer task: \(taskIdentifier ?? 0)")
 
         status = .cancelled
-
+        subTasks = []
         storageTransferDatabase.removeTransferRequest(task: self)
     }
 


### PR DESCRIPTION
*Description of changes:*
Tweaking the code in order to support pausing, resuming and cancelling multipart uploads.

Basically the main `StorageTransferTask` that was used for multipart uploads had no way of interacting with each of the subtasks corresponding to each part. So i've added a `subTasks` array only for multipart uploads, which is then called respectively on each corresponding method.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] ~All integration tests pass~
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
