### PR TITLE
fix(datastore): Add back delete(modelType:withId) API

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior.swift
@@ -7,6 +7,7 @@
 
 extension DataStoreCategory: DataStoreBaseBehavior {
 
+    @discardableResult
     public func save<M: Model>(_ model: M,
                                where condition: QueryPredicate? = nil) async throws -> M {
         try await plugin.save(model, where: condition)
@@ -40,7 +41,13 @@ extension DataStoreCategory: DataStoreBaseBehavior {
                                  where predicate: QueryPredicate? = nil) async throws {
         try await plugin.delete(model, where: predicate)
     }
-
+    
+    public func delete<M: Model>(_ modelType: M.Type,
+                                 withId id: String,
+                                 where predicate: QueryPredicate? = nil) async throws {
+        try await plugin.delete(modelType, withId: id, where: predicate)
+    }
+    
     public func delete<M: Model>(_ modelType: M.Type,
                                  withIdentifier id: String,
                                  where predicate: QueryPredicate? = nil) async throws

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -12,6 +12,7 @@ public typealias DataStoreCategoryBehavior = DataStoreBaseBehavior & DataStoreSu
 public protocol DataStoreBaseBehavior {
 
     /// Saves the model to storage. If sync is enabled, also initiates a sync of the mutation to the remote API
+    @discardableResult
     func save<M: Model>(_ model: M,
                         where condition: QueryPredicate?) async throws -> M
 
@@ -35,6 +36,10 @@ public protocol DataStoreBaseBehavior {
     func delete<M: Model>(_ model: M,
                           where predicate: QueryPredicate?) async throws
 
+    func delete<M: Model>(_ modelType: M.Type,
+                          withId id: String,
+                          where predicate: QueryPredicate?) async throws
+    
     func delete<M: Model>(_ modelType: M.Type,
                           withIdentifier id: String,
                           where predicate: QueryPredicate?) async throws where M: ModelIdentifiable,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -230,7 +230,28 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
 
     // MARK: - Delete
+    @available(*, deprecated, renamed: "delete(withIdentifier:)")
+    public func delete<M: Model>(_ modelType: M.Type,
+                                 withId id: String,
+                                 where predicate: QueryPredicate?) async throws {
+        try await delete(modelType, modelSchema: modelType.schema, withId: id, where: predicate)
+
+    }
     
+    @available(*, deprecated, renamed: "delete(withIdentifier:)")
+    public func delete<M: Model>(_ modelType: M.Type,
+                                 modelSchema: ModelSchema,
+                                 withId id: String,
+                                 where predicate: QueryPredicate? = nil) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            initStorageEngineAndStartSync()
+            storageEngine.delete(modelType, modelSchema: modelSchema, withId: id, condition: predicate) { result in
+                self.onDeleteCompletion(result: result, modelSchema: modelSchema) { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
     public func delete<M: Model>(_ modelType: M.Type,
                                  withIdentifier identifier: String,
                                  where predicate: QueryPredicate? = nil,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/ModelStorageBehavior.swift
@@ -21,6 +21,13 @@ protocol ModelStorageBehavior {
                         condition: QueryPredicate?,
                         completion: @escaping DataStoreCallback<M>)
 
+    @available(*, deprecated, message: "Use delete(:modelSchema:withIdentifier:predicate:completion")
+    func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
+                          withId id: Model.Identifier,
+                          condition: QueryPredicate?,
+                          completion: @escaping DataStoreCallback<M?>)
+    
     func delete<M: Model>(_ modelType: M.Type,
                           modelSchema: ModelSchema,
                           withIdentifier identifier: ModelIdentifierProtocol,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -211,6 +211,25 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
         }
     }
 
+    func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
+                          withId id: Model.Identifier,
+                          condition: QueryPredicate? = nil,
+                          completion: (DataStoreResult<M?>) -> Void) {
+        delete(untypedModelType: modelType,
+               modelSchema: modelSchema,
+               withId: id,
+               condition: condition) { result in
+            switch result {
+            case .success:
+                completion(.success(nil))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+    
+    
     func delete<M>(_ modelType: M.Type,
                    modelSchema: ModelSchema,
                    withIdentifier identifier: ModelIdentifierProtocol,
@@ -228,7 +247,19 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
             }
         }
     }
-
+    
+    func delete(untypedModelType modelType: Model.Type,
+                modelSchema: ModelSchema,
+                withId id: Model.Identifier,
+                condition: QueryPredicate? = nil,
+                completion: DataStoreCallback<Void>) {
+        delete(untypedModelType: modelType,
+               modelSchema: modelSchema,
+               withIdentifier: DefaultModelIdentifier<AnyModel>.makeDefault(id: id),
+               condition: condition,
+               completion: completion)
+    }
+    
     func delete(untypedModelType modelType: Model.Type,
                 modelSchema: ModelSchema,
                 withIdentifier id: ModelIdentifierProtocol,

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -83,6 +83,14 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
 
     func delete<M: Model>(_ modelType: M.Type,
                           modelSchema: ModelSchema,
+                          withId id: String,
+                          condition: QueryPredicate?,
+                          completion: @escaping DataStoreCallback<M?>) {
+        XCTFail("Not expected to execute")
+    }
+    
+    func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
                           filter: QueryPredicate,
                           completion: @escaping DataStoreCallback<[M]>) {
         XCTFail("Not expected to execute")
@@ -318,6 +326,14 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
                         modelSchema: ModelSchema,
                         condition where: QueryPredicate?,
                         completion: @escaping DataStoreCallback<M>) {
+        XCTFail("Not expected to execute")
+    }
+    
+    func delete<M: Model>(_ modelType: M.Type,
+                          modelSchema: ModelSchema,
+                          withId id: String,
+                          condition: QueryPredicate?,
+                          completion: @escaping DataStoreCallback<M?>) {
         XCTFail("Not expected to execute")
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds back `delete(modelType:withId)`. It was incorrectly removed during the migration to Async APIs

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
