### PR TITLE
feat(Analytics): Adding support for an array parameter in `unregisterGlobalProperties`

### DIFF
--- a/Amplify/Categories/Analytics/AnalyticsCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Analytics/AnalyticsCategory+ClientBehavior.swift
@@ -50,4 +50,13 @@ extension AnalyticsCategory {
     public func unregisterGlobalProperties(_ keys: String...) {
         plugin.unregisterGlobalProperties(keys.isEmpty ? nil : Set<String>(keys))
     }
+    
+    /// Registered global properties can be unregistered though this method. In case no keys are provided, *all*
+    /// registered global properties will be unregistered. Duplicate keys will be ignored. This method can be called
+    /// from `Amplify.Analytics` and is a wrapper for `unregisterGlobalProperties(_ keys: Set<String>? = nil)`
+    ///
+    /// - Parameter keys: an array of property names to unregister
+    public func unregisterGlobalProperties(_ keys: [String]) {
+        plugin.unregisterGlobalProperties(keys.isEmpty ? nil : Set(keys))
+    }
 }

--- a/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryClientAPITests.swift
@@ -107,6 +107,19 @@ class AnalyticsCategoryClientAPITests: XCTestCase {
         analytics.unregisterGlobalProperties("one", "two")
         waitForExpectations(timeout: 1.0)
     }
+    
+    func testUnregisterGlobalPropertiesWithArrayParameter() throws {
+        let expectedMessage = "unregisterGlobalProperties(_:)"
+        let methodInvoked = expectation(description: "Expected method was invoked on plugin")
+        plugin.listeners.append { message in
+            if message == expectedMessage {
+                methodInvoked.fulfill()
+            }
+        }
+        let properties: [String] = ["one", "two"]
+        analytics.unregisterGlobalProperties(properties)
+        waitForExpectations(timeout: 1.0)
+    }
 
     func testFlushEvents() {
         let expectedMessage = "flushEvents()"


### PR DESCRIPTION
*Description of changes:*
Adding support for an array parameter in `unregisterGlobalProperties`. We already provide support for a variadic parameter as well, so why not.

*Check points: (check or cross out if not relevant)*

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
