### PR TITLE
fix(auth): access control in signoutresult and errors

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSCognitoSignOutResult.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSCognitoSignOutResult.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public enum AWSCognitoSignOutResult: AuthSignOutResult {
 
-    var signedOutLocally: Bool {
+    public var signedOutLocally: Bool {
         if case .failed = self {
             return false
         }
@@ -27,15 +27,15 @@ public enum AWSCognitoSignOutResult: AuthSignOutResult {
 }
 
 public struct AWSCognitoRevokeTokenError {
-    let refreshToken: String
-    let error: AuthError
+    public let refreshToken: String
+    public let error: AuthError
 }
 
 public struct AWSCognitoGlobalSignOutError {
-    let accessToken: String
-    let error: AuthError
+    public let accessToken: String
+    public let error: AuthError
 }
 
 public struct AWSCognitoHostedUIError {
-    let error: AuthError
+    public let error: AuthError
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
A few properties related to `AWSCognitoSignOutResult` are internal. This change makes them publicly accessible.

- `AWSCognitoSignOutResult`
    - `signOutLocally`
- `AWSCognitoRevokeTokenError`
    - `refreshToken`
    - `error`
- `AWSCognitoGlobalSignOutError`
    - `refreshToken`
    - `error`
- `AWSCognitoHostedUIError`
    - `error`

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
