### PR TITLE
fix(api): populate the auth mode when parsing the request response

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListProvider.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListProvider.swift
@@ -59,6 +59,7 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
             elements: listResponse.items,
             nextToken: listResponse.nextToken,
             apiName: payload.apiName,
+            authMode: payload.authMode,
             limit: payload.limit,
             filter: payload.graphQLFilter
         )

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListProviderTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListProviderTests.swift
@@ -62,7 +62,7 @@ class AppSyncListProviderTests: XCTestCase {
         let appSyncPayload = AppSyncListPayload(
             graphQLData: json,
             apiName: "apiName",
-            authMode: nil,
+            authMode: .amazonCognitoUserPools,
             variables: variables
         )
         let provider = try AppSyncListProvider<Post4>(payload: appSyncPayload)
@@ -73,6 +73,7 @@ class AppSyncListProviderTests: XCTestCase {
         XCTAssertEqual(elements.count, 2)
         XCTAssertEqual(nextToken, "nextToken")
         XCTAssertEqual(provider.apiName, "apiName")
+        XCTAssertEqual(provider.authMode, .amazonCognitoUserPools)
         XCTAssertEqual(provider.limit, 500)
         XCTAssertNotNil(filter)
     }


### PR DESCRIPTION
fixes #4159 

fix(api): populate the auth mode when parsing the request response. So AppSyncListProvider.getNextPage() will have the auth mode.

## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
Without storing the auth mode from the server response, calling AppSyncListProvider.getNextPage() won't have the auth mode. 


See the guide here: https://docs.amplify.aws/swift/build-a-backend/data/query-data/
Set the request auth mode to `.amazonCognitoUserPools`
The expression `currentPage.getNextPage()` will throw a 401 unauthorized error.
```
var allTodos: [Todo]
let todo = Todo.keys
    let predicate = todo.name == "my first todo" && todo.description == "todo description"
    let request = GraphQLRequest<Todo>.list(Todo.self, where: predicate, authMode: .amazonCognitoUserPools, limit: 1000)
    let result = try await Amplify.API.query(request: request)
        switch result {
        case .success(let todos):
            print("Successfully retrieved list of todos: \(todos)")
            let currentPage = todos
            allTodos.append(contentsOf: todos)
            if currentPage.hasNextPage() {
                do {
                    let nextPage = try await currentPage.getNextPage()
                    allTodos.append(contentsOf: nextPage)
                }
            }
        case .failure(let error):
            print("Got failed result with \(error.errorDescription)")
        }
```

## Description
<!-- Why is this change required? What problem does it solve? -->

Without storing the auth mode from the server response, calling AppSyncListProvider.getNextPage() won't have the auth mode. Without the correct auth mode, the client will receive 401 unauthorized failure.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
