### PR TITLE
chore: update Amplify.Publisher documentation examples to reflect the fact that Amplify.API.subscribe is no longer async and no longer throws

### DIFF
--- a/Amplify/Core/Support/Amplify+Publisher.swift
+++ b/Amplify/Core/Support/Amplify+Publisher.swift
@@ -55,7 +55,7 @@ public extension Amplify {
         ///
         /// Example Usage
         /// ```
-        /// let subscription = try await Amplify.API.subscribe(
+        /// let subscription = Amplify.API.subscribe(
         ///     request: .subscription(of: Todo.self, type: .onCreate)
         /// )
         ///

--- a/README-combine-support.md
+++ b/README-combine-support.md
@@ -34,7 +34,7 @@ let sink = Amplify.Publisher.create {
 ```
 
 ```swift
-let subscription = try await Amplify.API.subscribe(
+let subscription = Amplify.API.subscribe(
     request: .subscription(of: Todo.self, type: .onCreate)
 )
 


### PR DESCRIPTION
*Description of changes:*
update Amplify.Publisher documentation examples to reflect the fact that Amplify.API.subscribe is no longer async and no longer throws

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
