### PR TITLE
feat(Auth): Add retry errors for OTP confirm sign in

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/PasswordlessHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/PasswordlessHelper.swift
@@ -1,0 +1,66 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Amplify
+
+struct PasswordlessHelper {
+
+    static func getCodeDeliveryDetails(parameters: [String: String]) -> AuthCodeDeliveryDetails {
+
+        var deliveryDestination = DeliveryDestination.unknown(nil)
+        var attribute: AuthUserAttributeKey? = nil
+
+        // Retrieve Delivery medium and destination
+        let medium = parameters["deliveryMedium"]
+        let destination = parameters["destination"]
+        if medium == "SMS" {
+            deliveryDestination = .sms(destination)
+        } else if medium == "EMAIL" {
+            deliveryDestination = .email(destination)
+        }
+
+        // Retrieve attribute name
+        if let attributeName = parameters["attributeName"] {
+            attribute = AuthUserAttributeKey(rawValue: attributeName)
+        }
+
+        return AuthCodeDeliveryDetails(
+            destination: deliveryDestination,
+            attributeKey: attribute)
+    }
+
+    static func getResultForChallengeParams(
+        _ challengeParams: [String: String]?,
+        signInMethod: PasswordlessCustomAuthSignInMethod
+    ) throws -> AuthSignInResult {
+        if let errorCode = challengeParams?["errorCode"]{
+            switch errorCode {
+            case "CodeMismatchException":
+                throw AuthError.service(
+                    "Provided code does not match what the server was expecting.",
+                    AuthPluginErrorConstants.codeMismatchError,
+                    AWSCognitoAuthError.codeMismatch)
+            default:
+                throw AuthError.service(
+                    "Unknown service error occurred. Error code:  \(errorCode)",
+                    AmplifyErrorMessages.shouldNotHappenReportBugToAWS(), nil)
+            }
+        }
+
+        // Ask the customer for the next step
+        switch signInMethod{
+        case .otp:
+            return .init(nextStep: .confirmSignInWithOTP(
+                PasswordlessHelper.getCodeDeliveryDetails(parameters: challengeParams ?? [:]), nil))
+        case .magicLink:
+            return .init(nextStep: .confirmSignInWithMagicLink(
+                PasswordlessHelper.getCodeDeliveryDetails(parameters: challengeParams ?? [:]), nil))
+        }
+    }
+
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/PasswordlessSignInHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/PasswordlessSignInHelper.swift
@@ -137,15 +137,8 @@ struct PasswordlessSignInHelper: DefaultLogger {
             return nil
 
         case .provideChallengeResponse:
-            // Ask the customer for the next step
-            switch signInRequestMetadata.signInMethod{
-            case .otp:
-                return .init(nextStep: .confirmSignInWithOTP(
-                    getCodeDeliveryDetails(parameters: challengeParams ?? [:]), nil))
-            case .magicLink:
-                return .init(nextStep: .confirmSignInWithMagicLink(
-                    getCodeDeliveryDetails(parameters: challengeParams ?? [:]), nil))
-            }
+            return try PasswordlessHelper.getResultForChallengeParams(
+                challengeParams, signInMethod: signInRequestMetadata.signInMethod)
         }
     }
 
@@ -218,30 +211,6 @@ struct PasswordlessSignInHelper: DefaultLogger {
             return clientMetadata
         }
         return [:]
-    }
-
-    private func getCodeDeliveryDetails(parameters: [String: String]) -> AuthCodeDeliveryDetails {
-
-        var deliveryDestination = DeliveryDestination.unknown(nil)
-        var attribute: AuthUserAttributeKey? = nil
-
-        // Retrieve Delivery medium and destination
-        let medium = parameters["deliveryMedium"]
-        let destination = parameters["destination"]
-        if medium == "SMS" {
-            deliveryDestination = .sms(destination)
-        } else if medium == "EMAIL" {
-            deliveryDestination = .email(destination)
-        }
-
-        // Retrieve attribute name
-        if let attributeName = parameters["attributeName"] {
-            attribute = AuthUserAttributeKey(rawValue: attributeName)
-        }
-
-        return AuthCodeDeliveryDetails(
-            destination: deliveryDestination,
-            attributeKey: attribute)
     }
 
     // MARK: Sign In Cancellation

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthConfirmSignInWithOTPTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthConfirmSignInWithOTPTaskTests.swift
@@ -77,4 +77,57 @@ class AWSAuthConfirmSignInWithOTPTaskTests: BasePluginTest {
         }
     }
 
+    /// Test a  confirmSignInWithOTP call when sending an invalid code
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service calls should throw an exception
+    /// - When:
+    ///    - I invoke confirmSignInWithOTP with an invalid confirmation code
+    /// - Then:
+    ///    - I should get a codeMismatch service exception
+    ///
+    func testConfirmSignInWithOTP() async {
+
+        let customerMetadata = [
+            "somekey": "somevalue"
+        ]
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { request in
+                XCTAssertEqual(request.challengeName, .customChallenge)
+                XCTAssertEqual(request.challengeResponses?["ANSWER"], "code")
+                XCTAssertEqual(request.clientMetadata?["Amplify.Passwordless.signInMethod"], "OTP")
+                XCTAssertEqual(request.clientMetadata?["Amplify.Passwordless.action"], "CONFIRM")
+                XCTAssertEqual(request.clientMetadata?["somekey"], "somevalue")
+
+                return RespondToAuthChallengeOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_CHALLENGE_RESPONSE",
+                        "errorCode": "CodeMismatchException"
+                    ],
+                    session: "session")
+            })
+
+        do {
+            let confirmSignInOptions = AWSAuthConfirmSignInPasswordlessOptions(
+                metadata: customerMetadata)
+            let option = AuthConfirmSignInWithOTPRequest.Options(pluginOptions: confirmSignInOptions)
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Confirm Sign In should not succeed")
+        } catch AuthError.service(_, _, let error) {
+            guard let cognitoError = error as? AWSCognitoAuthError else {
+                XCTFail("Underlying error should be AWSCognitoAuthError instead got \(String(describing: error))")
+                return
+            }
+            guard case .codeMismatch = cognitoError else {
+                XCTFail("Underlying error should be .codeMismatch")
+                return
+            }
+        } catch {
+            XCTFail("Should throw a Auth.service error instead got \(error)")
+        }
+    }
+
 }


### PR DESCRIPTION
## Description
<!-- Why is this change required? What problem does it solve? -->
* Adding logic to handle retries when confirming sign in with OTP. 
* Also handling if `PROVIDE_CHALLENGE_RESPONSE` will be result from Cognito Auth. 

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
