### PR TITLE
fix(core): Switching the HTTP Client to SDK's client engine

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Utils/CustomHttpClientEngine/PluginClientEngine.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Utils/CustomHttpClientEngine/PluginClientEngine.swift
@@ -13,5 +13,5 @@ import AWSClientRuntime
 public func baseClientEngine(
     for configuration: AWSClientConfiguration<some AWSServiceSpecificConfiguration>
 ) -> HTTPClient {
-    return FoundationClientEngine()
+    return configuration.httpClientEngine
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "47922c05dd66be717c7bce424651a534456717b7",
-        "version" : "0.36.2"
+        "revision" : "c1fb1783ba388fe2549957260ab5670f2700c56c",
+        "version" : "0.36.3"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "8a5b0105c1b8a1d26a9435fb0af3959a7f5de578",
-        "version" : "0.41.1"
+        "revision" : "9fe617cde2d7abca48ae91542f1f75e28f82b86e",
+        "version" : "0.41.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let platforms: [SupportedPlatform] = [
     .watchOS(.v9)
 ]
 let dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/awslabs/aws-sdk-swift.git", exact: "0.36.2"),
+    .package(url: "https://github.com/awslabs/aws-sdk-swift.git", exact: "0.36.3"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", exact: "0.15.0"),
     .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.1.0"),
     .package(url: "https://github.com/aws-amplify/amplify-swift-utils-notifications.git", from: "1.1.0")


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

 [![Integration Tests | Auth](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_auth.yml/badge.svg?branch=switch-back-http-client)](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_auth.yml)

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
