### PR TITLE
fix(analytics): iterate sqlite rows with failableNext

### DIFF
--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/LocalStorage/AnalyticsEventSQLStorage.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/LocalStorage/AnalyticsEventSQLStorage.swift
@@ -142,9 +142,9 @@ class AnalyticsEventSQLStorage: AnalyticsEventStorage {
         ORDER BY timestamp ASC
         LIMIT ?
         """
-        let rows = try dbAdapter.executeQuery(queryStatement, [limit])
+        let rows = try dbAdapter.executeQuery(queryStatement, [limit]).makeIterator()
         var result = [PinpointEvent]()
-        for element in rows {
+        while let element = try rows.failableNext() {
             if let event = PinpointEvent.convertToEvent(element) {
                 result.append(event)
             }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

https://github.com/aws-amplify/amplify-swift/issues/3855

## Description
<!-- Why is this change required? What problem does it solve? -->

The [default iteration behavior](https://github.com/stephencelis/SQLite.swift/blob/master/Sources/SQLite/Core/Statement.swift#L218) for SQLite statement results uses `try!`, which throws a runtime error that can't be caught by Swift's standard `do..try` mechanism. Since the analytics category runs as a background monitoring thread, it shouldn't cause the app to enter an error state. Instead, use the alternative throwable API [`failableNext`](https://github.com/stephencelis/SQLite.swift/blob/master/Sources/SQLite/Core/Statement.swift#L233) to avoid runtime errors.


## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
