### PR TITLE
fix(datastore): InitializeSubscription race condition disconnected event

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
@@ -102,7 +102,7 @@ final class ModelSyncedEventEmitter {
             return modelSchema.name == event.modelName
         case .mutationEventDropped(let modelName, _):
             return modelSchema.name == modelName
-        case .initialized, .started, .paused:
+        case .notStarted, .initialized, .started, .paused:
             return false
         }
     }
@@ -130,7 +130,7 @@ final class ModelSyncedEventEmitter {
                 modelSyncedEventTopic.send(.mutationEventApplied(event))
             case .mutationEventDropped(let modelName, let error):
                 modelSyncedEventTopic.send(.mutationEventDropped(modelName: modelName, error: error))
-            case .initialized, .started, .paused:
+            case .notStarted, .initialized, .started, .paused:
                 return
             }
             return
@@ -161,7 +161,7 @@ final class ModelSyncedEventEmitter {
             if shouldSendModelSyncedEvent {
                 sendModelSyncedEvent()
             }
-        case .initialized, .started, .paused:
+        case .notStarted, .initialized, .started, .paused:
             return
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
@@ -102,7 +102,7 @@ final class ModelSyncedEventEmitter {
             return modelSchema.name == event.modelName
         case .mutationEventDropped(let modelName, _):
             return modelSchema.name == modelName
-        case .notStarted, .initialized, .started, .paused:
+        case .idle, .initialized, .started, .paused:
             return false
         }
     }
@@ -130,7 +130,7 @@ final class ModelSyncedEventEmitter {
                 modelSyncedEventTopic.send(.mutationEventApplied(event))
             case .mutationEventDropped(let modelName, let error):
                 modelSyncedEventTopic.send(.mutationEventDropped(modelName: modelName, error: error))
-            case .notStarted, .initialized, .started, .paused:
+            case .idle, .initialized, .started, .paused:
                 return
             }
             return
