### PR TITLE
fix(datastore-v1): synchronize multiple storageEngine initializations

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -10,6 +10,12 @@ import Combine
 import AWSPluginsCore
 import Foundation
 
+enum InitStorageEngineResult {
+    case successfullyInitialized
+    case alreadyInitialized
+    case failure(DataStoreError)
+}
+
 final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
 
     public var key: PluginKey = "awsDataStorePlugin"
@@ -110,12 +116,12 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
     /// Initializes the underlying storage engine
     /// - Returns: success if the engine is successfully initialized or
     ///            a failure with a DataStoreError
-    func initStorageEngine() -> DataStoreResult<Void> {
+    func initStorageEngine() -> InitStorageEngineResult {
         storageEngineInitQueue.sync {
             if storageEngine != nil {
-                return .successfulVoid
+                return .alreadyInitialized
             }
-            var result: DataStoreResult<Void>
+
             do {
                 if #available(iOS 13.0, *) {
                     if self.dataStorePublisher == nil {
@@ -125,12 +131,13 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
                 try resolveStorageEngine(dataStoreConfiguration: dataStoreConfiguration)
                 try storageEngine.setUp(modelSchemas: ModelRegistry.modelSchemas)
                 try storageEngine.applyModelMigrations(modelSchemas: ModelRegistry.modelSchemas)
-                result = .successfulVoid
+
+                return .successfullyInitialized
             } catch {
-                result = .failure(causedBy: error)
                 log.error(error: error)
+                return .failure(.invalidOperation(causedBy: error))
             }
-            return result
+
         }
     }
 
@@ -144,7 +151,9 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
         }
 
         switch initStorageEngine() {
-        case .success:
+        case .alreadyInitialized:
+            completion(.successfulVoid)
+        case .successfullyInitialized:
             storageEngine.startSync { result in
 
                 self.operationQueue.operations.forEach { operation in


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- applying commits from https://github.com/aws-amplify/amplify-ios/pull/2377

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
