### PR TITLE
fix(Storage): getURL to use function parameter 'options'

### DIFF
--- a/Amplify/Categories/Storage/StorageCategory+ClientBehavior+Combine.swift
+++ b/Amplify/Categories/Storage/StorageCategory+ClientBehavior+Combine.swift
@@ -61,7 +61,7 @@ extension StorageCategoryBehavior {
         key: String,
         options: StorageGetURLRequest.Options? = nil
     ) -> StorageGetURLOperation {
-        getURL(key: key, options: nil, resultListener: nil)
+        getURL(key: key, options: options, resultListener: nil)
     }
 
     /// List the object identifiers under the heiarchy specified by the path, relative to access level, from storage


### PR DESCRIPTION
*Issue #, if available:*
[Issue#2185](https://github.com/aws-amplify/amplify-ios/issues/2185)

*Description of changes:*
- Use parameter `options` instead of `nil` for function StorageCategoryBehavior [getURL(key:options:)](https://github.com/aws-amplify/amplify-ios/blob/main/Amplify/Categories/Storage/StorageCategory%2BClientBehavior%2BCombine.swift#L64).

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
