### PR TITLE
chore: run issue_comment github action only for issue comments

### DIFF
--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -21,7 +21,7 @@ jobs:
 
   adjust-labels:
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.state == 'open' }}
+    if: ${{ github.event.issue.state == 'open' && !github.event.issue.pull_request }}
     permissions:
       issues: write
     env:
@@ -30,7 +30,7 @@ jobs:
       REPOSITORY_NAME: ${{ github.event.repository.full_name }}
     steps:
       - name: remove pending-community-response when new comment received
-        if: ${{ !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association) && !github.event.issue.pull_request }}
+        if: ${{ !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association) }}
         shell: bash
         run: |
           gh issue edit $ISSUE_NUMBER --repo $REPOSITORY_NAME --remove-label "pending-community-response"


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
`issue_comment` github action keeps failing for pull request event as it doesn't have the required permissions to edit a pull request
https://github.com/aws-amplify/amplify-swift/actions/workflows/issue_comment.yml

## Description
<!-- Why is this change required? What problem does it solve? -->
Run `issue_comment` only for issue comments

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
