### PR TITLE
fix(Analytics): Fixing flaky unit tests

### DIFF
--- a/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/Pinpoint/SessionClientTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/Pinpoint/SessionClientTests.swift
@@ -186,8 +186,8 @@ class SessionClientTests: XCTestCase {
         XCTAssertEqual(recordCount, 2)
         let events = await analyticsClient.recordedEvents
         XCTAssertEqual(events.count, 2)
-        XCTAssertEqual(events.first?.eventType, SessionClient.Constants.Events.stop)
-        XCTAssertEqual(events.last?.eventType, SessionClient.Constants.Events.start)
+        XCTAssertNotNil(events.first(where: { $0.eventType == SessionClient.Constants.Events.stop }))
+        XCTAssertNotNil(events.first(where: { $0.eventType == SessionClient.Constants.Events.start }))
     }
 
 #if !os(macOS)
@@ -309,8 +309,8 @@ class SessionClientTests: XCTestCase {
         XCTAssertEqual(recordCount, 2)
         let events = await analyticsClient.recordedEvents
         XCTAssertEqual(events.count, 2)
-        XCTAssertEqual(events.first?.eventType, SessionClient.Constants.Events.stop)
-        XCTAssertEqual(events.last?.eventType, SessionClient.Constants.Events.start)
+        XCTAssertNotNil(events.first(where: { $0.eventType == SessionClient.Constants.Events.stop }))
+        XCTAssertNotNil(events.first(where: { $0.eventType == SessionClient.Constants.Events.start }))
     }
 #endif
     func testApplicationTerminated_shouldRecordStopEvent() async {


### PR DESCRIPTION
*Description of changes:*
Since events are recoded asynchronously by the `SessionClient`, it's not safe to assume their order in the mocked `AnalyticsClient`.
So I'm instead just validating that they exist.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
