### PR TITLE
fix(datastore): Setting nil values for empty associated models

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -41,12 +41,28 @@ extension Model {
             let name = modelField.name
 
             guard let value = modelFieldValue else {
-                // don't invalidate fields of type .model
-                // as we'll take care of this later on (see line 61)
+                // Special case for associated models when the value is `nil`, by setting all of the associated
+                // model's primary key fields (targetNames) to `nil`.
                 if case .model = modelField.type {
-                    continue
+                    let fieldNames = getFieldNameForAssociatedModels(modelField: modelField)
+                    for fieldName in fieldNames {
+                        // Only set to `nil` if it has not been set already. For hasOne relationships, where the
+                        // target name of the associated model is explicitly on this model as a field property, we
+                        // cannot guardteed which field is processed first, thus if there is a value for the explicit
+                        // field and was already set, don't overwrite it.
+                        if input[fieldName] == nil {
+                            // Always setting the value to `nil` is not necessary for create mutations, since leaving it
+                            // out will also reflect that there's no associated model. However, we always set it to `nil`
+                            // to account for the update mutation use cases where the caller may be de-associating the
+                            // model from the associated model, which is why the `nil` is required in input variables
+                            // to persist the removal the association.
+                            input.updateValue(nil, forKey: fieldName)
+                        }
+                    }
+                } else {
+                    input.updateValue(nil, forKey: name)
                 }
-                input.updateValue(nil, forKey: name)
+                
                 continue
             }
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -48,7 +48,7 @@ extension Model {
                     for fieldName in fieldNames {
                         // Only set to `nil` if it has not been set already. For hasOne relationships, where the
                         // target name of the associated model is explicitly on this model as a field property, we
-                        // cannot guardteed which field is processed first, thus if there is a value for the explicit
+                        // cannot guarantee which field is processed first, thus if there is a value for the explicit
                         // field and was already set, don't overwrite it.
                         if input[fieldName] == nil {
                             // Always setting the value to `nil` is not necessary for create mutations, since leaving it

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionOptionalAssociations.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionOptionalAssociations.swift
@@ -178,7 +178,7 @@ class DataStoreConnectionOptionalAssociations: SyncEngineIntegrationV2TestBase {
     }
 
     func testRemovePostFromCommentAndBlogFromPost() throws {
-        setUp(withModels: TestModelRegistration(), logLevel: .verbose)
+        setUp(withModels: TestModelRegistration())
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(),
               let post = savePost(withBlog: blog),
@@ -201,7 +201,7 @@ class DataStoreConnectionOptionalAssociations: SyncEngineIntegrationV2TestBase {
         queriedComment.post = nil
         // A mock GraphQL request is created to assert that the request variables contains the "postId"
         // with the value `nil` which is sent to the API to persist the removal of the association.
-        let request = GraphQLRequest<Comment>.createMutation(of: queriedComment, version: 1)
+        let request = GraphQLRequest<Comment8>.createMutation(of: queriedComment, version: 1)
         guard let variables = request.variables,
               let input = variables["input"] as? [String: Any?],
               let postValue = input["postId"],
@@ -211,7 +211,7 @@ class DataStoreConnectionOptionalAssociations: SyncEngineIntegrationV2TestBase {
         }
 
         guard saveComment(queriedComment) != nil else {
-            XCTFail("Failed to update comment and post")
+            XCTFail("Failed to update comment")
             return
         }
         guard let queriedCommentWithoutPost = queryComment(id: comment.id) else {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/2336

*Description of changes:*
Verified that there was a regression from the CPK changes at this file: https://github.com/aws-amplify/amplify-ios/pull/1752/files#diff-2fa30b26d50da3e22bdbe4d8e4eb16bb22011672699f804c0926fa34629c5cc2 CPK was released in 1.28.0, and verified that the failing test `DataStoreConnectionOptionalAssociations.testRemovePostFromCommentAndBlogFromPost` is passing in 1.27.1 (last 1.27.x version).

This PR updates the logic for translating a model instance over to the GraphQL request variables "input" object. 

The following example uses Comment and Post, where a post has many comments and the comment belongs to a post.

Previously, before CPK changes, when a model with an associated field with its value populated will be translated to 
```
"input": {
   "id": "commentId",
   "postId": "associatedPostId"
}
```
When the model with associated field does not have the value populated, it will be translated to 
```
"input": {
   "id": "commentId",
   "postId": nil
}
```
With the CPK changes, the model is now being translated to 
```
"input": {
   "id": "commentId"
}
```
The problem is that it is missing the associated field and `nil` value in the input. For create mutations, this is a valid request, and the comment gets created without associating to any post. The comment can be updated later to be associated with a post. For update mutations, where the comment was created with a post and then removed from the comment instance, then the update mutation request is created, is what's causing issues. The removal of the post is not sent as part of the update mutation for the deassociation. 

By always setting the associated fields to `nil` when the value does not exist will fix the problem. The create mutation will also be affected since uses the same translation code, which simply reverts the behavior back to what it was previously. We may consider passing in the mutationType to better control when this logic happens.

Testing  (status: done)
- DataStoreIntegrationTests (includes V2 and CPK)
- DataStoreAuthTests (includes MultiAuth, Cognito Auth, IAM Auth)
- CPK sample app testing

PR for V2 --> https://github.com/aws-amplify/amplify-ios/pull/2361

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
