### PR TITLE
chore: update readme with correct Xcode version for visionOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,7 @@ This library is licensed under the Apache 2.0 License.
 
 ## Installation
 
-Amplify requires the following Xcode versions, according to the targeted platform:
-
-| Platform      | Xcode Version |
-| -------------:| ------------: |
-| iOS           | 15.0+         |
-| macOS         | 15.0+         |
-| tvOS          | 15.0+         |
-| watchOS       | 15.0+         |
-| visionOS      | 15.0+         |
+Amplify requires Xcode 15.0 or later for all the supported platforms.
 
 | For more detailed instructions, follow the getting started guides in our [documentation site](https://docs.amplify.aws/lib/q/platform/ios)   |
 |-------------------------------------------------|


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
The aim of the PR is to fix the minimum supported version of Xcode in Amplify Swift. 

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
