### PR TITLE
 chore: fix integration tests

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/WebSocket/WebSocketClient.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/WebSocket/WebSocketClient.swift
@@ -286,11 +286,11 @@ extension WebSocketClient {
         }
 
         switch stateChange {
-        case (.online, .offline), (.none, .offline), (.online, .none):
+        case (.online, .offline):
             log.debug("[WebSocketClient] NetworkMonitor - Device went offline or network status became unknown")
             self.connection?.cancel(with: .invalid, reason: nil)
             self.subject.send(.disconnected(.invalid, nil))
-        case (.offline, .online), (.none, .online):
+        case (.offline, .online):
             log.debug("[WebSocketClient] NetworkMonitor - Device back online")
             await self.createConnectionAndRead()
         default:


### PR DESCRIPTION
This pull request makes a targeted update to the network state handling logic in the `WebSocketClient` extension. The change refines the conditions under which the WebSocket connection is canceled or re-established, making the state transitions more explicit and reducing ambiguity.

Network state transition handling:

* Refined the switch cases in `WebSocketClient` to only trigger disconnect or reconnect actions on explicit transitions between `.online` and `.offline`, removing cases where the network state is `.none` (unknown). This helps avoid unnecessary connection changes when the network status is ambiguous. (`AmplifyPlugins/Core/AWSPluginsCore/WebSocket/WebSocketClient.swift`)

Integration Tests: https://github.com/aws-amplify/amplify-swift/actions/runs/17623491160/job/50074482396

## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
