### PR TITLE
fix(api): create sequence before run task in InternalTaskAsyncThrowingSequence

### DIFF
--- a/Amplify/Core/Support/Internal/InternalTask+AsyncSequence.swift
+++ b/Amplify/Core/Support/Internal/InternalTask+AsyncSequence.swift
@@ -38,14 +38,15 @@ public extension InternalTaskAsyncThrowingSequence where Self: InternalTaskRunne
 
     var sequence: AmplifyAsyncThrowingSequence<InProcess> {
         guard let sequence = context.sequence else {
+            let sequence = AmplifyAsyncThrowingSequence<InProcess>(parent: self, bufferingPolicy: context.bufferingPolicy)
+            context.sequence = sequence
+
             let task = Task { [weak self] in
                 guard let self = self else { return }
                 try await self.run()
             }
-
-            let sequence = AmplifyAsyncThrowingSequence<InProcess>(parent: self, bufferingPolicy: context.bufferingPolicy)
             self.context.task = task
-            context.sequence = sequence
+
             return sequence
         }
 


### PR DESCRIPTION
*Issue #, if available:*

- [Failed CI test case](https://app.circleci.com/pipelines/github/aws-amplify/amplify-ios/7011/workflows/feab23cf-6c2b-4330-a2e2-d9de7c9b38f2/jobs/48372)

*Description of changes:*

- Move `sequence` creation before triggering `run`. As in the `run` function, it will try to [send events](https://github.com/aws-amplify/amplify-ios/blob/dev-preview/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift#L111) to `sequence`. If `sequence` is not created yet, the event [will be dropped silently](https://github.com/aws-amplify/amplify-ios/blob/dev-preview/Amplify/Core/Support/Internal/InternalTask%2BAsyncSequence.swift#L84). 

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
