### PR TITLE
fix(Auth): Adding credentialsProvider to Cognito clients

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -111,7 +111,8 @@ extension AWSCognitoAuthPlugin {
                 configuration.retryStrategyOptions = RetryStrategyOptions(maxRetriesBase: Int(maxRetryUnwrapped))
             }
 
-            configuration.credentialsProvider = AmplifyAWSCredentialsProvider()
+            let authService = AWSAuthService()
+            configuration.credentialsProvider = authService.getCredentialsProvider()
 
             return CognitoIdentityProviderClient(config: configuration)
         default:
@@ -135,7 +136,8 @@ extension AWSCognitoAuthPlugin {
                 configuration.retryStrategyOptions = RetryStrategyOptions(maxRetriesBase: Int(maxRetryUnwrapped))
             }
 
-            configuration.credentialsProvider = AmplifyAWSCredentialsProvider()
+            let authService = AWSAuthService()
+            configuration.credentialsProvider = authService.getCredentialsProvider()
 
             return CognitoIdentityClient(config: configuration)
         default:

--- a/AmplifyPlugins/Core/AmplifyCredentials/AmplifyAWSCredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentials/AmplifyAWSCredentialsProvider.swift
@@ -13,8 +13,6 @@ import Foundation
 
 public class AmplifyAWSCredentialsProvider: AWSClientRuntime.CredentialsProviding {
 
-    public init() { }
-
     public func getCredentials() async throws -> AWSClientRuntime.AWSCredentials {
         let authSession = try await Amplify.Auth.fetchAuthSession()
         if let awsCredentialsProvider = authSession as? AuthAWSCredentialsProvider {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
#3743 

## Description
<!-- Why is this change required? What problem does it solve? -->
When initializing the Cognito client, there was no `credentialsProvider` initialized. This change introduce the initialization of the `credentialsProvider` from the `AuthService`.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