@@ -161,7 +161,7 @@ final class ModelSyncedEventEmitter {
             if shouldSendModelSyncedEvent {
                 sendModelSyncedEvent()
             }
-        case .notStarted, .initialized, .started, .paused:
+        case .idle, .initialized, .started, .paused:
             return
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
@@ -34,12 +34,14 @@ extension RemoteSyncEngine {
     func onReceive(receiveValue: IncomingEventReconciliationQueueEvent) {
         switch receiveValue {
         case .initialized:
+            log.verbose("[InitializeSubscription.5] RemoteSyncEngine IncomingEventReconciliationQueueEvent.initialized")
             log.verbose("[Lifecycle event 1]: subscriptionsEstablished")
             let payload = HubPayload(eventName: HubPayload.EventName.DataStore.subscriptionsEstablished)
             Amplify.Hub.dispatch(to: .dataStore, payload: payload)
             remoteSyncTopicPublisher.send(.subscriptionsInitialized)
             stateMachine.notify(action: .initializedSubscriptions)
         case .started:
+            log.verbose("[InitializeSubscription.6] RemoteSyncEngine IncomingEventReconciliationQueueEvent.started")
             guard let api = self.api else {
                 let error = DataStoreError.internalOperation("api is unexpectedly `nil`", "", nil)
                 stateMachine.notify(action: .errored(error))
@@ -51,7 +53,7 @@ extension RemoteSyncEngine {
                                                                      reconciliationQueue))
         case .paused:
             remoteSyncTopicPublisher.send(.subscriptionsPaused)
-        case .mutationEventDropped, .mutationEventApplied:
+        case .notStarted, .mutationEventDropped, .mutationEventApplied:
             break
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
@@ -53,7 +53,7 @@ extension RemoteSyncEngine {
                                                                      reconciliationQueue))
         case .paused:
             remoteSyncTopicPublisher.send(.subscriptionsPaused)
-        case .notStarted, .mutationEventDropped, .mutationEventApplied:
+        case .idle, .mutationEventDropped, .mutationEventApplied:
             break
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RemoteSyncEngine.swift
@@ -181,7 +181,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
             notifySyncStarted()
 
         case .syncEngineActive:
-            break
+            log.debug("RemoteSyncEngine SyncEngineActive")
 
         case .cleaningUp(let error):
             cleanup(error: error)
@@ -276,7 +276,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
 
     private func initializeSubscriptions(api: APICategoryGraphQLBehavior,
                                          storageAdapter: StorageEngineAdapter) {
-        log.debug(#function)
+        log.debug("[InitializeSubscription] \(#function)")
         let syncableModelSchemas = ModelRegistry.modelSchemas.filter { $0.isSyncable }
         reconciliationQueue = reconciliationQueueFactory(syncableModelSchemas,
                                                          api,
@@ -294,6 +294,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     }
 
     private func performInitialSync() {
+        log.debug("[InitializeSubscription.6] performInitialSync")
         log.debug(#function)
 
         let initialSyncOrchestrator = initialSyncOrchestratorFactory(dataStoreConfiguration,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -27,7 +27,7 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
 
     private var modelReconciliationQueueSinks: [String: AnyCancellable]
 
-    private let eventReconciliationQueueTopic: PassthroughSubject<IncomingEventReconciliationQueueEvent, DataStoreError>
+    private let eventReconciliationQueueTopic: CurrentValueSubject<IncomingEventReconciliationQueueEvent, DataStoreError>
     var publisher: AnyPublisher<IncomingEventReconciliationQueueEvent, DataStoreError> {
         return eventReconciliationQueueTopic.eraseToAnyPublisher()
     }
@@ -39,8 +39,10 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
     private var modelReconciliationQueueFactory: ModelReconciliationQueueFactory
 
     private var isInitialized: Bool {
-        reconciliationQueueConnectionStatus.count == reconciliationQueues.count
+        Amplify.log.verbose("[InitializeSubscription.5] \(reconciliationQueueConnectionStatus.count)/\(modelSchemasCount) initialized")
+        return modelSchemasCount == reconciliationQueueConnectionStatus.count
     }
+    private let modelSchemasCount: Int
 
     init(modelSchemas: [ModelSchema],
          api: APICategoryGraphQLBehavior,
@@ -49,8 +51,9 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
          auth: AuthCategoryBehavior? = nil,
          authModeStrategy: AuthModeStrategy,
          modelReconciliationQueueFactory: ModelReconciliationQueueFactory? = nil) {
+        self.modelSchemasCount = modelSchemas.count
         self.modelReconciliationQueueSinks = [:]
-        self.eventReconciliationQueueTopic = PassthroughSubject<IncomingEventReconciliationQueueEvent, DataStoreError>()
+        self.eventReconciliationQueueTopic = CurrentValueSubject<IncomingEventReconciliationQueueEvent, DataStoreError>(.notStarted)
         self.reconciliationQueues = [:]
         self.reconciliationQueueConnectionStatus = [:]
         self.reconcileAndSaveQueue = ReconcileAndSaveQueue(modelSchemas)
@@ -66,6 +69,12 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
                 $0.modelSchema.name == modelName
             })
             let modelPredicate = syncExpression?.modelPredicate() ?? nil
+            guard reconciliationQueues[modelName] == nil else {
+                Amplify.DataStore.log
+                    .warn("Duplicate model name found: \(modelName), not subscribing")
+                continue
+            }
+            Amplify.log.verbose("[InitializeSubscription.5] Creating reconciliationQueues \(modelName) \(reconciliationQueues.count)")
             let queue = self.modelReconciliationQueueFactory(modelSchema,
                                                              storageAdapter,
                                                              api,
@@ -74,14 +83,11 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
                                                              auth,
                                                              authModeStrategy,
                                                              nil)
-            guard reconciliationQueues[modelName] == nil else {
-                Amplify.DataStore.log
-                    .warn("Duplicate model name found: \(modelName), not subscribing")
-                continue
-            }
             reconciliationQueues[modelName] = queue
+            Amplify.log.verbose("[InitializeSubscription.5] Sink reconciliationQueues \(modelName) \(reconciliationQueues.count)")
             let modelReconciliationQueueSink = queue.publisher.sink(receiveCompletion: onReceiveCompletion(completed:),
                                                                     receiveValue: onReceiveValue(receiveValue:))
+            Amplify.log.verbose("[InitializeSubscription.5] Sink done reconciliationQueues \(modelName) \(reconciliationQueues.count)")
             modelReconciliationQueueSinks[modelName] = modelReconciliationQueueSink
         }
     }
@@ -118,27 +124,32 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
     }
 
     private func onReceiveValue(receiveValue: ModelReconciliationQueueEvent) {
+
         switch receiveValue {
         case .mutationEvent(let event):
             eventReconciliationQueueTopic.send(.mutationEventApplied(event))
         case .mutationEventDropped(let modelName, let error):
             eventReconciliationQueueTopic.send(.mutationEventDropped(modelName: modelName, error: error))
         case .connected(modelName: let modelName):
+
             connectionStatusSerialQueue.async {
+                Amplify.log.verbose("[InitializeSubscription.4] .connected \(modelName)")
                 self.reconciliationQueueConnectionStatus[modelName] = true
                 if self.isInitialized {
+                    Amplify.log.verbose("[InitializeSubscription.6] connected isInitialized")
                     self.eventReconciliationQueueTopic.send(.initialized)
                 }
             }
         case .disconnected(modelName: let modelName, reason: .operationDisabled),
              .disconnected(modelName: let modelName, reason: .unauthorized):
             connectionStatusSerialQueue.async {
-                Amplify.log.debug("Disconnected subscription for \(modelName) reason: \(receiveValue)")
+                Amplify.log.verbose("[InitializeSubscription.4] subscription disconnected [\(modelName)] reason: [\(receiveValue)]")
                 // A disconnected subscription due to operation disabled or unauthorized will still contribute
                 // to the overall state of the reconciliation queue system on sending the `.initialized` event
                 // since subscriptions may be disabled and have to reconcile locally sourced mutation evemts.
                 self.reconciliationQueueConnectionStatus[modelName] = true
                 if self.isInitialized {
+                    Amplify.log.verbose("[InitializeSubscription.6] disconnected isInitialized")
                     self.eventReconciliationQueueTopic.send(.initialized)
                 }
             }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -17,12 +17,12 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
 
     private let asyncEvents: IncomingAsyncSubscriptionEventPublisher
     private let mapper: IncomingAsyncSubscriptionEventToAnyModelMapper
-    private let subscriptionEventSubject: PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError> 
+    private let subscriptionEventSubject: PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>
     private var mapperSink: AnyCancellable?
     var publisher: AnyPublisher<IncomingSubscriptionEventPublisherEvent, DataStoreError> {
         return subscriptionEventSubject.eraseToAnyPublisher()
     }
-    
+
     init(modelSchema: ModelSchema,
          api: APICategoryGraphQLBehavior,
          modelPredicate: QueryPredicate?,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/AWSIncomingSubscriptionEventPublisher.swift
@@ -17,12 +17,12 @@ final class AWSIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPubl
 
     private let asyncEvents: IncomingAsyncSubscriptionEventPublisher
     private let mapper: IncomingAsyncSubscriptionEventToAnyModelMapper
-    private let subscriptionEventSubject: PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>
+    private let subscriptionEventSubject: PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError> 
     private var mapperSink: AnyCancellable?
     var publisher: AnyPublisher<IncomingSubscriptionEventPublisherEvent, DataStoreError> {
         return subscriptionEventSubject.eraseToAnyPublisher()
     }
-
+    
     init(modelSchema: ModelSchema,
          api: APICategoryGraphQLBehavior,
          modelPredicate: QueryPredicate?,

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -188,7 +188,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
         case .success:
             incomingSubscriptionEvents.send(completion: .finished)
         case .failure(let apiError):
-            log.verbose("API Subscription failed for model `\(modelName)` with error: \(apiError.errorDescription)")
+            log.verbose("[InitializeSubscription.1] API.subscribe failed for `\(modelName)` error: \(apiError.errorDescription)")
             let dataStoreError = DataStoreError(error: apiError)
             incomingSubscriptionEvents.send(completion: .failure(dataStoreError))
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
@@ -10,7 +10,7 @@ import AWSPluginsCore
 import Combine
 
 enum IncomingEventReconciliationQueueEvent {
-    case notStarted
+    case idle
     case initialized
     case started
     case paused

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
@@ -10,6 +10,7 @@ import AWSPluginsCore
 import Combine
 
 enum IncomingEventReconciliationQueueEvent {
+    case notStarted
     case initialized
     case started
     case paused

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -71,7 +71,6 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
     private let reconcileAndSaveQueue: ReconcileAndSaveOperationQueue
 
     private var incomingEventsSink: AnyCancellable?
-    private var incomingEventsSink2: AnyCancellable?
     private var reconcileAndLocalSaveOperationSinks: AtomicValue<Set<AnyCancellable?>>
 
     private let modelReconciliationQueueSubject: CurrentValueSubject<ModelReconciliationQueueEvent, DataStoreError>
@@ -92,7 +91,7 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
         self.storageAdapter = storageAdapter
 
         self.modelPredicate = modelPredicate
-        self.modelReconciliationQueueSubject = CurrentValueSubject<ModelReconciliationQueueEvent, DataStoreError>(.notStarted)
+        self.modelReconciliationQueueSubject = CurrentValueSubject<ModelReconciliationQueueEvent, DataStoreError>(.idle)
         self.reconcileAndSaveQueue = reconcileAndSaveQueue
 
         self.incomingSubscriptionEventQueue = OperationQueue()

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
@@ -15,7 +15,7 @@ enum ModelConnectionDisconnectedReason {
 }
 
 enum ModelReconciliationQueueEvent {
-    case notStarted
+    case idle
     case started
     case paused
     case connected(modelName: String)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
@@ -15,6 +15,7 @@ enum ModelConnectionDisconnectedReason {
 }
 
 enum ModelReconciliationQueueEvent {
+    case notStarted
     case started
     case paused
     case connected(modelName: String)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -211,7 +211,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             case .initialized:
                 expectInitialized.fulfill()
             default:
-                break
+                XCTFail("Should not expect any other state, received: \(event)")
             }
         })
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -61,7 +61,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             case .initialized:
                 expectInitialized.fulfill()
             default:
-                XCTFail("Should not expect any other state, received: \(event)")
+                break
             }
         })
 
@@ -91,7 +91,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             case .initialized:
                 expectInitialized.fulfill()
             default:
-                XCTFail("Should not expect any other state, received: \(event)")
+                break
             }
         })
 
@@ -122,7 +122,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             case .initialized:
                 expectInitialized.fulfill()
             default:
-                XCTFail("Should not expect any other state, received: \(event)")
+                break
             }
         })
 
