### PR TITLE
chore: fix stress tests

### DIFF
--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -68,6 +68,7 @@ jobs:
           scheme: AuthStressTests
           destination: ${{ env.DESTINATION }}
           xcode_path: '/Applications/Xcode_${{ env.XCODE_VERSION }}.app'
+          other_flags: -parallel-testing-enabled NO
 
   geo-stress-test:
     needs: prepare-for-test
@@ -99,6 +100,7 @@ jobs:
           scheme: GeoStressTests
           destination: ${{ env.DESTINATION }}
           xcode_path: '/Applications/Xcode_${{ env.XCODE_VERSION }}.app'
+          other_flags: -parallel-testing-enabled NO
 
   storage-stress-test:
     needs: prepare-for-test
@@ -130,6 +132,7 @@ jobs:
           scheme: StorageStressTests
           destination: ${{ env.DESTINATION }}
           xcode_path: '/Applications/Xcode_${{ env.XCODE_VERSION }}.app'
+          other_flags: -parallel-testing-enabled NO
 
   datastore-stress-test:
     needs: prepare-for-test
@@ -161,6 +164,7 @@ jobs:
           scheme: DatastoreStressTests
           destination: ${{ env.DESTINATION }}
           xcode_path: '/Applications/Xcode_${{ env.XCODE_VERSION }}.app'
+          other_flags: -parallel-testing-enabled NO
 
   graphql-api-stress-test:
     needs: prepare-for-test
@@ -192,3 +196,4 @@ jobs:
           scheme: GraphQLAPIStressTests
           destination: ${{ env.DESTINATION }}
           xcode_path: '/Applications/Xcode_${{ env.XCODE_VERSION }}.app'
+          other_flags: -parallel-testing-enabled NO

--- a/AmplifyPlugins/API/Tests/APIHostApp/GraphQLAPIStressTests/GraphQLAPIStressTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/GraphQLAPIStressTests/GraphQLAPIStressTests.swift
@@ -75,7 +75,6 @@ final class APIStressTests: XCTestCase {
         let progressInvoked = expectation(description: "progress invoked")
         progressInvoked.expectedFulfillmentCount = concurrencyLimit
 
-        let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
 
@@ -98,7 +97,7 @@ final class APIStressTests: XCTestCase {
                         case .data(let result):
                             switch result {
                             case .success(let post):
-                                if post.id == uuid {
+                                if post.title == title {
                                     progressInvoked.fulfill()
                                 }
                             case .failure(let error):
@@ -118,7 +117,7 @@ final class APIStressTests: XCTestCase {
         let sequenceCount = await sequenceActor.sequences.count
         XCTAssertEqual(sequenceCount, concurrencyLimit)
 
-        guard try await createPost(id: uuid, title: title) != nil else {
+        guard try await Self.createPost(id: UUID().uuidString, title: title) != nil else {
             XCTFail("Failed to create post")
             return
         }
@@ -144,7 +143,7 @@ final class APIStressTests: XCTestCase {
             Task {
                 let id = UUID().uuidString
                 let title = "title" + String(index)
-                let post = try await createPost(id: id, title: title)
+                let post = try await APIStressTests.createPost(id: id, title: title)
                 XCTAssertNotNil(post)
                 XCTAssertEqual(id, post?.id)
                 XCTAssertEqual(title, post?.title)
@@ -169,7 +168,7 @@ final class APIStressTests: XCTestCase {
             Task {
                 let id = UUID().uuidString
                 let title = "title" + String(index)
-                let post = try await createPost(id: id, title: title)
+                let post = try await APIStressTests.createPost(id: id, title: title)
                 XCTAssertNotNil(post)
                 XCTAssertEqual(id, post?.id)
                 XCTAssertEqual(title, post?.title)
@@ -184,7 +183,7 @@ final class APIStressTests: XCTestCase {
             Task {
                 var post = await postActor.posts[index]
                 post.title = "newTitle" + String(index)
-                let updatedPost = try await mutatePost(post)
+                let updatedPost = try await APIStressTests.mutatePost(post)
                 XCTAssertNotNil(updatedPost)
                 XCTAssertEqual(post.id, updatedPost.id)
                 XCTAssertEqual(post.title, updatedPost.title)
@@ -211,7 +210,7 @@ final class APIStressTests: XCTestCase {
             Task {
                 let id = UUID().uuidString
                 let title = "title" + String(index)
-                let post = try await createPost(id: id, title: title)
+                let post = try await APIStressTests.createPost(id: id, title: title)
                 XCTAssertNotNil(post)
                 XCTAssertEqual(id, post?.id)
                 XCTAssertEqual(title, post?.title)
@@ -225,7 +224,7 @@ final class APIStressTests: XCTestCase {
         DispatchQueue.concurrentPerform(iterations: concurrencyLimit) { index in
             Task {
                 let post = await postActor.posts[index]
-                let deletedPost = try await deletePost(post: post)
+                let deletedPost = try await APIStressTests.deletePost(post: post)
                 XCTAssertNotNil(deletedPost)
                 XCTAssertEqual(post.id, deletedPost.id)
                 XCTAssertEqual(post.title, deletedPost.title)
@@ -252,7 +251,7 @@ final class APIStressTests: XCTestCase {
             Task {
                 let id = UUID().uuidString
                 let title = "title" + String(index)
-                let post = try await createPost(id: id, title: title)
+                let post = try await APIStressTests.createPost(id: id, title: title)
                 XCTAssertNotNil(post)
                 XCTAssertEqual(id, post?.id)
                 XCTAssertEqual(title, post?.title)
@@ -301,12 +300,12 @@ final class APIStressTests: XCTestCase {
 
     // MARK: - Helpers
 
-    func createPost(id: String, title: String) async throws -> Post? {
+    static func createPost(id: String, title: String) async throws -> Post? {
         let post = Post(id: id, title: title, status: .active, content: "content")
         return try await createPost(post: post)
     }
 
-    func createPost(post: Post) async throws -> Post? {
+    static func createPost(post: Post) async throws -> Post? {
         let data = try await Amplify.API.mutate(request: .create(post))
         switch data {
         case .success(let post):
@@ -316,7 +315,7 @@ final class APIStressTests: XCTestCase {
         }
     }
 
-    func mutatePost(_ post: Post) async throws -> Post {
+    static func mutatePost(_ post: Post) async throws -> Post {
         let data = try await Amplify.API.mutate(request: .update(post))
         switch data {
         case .success(let post):
@@ -326,7 +325,7 @@ final class APIStressTests: XCTestCase {
         }
     }
 
-    func deletePost(post: Post) async throws -> Post {
+    static func deletePost(post: Post) async throws -> Post {
         let data = try await Amplify.API.mutate(request: .delete(post))
         switch data {
         case .success(let post):


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
None

## Description
<!-- Why is this change required? What problem does it solve? -->
This PR 
- disables parallel testing in stress tests
- fixes `testMultipleSubscriptions()` in `APIStressTests`

Failing run: https://github.com/aws-amplify/amplify-swift/actions/runs/19480644472

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
