### PR TITLE
fix(hub): replace atomicdictionary with dict and lock

### DIFF
--- a/Amplify/DefaultPlugins/AWSHubPlugin/AWSHubPlugin.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/AWSHubPlugin.swift
@@ -60,18 +60,13 @@ final public class AWSHubPlugin: HubCategoryPlugin {
                        isIncluded filter: HubFilter? = nil,
                        listener: @escaping HubListener) -> UnsubscribeToken {
         let filteredListener = FilteredListener(for: channel, filter: filter, listener: listener)
-        Task {
-            await dispatcher.insert(filteredListener)
-        }
-
+        dispatcher.insert(filteredListener)
         let unsubscribeToken = UnsubscribeToken(channel: channel, id: filteredListener.id)
         return unsubscribeToken
     }
 
     public func removeListener(_ token: UnsubscribeToken) {
-        Task {
-            await dispatcher.removeListener(withId: token.id)
-        }
+        dispatcher.removeListener(withId: token.id)
     }
 
     // MARK: - Custom Plugin methods
@@ -81,7 +76,7 @@ final public class AWSHubPlugin: HubCategoryPlugin {
     /// - Parameter token: The UnsubscribeToken of the listener to check
     /// - Returns: True if the dispatcher has a listener registered with `token`
     public func hasListener(withToken token: UnsubscribeToken) async -> Bool {
-        return await dispatcher.hasListener(withId: token.id)
+        dispatcher.hasListener(withId: token.id)
     }
 
 }

--- a/Amplify/DefaultPlugins/AWSHubPlugin/AWSHubPlugin.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/AWSHubPlugin.swift
@@ -75,7 +75,7 @@ final public class AWSHubPlugin: HubCategoryPlugin {
     ///
     /// - Parameter token: The UnsubscribeToken of the listener to check
     /// - Returns: True if the dispatcher has a listener registered with `token`
-    public func hasListener(withToken token: UnsubscribeToken) async -> Bool {
+    public func hasListener(withToken token: UnsubscribeToken) -> Bool {
         dispatcher.hasListener(withId: token.id)
     }
 

--- a/Amplify/DefaultPlugins/AWSHubPlugin/AWSHubPlugin.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/AWSHubPlugin.swift
@@ -41,8 +41,8 @@ final public class AWSHubPlugin: HubCategoryPlugin {
     }
 
     /// Removes listeners and empties the message queue
-    public func reset() async {
-        await dispatcher.destroy()
+    public func reset() {
+        dispatcher.destroy()
     }
 
     public func dispatch(to channel: HubChannel, payload: HubPayload) {

--- a/Amplify/DefaultPlugins/AWSHubPlugin/Internal/HubChannelDispatcher.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/Internal/HubChannelDispatcher.swift
@@ -76,14 +76,16 @@ final class HubChannelDispatcher {
     /// whether a given listener closure has completed. If your test encounters errors like "Hub is not configured"
     /// after you issue an `await Amplify.reset()`, you may wish to add additional sleep around your code
     /// that calls `await Amplify.reset()`.
-    func destroy() async {
-        listenersById.removeAll()
+    func destroy() {
+        destroyListeners()
         messageQueue.cancelAllOperations()
-        await withCheckedContinuation { continuation in
-            messageQueue.addBarrierBlock {
-                continuation.resume()
-            }
-        }
+        messageQueue.addBarrierBlock { }
+    }
+
+    private func destroyListeners() {
+        defer { os_unfair_lock_unlock(lock) }
+        os_unfair_lock_lock(lock)
+        listenersById.removeAll()
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Removes usage of actor based `AtomicDictionary` in `HubChannelDispatcher` and replaces it with a normal dictionary with `os_unfair_lock` to ensure mutual exclusion. This change is necessary because the actor based approach occasionally led to operations being completed before listeners were set.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
