### PR TITLE
fix(datastore): observeQuery snapshot on .modelSynced event

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin.swift
@@ -216,10 +216,10 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
             dataStorePublisher.send(input: mutationEvent)
         case .modelSyncedEvent(let modelSyncedEvent):
             log.verbose("Emitting DataStore event: modelSyncedEvent \(modelSyncedEvent)")
+            dispatchedModelSyncedEvents[modelSyncedEvent.modelName]?.set(true)
             let modelSyncedEventPayload = HubPayload(eventName: HubPayload.EventName.DataStore.modelSynced,
                                                      data: modelSyncedEvent)
             Amplify.Hub.dispatch(to: .dataStore, payload: modelSyncedEventPayload)
-            dispatchedModelSyncedEvents[modelSyncedEvent.modelName]?.set(true)
         case .syncQueriesReadyEvent:
             log.verbose("[Lifecycle event 4]: syncQueriesReady")
             let syncQueriesReadyEventPayload = HubPayload(eventName: HubPayload.EventName.DataStore.syncQueriesReady)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
@@ -12,6 +12,7 @@ import Combine
 
 @testable import Amplify
 @testable import AWSDataStorePlugin
+import AmplifyAsyncTesting
 
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
@@ -37,13 +38,52 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     ///    - The first snapshot should have `isSynced` false
     ///    - Eventually one of the query snapshots will be returned with `isSynced` true
     ///
+    func testObserveQueryAsyncInitialSync() async throws {
+        await setUp(withModels: TestModelRegistration())
+        try startAmplify()
+        try await clearDataStore()
+        let snapshotWithIsSynced = asyncExpectation(description: "query snapshot with isSynced true")
+        let querySnapshotsCancelled = asyncExpectation(description: "query snapshots cancelled")
+        let querySnapshots = Amplify.DataStore.observeQuery(for: Post.self)
+        let task = Task {
+            var snapshots = [DataStoreQuerySnapshot<Post>]()
+            do {
+                for try await querySnapshot in querySnapshots {
+                    snapshots.append(querySnapshot)
+                    if querySnapshot.isSynced {
+                        await snapshotWithIsSynced.fulfill()
+                    }
+                }
+            } catch {
+                XCTFail("\(error)")
+            }
+            XCTAssertTrue(snapshots.count >= 2)
+            XCTAssertFalse(snapshots[0].isSynced)
+            await querySnapshotsCancelled.fulfill()
+        }
+        let receivedPost = asyncExpectation(description: "received Post")
+        try await savePostAndWaitForSync(Post(title: "title", content: "content", createdAt: .now()),
+                                         postSyncedExpctation: receivedPost)
+        await waitForExpectations([snapshotWithIsSynced, receivedPost], timeout: 100)
+        task.cancel()
+        await waitForExpectations([querySnapshotsCancelled], timeout: 10)
+    }
+
+    /// ObserveQuery API will eventually return query snapshot with `isSynced` true
+    ///
+    /// - Given: DataStore is cleared
+    /// - When:
+    ///    - ObserveQuery API is called to start the sync engine
+    /// - Then:
+    ///    - The first snapshot should have `isSynced` false
+    ///    - Eventually one of the query snapshots will be returned with `isSynced` true
+    ///
     func testObserveQueryInitialSync() async throws {
         await setUp(withModels: TestModelRegistration())
         try startAmplify()
         try await clearDataStore()
         var snapshots = [DataStoreQuerySnapshot<Post>]()
-        let snapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
-        snapshotWithIsSynced.assertForOverFulfill = false
+        let snapshotWithIsSynced = asyncExpectation(description: "query snapshot with isSynced true")
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self)).sink { completed in
             switch completed {
             case .finished:
@@ -54,16 +94,58 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         } receiveValue: { querySnapshot in
             snapshots.append(querySnapshot)
             if querySnapshot.isSynced {
-                snapshotWithIsSynced.fulfill()
+                Task { await snapshotWithIsSynced.fulfill() }
             }
         }.store(in: &cancellables)
-        let receivedPost = expectation(description: "received Post")
+        let receivedPost = asyncExpectation(description: "received Post")
         try await savePostAndWaitForSync(Post(title: "title", content: "content", createdAt: .now()),
-                                     postSyncedExpctation: receivedPost)
-        await waitForExpectations(timeout: 100)
-
+                                         postSyncedExpctation: receivedPost)
+        await waitForExpectations([snapshotWithIsSynced, receivedPost], timeout: 100)
+        
         XCTAssertTrue(snapshots.count >= 2)
         XCTAssertFalse(snapshots[0].isSynced)
