### PR TITLE
fix(auth): allow removing and adding identity pool for an already deployed app

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/UserPoolConfigurationData.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/UserPoolConfigurationData.swift
@@ -57,6 +57,14 @@ struct UserPoolConfigurationData: Equatable {
     func getIdentityProviderName() -> String {
         return "cognito-idp.\(region).amazonaws.com/\(poolId)"
     }
+
+    static func isNamespacingEqual(
+        lhs: UserPoolConfigurationData?,
+        rhs: UserPoolConfigurationData?) -> Bool {
+            return lhs?.poolId == rhs?.poolId
+            && lhs?.clientId == rhs?.clientId
+            && lhs?.region == rhs?.region
+        }
 }
 
 extension UserPoolConfigurationData: Codable { }


### PR DESCRIPTION

## Issue \#
#4008 

This pull request enhances the migration logic for AWS Cognito credential storage in the `AWSCognitoAuthCredentialStore` and introduces a helper method in `UserPoolConfigurationData` to compare user pool configurations. The changes aim to ensure smoother transitions between old and new configurations during migrations.

### Credential Migration Enhancements:

* **Added migration logic for user pool configuration:** Updated the migration conditions to account for scenarios where old and new user pool configurations exist and have matching namespaces. This ensures data is correctly transferred when identity pool is added or removed when the user pool remains the same.  

## Description
<!-- Why is this change required? What problem does it solve? -->

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
