### PR TITLE
fix(datastore-v2): InitializeSubscription race condition disconnected event

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/AWSDataStorePlugin.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AWSDataStorePlugin.xcscheme
@@ -37,6 +37,11 @@
                BlueprintName = "AWSDataStoreCategoryPluginTests"
                ReferencedContainer = "container:">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "OutgoingMutationQueueNetworkTests/testLastMutationSentWhenNoNetwork()">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
@@ -207,7 +207,30 @@ extension AWSInitialSyncOrchestrator {
               else {
             return false
         }
+        
+        // The following check is to catgorize the error as an unauthorized error when the process fails to retrieve
+        // the autorization token. This is taken directly from `AuthTokenURLRequestInterceptor`'s error handling path
+        // that returns an APIError.operationError with an underlying AuthError.
+        //
+        // A signed out user, or a signed in user's session that has expired, will result the `getToken()` to
+        // return an error. The request is never sent over the network to the service to apply its auth check and is
+        // returned immediately to this calling code.
+        //
+        // The check itself is not the most ideal contract for checking when there is an authorization error, however it
+        // does have some stability since `operationError` is a local implementation detail. The underlying error check
+        // for AuthError means that the AuthError could be any case. For example, if the AuthError changes, it will
+        // still be categorized as unauthorized by this code. If a specific type like `AuthError.unauthorized` is
+        // introduced in the future, this code will still return true, which is crucial to prevent the sync
+        // orchestrator from failing the entire sync process.
+        if case let .api(amplifyError, _) = datastoreError,
+           let apiError = amplifyError as? APIError,
+           case .operationError(_, _, let underlyingError) = apiError,
+           (underlyingError as? AuthError) != nil {
+            return true
+        }
 
+        // If token was retrieved, and request was sent, but service returned an error response,
+        // check that it is an Unauthorized error from the GraphQL response payload.
         if case let .api(apiError, _) = datastoreError,
            let responseError = apiError as? GraphQLResponseError<ResponseType>,
            let graphQLError = graphqlErrors(from: responseError)?.first,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
@@ -208,8 +208,8 @@ extension AWSInitialSyncOrchestrator {
             return false
         }
         
-        // The following check is to catgorize the error as an unauthorized error when the process fails to retrieve
-        // the autorization token. This is taken directly from `AuthTokenURLRequestInterceptor`'s error handling path
+        // The following check is to categorize the error as an unauthorized error when the process fails to retrieve
+        // the authorization token. This is taken directly from `AuthTokenURLRequestInterceptor`'s error handling path
         // that returns an APIError.operationError with an underlying AuthError.
         //
         // A signed out user, or a signed in user's session that has expired, will result the `getToken()` to

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
@@ -101,7 +101,7 @@ final class ModelSyncedEventEmitter {
             return modelSchema.name == event.modelName
         case .mutationEventDropped(let modelName, _):
             return modelSchema.name == modelName
-        case .initialized, .started, .paused:
+        case .idle, .initialized, .started, .paused:
             return false
         }
     }
@@ -129,7 +129,7 @@ final class ModelSyncedEventEmitter {
                 modelSyncedEventTopic.send(.mutationEventApplied(event))
             case .mutationEventDropped(let modelName, let error):
                 modelSyncedEventTopic.send(.mutationEventDropped(modelName: modelName, error: error))
-            case .initialized, .started, .paused:
+            case .idle, .initialized, .started, .paused:
                 return
             }
             return
@@ -160,7 +160,7 @@ final class ModelSyncedEventEmitter {
             if shouldSendModelSyncedEvent {
                 sendModelSyncedEvent()
             }
-        case .initialized, .started, .paused:
+        case .idle, .initialized, .started, .paused:
             return
         }
     }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift
@@ -33,12 +33,14 @@ extension RemoteSyncEngine {
     func onReceive(receiveValue: IncomingEventReconciliationQueueEvent) {
         switch receiveValue {
         case .initialized:
+            log.verbose("[InitializeSubscription.5] RemoteSyncEngine IncomingEventReconciliationQueueEvent.initialized")
             log.verbose("[Lifecycle event 1]: subscriptionsEstablished")
             let payload = HubPayload(eventName: HubPayload.EventName.DataStore.subscriptionsEstablished)
             Amplify.Hub.dispatch(to: .dataStore, payload: payload)
             remoteSyncTopicPublisher.send(.subscriptionsInitialized)
             stateMachine.notify(action: .initializedSubscriptions)
         case .started:
+            log.verbose("[InitializeSubscription.6] RemoteSyncEngine IncomingEventReconciliationQueueEvent.started")
             guard let api = self.api else {
                 let error = DataStoreError.internalOperation("api is unexpectedly `nil`", "", nil)
                 stateMachine.notify(action: .errored(error))
@@ -50,7 +52,7 @@ extension RemoteSyncEngine {
                                                                      reconciliationQueue))
         case .paused:
             remoteSyncTopicPublisher.send(.subscriptionsPaused)
-        case .mutationEventDropped, .mutationEventApplied:
+        case .idle, .mutationEventDropped, .mutationEventApplied:
             break
         }
     }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
@@ -179,7 +179,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
             notifySyncStarted()
 
         case .syncEngineActive:
-            break
+            log.debug("RemoteSyncEngine SyncEngineActive")
 
         case .cleaningUp(let error):
             cleanup(error: error)
@@ -274,7 +274,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     
     private func initializeSubscriptions(api: APICategoryGraphQLBehaviorExtended,
                                          storageAdapter: StorageEngineAdapter) async {
-        log.debug(#function)
+        log.debug("[InitializeSubscription] \(#function)")
         let syncableModelSchemas = ModelRegistry.modelSchemas.filter { $0.isSyncable }
         reconciliationQueue = await reconciliationQueueFactory(syncableModelSchemas,
                                                                api,
@@ -292,7 +292,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     }
 
     private func performInitialSync() {
-        log.debug(#function)
+        log.debug("[InitializeSubscription.6] \(#function)")
 
         let initialSyncOrchestrator = initialSyncOrchestratorFactory(dataStoreConfiguration,
                                                                      authModeStrategy,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -187,7 +187,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
         case .success:
             incomingSubscriptionEvents.send(completion: .finished)
         case .failure(let apiError):
-            log.verbose("API Subscription failed for model `\(modelName)` with error: \(apiError.errorDescription)")
+            log.verbose("[InitializeSubscription.1] API.subscribe failed for `\(modelName)` error: \(apiError.errorDescription)")
             let dataStoreError = DataStoreError(error: apiError)
             incomingSubscriptionEvents.send(completion: .failure(dataStoreError))
         }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
@@ -10,6 +10,7 @@ import AWSPluginsCore
 import Combine
 
 enum IncomingEventReconciliationQueueEvent {
+    case idle
     case initialized
     case started
     case paused

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -71,7 +71,7 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
     private var incomingEventsSink: AnyCancellable?
     private var reconcileAndLocalSaveOperationSinks: AtomicValue<Set<AnyCancellable?>>
 
-    private let modelReconciliationQueueSubject: PassthroughSubject<ModelReconciliationQueueEvent, DataStoreError>
+    private let modelReconciliationQueueSubject: CurrentValueSubject<ModelReconciliationQueueEvent, DataStoreError>
     var publisher: AnyPublisher<ModelReconciliationQueueEvent, DataStoreError> {
         return modelReconciliationQueueSubject.eraseToAnyPublisher()
     }
@@ -89,7 +89,7 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
         self.storageAdapter = storageAdapter
 
         self.modelPredicate = modelPredicate
-        self.modelReconciliationQueueSubject = PassthroughSubject<ModelReconciliationQueueEvent, DataStoreError>()
+        self.modelReconciliationQueueSubject = CurrentValueSubject<ModelReconciliationQueueEvent, DataStoreError>(.idle)
 
         self.reconcileAndSaveQueue = reconcileAndSaveQueue
 
@@ -118,11 +118,11 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
             .publisher
             .sink(receiveCompletion: { [weak self] completion in
                 self?.receiveCompletion(completion)
-                }, receiveValue: { [weak self] receiveValue in
-                    self?.receive(receiveValue)
+            }, receiveValue: { [weak self] receiveValue in
+                self?.receive(receiveValue)
             })
     }
-
+    
     /// (Re)starts the incoming subscription event queue.
     func start() {
         incomingSubscriptionEventQueue.isSuspended = false
@@ -202,18 +202,20 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
             modelReconciliationQueueSubject.send(completion: .finished)
         case .failure(let dataStoreError):
             if case let .api(error, _) = dataStoreError,
-               case let APIError.operationError(_, _, underlyingError) = error,
-               isUnauthorizedError(underlyingError) {
+               case let APIError.operationError(errorDescription, _, underlyingError) = error,
+               isUnauthorizedError(errorDescription: errorDescription, underlyingError) {
+                log.verbose("[InitializeSubscription.3] AWSModelReconciliationQueue determined unauthorized \(modelSchema.name)")
                 modelReconciliationQueueSubject.send(.disconnected(modelName: modelSchema.name, reason: .unauthorized))
                 return
             }
             if case let .api(error, _) = dataStoreError,
                case let APIError.operationError(_, _, underlyingError) = error,
                isOperationDisabledError(underlyingError) {
+                log.verbose("[InitializeSubscription.3] AWSModelReconciliationQueue determined isOperationDisabledError \(modelSchema.name)")
                 modelReconciliationQueueSubject.send(.disconnected(modelName: modelSchema.name, reason: .operationDisabled))
                 return
             }
-            log.error("receiveCompletion: error: \(dataStoreError)")
+            log.error("[InitializeSubscription.3] AWSModelReconciliationQueue receiveCompletion: error: \(dataStoreError)")
             modelReconciliationQueueSubject.send(completion: .failure(dataStoreError))
         }
     }
@@ -262,7 +264,10 @@ extension AWSModelReconciliationQueue {
         return errorTypeValue
     }
 
-    private func isUnauthorizedError(_ error: Error?) -> Bool {
+    private func isUnauthorizedError(errorDescription: String, _ error: Error?) -> Bool {
+        if errorDescription.range(of: "Unauthorized", options: .caseInsensitive) != nil {
+            return true
+        }
         if let responseError = error as? GraphQLResponseError<ResponseType>,
            let graphQLError = graphqlErrors(from: responseError)?.first,
            let errorTypeValue = errorTypeValueFrom(graphQLError: graphQLError),

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
@@ -15,6 +15,7 @@ enum ModelConnectionDisconnectedReason {
 }
 
 enum ModelReconciliationQueueEvent {
+    case idle
     case started
     case paused
     case connected(modelName: String)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -48,6 +48,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     // This test case attempts to hit a race condition, and may be required to execute multiple times
     // in order to demonstrate the bug
     func testTwoConnectionStatusUpdatesAtSameTime() async {
+        let expectStarted = expectation(description: "eventQueue expected to send out started state")
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
 
         let eventQueue = await initEventQueue(modelSchemas: [Post.schema, Comment.schema])
@@ -58,6 +59,10 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             XCTFail("Not expecting this to call")
         }, receiveValue: { event  in
             switch event {
+            case .idle:
+                break
+            case .started:
+                expectStarted.fulfill()
             case .initialized:
                 expectInitialized.fulfill()
             default:
@@ -80,6 +85,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     }
 
     func testSubscriptionFailedWithSingleModelUnauthorizedError() async {
+        let expectStarted = expectation(description: "eventQueue expected to send out started state")
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
         let eventQueue = await initEventQueue(modelSchemas: [Post.schema])
         eventQueue.start()
@@ -88,6 +94,10 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             XCTFail("Not expecting this to call")
         }, receiveValue: { event  in
             switch event {
+            case .idle:
+                break
+            case .started:
+                expectStarted.fulfill()
             case .initialized:
                 expectInitialized.fulfill()
             default:
@@ -111,6 +121,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     // This test case tests that initialized event is received even if only one
     // model subscriptions out of two failed - Post subscription will fail but Comment will succeed
     func testSubscriptionFailedWithMultipleModels() async {
+        let expectStarted = expectation(description: "eventQueue expected to send out started state")
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
         let eventQueue = await initEventQueue(modelSchemas: [Post.schema, Comment.schema])
         eventQueue.start()
@@ -119,6 +130,10 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             XCTFail("Not expecting this to call")
         }, receiveValue: { event  in
             switch event {
+            case .idle:
+                break
+            case .started:
+                expectStarted.fulfill()
             case .initialized:
                 expectInitialized.fulfill()
             default:
@@ -143,6 +158,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     }
 
     func testSubscriptionFailedWithSingleModelOperationDisabled() async {
+        let expectStarted = expectation(description: "eventQueue expected to send out started state")
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
         let eventQueue = await initEventQueue(modelSchemas: [Post.schema])
         eventQueue.start()
@@ -151,6 +167,10 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             XCTFail("Not expecting this to call")
         }, receiveValue: { event  in
             switch event {
+            case .idle:
+                break
+            case .started:
+                expectStarted.fulfill()
             case .initialized:
                 expectInitialized.fulfill()
             default:
@@ -177,6 +197,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
     // Post subscription will fail with a "OperationDisabled",
     // but Comment subscription will succeed
     func testSubscriptionFailedBecauseOfOperationDisabledWithMultipleModels() async {
+        let expectStarted = expectation(description: "eventQueue expected to send out started state")
         let expectInitialized = expectation(description: "eventQueue expected to send out initialized state")
         let eventQueue = await initEventQueue(modelSchemas: [Post.schema])
         eventQueue.start()
@@ -185,13 +206,17 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             XCTFail("Not expecting this to call")
         }, receiveValue: { event  in
             switch event {
+            case .idle:
+                break
+            case .started:
+                expectStarted.fulfill()
             case .initialized:
                 expectInitialized.fulfill()
             default:
                 XCTFail("Should not expect any other state, received: \(event)")
             }
         })
-
+        
         let reconciliationQueues = MockModelReconciliationQueue.mockModelReconciliationQueues
         for (queueName, queue) in reconciliationQueues {
             let cancellableOperation = CancelAwareBlockOperation {

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -427,8 +427,13 @@ extension ModelReconciliationQueueBehaviorTests {
 
         let queueSink = queue.publisher.sink(receiveCompletion: { value in
             XCTFail("Not expecting a call to completion, received \(value)")
-        }, receiveValue: { _ in
-            eventSentViaPublisher.fulfill()
+        }, receiveValue: { event in
+            switch event {
+            case .idle:
+                break
+            default:
+                eventSentViaPublisher.fulfill()
+            }
         })
 
         subscriptionEventsSubject.send(completion: completion)
@@ -450,8 +455,13 @@ extension ModelReconciliationQueueBehaviorTests {
 
         let queueSink = queue.publisher.sink(receiveCompletion: { value in
             XCTFail("Not expecting a call to completion, received \(value)")
-        }, receiveValue: { _ in
-            eventSentViaPublisher.fulfill()
+        }, receiveValue: { event in
+            switch event {
+            case .idle:
+                break
+            default:
+                eventSentViaPublisher.fulfill()
+            }
         })
 
         subscriptionEventsSubject.send(completion: completion)
@@ -474,7 +484,12 @@ extension ModelReconciliationQueueBehaviorTests {
         let queueSink = queue.publisher.sink(receiveCompletion: { _ in
             eventSentViaPublisher.fulfill()
         }, receiveValue: { value in
-            XCTFail("Not expecting a successful call, received \(value)")
+            switch value {
+            case .idle:
+                break
+            default:
+                XCTFail("Not expecting a successful call, received \(value)")
+            }
         })
 
         subscriptionEventsSubject.send(completion: completion)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR is the V2 version of https://github.com/aws-amplify/amplify-ios/pull/2319

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