@@ -154,7 +154,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             case .initialized:
                 expectInitialized.fulfill()
             default:
-                XCTFail("Should not expect any other state, received: \(event)")
+                break
             }
         })
 
@@ -188,7 +188,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             case .initialized:
                 expectInitialized.fulfill()
             default:
-                XCTFail("Should not expect any other state, received: \(event)")
+                break
             }
         })
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -48,6 +48,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     // This test case attempts to hit a race condition, and may be required to execute multiple times
     // in order to demonstrate the bug
     func testTwoConnectionStatusUpdatesAtSameTime() {
+        let expectStarted = expectation(description: "eventQueue expected to send out started state")
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
 
         let eventQueue = initEventQueue(modelSchemas: [Post.schema, Comment.schema])
@@ -58,10 +59,14 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             XCTFail("Not expecting this to call")
         }, receiveValue: { event  in
             switch event {
+            case .idle:
+                break
+            case .started:
+                expectStarted.fulfill()
             case .initialized:
                 expectInitialized.fulfill()
             default:
-                break
+                XCTFail("Should not expect any other state, received: \(event)")
             }
         })
 
@@ -80,6 +85,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     }
 
     func testSubscriptionFailedWithSingleModelUnauthorizedError() {
+        let expectStarted = expectation(description: "eventQueue expected to send out started state")
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
         let eventQueue = initEventQueue(modelSchemas: [Post.schema])
         eventQueue.start()
@@ -88,10 +94,14 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             XCTFail("Not expecting this to call")
         }, receiveValue: { event  in
             switch event {
+            case .idle:
+                break
+            case .started:
+                expectStarted.fulfill()
             case .initialized:
                 expectInitialized.fulfill()
             default:
-                break
+                XCTFail("Should not expect any other state, received: \(event)")
             }
         })
 