+    }
+
+    /// ObserveQuery API will eventually return a snapshot when sync state is toggled  from false to true.
+    ///  A `.modelSynced` event from the hub is internally received
+    ///
+    /// - Given: DataStore is cleared
+    /// - When:
+    ///    - ObserveQuery API is called to start the sync engine
+    ///    - A model is saved but not yet synced
+    /// - Then:
+    ///    - A query snapshot is received on `.modelSynced`
+    ///
+    func testObserveQueryWhenModelSyncedEvent() async throws {
+        await setUp(withModels: TestModelRegistration())
+        try startAmplify()
+        try await clearDataStore()
+        var snapshots = [DataStoreQuerySnapshot<Post>]()
+        var isObserveQueryReadyForTest = false
+        let observeQueryReadyForTest = asyncExpectation(description: "received query snapshot with .isSynced true")
+        let snapshotWithPost = asyncExpectation(description: "received first snapshot")
+        let post = Post(title: "title", content: "content", createdAt: .now())
+        Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self)).sink { completed in
+            switch completed {
+            case .finished:
+                break
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        } receiveValue: { querySnapshot in
+            snapshots.append(querySnapshot)
+            if !isObserveQueryReadyForTest && querySnapshot.isSynced {
+                isObserveQueryReadyForTest = true
+                Task { await observeQueryReadyForTest.fulfill() }
+            }
+            if querySnapshot.items.contains(where: { $0.id == post.id }) {
+                Task { await snapshotWithPost.fulfill() }
+            }
+        }.store(in: &cancellables)
+        await waitForExpectations([observeQueryReadyForTest], timeout: 100)
+        
+        _ = try await Amplify.DataStore.save(post)
+        await waitForExpectations([snapshotWithPost], timeout: 100)
     }
 
     /// Apply a query predicate "title begins with 'xyz'"
@@ -77,14 +159,18 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     func testInitialSyncWithPredicate() async throws {
         await setUp(withModels: TestModelRegistration(), logLevel: .info)
         try startAmplify()
-        try await savePostAndWaitForSync(Post(title: "xyz 1", content: "content", createdAt: .now()))
-        try await savePostAndWaitForSync(Post(title: "xyz 2", content: "content", createdAt: .now()))
-        try await savePostAndWaitForSync(Post(title: "xyz 3", content: "content", createdAt: .now()))
+        let post1 = Post(title: "xyz 1", content: "content", createdAt: .now())
+        let post2 = Post(title: "xyz 2", content: "content", createdAt: .now())
+        let post3 = Post(title: "xyz 3", content: "content", createdAt: .now())
+        try await savePostAndWaitForSync(post1)
+        try await savePostAndWaitForSync(post2)
+        try await savePostAndWaitForSync(post3)
         try await clearDataStore()
         var snapshots = [DataStoreQuerySnapshot<Post>]()
-        let snapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
-        snapshotWithIsSynced.assertForOverFulfill = false
+        let snapshotWithIsSynced = asyncExpectation(description: "query snapshot with isSynced true")
         var snapshotWithIsSyncedFulfilled = false
+        let receivedPostFromObserveQuery = asyncExpectation(description: "received Post")
+        let post4 = Post(title: "xyz 4", content: "content", createdAt: .now())
         let predicate = Post.keys.title.beginsWith("xyz")
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self, where: predicate)).sink { completed in
             switch completed {
@@ -94,23 +180,26 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
                 XCTFail("\(error)")
             }
         } receiveValue: { querySnapshot in
-            if !snapshotWithIsSyncedFulfilled {
-                snapshots.append(querySnapshot)
-
-                if querySnapshot.isSynced {
-                    snapshotWithIsSyncedFulfilled = true
-                    snapshotWithIsSynced.fulfill()
+            snapshots.append(querySnapshot)
+            if !snapshotWithIsSyncedFulfilled && querySnapshot.isSynced {
+                snapshotWithIsSyncedFulfilled = true
+                Task { await snapshotWithIsSynced.fulfill() }
+            } else if snapshotWithIsSyncedFulfilled {
+                if querySnapshot.items.count >= 4 && querySnapshot.items.contains(where: { post in
+                    post.title.contains("xyz")
+                }){
+                    Task { await receivedPostFromObserveQuery.fulfill() }
                 }
             }
+            
         }.store(in: &cancellables)
 
-        let receivedPost = expectation(description: "received Post")
-        try await savePostAndWaitForSync(Post(title: "xyz", content: "content", createdAt: .now()),
-                                     postSyncedExpctation: receivedPost)
-        await waitForExpectations(timeout: 100)
+        await waitForExpectations([snapshotWithIsSynced], timeout: 100)
+    
+        try await savePostAndWaitForSync(post4)
+        await waitForExpectations([receivedPostFromObserveQuery], timeout: 100)
+        
         XCTAssertTrue(snapshots.count >= 2)
-        XCTAssertFalse(snapshots[0].isSynced)
-        log.info("\(snapshots)")
     }
 
     /// Apply a sort order. A query snapshot with the recently saved post should be the last item when
@@ -128,8 +217,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         try await clearDataStore()
         let post1 = Post(title: "title", content: "content", createdAt: .now())
         let post2 = Post(title: "title", content: "content", createdAt: .now().add(value: 1, to: .second))
-        let snapshotWithSavedPost = expectation(description: "query snapshot with saved post")
-        snapshotWithSavedPost.assertForOverFulfill = false
+        let snapshotWithSavedPost = asyncExpectation(description: "query snapshot with saved post")
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self, sort: .ascending(Post.keys.createdAt)))
         .sink { completed in
             switch completed {
@@ -147,15 +235,13 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
                 let actualPost1 = items.removeLast()
                 XCTAssertEqual(actualPost2.id, post2.id)
                 XCTAssertEqual(actualPost1.id, post1.id)
-                snapshotWithSavedPost.fulfill()
+                Task { await snapshotWithSavedPost.fulfill() }
             }
         }.store(in: &cancellables)
 
