### PR TITLE
chore(ci): add cloudwatch monitoring for getting started smoke test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,18 @@ orbs:
       macos: circleci/macos@2
       node: circleci/node@5.0.2
       ruby: circleci/ruby@1.6.0
+      aws-cli: circleci/aws-cli@3.1.1
     commands:
+      send-metric-on-fail:
+        description: Send failure datapoint to cloudwatch
+        steps:
+          - run:
+              name: Send failure datapoint to cloudwatch
+              command: |
+                payload="{\"jobName\": \"${CIRCLE_JOB}\", \"projectRepoName\": \"${CIRCLE_PROJECT_REPONAME}\"}"
+                echo $payload
+                aws lambda invoke --function-name CircleCIWorkflowFailureHandler --payload "$payload" --cli-binary-format raw-in-base64-out response.json
+              when: on_fail
       run-with-retry:
         description: Run command with retry
         parameters:
@@ -73,6 +84,10 @@ orbs:
         steps:
           - checkout:
               path: ~/ios-canaries
+          - aws-cli/setup:
+              role-session-name: ${CIRCLE_WORKFLOW_JOB_ID}
+              role-arn: ${AWS_ROLE_ARN}
+              session-duration: '2000'
           - node/install
           - run: npm install -g @aws-amplify/cli
           - run: amplify init --quickstart --frontend ios
@@ -87,6 +102,7 @@ orbs:
           - run-with-retry:
               label: Run tests
               command: bundle exec fastlane scan
+          - send-metric-on-fail
 
 defaults: &defaults
   macos:
@@ -441,10 +457,14 @@ workflows:
         - equal: [ "Canaries", << pipeline.schedule.name >> ]
     jobs:
       - getting-started-smoke-test/ios:
+          context:
+            - cloudwatch-monitoring
           xcode-version: "13.3.0"
           simulator-os-version: "15.4"
           simulator-device: "iPhone 13"
       - getting-started-smoke-test/ios:
+          context:
+            - cloudwatch-monitoring
           xcode-version: "12.5.1"
           simulator-os-version: "14.5"
           simulator-device: "iPhone 12"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Enhancement for the getting started workflow in circleCI(https://github.com/aws-amplify/amplify-ios/pull/1884). We added cloudwatch monitoring for the workflow, so the devops team could get notified right away if there's any issues with the workflow. The change should not alter any existing behavior.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