@@ -111,6 +121,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     // This test case tests that initialized event is received even if only one
     // model subscriptions out of two failed - Post subscription will fail but Comment will succeed
     func testSubscriptionFailedWithMultipleModels() {
+        let expectStarted = expectation(description: "eventQueue expected to send out started state")
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
         let eventQueue = initEventQueue(modelSchemas: [Post.schema, Comment.schema])
         eventQueue.start()
@@ -119,10 +130,14 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             XCTFail("Not expecting this to call")
         }, receiveValue: { event  in
             switch event {
+            case .idle:
+                break
+            case .started:
+                expectStarted.fulfill()
             case .initialized:
                 expectInitialized.fulfill()
             default:
-                break
+                XCTFail("Should not expect any other state, received: \(event)")
             }
         })
 
@@ -143,6 +158,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     }
 
     func testSubscriptionFailedWithSingleModelOperationDisabled() {
+        let expectStarted = expectation(description: "eventQueue expected to send out started state")
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
         let eventQueue = initEventQueue(modelSchemas: [Post.schema])
         eventQueue.start()
@@ -151,10 +167,14 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             XCTFail("Not expecting this to call")
         }, receiveValue: { event  in
             switch event {
+            case .idle:
+                break
+            case .started:
+                expectStarted.fulfill()
             case .initialized:
                 expectInitialized.fulfill()
             default:
-                break
+                XCTFail("Should not expect any other state, received: \(event)")
             }
         })
 
