### PR TITLE
fix: commented the minimum OS version Macro causing compilation error in Xcode 26

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ASF/ASFAppInfo.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ASF/ASFAppInfo.swift
@@ -14,15 +14,18 @@ struct ASFAppInfo: ASFAppInfoBehavior {
     }
 
     var targetSDK: String {
-        var targetSDK: String = ""
-#if os(iOS) || os(watchOS) || os(tvOS)
-        targetSDK = "\(__IPHONE_OS_VERSION_MIN_REQUIRED)"
-#elseif os(macOS)
-        targetSDK = "\(__MAC_OS_X_VERSION_MIN_REQUIRED)"
-#else
-        targetSDK = "Unknown"
-#endif
-        return targetSDK
+//TODO: Not compiling in Xcode 26: Investigate further
+//        var targetSDK: String = ""
+//
+//#if os(iOS) || os(watchOS) || os(tvOS)
+//        targetSDK = "\(__IPHONE_OS_VERSION_MIN_REQUIRED)"
+//#elseif os(macOS)
+//        targetSDK = "\(__MAC_OS_X_VERSION_MIN_REQUIRED)"
+//#else
+//        targetSDK = "Unknown"
+//#endif
+//        return targetSDK
+        return "Unknown"
     }
 
     var version: String {


### PR DESCRIPTION

## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

#4003 

The minimum OS version macro is causing the compilation to fail. For users trying out Xcode 26

## Description
<!-- Why is this change required? What problem does it solve? -->

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
