### PR TITLE
Prevent clearing shared keychains

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AWSCognitoAuthCredentialStore.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AWSCognitoAuthCredentialStore.swift
@@ -62,7 +62,13 @@ struct AWSCognitoAuthCredentialStore {
         saveStoredAccessGroup()
 
         if !userDefaults.bool(forKey: isKeychainConfiguredKey) {
-            try? clearAllCredentials()
+            // We can't reliably clear credentials if the Keychain has a shared access group.
+            // This is because each app/extension has its own UserDefaults.
+            // If a user authenticates in an app, the app or extension that shares the keychain would clear the shared credentials.
+            // We must only clear credentials if a shared Keychain is not being used.
+            if accessGroup == nil {
+                try? clearAllCredentials() // clear if not using shared keychain
+            }
             userDefaults.set(true, forKey: isKeychainConfiguredKey)
         }
 


### PR DESCRIPTION
## Issue \#
#4076

## Description
This change prevents shared Keychains (accessGroup) from being cleared on a fresh install. Since UserDefaults are not shared across apps/extensions, we have no reliable way to determine if this is the first launch of *all* apps/extensions that are using the provided accessGroup.

The caveat here is that if a user uninstalls and reinstalls an application, the credentials will not be wiped like they are in the standard, non shared Keychain usage. This change is necessary though given the above description.


## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