-        let receivedPost1 = expectation(description: "received Post")
-        try await savePostAndWaitForSync(post1, postSyncedExpctation: receivedPost1)
-        let receivedPost2 = expectation(description: "received Post")
-        try await savePostAndWaitForSync(post2, postSyncedExpctation: receivedPost2)
-        await waitForExpectations(timeout: 100)
+        try await savePostAndWaitForSync(post1)
+        try await savePostAndWaitForSync(post2)
+        await waitForExpectations([snapshotWithSavedPost], timeout: 100)
     }
 
     /// ObserveQuery with DataStore delta sync. Ensure datastore has synced the models and stopped.
@@ -175,8 +261,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         let numberOfPosts = try await queryNumberOfPosts()
         XCTAssertTrue(numberOfPosts > 0)
         try await stopDataStore()
-        let snapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
-        snapshotWithIsSynced.assertForOverFulfill = false
+        let snapshotWithIsSynced = asyncExpectation(description: "query snapshot with isSynced true")
         var snapshots = [DataStoreQuerySnapshot<Post>]()
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self)).sink { completed in
             switch completed {
@@ -188,13 +273,13 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         } receiveValue: { querySnapshot in
             snapshots.append(querySnapshot)
             if querySnapshot.isSynced {
-                snapshotWithIsSynced.fulfill()
+                Task { await snapshotWithIsSynced.fulfill() }
             }
         }.store(in: &cancellables)
-        let receivedPost = expectation(description: "received Post")
+        let receivedPost = asyncExpectation(description: "received Post")
         try await savePostAndWaitForSync(Post(title: "title", content: "content", createdAt: .now()),
-                                     postSyncedExpctation: receivedPost)
-        await waitForExpectations(timeout: 100)
+                                         postSyncedExpctation: receivedPost)
+        await waitForExpectations([snapshotWithIsSynced, receivedPost], timeout: 100)
         XCTAssertTrue(snapshots.count >= 2)
         XCTAssertFalse(snapshots[0].isSynced)
         XCTAssertTrue(snapshots.last!.isSynced)
