### PR TITLE
chore: add non-throwing create publisher overload

### DIFF
--- a/Amplify/Core/Support/Amplify+Publisher.swift
+++ b/Amplify/Core/Support/Amplify+Publisher.swift
@@ -50,6 +50,34 @@ public extension Amplify {
             .handleEvents(receiveCancel: { task.cancel() } )
             .eraseToAnyPublisher()
         }
+
+        /// Create a Combine Publisher for a given non-throwing Task.
+        ///
+        /// Example Usage
+        /// ```
+        /// let sink = Amplify.Publisher.create {
+        ///     try await Amplify.Auth.signOut()
+        /// }
+        ///     .sink(receiveValue: { value in
+        ///         // handle value
+        ///     })
+        /// ```
+        ///
+        /// - Parameter operation: The Task for which to create the Publisher.
+        /// - Returns: The Publisher for the given Task.
+        public static func create<Success>(
+            _ operation: @escaping @Sendable () async -> Success
+        ) -> AnyPublisher<Success, Never> {
+            let task = Task(operation: operation)
+            return Future() { promise in
+                Task {
+                    let value = await task.value
+                    promise(.success(value))
+                }
+            }
+            .handleEvents(receiveCancel: { task.cancel() } )
+            .eraseToAnyPublisher()
+        }
         
         /// Create a Combine Publisher for a given AsyncSequence.
         ///


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

### Current State
`Amplify.Publisher.create` allows for converting an async throwing function (e.g. `func foo() async throws -> Int`) into a `AnyPublisher<Int, Error>`. This publisher can then be leveraged like so:
```swift
Amplify.Publisher.create { 
  try await foo()
}.sink(
  receiveCompletion: { competion in 
    // handle completion
  },
  receiveValue: { value in 
    // handle value
  }
)
```
The `receiveValue` block will be invoked upon `foo()` successfully returning an `Int` and the `receiveCompletion` block will be invoked if `foo()` decides to throw. 

This works perfectly when the function throws, but is less ergonomic and borderline confusing when an async non-throwing function is passed into `create(_:)`. Let's look at an example: 

```swift
func bar() async -> String { "Hello, world!" }

Amplify.Publisher.create { 
  await bar()
}.sink(
  receiveCompletion: { competion in 
    // when is this invoked?
  },
  receiveValue: { value in 
    // handle value
  }
)
```

`create(_:)` returns an `AnyPublisher<Success, Error>` regardless of whether the argument received throws or not. Resulting in the caller being required to include a `receiveCompletion` block, despite it being unnecessary. 

### Change
Nothing changes on the existing`create(_:)` API. This change adds an overload that accepts a non-throwing argument and returns `AnyPublisher<Success, Never>`

This allows for:
```swift
func bar() async -> String { "Hello, world!" }

Amplify.Publisher.create { 
  await bar()
}
.sink(receiveValue: { value in 
  // handle value
})
```

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
