### PR TITLE
fix(auth): add prewarming check

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -193,6 +193,7 @@ extension AWSCognitoAuthPlugin {
         return analyticsHandler
     }
 
+    @MainActor
     private func makeCredentialStore() -> AmplifyAuthCredentialStoreBehavior {
         return AWSCognitoAuthCredentialStore(
             authConfiguration: authConfiguration,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/AWSCognitoAuthCredentialStoreTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/AWSCognitoAuthCredentialStoreTests.swift
@@ -35,6 +35,7 @@ class AWSCognitoAuthCredentialStoreTests: XCTestCase {
     /// - Then:
     ///    - The isKeychainConfigured flag should NOT be set in UserDefaults
     ///    - No keychain operations should be attempted
+    @MainActor
     func testInitSkipsWhenProtectedDataUnavailable() {
         // Given: Simulate protected data unavailable (iOS prewarming scenario)
         let protectedDataAvailable = false
@@ -63,6 +64,7 @@ class AWSCognitoAuthCredentialStoreTests: XCTestCase {
     /// - When: AWSCognitoAuthCredentialStore is initialized
     /// - Then:
     ///    - The isKeychainConfigured flag should be set in UserDefaults
+    @MainActor
     func testInitProceedsWhenProtectedDataAvailable() {
         // Given: Simulate protected data available (normal launch)
         let protectedDataAvailable = true
@@ -93,6 +95,7 @@ class AWSCognitoAuthCredentialStoreTests: XCTestCase {
     /// - Then:
     ///    - The initialization should skip without clearing credentials
     ///    - The isKeychainConfigured flag should remain unchanged
+    @MainActor
     func testCredentialsPreservedDuringPrewarming() {
         // Given: Simulate a scenario where keychain was previously configured
         UserDefaults.standard.set(true, forKey: isKeychainConfiguredKey)


### PR DESCRIPTION

## Description
<!-- Why is this change required? What problem does it solve? -->
This pull request introduces a safeguard in the `AWSCognitoAuthCredentialStore` to prevent credential loss during iOS prewarming or before the first device unlock, when protected data (such as Keychain and UserDefaults) may not be available. It adds a check to defer initialization that depends on protected data and includes comprehensive unit tests to verify this behavior.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