@@ -216,20 +301,18 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     ///     - Delete a model that does NOT match the predicate. No snapshot is emitted
     func testPredicateWithCreateUpdateDelete() async throws {
         await setUp(withModels: TestModelRegistration(), logLevel: .verbose)
-        try startAmplify()
+        try await startAmplifyAndWaitForReady()
         let testId = UUID().uuidString
         var snapshotCount = 0
         let predicate = Post.keys.title.beginsWith("xyz") && Post.keys.content == testId
-        let snapshotExpectation1 = expectation(description: "received snapshot 1")
-        var onSnapshot: ((DataStoreQuerySnapshot<Post>) -> Void) = { querySnapshot in
-            snapshotCount += 1
-            let items = querySnapshot.items
-            if snapshotCount == 1 {
-                self.log.info("1. \(querySnapshot)")
-                XCTAssertEqual(items.count, 0)
-                snapshotExpectation1.fulfill()
-            }
-        }
+        let snapshotExpectation1 = asyncExpectation(description: "received snapshot 1")
+        let snapshotExpectation23 = asyncExpectation(description: "received snapshot 2 / 3",
+                                                     expectedFulfillmentCount: 2)
+        let snapshotExpectation4 = asyncExpectation(description: "received snapshot 4")
+        let snapshotExpectation56 = asyncExpectation(description: "received snapshot 5 / 6",
+                                                     expectedFulfillmentCount: 2)
+        let snapshotExpectation7 = asyncExpectation(description: "received snapshot 7")
+        let snapshotExpectation8 = asyncExpectation(description: "received snapshot 8")
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self, where: predicate)).sink { completed in
             switch completed {
             case .finished:
@@ -237,98 +320,80 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
             case .failure(let error):
                 XCTFail("\(error)")
             }
-        } receiveValue: { onSnapshot($0) }.store(in: &cancellables)
-        await waitForExpectations(timeout: 10)
+        } receiveValue: { querySnapshot in
+            snapshotCount += 1
+            let items = querySnapshot.items
+            if snapshotCount == 1 {
+                self.log.info("manamaha 1. \(querySnapshot)")
+                XCTAssertEqual(items.count, 0)
+                Task { await snapshotExpectation1.fulfill() }
+            } else if snapshotCount == 2 || snapshotCount == 3 {
+                // See (1), subsequent snapshot should have item with "xyz 1".
+                self.log.info("manamaha 2/3. \(querySnapshot)")
+                XCTAssertEqual(items.count, 1)
+                XCTAssertEqual(items[0].title, "xyz 1")
+                Task { await snapshotExpectation23.fulfill() }
+            } else if snapshotCount == 4 {
+                // See (2), should not be added to the snapshot.
+                // See (3), should be removed from the snapshot. So the resulting snapshot is empty.
+                self.log.info("manamaha 4. \(querySnapshot)")
+                XCTAssertEqual(items.count, 0)
+                Task { await snapshotExpectation4.fulfill() }
+            } else if snapshotCount == 5 || snapshotCount == 6 {
+                // See (4). the post that now matches the snapshot should be added
+                self.log.info("manamaha 5/6. \(querySnapshot)")
+                XCTAssertEqual(items.count, 1)
+                XCTAssertEqual(items[0].title, "xyz 2")
+                Task { await snapshotExpectation56.fulfill() }
+            } else if snapshotCount == 7 {
+                // See (5). the post that matched the predicate was deleted
+                self.log.info("manamaha 7. \(querySnapshot)")
+                XCTAssertEqual(items.count, 0)
+                Task { await snapshotExpectation7.fulfill() }
+            } else if snapshotCount == 8 {
+                // See (6). Snapshot that is emitted due to "xyz 3" should not contain the deleted model
+                self.log.info("manamaha 8. \(querySnapshot)")
+                XCTAssertEqual(items.count, 1)
+                XCTAssertEqual(items[0].title, "xyz 3")
+                Task { await snapshotExpectation8.fulfill() }
+            }
+        }.store(in: &cancellables)
+        await waitForExpectations([snapshotExpectation1], timeout: 10)
         
         // (1) Add model that matches predicate - should be received on the snapshot
         let postMatchPredicate = Post(title: "xyz 1", content: testId, createdAt: .now())
-        let snapshotExpectation23 = expectation(description: "received snapshot 2 / 3")
-        snapshotExpectation23.expectedFulfillmentCount = 2
-        onSnapshot = { querySnapshot in
-            snapshotCount += 1
-            let items = querySnapshot.items
-            if snapshotCount == 2 || snapshotCount == 3 {
-                // See (1), subsequent snapshot should have item with "xyz 1".
-                self.log.info("2/3. \(querySnapshot)")
-                XCTAssertEqual(items.count, 1)
-                XCTAssertEqual(items[0].title, "xyz 1")
-                snapshotExpectation23.fulfill()
-            }
-        }
+        
         try await savePostAndWaitForSync(postMatchPredicate)
-
+        await waitForExpectations([snapshotExpectation23], timeout: 10)
+        
         // (2) Add model that does not match predicate - should not be received on the snapshot
         // (3) Update model that used to match the predicate to no longer match - should be removed from snapshot
         let postDoesNotMatch = Post(title: "doesNotMatch", content: testId, createdAt: .now())
-        let snapshotExpectation4 = expectation(description: "received snapshot 4")
-        onSnapshot = { querySnapshot in
-            snapshotCount += 1
-            let items = querySnapshot.items
-            if snapshotCount == 4 {
-                // See (2), should not be added to the snapshot.
-                // See (3), should be removed from the snapshot. So the resulting snapshot is empty.
-                self.log.info("4. \(querySnapshot)")
-                XCTAssertEqual(items.count, 0)
-                snapshotExpectation4.fulfill()
-            }
-        }
-        let postDoesNotMatchExpectation = expectation(description: "received postDoesNotMatchExpectation")
+        let postDoesNotMatchExpectation = asyncExpectation(description: "received postDoesNotMatchExpectation")
         try await savePostAndWaitForSync(postDoesNotMatch, postSyncedExpctation: postDoesNotMatchExpectation)
         var postMatchPredicateNoLongerMatches = postMatchPredicate
         postMatchPredicateNoLongerMatches.title = "doesNotMatch"
         try await savePostAndWaitForSync(postMatchPredicateNoLongerMatches)
-
-
+        await waitForExpectations([snapshotExpectation4], timeout: 10)
+        
         // (4) Update model that does not match predicate to match - should be added to snapshot
-        let snapshotExpectation56 = expectation(description: "received snapshot 5 / 6")
-        snapshotExpectation56.expectedFulfillmentCount = 2
         var postDoesNotMatchNowMatches = postDoesNotMatch
         postDoesNotMatchNowMatches.title = "xyz 2"
