### PR TITLE
fix(auth): Build failure due to unsafe flag

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/AWSCognitoAuthPlugin.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AWSCognitoAuthPlugin.xcscheme
@@ -43,6 +43,16 @@
                </Test>
             </SkippedTests>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AmplifyBigIntegerTests"
+               BuildableName = "AmplifyBigIntegerTests"
+               BlueprintName = "AmplifyBigIntegerTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/AmplifyPlugins/Auth/Sources/libtommath/README.md
+++ b/AmplifyPlugins/Auth/Sources/libtommath/README.md
@@ -1,3 +1,8 @@
 # libtommath
 
-This is the fork for [LibTomMath](https://github.com/libtom/libtommath). Fork is created from the v1.2.0 at the commit 6ca6898bf37f583c4cc9943441cd60dd69f4b8f2 and renamed files and variables with `amplify` prefix.
+This is the fork for [LibTomMath](https://github.com/libtom/libtommath). Fork is created from the v1.2.0 at the commit 6ca6898bf37f583c4cc9943441cd60dd69f4b8f2 
+With the following changes:
+
+- Renamed files and variables with `amplify` prefix.
+- Removed unsupported platform code from Sources/libtommath/amplify_bn_s_mp_rand_platform.c
+- Removed compile time warning due to unreachable code in Sources/libtommath/amplify_bn_mp_set_double.c

--- a/AmplifyPlugins/Auth/Sources/libtommath/amplify_bn_s_mp_rand_platform.c
+++ b/AmplifyPlugins/Auth/Sources/libtommath/amplify_bn_s_mp_rand_platform.c
@@ -138,11 +138,7 @@ amplify_mp_err s_read_ltm_rng(void *p, size_t n);
 amplify_mp_err amplify_s_mp_rand_platform(void *p, size_t n)
 {
    amplify_mp_err err = AMPLIFY_MP_ERR;
-   if ((err != AMPLIFY_MP_OKAY) && AMPLIFY_MP_HAS(S_READ_ARC4RANDOM)) err = s_read_arc4random(p, n);
-   if ((err != AMPLIFY_MP_OKAY) && AMPLIFY_MP_HAS(S_READ_WINCSP))     err = s_read_wincsp(p, n);
-   if ((err != AMPLIFY_MP_OKAY) && AMPLIFY_MP_HAS(S_READ_GETRANDOM))  err = s_read_getrandom(p, n);
    if ((err != AMPLIFY_MP_OKAY) && AMPLIFY_MP_HAS(S_READ_URANDOM))    err = s_read_urandom(p, n);
-   if ((err != AMPLIFY_MP_OKAY) && AMPLIFY_MP_HAS(S_READ_LTM_RNG))    err = s_read_ltm_rng(p, n);
    return err;
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -160,9 +160,6 @@ let authTargets: [Target] = [
             "changes.txt",
             "LICENSE",
             "README.md"
-        ],
-        cSettings: [
-            .unsafeFlags(["-flto=thin"])  // for Dead Code Elimination
         ]
     ),
     .testTarget(


### PR DESCRIPTION
*Description of changes:*
SPM does not support using unsafe flag in a versioned release.  This PR changes the internal implementation of libtommath to remove unused code for un-supported platforms, so that we no longer need to use unsafeflag for dead code elimintation.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