@@ -177,6 +197,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     // Post subscription will fail with a "OperationDisabled",
     // but Comment subscription will succeed
     func testSubscriptionFailedBecauseOfOperationDisabledWithMultipleModels() {
+        let expectStarted = expectation(description: "eventQueue expected to send out started state")
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
         let eventQueue = initEventQueue(modelSchemas: [Post.schema])
         eventQueue.start()
@@ -185,6 +206,8 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             XCTFail("Not expecting this to call")
         }, receiveValue: { event  in
             switch event {
+            case .started:
+                expectStarted.fulfill()
             case .initialized:
                 expectInitialized.fulfill()
             default:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -440,8 +440,13 @@ extension ModelReconciliationQueueBehaviorTests {
 
         let queueSink = queue.publisher.sink(receiveCompletion: { value in
             XCTFail("Not expecting a call to completion, received \(value)")
-        }, receiveValue: { _ in
-            eventSentViaPublisher.fulfill()
+        }, receiveValue: { event in
+            switch event {
+            case .notStarted:
+                break
+            default:
+                eventSentViaPublisher.fulfill()
+            }
         })
 
         subscriptionEventsSubject.send(completion: completion)
@@ -462,8 +467,13 @@ extension ModelReconciliationQueueBehaviorTests {
 
         let queueSink = queue.publisher.sink(receiveCompletion: { value in
             XCTFail("Not expecting a call to completion, received \(value)")
-        }, receiveValue: { _ in
-            eventSentViaPublisher.fulfill()
+        }, receiveValue: { event in
+            switch event {
+            case .notStarted:
+                break
+            default:
+                eventSentViaPublisher.fulfill()
+            }
         })
 
         subscriptionEventsSubject.send(completion: completion)
@@ -485,7 +495,12 @@ extension ModelReconciliationQueueBehaviorTests {
         let queueSink = queue.publisher.sink(receiveCompletion: { _ in
             eventSentViaPublisher.fulfill()
         }, receiveValue: { value in
-            XCTFail("Not expecting a successful call, received \(value)")
+            switch value {
+            case .notStarted:
+                break
+            default:
+                XCTFail("Not expecting a successful call, received \(value)")
+            }
         })
 
         subscriptionEventsSubject.send(completion: completion)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -442,7 +442,7 @@ extension ModelReconciliationQueueBehaviorTests {
             XCTFail("Not expecting a call to completion, received \(value)")
         }, receiveValue: { event in
             switch event {
-            case .notStarted:
+            case .idle:
                 break
             default:
                 eventSentViaPublisher.fulfill()
@@ -469,7 +469,7 @@ extension ModelReconciliationQueueBehaviorTests {
             XCTFail("Not expecting a call to completion, received \(value)")
         }, receiveValue: { event in
             switch event {
-            case .notStarted:
+            case .idle:
                 break
             default:
                 eventSentViaPublisher.fulfill()
@@ -496,7 +496,7 @@ extension ModelReconciliationQueueBehaviorTests {
             eventSentViaPublisher.fulfill()
         }, receiveValue: { value in
             switch value {
-            case .notStarted:
+            case .idle:
                 break
             default:
                 XCTFail("Not expecting a successful call, received \(value)")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When the sync process starts (RemoteSyncEngine) and initializes API subscriptions, this work is performed through various components that publish events through Combine publishers backed by a PassThroughSubject, in this pattern:
```
let component = Component()
let sink = component.publisher.sink { event in 
  // handle event
}
```
The problem with this pattern is that the subscriber to the publisher may miss some values if the Component's initialization code results in sending values before it returns, which occurs before `component.publisher.sink` is finished. 

In this specific case where subscriptions are being established through API usually take a few network trips to perform the websocket handshake, in which the Component calling code would already have subscribed for events. In the failure case, where the websocket subscription request returns "Unauthorized" and sends this as a event on the publisher, then the caller may sometimes miss this, which is a race condition.

```
let component = Component()
let sink = component.publisher.sink { event in  // 2. subscribe to the publisher
  // 3. handle the event
}

Component {
  init() {
     API.subscribe() { results in
        publisher.send(result) // 1. publisher sends the result
     }
  }
}
```
1. publisher sends the result, which may occur before (2)
2. Subscribe to the publisher, which may occur after (1)
3. The event is never handled, since it has occurred already.

In this PR, the functional change is replace PassThroughSubject with CurrentValueSubject so that subscribers can retrieve the last stored value. In the scenario described where values are sent before the subscriber finishes subscribing to the publisher, the CurrentValueSubject will give the last value back.

Second change in this PR is related to subscription Unauthorized checks. there was an edge case for IAM auth types where unauthorized was returned on the message level, and not on the AppSync GraphQL error payload.

A logging stack is also added here called `[InitializeSubscription.<Stack>]` where `<Stack>` is a number that increments for context. A similar pattern was done before for datastore's lifecycle events as `[Lifecycle event <Stack>]` that I found useful. 

<details>
<summary>Filter on `[InitializeSubscription` example logs</summary>



```
2022-09-17 00:48:54.619455-0400 Sample[8585:55714566] [RemoteSyncEngine] [InitializeSubscription] initializeSubscriptions(api:storageAdapter:)
2022-09-17 00:48:54.620119-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Creating reconciliationQueues Model1 0
2022-09-17 00:48:55.376553-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink reconciliationQueues Model1 1
2022-09-17 00:48:55.376725-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink done reconciliationQueues Model1 1
2022-09-17 00:48:55.376780-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Creating reconciliationQueues Model2 1
2022-09-17 00:48:55.728990-0400 Sample[8585:55714561] [IncomingAsyncSubscriptionEventPublisher] [InitializeSubscription.1] API.subscribe failed for `Model2` error: Subscription item event failed with error: Unauthorized
2022-09-17 00:48:55.774959-0400 Sample[8585:55714566] [AWSModelReconciliationQueue] [InitializeSubscription.3] AWSModelReconciliationQueue determined unauthorized Model2
2022-09-17 00:48:55.775001-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink reconciliationQueues Model2 2
2022-09-17 00:48:55.775065-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink done reconciliationQueues Model2 2
2022-09-17 00:48:55.775127-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Creating reconciliationQueues Model3 2
2022-09-17 00:48:55.776150-0400 Sample[8585:55714560] [Amplify] [InitializeSubscription.4] AWSIncomingEventReconciliationQueue subscription disconnected [Model2] reason: [disconnected(modelName: "Model2", reason: AWSDataStorePlugin.ModelConnectionDisconnectedReason.unauthorized)]
2022-09-17 00:48:55.776232-0400 Sample[8585:55714560] [Amplify] [InitializeSubscription.5] 1/12 initialized
2022-09-17 00:48:55.805770-0400 Sample[8585:55714560] [Amplify] [InitializeSubscription.4] AWSIncomingEventReconciliationQueue .connected Model1
2022-09-17 00:48:55.805876-0400 Sample[8585:55714560] [Amplify] [InitializeSubscription.5] 2/12 initialized
2022-09-17 00:48:55.870551-0400 Sample[8585:55714656] [IncomingAsyncSubscriptionEventPublisher] [InitializeSubscription.1] API.subscribe failed for `Model2` error: Subscription item event failed with error: Unauthorized
2022-09-17 00:48:55.886301-0400 Sample[8585:55714564] [IncomingAsyncSubscriptionEventPublisher] [InitializeSubscription.1] API.subscribe failed for `Model2` error: Subscription item event failed with error: Unauthorized
2022-09-17 00:48:56.126796-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink reconciliationQueues Model3 3
2022-09-17 00:48:56.126922-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink done reconciliationQueues Model3 3
2022-09-17 00:48:56.127180-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Creating reconciliationQueues Model4 3
2022-09-17 00:48:56.271893-0400 Sample[8585:55714670] [Amplify] [InitializeSubscription.4] AWSIncomingEventReconciliationQueue .connected Model3
2022-09-17 00:48:56.271964-0400 Sample[8585:55714670] [Amplify] [InitializeSubscription.5] 3/12 initialized
2022-09-17 00:48:56.531710-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink reconciliationQueues Model4 4
2022-09-17 00:48:56.531899-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink done reconciliationQueues Model4 4
2022-09-17 00:48:56.532038-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Creating reconciliationQueues Model5 4
2022-09-17 00:48:56.701819-0400 Sample[8585:55714564] [Amplify] [InitializeSubscription.4] AWSIncomingEventReconciliationQueue .connected Model4
2022-09-17 00:48:56.701916-0400 Sample[8585:55714564] [Amplify] [InitializeSubscription.5] 4/12 initialized
2022-09-17 00:48:56.959050-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink reconciliationQueues Model5 5
2022-09-17 00:48:56.959301-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink done reconciliationQueues Model5 5
2022-09-17 00:48:56.959638-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Creating reconciliationQueues Model6 5
2022-09-17 00:48:57.126168-0400 Sample[8585:55714564] [Amplify] [InitializeSubscription.4] AWSIncomingEventReconciliationQueue .connected Model5
2022-09-17 00:48:57.126402-0400 Sample[8585:55714564] [Amplify] [InitializeSubscription.5] 5/12 initialized
2022-09-17 00:48:57.353387-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink reconciliationQueues Model6 6
2022-09-17 00:48:57.353683-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink done reconciliationQueues Model6 6
2022-09-17 00:48:57.353800-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Creating reconciliationQueues Model7 6
2022-09-17 00:48:57.499627-0400 Sample[8585:55714656] [Amplify] [InitializeSubscription.4] AWSIncomingEventReconciliationQueue .connected Model6
2022-09-17 00:48:57.499709-0400 Sample[8585:55714656] [Amplify] [InitializeSubscription.5] 6/12 initialized
2022-09-17 00:48:57.720243-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink reconciliationQueues Model7 7
2022-09-17 00:48:57.720297-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink done reconciliationQueues Model7 7
2022-09-17 00:48:57.720399-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Creating reconciliationQueues Model8 7
2022-09-17 00:48:57.869776-0400 Sample[8585:55714561] [Amplify] [InitializeSubscription.4] AWSIncomingEventReconciliationQueue .connected Model7
2022-09-17 00:48:57.869822-0400 Sample[8585:55714561] [Amplify] [InitializeSubscription.5] 7/12 initialized
2022-09-17 00:48:58.136124-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink reconciliationQueues Model8 8
2022-09-17 00:48:58.136265-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink done reconciliationQueues Model8 8
2022-09-17 00:48:58.136427-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Creating reconciliationQueues Model9 8
2022-09-17 00:48:58.314653-0400 Sample[8585:55714733] [Amplify] [InitializeSubscription.4] AWSIncomingEventReconciliationQueue .connected Model8
2022-09-17 00:48:58.314758-0400 Sample[8585:55714733] [Amplify] [InitializeSubscription.5] 8/12 initialized
2022-09-17 00:48:58.532812-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink reconciliationQueues Model9 9
2022-09-17 00:48:58.532887-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink done reconciliationQueues Model9 9
2022-09-17 00:48:58.532952-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Creating reconciliationQueues Model10 9
2022-09-17 00:48:58.679029-0400 Sample[8585:55714561] [Amplify] [InitializeSubscription.4] AWSIncomingEventReconciliationQueue .connected Model9
2022-09-17 00:48:58.679147-0400 Sample[8585:55714561] [Amplify] [InitializeSubscription.5] 9/12 initialized
2022-09-17 00:48:58.932052-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink reconciliationQueues Model10 10
2022-09-17 00:48:58.932264-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink done reconciliationQueues Model10 10
2022-09-17 00:48:58.932384-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Creating reconciliationQueues Model11 10
2022-09-17 00:48:59.077234-0400 Sample[8585:55714656] [Amplify] [InitializeSubscription.4] AWSIncomingEventReconciliationQueue .connected Model10
2022-09-17 00:48:59.077302-0400 Sample[8585:55714656] [Amplify] [InitializeSubscription.5] 10/12 initialized
2022-09-17 00:48:59.146714-0400 Sample[8585:55714732] [IncomingAsyncSubscriptionEventPublisher] [InitializeSubscription.1] API.subscribe failed for `Model11` error: Subscription item event failed with error: Unauthorized
2022-09-17 00:48:59.294479-0400 Sample[8585:55714734] [IncomingAsyncSubscriptionEventPublisher] [InitializeSubscription.1] API.subscribe failed for `Model11` error: Subscription item event failed with error: Unauthorized
2022-09-17 00:48:59.335023-0400 Sample[8585:55714566] [AWSModelReconciliationQueue] [InitializeSubscription.3] AWSModelReconciliationQueue determined unauthorized Model11
2022-09-17 00:48:59.335865-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink reconciliationQueues Model11 11
2022-09-17 00:48:59.335951-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink done reconciliationQueues Model11 11
2022-09-17 00:48:59.335988-0400 Sample[8585:55714560] [Amplify] [InitializeSubscription.4] AWSIncomingEventReconciliationQueue subscription disconnected [Model11] reason: [disconnected(modelName: "Model11", reason: AWSDataStorePlugin.ModelConnectionDisconnectedReason.unauthorized)]
2022-09-17 00:48:59.336002-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Creating reconciliationQueues Model12 11
2022-09-17 00:48:59.339209-0400 Sample[8585:55714560] [Amplify] [InitializeSubscription.5] 11/12 initialized
2022-09-17 00:48:59.402281-0400 Sample[8585:55714560] [IncomingAsyncSubscriptionEventPublisher] [InitializeSubscription.1] API.subscribe failed for `Model11` error: Subscription item event failed with error: Unauthorized
2022-09-17 00:48:59.803267-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink reconciliationQueues FilterMetadata 12
2022-09-17 00:48:59.803364-0400 Sample[8585:55714566] [Amplify] [InitializeSubscription.5] Sink done reconciliationQueues Model12 12
2022-09-17 00:48:59.950818-0400 Sample[8585:55714670] [Amplify] [InitializeSubscription.4] AWSIncomingEventReconciliationQueue .connected Model12
2022-09-17 00:48:59.950915-0400 Sample[8585:55714670] [Amplify] [InitializeSubscription.5] 12/12 initialized
2022-09-17 00:48:59.951002-0400 Sample[8585:55714670] [Amplify] [InitializeSubscription.6] connected isInitialized
2022-09-17 00:48:59.955581-0400 Sample[8585:55714670] [RemoteSyncEngine] [InitializeSubscription.5] RemoteSyncEngine IncomingEventReconciliationQueueEvent.initialized
2022-09-17 00:48:59.957140-0400 Sample[8585:55714670] [RemoteSyncEngine] [InitializeSubscription.6] performInitialSync
2022-09-17 00:49:02.136669-0400 Sample[8585:55714670] [RemoteSyncEngine] [InitializeSubscription.6] RemoteSyncEngine IncomingEventReconciliationQueueEvent.started

```
</details>

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