-        onSnapshot = { querySnapshot in
-            snapshotCount += 1
-            let items = querySnapshot.items
-            if snapshotCount == 5 || snapshotCount == 6 {
-                // See (4). the post that now matches the snapshot should be added
-                self.log.info("5/6. \(querySnapshot)")
-                XCTAssertEqual(items.count, 1)
-                XCTAssertEqual(items[0].title, "xyz 2")
-                snapshotExpectation56.fulfill()
-            }
-        }
         try await savePostAndWaitForSync(postDoesNotMatchNowMatches)
-
+        await waitForExpectations([snapshotExpectation56], timeout: 10)
+        
         // (5) Delete the model that matches the predicate - should be removed
-        let snapshotExpectation7 = expectation(description: "received snapshot 7")
-        onSnapshot = { querySnapshot in
-            snapshotCount += 1
-            let items = querySnapshot.items
-            if snapshotCount == 7 {
-                // See (5). the post that matched the predicate was deleted
-                self.log.info("7. \(querySnapshot)")
-                XCTAssertEqual(items.count, 0)
-                snapshotExpectation7.fulfill()
-            }
-        }
         try await deletePostAndWaitForSync(postDoesNotMatchNowMatches)
-
+        await waitForExpectations([snapshotExpectation7], timeout: 10)
+        
         // (6) Delete the model that does not match predicate - should have no snapshot emitted
-        let snapshotExpectation8 = expectation(description: "received snapshot 8")
-        onSnapshot = { querySnapshot in
-            snapshotCount += 1
-            let items = querySnapshot.items
-            if snapshotCount == 8 {
-                // See (6). Snapshot that is emitted due to "xyz 3" should not contain the deleted model
-                self.log.info("8. \(querySnapshot)")
-                XCTAssertEqual(items.count, 1)
-                XCTAssertEqual(items[0].title, "xyz 3")
-                snapshotExpectation8.fulfill()
-            }
-        }
-        let postMatchPredicateNoLongerMatchesExpectation = expectation(description: " received")
+        let postMatchPredicateNoLongerMatchesExpectation = asyncExpectation(description: " received")
         try await deletePostAndWaitForSync(postMatchPredicateNoLongerMatches,
-                                       postSyncedExpctation: postMatchPredicateNoLongerMatchesExpectation)
+                                           postSyncedExpctation: postMatchPredicateNoLongerMatchesExpectation)
+
         // Save "xyz 3" to force a snapshot to be emitted
         try await savePostAndWaitForSync(Post(title: "xyz 3", content: testId, createdAt: .now()))
+        await waitForExpectations([snapshotExpectation8], timeout: 10)
     }
 
     /// ObserveQuery is set up with a sort order.
@@ -344,17 +409,17 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     ///
     func testSortWithCreateUpdateDelete() async throws {
         await setUp(withModels: TestModelRegistration(), logLevel: .info)
-        try startAmplify()
+        try await startAmplifyAndWaitForReady()
 
         let testId = UUID().uuidString
         var snapshotCount = 0
-        let snapshotExpectation1 = expectation(description: "received snapshot 1")
+        let snapshotExpectation1 = asyncExpectation(description: "received snapshot 1")
         var onSnapshot: ((DataStoreQuerySnapshot<Post>) -> Void) = { querySnapshot in
             snapshotCount += 1
             let items = querySnapshot.items
             if snapshotCount == 1 {
                 XCTAssertEqual(items.count, 0)
-                snapshotExpectation1.fulfill()
+                Task { await snapshotExpectation1.fulfill() }
             }
         }
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self,
@@ -368,25 +433,25 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
                 XCTFail("\(error)")
             }
         } receiveValue: { onSnapshot($0) }.store(in: &cancellables)
-        await waitForExpectations(timeout: 10)
+        await waitForExpectations([snapshotExpectation1], timeout: 10)
 
         // (1) Add several models
-        let snapshotExpectation23 = expectation(description: "received snapshot 2 / 3")
-        snapshotExpectation23.expectedFulfillmentCount = 2
+        let snapshotExpectation23 = asyncExpectation(description: "received snapshot 2 / 3",
+                                                     expectedFulfillmentCount: 2)
         onSnapshot = { querySnapshot in
             snapshotCount += 1
             let items = querySnapshot.items
             if snapshotCount == 2 || snapshotCount == 3 {
                 XCTAssertEqual(items.count, 1)
                 XCTAssertEqual(items[0].title, "a")
-                snapshotExpectation23.fulfill()
+                Task { await snapshotExpectation23.fulfill() }
             }
         }
         let postA = Post(title: "a", content: testId, createdAt: .now())
         try await savePostAndWaitForSync(postA)
 
