### PR TITLE
fix(Logging): adding internal configure auth hub event listener to fix logging race condition

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/AuthConfigureOperation.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/AuthConfigureOperation.swift
@@ -37,6 +37,9 @@ class AuthConfigureOperation: ConfigureOperation {
     override public func main() {
         if isCancelled {
             finish()
+            dispatch(result: .failure(AuthError.configuration(
+                "Configuration operation was cancelled",
+                "", nil)))
             return
         }
 
@@ -51,6 +54,7 @@ class AuthConfigureOperation: ConfigureOperation {
             for await state in stateSequences {
                 if case .configured = state {
                     finish()
+                    dispatch(result: .success(()))
                     break
                 }
             }

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingCategoryClient.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingCategoryClient.swift
@@ -87,9 +87,10 @@ final class AWSCloudWatchLoggingCategoryClient {
         enum CognitoEventName: String {
             case signInAPI = "Auth.signInAPI"
             case signOutAPI = "Auth.signOutAPI"
+            case configured = "InternalConfigureAuth"
         }
         switch payload.eventName {
-        case HubPayload.EventName.Auth.signedIn, CognitoEventName.signInAPI.rawValue:
+        case HubPayload.EventName.Auth.signedIn, CognitoEventName.signInAPI.rawValue, CognitoEventName.configured.rawValue:
             takeUserIdentifierFromCurrentUser()
         case HubPayload.EventName.Auth.signedOut, CognitoEventName.signOutAPI.rawValue:
             self.userIdentifier = nil

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingPlugin.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingPlugin.swift
@@ -154,10 +154,6 @@ public class AWSCloudWatchLoggingPlugin: LoggingCategoryPlugin {
             let localStore: LoggingConstraintsLocalStore = UserDefaults.standard
             localStore.reset()
         }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
-            self.loggingClient.takeUserIdentifierFromCurrentUser()
-        }
     }
 }
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
#3897 

## Description
<!-- Why is this change required? What problem does it solve? -->
[![Integration Tests | API - All](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_api.yml/badge.svg?branch=fix-3897)](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_api.yml)

There is a race condition where the Auth category is not configured when logging needs current users identifier. The fix removes the delayed call to fetch the current users identifier and relies on the Hub Event to update users identifier. 

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
