### PR TITLE
fix(Analytics): Removing targetingRegion from the configuration struct

### DIFF
--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Configure.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Configure.swift
@@ -41,10 +41,6 @@ extension AWSPinpointAnalyticsPlugin {
         log.verbose("Setting PinpointContextConfiguration.isDebug to true")
         #endif
 
-        if configuration.region != configuration.targetingRegion {
-            log.warn("Different regions between Analytics and Targeting is not supported. The Analytics region will be used.")
-        }
-
         let sessionBackgroundTimeout: TimeInterval
         if configuration.autoSessionTrackingInterval == .max {
             sessionBackgroundTimeout = .infinity

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Constants/AnalyticsErrorConstants.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Constants/AnalyticsErrorConstants.swift
@@ -31,11 +31,6 @@ struct AnalyticsPluginErrorConstant {
         "Make sure the value for the `PinpointAnalytics` is a dictionary literal with `AppId` and `Region`"
     )
 
-    static let missingPinpointTargetingConfiguration: AnalyticsPluginErrorString = (
-        "Plugin is missing `PinpointTargeting` section.",
-        "Add the `PinpointTargeting` section to the plugin."
-    )
-
     static let pinpointTargetingConfigurationExpected: AnalyticsPluginErrorString = (
         "Configuration at `PinpointTargeting` is not a dictionary literal",
         "Make sure the value for the `PinpointTargeting` is a dictionary literal with `Region`"

--- a/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/Configuration/AWSPinpointAnalyticsPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/Configuration/AWSPinpointAnalyticsPluginConfigurationTests.swift
@@ -27,10 +27,10 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
         (AWSPinpointAnalyticsPluginConfiguration.appIdConfigKey, "testAppId"),
         (AWSPinpointAnalyticsPluginConfiguration.regionConfigKey, "us-east-1")
     )
-    let regionConfiguration = JSONValue(dictionaryLiteral:
-        (AWSPinpointAnalyticsPluginConfiguration.regionConfigKey, "us-east-1"))
 
-    func testConfigureSuccess() throws {
+    func testConfigureSuccess_withTargetingConfiguration() throws {
+        let regionConfiguration = JSONValue(dictionaryLiteral:
+            (AWSPinpointAnalyticsPluginConfiguration.regionConfigKey, "us-east-1"))
         let analyticsPluginConfig = JSONValue(
             dictionaryLiteral:
             (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
@@ -42,7 +42,28 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
             XCTAssertNotNil(config)
             XCTAssertEqual(config.appId, testAppId)
             XCTAssertEqual(config.region, testRegion)
-            XCTAssertEqual(config.targetingRegion, testRegion)
+            XCTAssertEqual(config.autoFlushEventsInterval,
+                           AWSPinpointAnalyticsPluginConfiguration.defaultAutoFlushEventsInterval)
+            XCTAssertEqual(config.trackAppSessions,
+                           AWSPinpointAnalyticsPluginConfiguration.defaultTrackAppSession)
+            XCTAssertEqual(config.autoSessionTrackingInterval,
+                           AWSPinpointAnalyticsPluginConfiguration.defaultAutoSessionTrackingInterval)
+        } catch {
+            XCTFail("Failed to instantiate analytics plugin configuration")
+        }
+    }
+    
+    func testConfigureSuccess_withoutTargetingConfiguration() throws {
+        let analyticsPluginConfig = JSONValue(
+            dictionaryLiteral:
+            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration)
+        )
+
+        do {
+            let config = try AWSPinpointAnalyticsPluginConfiguration(analyticsPluginConfig)
+            XCTAssertNotNil(config)
+            XCTAssertEqual(config.appId, testAppId)
+            XCTAssertEqual(config.region, testRegion)
             XCTAssertEqual(config.autoFlushEventsInterval,
                            AWSPinpointAnalyticsPluginConfiguration.defaultAutoFlushEventsInterval)
             XCTAssertEqual(config.trackAppSessions,
@@ -58,7 +79,6 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
         let analyticsPluginConfig = JSONValue(
             dictionaryLiteral:
             (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration),
             (AWSPinpointAnalyticsPluginConfiguration.autoFlushEventsIntervalKey, autoFlushInterval)
         )
 
@@ -67,7 +87,6 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
             XCTAssertNotNil(config)
             XCTAssertEqual(config.appId, testAppId)
             XCTAssertEqual(config.region, testRegion)
-            XCTAssertEqual(config.targetingRegion, testRegion)
             XCTAssertEqual(config.autoFlushEventsInterval, testAutoFlushInterval)
             XCTAssertEqual(config.trackAppSessions,
                            AWSPinpointAnalyticsPluginConfiguration.defaultTrackAppSession)
@@ -83,7 +102,6 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
         let analyticsPluginConfig = JSONValue(
             dictionaryLiteral:
             (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration),
             (AWSPinpointAnalyticsPluginConfiguration.autoFlushEventsIntervalKey, autoFlushInterval)
         )
 
@@ -101,7 +119,6 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
         let analyticsPluginConfig = JSONValue(
             dictionaryLiteral:
             (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration),
             (AWSPinpointAnalyticsPluginConfiguration.trackAppSessionsKey, trackAppSession)
         )
 
@@ -110,7 +127,6 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
             XCTAssertNotNil(config)
             XCTAssertEqual(config.appId, testAppId)
             XCTAssertEqual(config.region, testRegion)
-            XCTAssertEqual(config.targetingRegion, testRegion)
             XCTAssertEqual(config.autoFlushEventsInterval,
                            AWSPinpointAnalyticsPluginConfiguration.defaultAutoFlushEventsInterval)
             XCTAssertEqual(config.trackAppSessions, testTrackAppSession)
@@ -125,7 +141,6 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
         let analyticsPluginConfig = JSONValue(
             dictionaryLiteral:
             (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration),
             (AWSPinpointAnalyticsPluginConfiguration.autoSessionTrackingIntervalKey, autoSessionTrackingInterval)
         )
 
@@ -134,7 +149,6 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
             XCTAssertNotNil(config)
             XCTAssertEqual(config.appId, testAppId)
             XCTAssertEqual(config.region, testRegion)
-            XCTAssertEqual(config.targetingRegion, testRegion)
             XCTAssertEqual(config.autoFlushEventsInterval,
                            AWSPinpointAnalyticsPluginConfiguration.defaultAutoFlushEventsInterval)
             XCTAssertEqual(config.trackAppSessions, AWSPinpointAnalyticsPluginConfiguration.defaultTrackAppSession)
@@ -149,7 +163,6 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
         let analyticsPluginConfig = JSONValue(
             dictionaryLiteral:
             (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration),
             (AWSPinpointAnalyticsPluginConfiguration.autoSessionTrackingIntervalKey, autoSessionTrackingInterval)
         )
 
@@ -177,9 +190,11 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
     }
 
     func testConfigureThrowsErrorForMissingPinpointAnalyticsConfiguration() {
+        
         let analyticsPluginConfig = JSONValue(
             dictionaryLiteral:
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration))
+                (AWSPinpointAnalyticsPluginConfiguration.regionConfigKey, region)
+        )
 
         XCTAssertThrowsError(try AWSPinpointAnalyticsPluginConfiguration(analyticsPluginConfig)) { error in
             guard case let PluginError.pluginConfigurationError(errorDescription, _, _) = error else {
@@ -195,8 +210,7 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
         let pinpointAnalyticsPluginConfiguration = JSONValue(stringLiteral: "notDictionary")
         let analyticsPluginConfig = JSONValue(
             dictionaryLiteral:
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration)
+            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration)
         )
 
         XCTAssertThrowsError(try AWSPinpointAnalyticsPluginConfiguration(analyticsPluginConfig)) { error in
@@ -215,8 +229,7 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
             (AWSPinpointAnalyticsPluginConfiguration.regionConfigKey, region))
         let analyticsPluginConfig = JSONValue(
             dictionaryLiteral:
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration)
+            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration)
         )
 
         XCTAssertThrowsError(try AWSPinpointAnalyticsPluginConfiguration(analyticsPluginConfig)) { error in
@@ -236,8 +249,7 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
         )
         let analyticsPluginConfig = JSONValue(
             dictionaryLiteral:
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration)
+            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration)
         )
 
         XCTAssertThrowsError(try AWSPinpointAnalyticsPluginConfiguration(analyticsPluginConfig)) { error in
@@ -257,8 +269,7 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
         )
         let analyticsPluginConfig = JSONValue(
             dictionaryLiteral:
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration)
+            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration)
         )
 
         XCTAssertThrowsError(try AWSPinpointAnalyticsPluginConfiguration(analyticsPluginConfig)) { error in
@@ -276,8 +287,7 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
             (AWSPinpointAnalyticsPluginConfiguration.appIdConfigKey, appId))
         let analyticsPluginConfig = JSONValue(
             dictionaryLiteral:
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration)
+            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration)
         )
 
         XCTAssertThrowsError(try AWSPinpointAnalyticsPluginConfiguration(analyticsPluginConfig)) { error in
@@ -297,8 +307,7 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
         )
         let analyticsPluginConfig = JSONValue(
             dictionaryLiteral:
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration)
+            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration)
         )
 
         XCTAssertThrowsError(try AWSPinpointAnalyticsPluginConfiguration(analyticsPluginConfig)) { error in
@@ -318,95 +327,7 @@ class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
         )
         let analyticsPluginConfig = JSONValue(
             dictionaryLiteral:
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration)
-        )
-
-        XCTAssertThrowsError(try AWSPinpointAnalyticsPluginConfiguration(analyticsPluginConfig)) { error in
-            guard case let PluginError.pluginConfigurationError(errorDescription, _, _) = error else {
-                XCTFail("Expected PluginError pluginConfigurationError, got: \(error)")
-                return
-            }
-            XCTAssertEqual(errorDescription, AnalyticsPluginErrorConstant.emptyRegion.errorDescription)
-        }
-    }
-
-    func testConfigureThrowsErrorForMissingPinpointTargetingConfiguration() {
-        let analyticsPluginConfig = JSONValue(
-            dictionaryLiteral:
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration))
-
-        XCTAssertThrowsError(try AWSPinpointAnalyticsPluginConfiguration(analyticsPluginConfig)) { error in
-            guard case let PluginError.pluginConfigurationError(errorDescription, _, _) = error else {
-                XCTFail("Expected PluginError pluginConfigurationError, got: \(error)")
-                return
-            }
-            XCTAssertEqual(errorDescription,
-                           AnalyticsPluginErrorConstant.missingPinpointTargetingConfiguration.errorDescription)
-        }
-    }
-
-    func testConfigureThrowsErrorForMissingPinpointTargetingConfigurationObject() {
-        let regionConfiguration = JSONValue(stringLiteral: "notDictionary")
-        let analyticsPluginConfig = JSONValue(
-            dictionaryLiteral:
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration)
-        )
-
-        XCTAssertThrowsError(try AWSPinpointAnalyticsPluginConfiguration(analyticsPluginConfig)) { error in
-            guard case let PluginError.pluginConfigurationError(errorDescription, _, _) = error else {
-                XCTFail("Expected PluginError pluginConfigurationError, got: \(error)")
-                return
-            }
-            XCTAssertEqual(errorDescription,
-                           AnalyticsPluginErrorConstant.pinpointTargetingConfigurationExpected.errorDescription)
-        }
-    }
-
-    func testConfigureThrowsErrorForMissingPinpointTargetingRegion() {
-        let regionConfiguration = JSONValue(dictionaryLiteral:
-            ("MissingRegionKey", region))
-        let analyticsPluginConfig = JSONValue(
-            dictionaryLiteral:
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration)
-        )
-
-        XCTAssertThrowsError(try AWSPinpointAnalyticsPluginConfiguration(analyticsPluginConfig)) { error in
-            guard case let PluginError.pluginConfigurationError(errorDescription, _, _) = error else {
-                XCTFail("Expected PluginError pluginConfigurationError, got: \(error)")
-                return
-            }
-            XCTAssertEqual(errorDescription, AnalyticsPluginErrorConstant.missingRegion.errorDescription)
-        }
-    }
-
-    func testConfigureThrowsErrorForEmptyPinpointTargetingRegionValue() {
-        let regionConfiguration = JSONValue(dictionaryLiteral:
-            (AWSPinpointAnalyticsPluginConfiguration.regionConfigKey, ""))
-        let analyticsPluginConfig = JSONValue(
-            dictionaryLiteral:
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration)
-        )
-
-        XCTAssertThrowsError(try AWSPinpointAnalyticsPluginConfiguration(analyticsPluginConfig)) { error in
-            guard case let PluginError.pluginConfigurationError(errorDescription, _, _) = error else {
-                XCTFail("Expected PluginError pluginConfigurationError, got: \(error)")
-                return
-            }
-            XCTAssertEqual(errorDescription, AnalyticsPluginErrorConstant.emptyRegion.errorDescription)
-        }
-    }
-
-    func testConfigureThrowsErrorForInvalidPinpointTargetingRegionValue() {
-        let regionConfiguration = JSONValue(dictionaryLiteral:
-            (AWSPinpointAnalyticsPluginConfiguration.regionConfigKey, ""))
-        let analyticsPluginConfig = JSONValue(
-            dictionaryLiteral:
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration),
-            (AWSPinpointAnalyticsPluginConfiguration.pinpointTargetingConfigKey, regionConfiguration)
+            (AWSPinpointAnalyticsPluginConfiguration.pinpointAnalyticsConfigKey, pinpointAnalyticsPluginConfiguration)
         )
 
         XCTAssertThrowsError(try AWSPinpointAnalyticsPluginConfiguration(analyticsPluginConfig)) { error in


### PR DESCRIPTION
*Description of changes:*
Removing `targetingRegion` from `AWSPinpointAnalyticsPluginConfiguration` as it's not used, and it will allow us to update the docs to remove it from the manual configuration steps.

I've kept a warn log just in case someone manually defines different regions in their config file, informing that it's not supported.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [X] Documentation update for the change if required: https://github.com/aws-amplify/docs/pull/4642
- [X] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