-        let snapshotExpectation45 = expectation(description: "received snapshot 4 / 5")
-        snapshotExpectation45.expectedFulfillmentCount = 2
+        let snapshotExpectation45 = asyncExpectation(description: "received snapshot 4 / 5",
+                                                     expectedFulfillmentCount: 2)
         onSnapshot = { querySnapshot in
             snapshotCount += 1
             let items = querySnapshot.items
@@ -394,14 +459,14 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
                 XCTAssertEqual(items.count, 2)
                 XCTAssertEqual(items[0].title, "a")
                 XCTAssertEqual(items[1].title, "m")
-                snapshotExpectation45.fulfill()
+                Task { await snapshotExpectation45.fulfill() }
             }
         }
         let postM = Post(title: "m", content: testId, createdAt: .now())
         try await savePostAndWaitForSync(postM)
 
-        let snapshotExpectation67 = expectation(description: "received snapshot 6 / 7")
-        snapshotExpectation67.expectedFulfillmentCount = 2
+        let snapshotExpectation67 = asyncExpectation(description: "received snapshot 6 / 7",
+                                                     expectedFulfillmentCount: 2)
         onSnapshot = { querySnapshot in
             snapshotCount += 1
             let items = querySnapshot.items
@@ -410,15 +475,15 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
                 XCTAssertEqual(items[0].title, "a")
                 XCTAssertEqual(items[1].title, "m")
                 XCTAssertEqual(items[2].title, "z")
-                snapshotExpectation67.fulfill()
+                Task { await snapshotExpectation67.fulfill() }
             }
         }
         let postZ = Post(title: "z", content: testId, createdAt: .now())
         try await savePostAndWaitForSync(postZ)
 
         // (2) Update models to move them into different orders
-        let snapshotExpectation89 = expectation(description: "received snapshot 8 / 9")
-        snapshotExpectation89.expectedFulfillmentCount = 2
+        let snapshotExpectation89 = asyncExpectation(description: "received snapshot 8 / 9",
+                                                     expectedFulfillmentCount: 2)
         onSnapshot = { querySnapshot in
             snapshotCount += 1
             let items = querySnapshot.items
@@ -427,16 +492,16 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
                 XCTAssertEqual(items[0].title, "m")
                 XCTAssertEqual(items[1].title, "n")
                 XCTAssertEqual(items[2].title, "z")
-                snapshotExpectation89.fulfill()
+                Task { await snapshotExpectation89.fulfill() }
             }
         }
         var postNFromA = postA
         postNFromA.title = "n"
         try await savePostAndWaitForSync(postNFromA)
         
-        let snapshotExpectation1011 = expectation(description: "received snapshot 10 / 11")
-        snapshotExpectation1011.expectedFulfillmentCount = 2
-        onSnapshot = { querySnapshot in
+        let snapshotExpectation1011 = asyncExpectation(description: "received snapshot 10 / 11",
+                                                       expectedFulfillmentCount: 2)
+            onSnapshot = { querySnapshot in
             snapshotCount += 1
             let items = querySnapshot.items
             if snapshotCount == 10 || snapshotCount == 11 {
@@ -444,7 +509,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
                 XCTAssertEqual(items[0].title, "b")
                 XCTAssertEqual(items[1].title, "m")
                 XCTAssertEqual(items[2].title, "n")
-                snapshotExpectation1011.fulfill()
+                Task { await snapshotExpectation1011.fulfill() }
             }
         }
         var postBFromZ = postZ
@@ -452,7 +517,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         try await savePostAndWaitForSync(postBFromZ)
 
         // (3) Delete models
-        let snapshotExpectation12 = expectation(description: "received snapshot 12")
+        let snapshotExpectation12 = asyncExpectation(description: "received snapshot 12")
         onSnapshot = { querySnapshot in
             snapshotCount += 1
             let items = querySnapshot.items
@@ -460,30 +525,30 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
                 XCTAssertEqual(items.count, 2)
                 XCTAssertEqual(items[0].title, "b")
                 XCTAssertEqual(items[1].title, "n")
-                snapshotExpectation12.fulfill()
+                Task { await snapshotExpectation12.fulfill() }
             }
         }
         try await deletePostAndWaitForSync(postM)
         
-        let snapshotExpectation13 = expectation(description: "received snapshot 13")
+        let snapshotExpectation13 = asyncExpectation(description: "received snapshot 13")
         onSnapshot = { querySnapshot in
             snapshotCount += 1
             let items = querySnapshot.items
             if snapshotCount == 13 {
                 XCTAssertEqual(items.count, 1)
                 XCTAssertEqual(items[0].title, "b")
-                snapshotExpectation13.fulfill()
+                Task { await snapshotExpectation13.fulfill() }
             }
         }
         try await deletePostAndWaitForSync(postNFromA)
         
-        let snapshotExpectation14 = expectation(description: "received snapshot 13")
+        let snapshotExpectation14 = asyncExpectation(description: "received snapshot 13")
         onSnapshot = { querySnapshot in
             snapshotCount += 1
             let items = querySnapshot.items
             if snapshotCount == 14 {
                 XCTAssertEqual(items.count, 0)
-                snapshotExpectation14.fulfill()
+                Task { await snapshotExpectation14.fulfill() }
             }
         }
         try await deletePostAndWaitForSync(postBFromZ)
