### PR TITLE
fix(datastore-v2): synchronize multiple storageEngine initializations

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin.swift
@@ -16,6 +16,12 @@ enum DataStoreState {
     case clear
 }
 
+enum InitStorageEngineResult {
+    case successfullyInitialized
+    case alreadyInitialized
+    case failure(DataStoreError)
+}
+
 final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
 
     public var key: PluginKey = "awsDataStorePlugin"
@@ -108,12 +114,6 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
         }
         resolveSyncEnabled()
         ModelListDecoderRegistry.registerDecoder(DataStoreListDecoder.self)
-    }
-
-    enum InitStorageEngineResult {
-        case successfullyInitialized
-        case alreadyInitialized
-        case failure(DataStoreError)
     }
     
     /// Initializes the underlying storage engine


### PR DESCRIPTION
*Issue #, if available:*

Fix failed [test cases](https://app.circleci.com/pipelines/github/aws-amplify/amplify-ios/7011/workflows/feab23cf-6c2b-4330-a2e2-d9de7c9b38f2/jobs/48370) for `AWSDataStoreLocalStoreTests`.

*Description of changes:*

Adding a new flag `isStorageEngineInitialized` to synchronize `storageEngine` initialization between multiple threads. 

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
