### PR TITLE
fix(logging): update protection level

### DIFF
--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Persistence/LogRotation.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Persistence/LogRotation.swift
@@ -209,9 +209,9 @@ final class LogRotation {
             contents: nil,
             attributes: [FileAttributeKey: Any]()
         )
-        if #available(macOS 11.0, *) {
+        if #available(macOS 11.0, iOS 9.0, *) {
             let resourceValues: [URLResourceKey: Any] = [
-                URLResourceKey.fileProtectionKey: URLFileProtection.complete,
+                URLResourceKey.fileProtectionKey: URLFileProtection.completeUntilFirstUserAuthentication,
                 URLResourceKey.isExcludedFromBackupKey: true
             ]
             try (fileURL as NSURL).setResourceValues(resourceValues)


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
#4097 

## Description
<!-- Why is this change required? What problem does it solve? -->

Updating the protection level to be not overly restrictive. 
https://developer.apple.com/documentation/foundation/urlfileprotection/completeuntilfirstuserauthentication

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
