### PR TITLE
fix(datastore): refactor to use TimeInterval.milliseconds (#2034)

### DIFF
--- a/Amplify/Core/Support/TimeInterval+Helper.swift
+++ b/Amplify/Core/Support/TimeInterval+Helper.swift
@@ -9,6 +9,10 @@ import Foundation
 
 extension TimeInterval {
 
+    public static func milliseconds(_ value: Double) -> TimeInterval {
+        return value / 1_000
+    }
+
     public static func seconds(_ value: Double) -> TimeInterval {
         return value
     }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -78,9 +78,7 @@ final class InitialSyncOperation: AsynchronousOperation {
             return nil
         }
 
-        // TODO: Update to use TimeInterval.milliseconds when it is pushed to main branch
-        // https://github.com/aws-amplify/amplify-ios/issues/398
-        let lastSyncDate = Date(timeIntervalSince1970: TimeInterval(lastSync) / 1_000)
+        let lastSyncDate = Date(timeIntervalSince1970: TimeInterval.milliseconds(Double(lastSync)))
         let secondsSinceLastSync = (lastSyncDate.timeIntervalSinceNow * -1)
         if secondsSinceLastSync < 0 {
             log.info("lastSyncTime was in the future, assuming base query")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is a cherry-pick of https://github.com/aws-amplify/amplify-ios/pull/2034 from `main` branch

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