@@ -500,28 +565,28 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     func testObserveQueryShouldResetOnDataStoreStop() async throws {
         await setUp(withModels: TestModelRegistration())
         try await startAmplifyAndWaitForReady()
-        let firstSnapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
+        let firstSnapshotWithIsSynced = asyncExpectation(description: "query snapshot with isSynced true")
         var onComplete: ((Subscribers.Completion<Error>) -> Void) = { _ in }
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self))
             .sink { onComplete($0) } receiveValue: { querySnapshot in
                 if querySnapshot.isSynced {
-                    firstSnapshotWithIsSynced.fulfill()
+                    Task { await firstSnapshotWithIsSynced.fulfill() }
                 }
             }.store(in: &cancellables)
-        await waitForExpectations(timeout: 100)
+        await waitForExpectations([firstSnapshotWithIsSynced], timeout: 10)
         
-        let observeQueryReceivedCompleted = expectation(description: "observeQuery received completed")
-        observeQueryReceivedCompleted.isInverted = true
+        let observeQueryReceivedCompleted = asyncExpectation(description: "observeQuery received completed",
+                                                             isInverted: true)
         onComplete = { completed in
             switch completed {
             case .finished:
-                observeQueryReceivedCompleted.fulfill()
+                Task { await observeQueryReceivedCompleted.fulfill() }
             case .failure(let error):
                 XCTFail("\(error)")
             }
         }
         try await Amplify.DataStore.stop()
-        await waitForExpectations(timeout: 10)
+        await waitForExpectations([observeQueryReceivedCompleted], timeout: 10)
     }
 
     /// Ensure clearing datastore will not complete the observeQuery subscribers.
@@ -535,96 +600,95 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     func testObserveQueryShouldResetOnDataStoreClear() async throws {
         await setUp(withModels: TestModelRegistration())
         try await startAmplifyAndWaitForReady()
-        let firstSnapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
+        let firstSnapshotWithIsSynced = asyncExpectation(description: "query snapshot with isSynced true")
         var onComplete: ((Subscribers.Completion<Error>) -> Void) = { _ in }
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self))
             .sink { onComplete($0) } receiveValue: { querySnapshot in
                 if querySnapshot.isSynced {
-                    firstSnapshotWithIsSynced.fulfill()
+                    Task { await firstSnapshotWithIsSynced.fulfill() }
                 }
             }.store(in: &cancellables)
-        await waitForExpectations(timeout: 100)
+        await waitForExpectations([firstSnapshotWithIsSynced], timeout: 100)
         
-        let observeQueryReceivedCompleted = expectation(description: "observeQuery received completed")
-        observeQueryReceivedCompleted.isInverted = true
+        let observeQueryReceivedCompleted = asyncExpectation(description: "observeQuery received completed",
+                                                             isInverted: true)
         onComplete = { completed in
             switch completed {
             case .finished:
-                observeQueryReceivedCompleted.fulfill()
+                Task { await observeQueryReceivedCompleted.fulfill() }
             case .failure(let error):
                 XCTFail("\(error)")
             }
         }
         try await Amplify.DataStore.clear()
-        await waitForExpectations(timeout: 10)
+        await waitForExpectations([observeQueryReceivedCompleted], timeout: 10)
     }
 
     func testObserveQueryShouldStartOnDataStoreStart() async throws {
         await setUp(withModels: TestModelRegistration())
         try await startAmplifyAndWaitForReady()
-        let firstSnapshot = expectation(description: "first query snapshot")
+        let firstSnapshot = asyncExpectation(description: "first query snapshot")
         var querySnapshots = [DataStoreQuerySnapshot<Post>]()
         var onComplete: ((Subscribers.Completion<Error>) -> Void) = { _ in }
         var onSnapshot: ((DataStoreQuerySnapshot<Post>) -> Void) = { querySnapshot in
             querySnapshots.append(querySnapshot)
             if querySnapshots.count == 1 {
-                firstSnapshot.fulfill()
+                Task { await firstSnapshot.fulfill() }
             }
         }
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self))
             .sink { onComplete($0) } receiveValue: { onSnapshot($0) }
             .store(in: &cancellables)
-        await waitForExpectations(timeout: 100)
+        await waitForExpectations([firstSnapshot], timeout: 100)
         
-        let observeQueryReceivedCompleted = expectation(description: "observeQuery received completed")
-        observeQueryReceivedCompleted.isInverted = true
+        let observeQueryReceivedCompleted = asyncExpectation(description: "observeQuery received completed",
+                                                             isInverted: true)
         onComplete = { completed in
             switch completed {
             case .finished:
-                observeQueryReceivedCompleted.fulfill()
+                Task { await observeQueryReceivedCompleted.fulfill() }
             case .failure(let error):
                 XCTFail("\(error)")
             }
         }
         try await Amplify.DataStore.stop()
