### PR TITLE
chore(Analytics): Renaming `identityId` to `userId`

### DIFF
--- a/Amplify/Categories/Analytics/AnalyticsCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Analytics/AnalyticsCategory+ClientBehavior.swift
@@ -6,8 +6,8 @@
 //
 
 extension AnalyticsCategory: AnalyticsCategoryBehavior {
-    public func identifyUser(_ identityId: String, withProfile userProfile: AnalyticsUserProfile? = nil) {
-        plugin.identifyUser(identityId, withProfile: userProfile)
+    public func identifyUser(userId: String, userProfile: AnalyticsUserProfile? = nil) {
+        plugin.identifyUser(userId: userId, userProfile: userProfile)
     }
 
     public func record(event: AnalyticsEvent) {

--- a/Amplify/Categories/Analytics/AnalyticsCategoryBehavior.swift
+++ b/Amplify/Categories/Analytics/AnalyticsCategoryBehavior.swift
@@ -16,9 +16,9 @@ public protocol AnalyticsCategoryBehavior {
     /// Allows you to tie a user to their actions and record traits about them. It includes
     /// an unique User ID and any optional traits you know about them like their email, name, etc.
     ///
-    /// - Parameter identityId: The unique identifier for the user
+    /// - Parameter userId: The unique identifier for the user
     /// - Parameter userProfile: User specific data (e.g. plan, accountType, email, age, location, etc)
-    func identifyUser(_ identityId: String, withProfile userProfile: AnalyticsUserProfile?)
+    func identifyUser(userId: String, userProfile: AnalyticsUserProfile?)
 
     /// Record the actions your users perform. Every action triggers what we call an “event”,
     /// which can also have associated properties.

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+ClientBehavior.swift
@@ -10,7 +10,7 @@ import AWSPinpoint
 import Foundation
 
 extension AWSPinpointAnalyticsPlugin {
-    public func identifyUser(_ identityId: String, withProfile userProfile: AnalyticsUserProfile?) {
+    public func identifyUser(userId: String, userProfile: AnalyticsUserProfile?) {
         if !isEnabled {
             log.warn("Cannot identify user. Analytics is disabled. Call Amplify.Analytics.enable() to enable")
             return
@@ -18,13 +18,13 @@ extension AWSPinpointAnalyticsPlugin {
 
         Task {
             let currentEndpointProfile =  await pinpoint.currentEndpointProfile()
-            currentEndpointProfile.addIdentityId(identityId)
+            currentEndpointProfile.addUserId(userId)
             if let userProfile = userProfile {
                 currentEndpointProfile.addUserProfile(userProfile)
             }
             do {
                 try await pinpoint.update(currentEndpointProfile)
-                Amplify.Hub.dispatchIdentifyUser(identityId, userProfile: userProfile)
+                Amplify.Hub.dispatchIdentifyUser(userId, userProfile: userProfile)
             } catch {
                 Amplify.Hub.dispatchIdentifyUser(AnalyticsErrorHelper.getDefaultError(error))
             }

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Endpoint/PinpointEndpointProfile.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Endpoint/PinpointEndpointProfile.swift
@@ -44,8 +44,8 @@ class PinpointEndpointProfile: Codable, AnalyticsPropertiesModel {
         self.user = user
     }
 
-    func addIdentityId(_ identityId: String) {
-        user.userId = identityId
+    func addUserId(_ userId: String) {
+        user.userId = userId
     }
 
     func addUserProfile(_ userProfile: AnalyticsUserProfile) {

--- a/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginClientBehaviorTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginClientBehaviorTests.swift
@@ -58,10 +58,10 @@ class AWSPinpointAnalyticsPluginClientBehaviorTests: AWSPinpointAnalyticsPluginT
                                                properties: testProperties)
         let expectedEndpointProfile = PinpointEndpointProfile(applicationId: "appId",
                                                               endpointId: "endpointId")
-        expectedEndpointProfile.addIdentityId(testIdentityId)
+        expectedEndpointProfile.addUserId(testIdentityId)
         expectedEndpointProfile.addUserProfile(userProfile)
 
-        analyticsPlugin.identifyUser(testIdentityId, withProfile: userProfile)
+        analyticsPlugin.identifyUser(userId: testIdentityId, userProfile: userProfile)
 
         waitForExpectations(timeout: 1)
         mockPinpoint.verifyCurrentEndpointProfile()
@@ -74,7 +74,7 @@ class AWSPinpointAnalyticsPluginClientBehaviorTests: AWSPinpointAnalyticsPluginT
     func testIdentifyUserDispatchesErrorForIsEnabledFalse() {
         analyticsPlugin.isEnabled = false
 
-        analyticsPlugin.identifyUser(testIdentityId, withProfile: nil)
+        analyticsPlugin.identifyUser(userId: testIdentityId, userProfile: nil)
 
         XCTAssertEqual(mockPinpoint.currentEndpointProfileCalled, 0)
         XCTAssertEqual(mockPinpoint.updateEndpointProfileCalled, 0)
@@ -109,10 +109,10 @@ class AWSPinpointAnalyticsPluginClientBehaviorTests: AWSPinpointAnalyticsPluginT
                                                properties: testProperties)
         let expectedEndpointProfile = PinpointEndpointProfile(applicationId: "appId",
                                                               endpointId: "endpointId")
-        expectedEndpointProfile.addIdentityId(testIdentityId)
+        expectedEndpointProfile.addUserId(testIdentityId)
         expectedEndpointProfile.addUserProfile(userProfile)
 
-        analyticsPlugin.identifyUser(testIdentityId, withProfile: userProfile)
+        analyticsPlugin.identifyUser(userId: testIdentityId, userProfile: userProfile)
 
         waitForExpectations(timeout: 1)
         mockPinpoint.verifyCurrentEndpointProfile()

--- a/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginIntegrationTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginIntegrationTests.swift
@@ -65,14 +65,14 @@ class AWSPinpointAnalyticsPluginIntergrationTests: XCTestCase {
                                                plan: "plan",
                                                location: location,
                                                properties: properties)
-        Amplify.Analytics.identifyUser(userId, withProfile: userProfile)
+        Amplify.Analytics.identifyUser(userId: userId, userProfile: userProfile)
 
         await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
 
         // Remove userId from the current endpoint
         let endpointClient = endpointClient()
         let currentProfile = await endpointClient.currentEndpointProfile()
-        currentProfile.addIdentityId("")
+        currentProfile.addUserId("")
         try await endpointClient.updateEndpointProfile(with: currentProfile)
     }
 

--- a/AmplifyTestCommon/Mocks/MockAnalyticsCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAnalyticsCategoryPlugin.swift
@@ -28,7 +28,7 @@ class MockAnalyticsCategoryPlugin: MessageReporter, AnalyticsCategoryPlugin {
         notify()
     }
 
-    func identifyUser(_ identityId: String, withProfile analyticsUserProfile: AnalyticsUserProfile?) {
+    func identifyUser(userId identityId: String, userProfile analyticsUserProfile: AnalyticsUserProfile?) {
         notify("identifyUser(\(identityId))")
     }
 

--- a/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryClientAPITests.swift
@@ -43,7 +43,7 @@ class AnalyticsCategoryClientAPITests: XCTestCase {
             }
         }
 
-        analytics.identifyUser("test")
+        analytics.identifyUser(userId: "test")
         waitForExpectations(timeout: 1.0)
     }
 

--- a/AmplifyTests/CoreTests/NotificationListeningAnalyticsPlugin.swift
+++ b/AmplifyTests/CoreTests/NotificationListeningAnalyticsPlugin.swift
@@ -28,7 +28,7 @@ class NotificationListeningAnalyticsPlugin: AnalyticsCategoryPlugin {
         }
     }
 
-    func identifyUser(_ identityId: String, withProfile userProfile: AnalyticsUserProfile?) {
+    func identifyUser(userId identityId: String, userProfile: AnalyticsUserProfile?) {
         // Do nothing
     }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/466

*Description of changes:*
Updating the `identifyUser` signature to
```swift
func identifyUser(userId: String, userProfile: AnalyticsUserProfile?)
```

This will bring [parity with Flutter](https://github.com/aws-amplify/amplify-flutter/blob/main/packages/analytics/amplify_analytics_pinpoint/lib/method_channel_amplify.dart#L110-L113), as well as improve readability for this method and make it clear what arguments to provide.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [X] Documentation update for the change if required: https://github.com/aws-amplify/docs/pull/4586
- [X] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
