### PR TITLE
fix(test): compare model identifier for deletion events

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/AWSDataStoreLazyLoadBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/AWSDataStoreLazyLoadBaseTest.swift
@@ -178,6 +178,7 @@ class AWSDataStoreLazyLoadBaseTest: XCTestCase {
                 if event.eventName == dataStoreEvents.outboxMutationProcessed,
                    let outboxMutationEvent = event.data as? OutboxMutationEvent,
                    outboxMutationEvent.modelName == model.modelName,
+                   outboxMutationEvent.element.model.identifier == model.identifier,
                    outboxMutationEvent.element.deleted == true {
                     Task { await modelSynced.fulfill() }
                     


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

- compare model identifier in hub event with deleting model to avoid flaky test cases

## General Checklist
<!-- Check or cross out if not relevant -->


- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