-        await waitForExpectations(timeout: 10)
+        await waitForExpectations([observeQueryReceivedCompleted], timeout: 10)
         
-        let observeQueryReceivedCompleted2 = expectation(description: "observeQuery received completed")
-        observeQueryReceivedCompleted2.isInverted = true
+        let observeQueryReceivedCompleted2 = asyncExpectation(description: "observeQuery received completed",
+                                                              isInverted: true)
         onComplete = { completed in
             switch completed {
             case .finished:
-                observeQueryReceivedCompleted2.fulfill()
+                Task { await observeQueryReceivedCompleted2.fulfill() }
             case .failure(let error):
                 XCTFail("\(error)")
             }
         }
-        let secondSnapshot = expectation(description: "second query snapshot")
+        let secondSnapshot = asyncExpectation(description: "second query snapshot")
         onSnapshot = { querySnapshot in
             querySnapshots.append(querySnapshot)
             if querySnapshots.count == 2 {
-                secondSnapshot.fulfill()
+                Task { await secondSnapshot.fulfill() }
             }
         }
         try await Amplify.DataStore.start()
-        await waitForExpectations(timeout: 10)
+        await waitForExpectations([secondSnapshot], timeout: 10)
     }
 
     // MARK: - Helpers
-
-    func savePostAndWaitForSync(_ post: Post, postSyncedExpctation: XCTestExpectation? = nil) async throws {
+    func savePostAndWaitForSync(_ post: Post, postSyncedExpctation: AsyncExpectation? = nil) async throws {
         // Wait for a fulfillment count of 2 (first event due to the locally source mutation saved to the local store
         // and the second event due to the subscription event received from the remote store)
-        let receivedPost = postSyncedExpctation ?? expectation(description: "received Post")
-        receivedPost.expectedFulfillmentCount = 2
-        receivedPost.assertForOverFulfill = false
-        
-        let task = Task {
+        let receivedPost = postSyncedExpctation ?? asyncExpectation(description: "received Post",
+                                                                    expectedFulfillmentCount: 2)
+        // legacy behavior of expectations created through APIs on XCTestCase
+        // receivedPost.assertForOverFulfill = false
+        Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await mutationEvent in mutationEvents {
                     if mutationEvent.modelId == post.id {
-                        receivedPost.fulfill()
+                        await receivedPost.fulfill()
                     }
                 }
             } catch {
@@ -634,22 +698,23 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         
         _ = try await Amplify.DataStore.save(post)
         if postSyncedExpctation == nil {
-            await waitForExpectations(timeout: 100)
+            await waitForExpectations([receivedPost], timeout: 100)
         }
     }
 
-    func deletePostAndWaitForSync(_ post: Post, postSyncedExpctation: XCTestExpectation? = nil) async throws {
-        let deletedPost = postSyncedExpctation ?? expectation(description: "deleted Post")
+    func deletePostAndWaitForSync(_ post: Post, postSyncedExpctation: AsyncExpectation? = nil) async throws {
         // Wait for a fulfillment count of 2 (first event due to the locally source mutation deleted from the local
         // store and the second event due to the subscription event received from the remote store)
-        deletedPost.expectedFulfillmentCount = 2
-        deletedPost.assertForOverFulfill = false
-        let task = Task {
+        let deletedPost = postSyncedExpctation ?? asyncExpectation(description: "deleted Post",
+                                                                   expectedFulfillmentCount: 2)
+        //  legacy behavior of expectations created through APIs on XCTestCase
+        //  deletedPost.assertForOverFulfill = false
+        Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await mutationEvent in mutationEvents {
                     if mutationEvent.modelId == post.id {
-                        deletedPost.fulfill()
+                        await deletedPost.fulfill()
                     }
                 }
             } catch {
@@ -659,7 +724,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         
         _ = try await Amplify.DataStore.delete(post)
         if postSyncedExpctation == nil {
-            await waitForExpectations(timeout: 100)
+            await waitForExpectations([deletedPost], timeout: 100)
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/1759
*Description of changes:*
(reference taken from https://github.com/aws-amplify/amplify-ios/pull/2105)
Datastore observeQuery is an API that produces streamlines of data snapshots along with its' syncState.
While producing data snapshots and syncing to the cloud, the isSynced value remains false and is toggled to true when the syncing process is complete. But there can be potential loss of snapshots in the toggle from the last snapshot during the sync and the first snapshot after the sync as there can be lot of items being changed at that point after toggle. And the snapshot to be produced after the sync is delayed as it waits for any new changes.
The fix is to listen on datastore .modelSynced where Items observed will be returned in a single snapshot on isSynced toggled from false to true. The operation will internally listen to .modelSynced event from the Hub, thus emitting required snapshots on toggle fixing the issue https://github.com/aws-amplify/amplify-ios/issues/1759
*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
