### PR TITLE
fix(core): remove AmplifyOperation unsubscribe function

### DIFF
--- a/Amplify/Core/Support/AmplifyOperation.swift
+++ b/Amplify/Core/Support/AmplifyOperation.swift
@@ -143,12 +143,6 @@ open class AmplifyOperation<Request: AmplifyOperationRequest, Success, Failure: 
         return token!
     }
 
-    func unsubscribe(token: UnsubscribeToken) {
-        guard let token = resultListenerUnsubscribeToken else { return }
-        Amplify.Hub.removeListener(token)
-        resultListenerUnsubscribeToken = nil
-    }
-
     /// Classes that override this method must emit a completion to the `resultPublisher` upon cancellation
     open override func cancel() {
         super.cancel()
@@ -160,10 +154,7 @@ open class AmplifyOperation<Request: AmplifyOperationRequest, Success, Failure: 
         )
         publish(result: .failure(cancellationError))
 #endif
-        if let token = resultListenerUnsubscribeToken {
-            unsubscribe(token: token)
-            resultListenerUnsubscribeToken = nil
-        }
+        removeResultListener()
     }
 
     /// Dispatches an event to the hub. Internally, creates an
@@ -188,7 +179,9 @@ open class AmplifyOperation<Request: AmplifyOperationRequest, Success, Failure: 
         guard let unsubscribeToken = resultListenerUnsubscribeToken else {
             return
         }
+
         Amplify.Hub.removeListener(unsubscribeToken)
+        resultListenerUnsubscribeToken = nil
     }
 
 }

--- a/AmplifyTests/CoreTests/AmplifyAsyncSequenceTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyAsyncSequenceTests.swift
@@ -212,7 +212,7 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
         XCTAssertFalse(operation.isCancelled)
         XCTAssertGreaterThanOrEqual(count, steps)
 
-        operation.unsubscribe(token: token)
+        Amplify.Hub.removeListener(token)
     }
 
     func testCancellingWithParentOperation() async throws {
@@ -250,7 +250,7 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
         XCTAssertTrue(operation.isCancelled)
         XCTAssertLessThan(count, steps)
 
-        operation.unsubscribe(token: token)
+        Amplify.Hub.removeListener(token)
     }
 
     func testThrowingValueProducingParentOperation() async throws {
@@ -288,7 +288,7 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
         XCTAssertFalse(operation.isCancelled)
         XCTAssertGreaterThanOrEqual(count, steps)
 
-        operation.unsubscribe(token: token)
+        Amplify.Hub.removeListener(token)
     }
 
     func testThrowingCancellingWithParentOperation() async throws {
@@ -326,7 +326,7 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
         XCTAssertTrue(operation.isCancelled)
         XCTAssertLessThan(count, steps)
 
-        operation.unsubscribe(token: token)
+        Amplify.Hub.removeListener(token)
     }
 
     private func send<Element>(elements: [Element], channel: AmplifyAsyncSequence<Element>, sleepSeconds: Double = 0.1) async throws {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`AmplifyOperation.unsubscribe` function is ignoring the parameter `token`.


*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
