### PR TITLE
fix(Storage): Addressing issues with race conditions

### DIFF
--- a/Amplify/Core/Support/AmplifyTask+OperationTaskAdapters.swift
+++ b/Amplify/Core/Support/AmplifyTask+OperationTaskAdapters.swift
@@ -69,11 +69,11 @@ public class AmplifyInProcessReportingOperationTaskAdapter<Request: AmplifyOpera
     public init(operation: AmplifyInProcessReportingOperation<Request, InProcess, Success, Failure>) {
         self.operation = operation
         self.childTask = ChildTask(parent: operation)
-        resultToken = operation.subscribe(resultListener: {[weak self] result in
+        resultToken = operation.subscribe(resultListener: { [weak self] result in
             guard let self = self else { return }
             self.resultListener(result)
         })
-        inProcessToken = operation.subscribe(inProcessListener: {[weak self] inProcess in
+        inProcessToken = operation.subscribe(inProcessListener: { [weak self] inProcess in
             guard let self = self else { return }
             self.inProcessListener(inProcess)
         })

--- a/Amplify/Core/Support/AmplifyTask+OperationTaskAdapters.swift
+++ b/Amplify/Core/Support/AmplifyTask+OperationTaskAdapters.swift
@@ -69,8 +69,14 @@ public class AmplifyInProcessReportingOperationTaskAdapter<Request: AmplifyOpera
     public init(operation: AmplifyInProcessReportingOperation<Request, InProcess, Success, Failure>) {
         self.operation = operation
         self.childTask = ChildTask(parent: operation)
-        resultToken = operation.subscribe(resultListener: resultListener)
-        inProcessToken = operation.subscribe(inProcessListener: inProcessListener)
+        resultToken = operation.subscribe(resultListener: {[weak self] result in
+            guard let self = self else { return }
+            self.resultListener(result)
+        })
+        inProcessToken = operation.subscribe(inProcessListener: {[weak self] inProcess in
+            guard let self = self else { return }
+            self.inProcessListener(inProcess)
+        })
     }
 
     deinit {

--- a/Amplify/Core/Support/AtomicDictionary.swift
+++ b/Amplify/Core/Support/AtomicDictionary.swift
@@ -7,41 +7,43 @@
 
 import Foundation
 
-actor AtomicDictionary<Key: Hashable, Value> {
+class AtomicDictionary<Key: Hashable, Value> {
+    private let lock: NSLocking
     private var value: [Key: Value]
 
     init(initialValue: [Key: Value] = [Key: Value]()) {
+        self.lock = NSLock()
         self.value = initialValue
     }
 
     var count: Int {
-        value.count
+        lock.execute { value.count }
     }
 
     var keys: [Key] {
-        Array(value.keys)
+        lock.execute { Array(value.keys) }
     }
 
     var values: [Value] {
-        Array(value.values)
+        lock.execute { Array(value.values) }
     }
 
     // MARK: - Functions
 
     func getValue(forKey key: Key) -> Value? {
-        value[key]
+        lock.execute { value[key] }
     }
 
     func removeAll() {
-        value = [:]
+        lock.execute { value = [:] }
     }
 
     @discardableResult
     func removeValue(forKey key: Key) -> Value? {
-        value.removeValue(forKey: key)
+        return lock.execute { value.removeValue(forKey: key) }
     }
 
     func set(value: Value, forKey key: Key) {
-        self.value[key] = value
+        lock.execute { self.value[key] = value }
     }
 }

--- a/Amplify/Core/Support/AtomicDictionary.swift
+++ b/Amplify/Core/Support/AtomicDictionary.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class AtomicDictionary<Key: Hashable, Value> {
+final class AtomicDictionary<Key: Hashable, Value> {
     private let lock: NSLocking
     private var value: [Key: Value]
 

--- a/Amplify/DefaultPlugins/AWSHubPlugin/AWSHubPlugin.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/AWSHubPlugin.swift
@@ -60,18 +60,14 @@ final public class AWSHubPlugin: HubCategoryPlugin {
                        isIncluded filter: HubFilter? = nil,
                        listener: @escaping HubListener) -> UnsubscribeToken {
         let filteredListener = FilteredListener(for: channel, filter: filter, listener: listener)
-        Task {
-            await dispatcher.insert(filteredListener)
-        }
+        dispatcher.insert(filteredListener)
 
         let unsubscribeToken = UnsubscribeToken(channel: channel, id: filteredListener.id)
         return unsubscribeToken
     }
 
     public func removeListener(_ token: UnsubscribeToken) {
-        Task {
-            await dispatcher.removeListener(withId: token.id)
-        }
+        dispatcher.removeListener(withId: token.id)
     }
 
     // MARK: - Custom Plugin methods
@@ -80,8 +76,8 @@ final public class AWSHubPlugin: HubCategoryPlugin {
     ///
     /// - Parameter token: The UnsubscribeToken of the listener to check
     /// - Returns: True if the dispatcher has a listener registered with `token`
-    public func hasListener(withToken token: UnsubscribeToken) async -> Bool {
-        return await dispatcher.hasListener(withId: token.id)
+    public func hasListener(withToken token: UnsubscribeToken) -> Bool {
+        return dispatcher.hasListener(withId: token.id)
     }
 
 }

--- a/Amplify/DefaultPlugins/AWSHubPlugin/Internal/HubChannelDispatcher.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/Internal/HubChannelDispatcher.swift
@@ -75,16 +75,14 @@ final class HubChannelDispatcher {
 
 extension HubChannelDispatcher: HubDispatchOperationDelegate {
     var listeners: [FilteredListener] {
-        get {
-            return Array(listenersById.values)
-        }
+        return Array(listenersById.values)
     }
 }
 
 protocol HubDispatchOperationDelegate: AnyObject {
     /// Used to let a dispatch operation retrieve the list of listeners at the time of invocation, rather than the time
     /// of queuing.
-    var listeners: [FilteredListener] { get async }
+    var listeners: [FilteredListener] { get }
 }
 
 final class HubDispatchOperation: Operation {
@@ -122,7 +120,7 @@ final class HubDispatchOperation: Operation {
         }
 
         Task {
-            guard let listeners = await delegate?.listeners else {
+            guard let listeners = delegate?.listeners else {
                 return
             }
 

--- a/Amplify/DefaultPlugins/AWSHubPlugin/Internal/HubChannelDispatcher.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/Internal/HubChannelDispatcher.swift
@@ -25,22 +25,22 @@ final class HubChannelDispatcher {
     ///
     /// - Parameter id: The ID of the listener to check
     /// - Returns: True if the dispatcher has a listener registered with `id`
-    func hasListener(withId id: UUID) async -> Bool {
-        return await listenersById.getValue(forKey: id) != nil
+    func hasListener(withId id: UUID) -> Bool {
+        return listenersById.getValue(forKey: id) != nil
     }
 
     /// Inserts `listener` into the `listenersById` dictionary by its ID
     ///
     /// - Parameter listener: The listener to add
-    func insert(_ listener: FilteredListener) async {
-        await listenersById.set(value: listener, forKey: listener.id)
+    func insert(_ listener: FilteredListener) {
+        listenersById.set(value: listener, forKey: listener.id)
     }
 
     /// Removes the listener identified by `id` from the `listeners` dictionary
     ///
     /// - Parameter id: The ID of the listener to remove
-    func removeListener(withId id: UUID) async {
-        await listenersById.removeValue(forKey: id)
+    func removeListener(withId id: UUID) {
+        listenersById.removeValue(forKey: id)
     }
 
     /// Dispatches `payload` to all listeners on `channel`
@@ -63,7 +63,7 @@ final class HubChannelDispatcher {
     /// after you issue an `await Amplify.reset()`, you may wish to add additional sleep around your code
     /// that calls `await Amplify.reset()`.
     func destroy() async {
-        await listenersById.removeAll()
+        listenersById.removeAll()
         messageQueue.cancelAllOperations()
         await withCheckedContinuation { continuation in
             messageQueue.addBarrierBlock {
@@ -75,8 +75,8 @@ final class HubChannelDispatcher {
 
 extension HubChannelDispatcher: HubDispatchOperationDelegate {
     var listeners: [FilteredListener] {
-        get async {
-            return Array(await listenersById.values)
+        get {
+            return Array(listenersById.values)
         }
     }
 }

--- a/Amplify/DefaultPlugins/AWSHubPlugin/Internal/HubChannelDispatcher.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/Internal/HubChannelDispatcher.swift
@@ -119,14 +119,12 @@ final class HubDispatchOperation: Operation {
             return
         }
 
-        Task {
-            guard let listeners = delegate?.listeners else {
-                return
-            }
-
-            let dispatcher = SerialDispatcher(channel: channel, payload: payload)
-            dispatcher.dispatch(to: listeners)
+        guard let listeners = delegate?.listeners else {
+            return
         }
+        
+        let dispatcher = SerialDispatcher(channel: channel, payload: payload)
+        dispatcher.dispatch(to: listeners)
     }
 
 }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageBackgroundEventsRegistryTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageBackgroundEventsRegistryTests.swift
@@ -40,12 +40,10 @@ class StorageBackgroundEventsRegistryTests: XCTestCase {
             XCTAssertFalse(otherHandled)
         }
 
-        Task {
-            handleEvents(for: identifier)
-            handleEvents(for: otherIdentifier)
-        }
-
         await waitForExpectations([done])
+
+        handleEvents(for: identifier)
+        handleEvents(for: otherIdentifier)
     }
 
     func testHandlingUnregisteredIdentifier() async throws {


### PR DESCRIPTION
*Description of changes:*
- Making `AtomicDictionary` a class again with an `NSLock` mechanism, as the `actor` approach created issues when the result was immediately dispatched without having time to register the listener (due to being an asynchronous call made inside the synchronous `subscribe` method)
- Wrapping operation listeners in closures that don't retain the adapter, so they are not kept around after the operations complete.
- Fixing `StorageBackgroundEventsRegistryTests.testRegisteringAndUnregister` which was attempting to resume a continuation before it finished being stored in the registry.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
