### PR TITLE
fix(predictions): close websocket with runtime error on service exception

### DIFF
--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/FaceLivenessSession.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/FaceLivenessSession.swift
@@ -210,11 +210,11 @@ public final class FaceLivenessSession: LivenessService {
                           connectingState == .normal,
                           let savedURLForReconnect,
                           let serverDate else {
-                        onServiceException(.init(event: exceptionEvent))
-                        // send onComplete with runtime error close code
                         if let runtimeError = URLSessionWebSocketTask.CloseCode(rawValue: 4_005) {
-                            onComplete(.unexpectedClosure(runtimeError))
+                            Amplify.log.verbose("\(#function): Closing websocket with runtime error")
+                            closeSocket(with: runtimeError)
                         }
+                        onServiceException(.init(event: exceptionEvent))
                         return .stopAndInvalidateSession
                     }
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
None

## Description
<!-- Why is this change required? What problem does it solve? -->
- This change closes the websocket on a rekognition service exception with a custom defined [runtime error](https://github.com/aws-amplify/amplify-ui-swift-liveness/blob/19807765e97163cf30fbbc1d50375893f2a4fd86/Sources/FaceLiveness/Views/Liveness/LivenessStateMachine.swift#L181). This can be used to teardown sessions/close camera from the `FaceLivenessDetectorViewModel`.
- Customer is returned the exception type through `onServiceException` callback. There is no change regarding this.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
