### PR TITLE
fix(Auth): Fix multiple continuation resumes in hostedUI

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUIASWebAuthenticationSession.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUIASWebAuthenticationSession.swift
@@ -62,7 +62,7 @@ class HostedUIASWebAuthenticationSession: NSObject, HostedUISessionBehavior {
 
             DispatchQueue.main.async {
                 var canStart = true
-                if #available(macOS 10.15.4, *) {
+                if #available(macOS 10.15.4, iOS 13.4, *) {
                     canStart = aswebAuthenticationSession.canStart
                 }
                 if canStart {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
#3362 

## Description
<!-- Why is this change required? What problem does it solve? -->
The PR is aimed at using weak references in the completion blocks of continuations to avoid any retain cycles and at the same time also use the `canStart` API available in ASWebAuthentication to only start if its possible. 

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
