### PR TITLE
fix: pin sdk transitive dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,10 @@ let dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/awslabs/aws-sdk-swift.git", exact: "0.2.6"),
     .package(url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git", from: "2.1.1"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", exact: "0.12.2"),
-    .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.1.0")
+    .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.1.0"),
+    .package(url: "https://github.com/awslabs/smithy-swift.git", exact: "0.2.5"),
+    .package(url: "https://github.com/awslabs/aws-crt-swift.git", exact: "0.2.2")
+
 ]
 let swiftSettings: [SwiftSetting]? = [.define("DEV_PREVIEW_BUILD")]
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
We pin our dependency on the AWS SDK for Swift to an exact version to ensure their new releases don't introduce breaking changes to our customers. However, the AWS SDK for Swift introduces two transitive dependencies `smithy-swift` and `aws-crt-swift`, which use the version requirement rule `from` rather than `exact`.  [[example](https://github.com/awslabs/aws-sdk-swift/blob/0.2.6/Package.swift#L323-L324)] 
New releases of `smithy-swift` and `aws-crt-swift` results in customer applications pulling in those versions, which can cause breaking behavioral changes. One such [change](https://github.com/awslabs/smithy-swift/pull/442) was discovered during development of this branch, leading to this PR.

Thankfully SPM has some sane rules around version requirement resolution. If we add direct dependencies on `smithy-swift` and `aws-crt-swift` in our own Package manifest, SPM will honor the more specific requirement. Thus adding `exact` will pin the versions of those dependencies.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
