### PR TITLE
fix(storage): clean up cached files upon completion

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
@@ -146,6 +146,10 @@ class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
             Task {
                 do {
                     let partialFileURL = try result.get()
+                    defer {
+                        // Clean up the temporary file after we're done with it
+                        self.fileSystem.removeFileIfExists(fileURL: partialFileURL)
+                    }
 
                     let operation = AWSS3SigningOperation.uploadPart(partNumber: partNumber, uploadId: uploadId)
                     let preSignedURL = try await serviceProxy.preSignedURLBuilder.getPreSignedURL(


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
#3959 

## Description
<!-- Why is this change required? What problem does it solve? -->

The temporary files are removed once the method completes its execution. 

```
                   defer {
                        // Clean up the temporary file after we're done with it
                        self.fileSystem.removeFileIfExists(fileURL: partialFileURL)
                    }
```

Integration Tests: [![Integration Tests | Storage](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_storage.yml/badge.svg?branch=storage-cache-cleanup)](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_storage.yml)

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
