### PR TITLE
chore: update maintainer list in new_issue action

### DIFF
--- a/.github/workflows/new_issue_maintainer.yml
+++ b/.github/workflows/new_issue_maintainer.yml
@@ -10,7 +10,10 @@ permissions:
 jobs:
   maintainer-opened:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.issue.pull_request && contains(fromJSON('["palpatim", "brennanMKE", "5d", "lawmicha", "harsh62", "thisisabhash", "ameter", "royjit", "atierian", "ukhan-amazon", "ruisebas", "phantumcode"]'), github.event.issue.user.login) }}
+    if: |
+      !github.event.issue.pull_request && 
+      contains(fromJSON('["palpatim", "brennanMKE", "5d", "harsh62", "thisisabhash", "ameter", "royjit", "atierian", "ukhan-amazon", "ruisebas", "phantumcode"]'), github.event.issue.user.login) ||
+      contains(fromJSON('["drochetti", "mikepschneider", "lawmicha", "dcipoletti", "dpilch", "manueliglesias", "svidgen", "david-mcafee", "poojamat", "AaronZyLee", "marcvberg", "iartemiev", "phani-srikar", "sundersc", "alharris-at", "yeung-wah", "manaswi223"]'), github.event.issue.user.login)
     steps:
       - name: add message if maintainer opened
         shell: bash

--- a/.github/workflows/new_issue_maintainer.yml
+++ b/.github/workflows/new_issue_maintainer.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   maintainer-opened:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.issue.pull_request && contains(fromJSON('["palpatim", "brennanMKE", "diegocstn", "lawmicha", "harsh62", "thisisabhash", "ameter", "royjit", "atierian", "ukhan-amazon", "ruisebas", "phantumcode"]'), github.event.issue.user.login) }}
+    if: ${{ !github.event.issue.pull_request && contains(fromJSON('["palpatim", "brennanMKE", "5d", "lawmicha", "harsh62", "thisisabhash", "ameter", "royjit", "atierian", "ukhan-amazon", "ruisebas", "phantumcode"]'), github.event.issue.user.login) }}
     steps:
       - name: add message if maintainer opened
         shell: bash


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Remove `diegocstn` and add `5d` in the maintainer list for GitHub action `new_issue_maintainer`.
Adds members of @aws-amplify/amplify-data to maintainer check.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [ ] ~Build succeeds with all target using Swift Package Manager~
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
