### PR TITLE
chore: reduce nightly unit test iteration count

### DIFF
--- a/.github/workflows/nightly_repeated_unittest.yml
+++ b/.github/workflows/nightly_repeated_unittest.yml
@@ -37,4 +37,4 @@ jobs:
       scheme: ${{ matrix.scheme }}
       timeout-minutes: 50
       generate_coverage_report: false
-      test_iterations_flags: -test-iterations 100 -run-tests-until-failure
+      test_iterations_flags: -test-iterations 25 -run-tests-until-failure


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

Nightly tests have been timing out because they are unable to complete 100 iterations. Reducing the number to 25. 

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
