### PR TITLE
fix(auth): resolve format string mismatch in ASF timestamp generation

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ASF/CognitoUserPoolASF.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ASF/CognitoUserPoolASF.swift
@@ -86,7 +86,7 @@ struct CognitoUserPoolASF: AdvancedSecurityBehavior {
         contextData: [String: String],
         userPoolId: String
     ) throws -> String {
-        let timestamp = String(format: "%lli", floor(Date().timeIntervalSince1970 * 1_000))
+        let timestamp = String(format: "%lli", Int64(Date().timeIntervalSince1970 * 1_000))
         let payload = [
             "contextData": contextData,
             "username": username,


### PR DESCRIPTION
## Issue
Fixes #4073

## Description
This PR resolves a format string mismatch warning that occurs during sign-in operations when using AWS Cognito's Advanced Security Features (ASF).

### Problem
The `prepareJsonPayload` method in `CognitoUserPoolASF.swift` was using `floor(Date().timeIntervalSince1970 * 1_000)` which returns a `Double`, but the format specifier `%lli` expects an `Int64`. This caused the following warning:

```
String(format:locale:arguments:): Provided argument types ["Swift.Double"] (with inferred specifiers ["%lf"]) do not match the format string's specifiers [Error Domain=NSCocoaErrorDomain Code=2048 "Format '%lli' does not match expected '%lf'"]
```

### Solution
Changed the timestamp generation to use `Int64(Date().timeIntervalSince1970 * 1_000)` instead of `floor()`. This:
- Eliminates the type mismatch warning
- Maintains the same functionality (both truncate to integer milliseconds)
- Aligns with the codebase pattern where millisecond timestamps consistently use `Int64` or `UInt64`
- Matches AWS Cognito ASF requirements for integer timestamps

### Testing
- Sign-in operations complete successfully without warnings
- Timestamp values remain functionally identical
- No behavioral changes to authentication flow

## Checklist
- [x] Fix addresses the root cause identified in issue #4073
- [x] Change is minimal and focused on the specific problem
- [x] Follows existing codebase patterns for timestamp handling