### PR TITLE
chore: fixing integration test failure

### DIFF
--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/CredentialStore/CredentialStoreConfigurationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/CredentialStore/CredentialStoreConfigurationTests.swift
@@ -122,7 +122,7 @@ class CredentialStoreConfigurationTests: AWSAuthBaseTest {
     /// - When:
     ///    - We invoke a new Credential store with new Auth Configuration where identity user pool gets added
     /// - Then:
-    ///    - The keychain should be cleared
+    ///    - The keychain should be NOT be cleared
     ///
     func testCredentialsMigratedOnNotSupportedConfigurationChange() {
         // Given
@@ -147,7 +147,7 @@ class CredentialStoreConfigurationTests: AWSAuthBaseTest {
 
         // Then
         let credentials = try? newCredentialStore.retrieveCredential()
-        XCTAssertNil(credentials)
+        XCTAssertNotNil(credentials)
     }
 
     /// Test clearing of existing credentials when a configuration changes for identity pool
@@ -175,8 +175,10 @@ class CredentialStoreConfigurationTests: AWSAuthBaseTest {
         }
 
         // When configuration changed
-        let newAuthConfig = AuthConfiguration.identityPools(IdentityPoolConfigurationData(poolId: "changed",
-                                                                                          region: "changed"))
+        let newAuthConfig = AuthConfiguration.identityPools(
+            IdentityPoolConfigurationData(
+                poolId: "changed",
+                region: "changed"))
         let newCredentialStore = AWSCognitoAuthCredentialStore(authConfiguration: newAuthConfig)
 
         // Then


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

Fixing integration test that got broken when migrating to/from identity pools

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
