### PR TITLE
fix(datastore-v2): macOS wrong type inference in RemoteSyncEngineTests

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
@@ -46,7 +46,7 @@ class RemoteSyncEngineTests: XCTestCase {
     }
 
     func testErrorOnNilStorageAdapter() throws {
-        guard let remoteSyncEngine else {
+        guard let remoteSyncEngine = remoteSyncEngine else {
             XCTFail("Failed to initialize remoteSyncEngine")
             return
         }


### PR DESCRIPTION
*Issue #, if available:*
Fixing failed test case [testErrorOnNilStorageAdapter](https://app.circleci.com/pipelines/github/aws-amplify/amplify-ios/6981/workflows/2b24658e-b00d-40b0-b38b-575b22dcbf95/jobs/47874).

*Description of changes:*
The type of `remoteSyncEngine` is forced unwrapped optional. 

Under macOS SDK the expression `remoteSyncEngine.publisher` is inferred to `Optional::publisher`.

<img width="808" alt="image" src="https://user-images.githubusercontent.com/459711/192880608-74b671c1-4337-4a78-a4f3-a28e3b5fdf97.png">

But under iOS SDK, the same expression is inferred correctly to `RemoteSyncEngine::publisher`

<img width="902" alt="image" src="https://user-images.githubusercontent.com/459711/192880730-d2b27c4f-2307-4b1a-9624-c23e0e6d8952.png">
 

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
