### PR TITLE
test(datastore): disable integration test workflows

### DIFF
--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -56,7 +56,7 @@ jobs:
           scheme: AWSPinpointAnalyticsPluginIntegrationTests
 
   api-integration-test:
-    continue-on-error: true
+    if: ${{ false }}
     needs: prepare-for-test
     runs-on: macos-12
     environment: IntegrationTest
@@ -112,6 +112,7 @@ jobs:
           scheme: GraphQLWithIAMIntegrationTests
 
   api-graphqluserpool-integration-test:
+    if: ${{ false }}
     needs: [api-integration-test]
     runs-on: macos-12
     environment: IntegrationTest
@@ -251,7 +252,7 @@ jobs:
           scheme: AWSCognitoAuthPluginIntegrationTests
 
   datastore-integration-test:
-    continue-on-error: true
+    if: ${{ false }}
     needs: prepare-for-test
     runs-on: macos-12
     environment: IntegrationTest
@@ -306,7 +307,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationHubTests
   datastore-integration-local-test:
-    continue-on-error: true
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-12
     environment: IntegrationTest
@@ -334,7 +335,7 @@ jobs:
           scheme: AWSDataStoreIntegrationLocalTests
 
   datastore-integration-V1-S1-test:
-    continue-on-error: true
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-12
     environment: IntegrationTest
@@ -740,7 +741,7 @@ jobs:
           workspace: DataStoreCategoryPlugin.xcworkspace
           scheme: AWSDataStoreIntegrationV2Scenario8V2Tests
   datastore-integration-V2-test:
-    continue-on-error: true
+    if: ${{ false }}
     needs: [datastore-integration-test]
     runs-on: macos-12
     environment: IntegrationTest


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The failing integration tests creates an ❌ on the pipeline. If flaky tests need to be tested on Github Actions, they can be done via a separate branch until they are consistent or in a forked repo

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
