### PR TITLE
fix(auth): return configuration error upon invalid redirect URI in hosted ui

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/HostedUI/ShowHostedUISignIn.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/HostedUI/ShowHostedUISignIn.swift
@@ -36,7 +36,7 @@ class ShowHostedUISignIn: NSObject, Action {
 
         guard let callbackURL = URL(string: hostedUIConfig.oauth.signInRedirectURI),
               let callbackURLScheme = callbackURL.scheme else {
-            let event = SignInEvent(eventType: .throwAuthError(.hostedUI(.signInURI)))
+            let event = HostedUIEvent(eventType: .throwError(.hostedUI(.signInURI)))
             logVerbose("\(#fileID) Sending event \(event)", environment: environment)
             await dispatcher.send(event)
             return

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SignIn/HostedUISignInState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SignIn/HostedUISignInState+Resolver.swift
@@ -30,7 +30,6 @@ extension HostedUISignInState {
 
             case .showingUI:
                 if case .throwError(let error) = event.isHostedUIEvent {
-                    // Remove this?
                     let action = CancelSignIn()
                     return .init(newState: .error(error), actions: [action])
                 }


### PR DESCRIPTION

## Issue \#
#3888 
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
Fixing HostedUI action to throw correct error for invalid configuration

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
