### PR TITLE
fix(auth): use auth flow type correctly from amplifyconfiguration.json

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AuthFlowType.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AuthFlowType.swift
@@ -34,6 +34,21 @@ public enum AuthFlowType {
     /// - `preferredFirstFactor`: the auth factor type the user should begin signing with if available. If the preferred first factor is not available, the flow would fallback to provide available first factors.
     case userAuth(preferredFirstFactor: AuthFactorType?)
 
+    internal init?(rawValue: String) {
+        switch rawValue {
+        case "CUSTOM_AUTH":
+            self = .customWithSRP
+        case "USER_SRP_AUTH":
+            self = .userSRP
+        case "USER_PASSWORD_AUTH":
+            self = .userPassword
+        case "USER_AUTH":
+            self = .userAuth
+        default:
+            return nil
+        }
+    }
+
     var rawValue: String {
         switch self {
         case .custom, .customWithSRP, .customWithoutSRP:

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ConfigurationHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ConfigurationHelper.swift
@@ -47,14 +47,17 @@ struct ConfigurationHelper {
 
         // parse `authFlowType`
         var authFlowType: AuthFlowType
+
+        // If Migration path is enabled, auth flow type should always be set to USER_PASSWORD_AUTH
         if case .boolean(let isMigrationEnabled) = cognitoUserPoolJSON.value(at: "MigrationEnabled"),
            isMigrationEnabled == true {
             authFlowType = .userPassword
         } else if let authJson = config.value(at: "Auth.Default"),
-                  case .string(let authFlowTypeJSON) = authJson.value(at: "authenticationFlowType"),
-                  authFlowTypeJSON == "CUSTOM_AUTH" {
-            authFlowType = .customWithSRP
+                  case .string(let authFlowTypeConfigValue) = authJson.value(at: "authenticationFlowType"),
+                  let authFlowTypeFromConfig = AuthFlowType(rawValue: authFlowTypeConfigValue) {
+            authFlowType = authFlowTypeFromConfig
         } else {
+            // if the auth flow type is not found from config, default to SRP
             authFlowType = .userSRP
         }
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
#3927 


## Description
<!-- Why is this change required? What problem does it solve? -->

The issue fixes the parsing of `USER_PASSWORD_AUTH` flow correctly from the `amplifyconfiguration.json`.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
