### PR TITLE
fix(Auth): throw correct error for an unknown session error

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/FetchAuthSessionOperationHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/FetchAuthSessionOperationHelper.swift
@@ -157,13 +157,21 @@ class FetchAuthSessionOperationHelper: DefaultLogger {
             }
 
         case .service(let error):
-            if let authError = (error as? AuthErrorConvertible)?.authError {
-                let session = AWSAuthCognitoSession(isSignedIn: isSignedIn,
-                                                    identityIdResult: .failure(authError),
-                                                    awsCredentialsResult: .failure(authError),
-                                                    cognitoTokensResult: .failure(authError))
-                return session
+            var authError: AuthError
+            if let convertedAuthError = (error as? AuthErrorConvertible)?.authError {
+                authError = convertedAuthError
+            } else {
+                authError = AuthError.service(
+                    "Unknown service error occurred",
+                    "See the attached error for more details",
+                    error)
             }
+            let session = AWSAuthCognitoSession(
+                isSignedIn: isSignedIn,
+                identityIdResult: .failure(authError),
+                awsCredentialsResult: .failure(authError),
+                cognitoTokensResult: .failure(authError))
+            return session
         default: break
 
         }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
The PR is aimed at fixing `fetchAuthSession` API's error when an unknown HTTP error is thrown by the service. 

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
