### PR TITLE
fix(api): add default user-agent header to API subscription requests

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
@@ -81,15 +81,17 @@ public class AWSGraphQLSubscriptionTaskRunner<R: Decodable>: InternalTaskRunner,
         // Retrieve request plugin option and
         // auth type in case of a multi-auth setup
         let pluginOptions = request.options.pluginOptions as? AWSPluginOptions
+        let urlRequest = generateSubscriptionURLRequest(from: endpointConfig)
 
         // Retrieve the subscription connection
         subscriptionQueue.sync {
             do {
                 subscriptionConnection = try subscriptionConnectionFactory
                     .getOrCreateConnection(for: endpointConfig,
-                                              authService: authService,
-                                              authType: pluginOptions?.authType,
-                                              apiAuthProviderFactory: apiAuthProviderFactory)
+                                           urlRequest: urlRequest,
+                                           authService: authService,
+                                           authType: pluginOptions?.authType,
+                                           apiAuthProviderFactory: apiAuthProviderFactory)
             } catch {
                 let error = APIError.operationError("Unable to get connection for api \(endpointConfig.name)", "", error)
                 fail(error)
@@ -104,6 +106,14 @@ public class AWSGraphQLSubscriptionTaskRunner<R: Decodable>: InternalTaskRunner,
                 self?.onAsyncSubscriptionEvent(event: event)
             })
         }
+    }
+
+    private func generateSubscriptionURLRequest(
+        from endpointConfig: AWSAPICategoryPluginConfiguration.EndpointConfig
+    ) -> URLRequest {
+        var urlRequest = URLRequest(url: endpointConfig.baseURL)
+        urlRequest.setValue(AWSAPIPluginsCore.baseUserAgent(), forHTTPHeaderField: URLRequestConstants.Header.userAgent)
+        return urlRequest
     }
     
     // MARK: - Subscription callbacks
@@ -269,15 +279,17 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
         // Retrieve request plugin option and
         // auth type in case of a multi-auth setup
         let pluginOptions = request.options.pluginOptions as? AWSPluginOptions
+        let urlRequest = generateSubscriptionURLRequest(from: endpointConfig)
 
         // Retrieve the subscription connection
         subscriptionQueue.sync {
             do {
                 subscriptionConnection = try subscriptionConnectionFactory
                     .getOrCreateConnection(for: endpointConfig,
-                                              authService: authService,
-                                              authType: pluginOptions?.authType,
-                                              apiAuthProviderFactory: apiAuthProviderFactory)
+                                           urlRequest: urlRequest,
+                                           authService: authService,
+                                           authType: pluginOptions?.authType,
+                                           apiAuthProviderFactory: apiAuthProviderFactory)
             } catch {
                 let error = APIError.operationError("Unable to get connection for api \(endpointConfig.name)", "", error)
                 dispatch(result: .failure(error))
@@ -293,6 +305,14 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
                 self?.onAsyncSubscriptionEvent(event: event)
             })
         }
+    }
+
+    private func generateSubscriptionURLRequest(
+        from endpointConfig: AWSAPICategoryPluginConfiguration.EndpointConfig
+    ) -> URLRequest {
+        var urlRequest = URLRequest(url: endpointConfig.baseURL)
+        urlRequest.setValue(AWSAPIPluginsCore.baseUserAgent(), forHTTPHeaderField: URLRequestConstants.Header.userAgent)
+        return urlRequest
     }
 
     // MARK: - Subscription callbacks

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/SubscriptionConnectionFactory.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/SubscriptionConnectionFactory.swift
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import Foundation
+
 import Amplify
 import AWSPluginsCore
 import AppSyncRealTimeClient
@@ -14,6 +16,7 @@ protocol SubscriptionConnectionFactory {
 
     /// Get connection based on the connection type
     func getOrCreateConnection(for endpointConfig: AWSAPICategoryPluginConfiguration.EndpointConfig,
+                               urlRequest: URLRequest,
                                authService: AWSAuthServiceBehavior,
                                authType: AWSAuthorizationType?,
                                apiAuthProviderFactory: APIAuthProviderFactory) throws -> SubscriptionConnection

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Mocks/MockSubscription.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Mocks/MockSubscription.swift
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import Foundation
+
 @testable import AWSAPIPlugin
 import Amplify
 
@@ -14,6 +16,7 @@ import AppSyncRealTimeClient
 struct MockSubscriptionConnectionFactory: SubscriptionConnectionFactory {
     typealias OnGetOrCreateConnection = (
         AWSAPICategoryPluginConfiguration.EndpointConfig,
+        URLRequest,
         AWSAuthServiceBehavior,
         AWSAuthorizationType?,
         APIAuthProviderFactory
@@ -27,11 +30,12 @@ struct MockSubscriptionConnectionFactory: SubscriptionConnectionFactory {
 
     func getOrCreateConnection(
         for endpointConfig: AWSAPICategoryPluginConfiguration.EndpointConfig,
+        urlRequest: URLRequest,
         authService: AWSAuthServiceBehavior,
         authType: AWSAuthorizationType?,
         apiAuthProviderFactory: APIAuthProviderFactory
     ) throws -> SubscriptionConnection {
-        try onGetOrCreateConnection(endpointConfig, authService, authType, apiAuthProviderFactory)
+        try onGetOrCreateConnection(endpointConfig, urlRequest,  authService, authType, apiAuthProviderFactory)
     }
 
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
@@ -68,7 +68,7 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
     }
 
     func testCancelSendsCompletion() async {
-        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _ in
+        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _, _ in
             return MockSubscriptionConnection(onSubscribe: { (_, _, eventHandler) -> SubscriptionItem in
                 let item = SubscriptionItem(requestString: "", variables: nil, eventHandler: { _, _ in
                 })
@@ -149,7 +149,7 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
     }
     
     func testFailureOnConnection() async {
-        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _ in
+        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _, _ in
             throw APIError.invalidConfiguration("something went wrong", "", nil)
         })
 
@@ -190,7 +190,7 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
 
     func testCallingCancelWhileCreatingConnectionShouldCallCompletionListener() async {
         let connectionCreation = expectation(description: "connection factory called")
-        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _ in
+        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _, _ in
             connectionCreation.fulfill()
             return MockSubscriptionConnection(onSubscribe: { (_, _, eventHandler) -> SubscriptionItem in
                 let item = SubscriptionItem(requestString: "", variables: nil, eventHandler: { _, _ in

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionTaskRunnerCancelTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionTaskRunnerCancelTests.swift
@@ -68,7 +68,7 @@ class AWSGraphQLSubscriptionTaskRunnerCancelTests: XCTestCase {
     }
     
     func testCancelSendsCompletion() async {
-        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _ in
+        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _, _ in
             return MockSubscriptionConnection(onSubscribe: { (_, _, eventHandler) -> SubscriptionItem in
                 let item = SubscriptionItem(requestString: "", variables: nil, eventHandler: { _, _ in
                 })
@@ -117,7 +117,7 @@ class AWSGraphQLSubscriptionTaskRunnerCancelTests: XCTestCase {
     }
     
     func testFailureOnConnection() async {
-        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _ in
+        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _, _ in
             throw APIError.invalidConfiguration("something went wrong", "", nil)
         })
 
@@ -149,7 +149,7 @@ class AWSGraphQLSubscriptionTaskRunnerCancelTests: XCTestCase {
 
     func testCallingCancelWhileCreatingConnectionShouldCallCompletionListener() async {
         let connectionCreation = asyncExpectation(description: "connection factory called")
-        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _ in
+        let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _, _ in
             Task { await connectionCreation.fulfill() }
             return MockSubscriptionConnection(onSubscribe: { (_, _, eventHandler) -> SubscriptionItem in
                 let item = SubscriptionItem(requestString: "", variables: nil, eventHandler: { _, _ in

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeCombineTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeCombineTests.swift
@@ -223,7 +223,7 @@ class GraphQLSubscribeCombineTests: OperationTestBase {
             return item
         }
 
-        let onGetOrCreateConnection: MockSubscriptionConnectionFactory.OnGetOrCreateConnection = { _, _, _, _  in
+        let onGetOrCreateConnection: MockSubscriptionConnectionFactory.OnGetOrCreateConnection = { _, _, _, _, _  in
             MockSubscriptionConnection(onSubscribe: onSubscribe, onUnsubscribe: { _ in })
         }
 

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTaskTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTaskTests.swift
@@ -279,7 +279,7 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
             return item
         }
 
-        let onGetOrCreateConnection: MockSubscriptionConnectionFactory.OnGetOrCreateConnection = { _, _, _, _  in
+        let onGetOrCreateConnection: MockSubscriptionConnectionFactory.OnGetOrCreateConnection = { _, _, _, _, _  in
             MockSubscriptionConnection(onSubscribe: onSubscribe, onUnsubscribe: { _ in })
         }
 

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTests.swift
@@ -238,7 +238,7 @@ class GraphQLSubscribeTests: OperationTestBase {
             return item
         }
 
-        let onGetOrCreateConnection: MockSubscriptionConnectionFactory.OnGetOrCreateConnection = { _, _, _, _  in
+        let onGetOrCreateConnection: MockSubscriptionConnectionFactory.OnGetOrCreateConnection = { _, _, _, _, _  in
             MockSubscriptionConnection(onSubscribe: onSubscribe, onUnsubscribe: { _ in })
         }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,14 +5,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
       "state" : {
-        "revision" : "da88cf1cab82e281e7277cd9feb9efc87a057041",
-        "version" : "2.1.1"
+        "revision" : "3de274c68a3cb60c8aec18b5bc0a8c07860219cd",
+        "version" : "3.0.0"
       }
     },
     {
       "identity" : "aws-crt-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/awslabs/aws-crt-swift",
+      "location" : "https://github.com/awslabs/aws-crt-swift.git",
       "state" : {
         "revision" : "afe23a2a2f6cf78e6d8803d7c9e0c8e6f50b6915",
         "version" : "0.4.0"
@@ -48,7 +48,7 @@
     {
       "identity" : "smithy-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/awslabs/smithy-swift",
+      "location" : "https://github.com/awslabs/smithy-swift.git",
       "state" : {
         "revision" : "f59ed07c29d4e03f91ea8324edf7a2486bd86a9c",
         "version" : "0.6.0"

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let platforms: [SupportedPlatform] = [.iOS(.v13), .macOS(.v10_15)]
 let dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/awslabs/aws-sdk-swift.git", exact: "0.6.0"),
-    .package(url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git", from: "2.1.1"),
+    .package(url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git", from: "3.0.0"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", exact: "0.13.2"),
     .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.1.0")
 ]


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
v1 - https://github.com/aws-amplify/amplify-swift/pull/2700
main - https://github.com/aws-amplify/amplify-swift/pull/2709 (You are here)

## Description
<!-- Why is this change required? What problem does it solve? -->
- upgrade dependency package `aws-amplify/aws-appsync-realtime-client-ios` to `v3.0.0`
  - adapt the new API
  - add default amplify `User-Agent` header to API subscription requests

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
