### PR TITLE
Jv/kinesis improve logs autoformat further tests

### DIFF
--- a/AmplifyClients/AmplifyKinesisClient/Sources/AmplifyKinesisClient.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Sources/AmplifyKinesisClient.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import AWSClientRuntime
-import AWSKinesis
 import AmplifyFoundation
 import AmplifyFoundationBridge
+import AWSClientRuntime
+import AWSKinesis
 import Foundation
 import SmithyIdentity
 
@@ -183,13 +183,12 @@ public class AmplifyKinesisClient {
     /// - Throws: KinesisError if the record cannot be saved
     @discardableResult
     public func record(data: Data, partitionKey: String, streamName: String) async throws
-        -> RecordData 
-    {
+        -> RecordData {
         guard isEnabledLocked else {
             logger.debug("Record collection is disabled, dropping record")
             return RecordData()
         }
-        logger.debug("Recording to stream: \(streamName)")
+        logger.verbose("Recording to stream: \(streamName)")
 
         return try await wrapErrorAndLog(
             operation: {
@@ -204,7 +203,7 @@ public class AmplifyKinesisClient {
                 logger.debug("Record completed successfully in \(timeMs)ms")
             },
             logFailure: { error, timeMs in
-                logger.error("Record failed in \(timeMs)ms: \(error.localizedDescription)")
+                logger.warn("Record failed in \(timeMs)ms: \(error.localizedDescription)")
             }
         )
     }
@@ -214,18 +213,18 @@ public class AmplifyKinesisClient {
     /// - Throws: KinesisError if flush fails
     @discardableResult
     public func flush() async throws -> FlushData {
-        logger.info("Starting flush")
+        logger.verbose("Starting flush")
         return try await wrapErrorAndLog(
             operation: {
                 try await recordClient.flush()
             },
             logSuccess: { data, timeMs in
-                logger.info(
+                logger.debug(
                     "Flush completed successfully in \(timeMs)ms - \(data.recordsFlushed) records flushed"
                 )
             },
             logFailure: { error, timeMs in
-                logger.error("Flush failed in \(timeMs)ms: \(error.localizedDescription)")
+                logger.warn("Flush failed in \(timeMs)ms: \(error.localizedDescription)")
             }
         )
     }
@@ -256,18 +255,18 @@ public class AmplifyKinesisClient {
     /// - Throws: KinesisError if cache cannot be cleared
     @discardableResult
     public func clearCache() async throws -> ClearCacheData {
-        logger.info("Clearing cache")
+        logger.verbose("Clearing cache")
         return try await wrapErrorAndLog(
             operation: {
                 try await recordClient.clearCache()
             },
             logSuccess: { data, timeMs in
-                logger.info(
+                logger.debug(
                     "Clear cache completed successfully in \(timeMs)ms - \(data.recordsCleared) records cleared"
                 )
             },
             logFailure: { error, timeMs in
-                logger.error("Clear cache failed in \(timeMs)ms: \(error.localizedDescription)")
+                logger.warn("Clear cache failed in \(timeMs)ms: \(error.localizedDescription)")
             }
         )
     }
@@ -305,7 +304,7 @@ public class AmplifyKinesisClient {
         }
         let timeMs = Int((CFAbsoluteTimeGetCurrent() - start) * 1_000)
 
-        if let error = error {
+        if let error {
             logFailure(error, timeMs)
             throw error
         } else {

--- a/AmplifyClients/AmplifyKinesisClient/Sources/Support/AutoFlushScheduler.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Sources/Support/AutoFlushScheduler.swift
@@ -34,11 +34,11 @@ actor AutoFlushScheduler {
                 }
                 guard let self, !Task.isCancelled else { break }
                 do {
-                    let data = try await self.recordClient.flush()
-                    self.logger.debug("Auto-flush completed: \(data.recordsFlushed) records flushed")
+                    let data = try await recordClient.flush()
+                    logger.debug("Auto-flush completed: \(data.recordsFlushed) records flushed")
                 } catch {
                     // Will retry on next cycle
-                    self.logger.warn("Auto-flush failed", error)
+                    logger.warn("Auto-flush failed", error)
                 }
             }
         }

--- a/AmplifyClients/AmplifyKinesisClient/Sources/Support/KinesisRecordSender.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Sources/Support/KinesisRecordSender.swift
@@ -48,9 +48,9 @@ final class KinesisRecordSender: RecordSender, @unchecked Sendable {
             records: kinesisRecords,
             streamName: streamName
         )
-        
+
         let output: PutRecordsOutput = try await kinesisClient.putRecords(input: input)
-        
+
         var successfulIds: [Int64] = []
         var retryableIds: [Int64] = []
         var failedIds: [Int64] = []
@@ -66,7 +66,7 @@ final class KinesisRecordSender: RecordSender, @unchecked Sendable {
             // - `ProvisionedThroughputExceededException`: Retryable - throughput limit exceeded
             // - `InternalFailure`: Retryable - internal service error
             // Both are retried
-            else if record.retryCount >= self.maxRetries {
+            else if record.retryCount >= maxRetries {
                 failedIds.append(record.id)
             } else {
                 retryableIds.append(record.id)

--- a/AmplifyClients/AmplifyKinesisClient/Sources/Support/RecordCacheError.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Sources/Support/RecordCacheError.swift
@@ -13,7 +13,7 @@ let defaultRecoverySuggestion: RecoverySuggestion = "Inspect the underlying erro
 
 /// Internal error type used by RecordClient/RecordStorage.
 /// Mapped to KinesisError via ``KinesisError/from(_:)``.
-internal enum RecordCacheError: Error {
+enum RecordCacheError: Error {
     /// Database operation failed.
     case database(ErrorDescription, RecoverySuggestion, Error? = nil)
     /// Cache limit exceeded — no space for new records.

--- a/AmplifyClients/AmplifyKinesisClient/Sources/Support/RecordClient.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Sources/Support/RecordClient.swift
@@ -80,9 +80,9 @@ actor RecordClient {
             "Kinesis SDK error flushing stream \(streamName): \(error.localizedDescription)"
           )
         } else {
-          // Cache/storage errors, network errors, and unexpected errors are critical
-          logger.error(
-            "Critical error flushing stream \(streamName): \(error.localizedDescription)"
+          // Network errors, storage errors, and unexpected errors — throw to caller
+          logger.warn(
+            "Error flushing stream \(streamName): \(error.localizedDescription)"
           )
           throw error
         }
@@ -100,11 +100,13 @@ actor RecordClient {
       try await storage.incrementRetryCount(ids: retryable.map(\.id))
       try await storage.deleteRecords(ids: expired.map(\.id))
 
-      let streamName = records[0].streamName
-      logger.warn(
-        "Deleted \(expired.count) records from stream \(streamName) "
-          + "that exceeded retry limit of \(maxRetries) after failed request"
-      )
+      if !expired.isEmpty {
+        let streamName = records[0].streamName
+        logger.warn(
+          "Deleted \(expired.count) records from stream \(streamName) "
+            + "that exceeded retry limit of \(maxRetries) after failed request"
+        )
+      }
     } catch {
       logger.error("Failed to update records for failed request: \(error.localizedDescription)")
     }

--- a/AmplifyClients/AmplifyKinesisClient/Sources/Support/SQLiteRecordStorage.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Sources/Support/SQLiteRecordStorage.swift
@@ -47,7 +47,7 @@ actor SQLiteRecordStorage: RecordStorage {
         self.database = try connection ?? Self.createFileConnection(identifier: identifier)
 
         try Self.setupSchema(on: database)
-        try self.resetCacheSizeFromDb()
+        try resetCacheSizeFromDb()
     }
 
     private static func createFileConnection(identifier: String) throws -> Connection {
@@ -153,7 +153,7 @@ actor SQLiteRecordStorage: RecordStorage {
                         defaultRecoverySuggestion
                     )
                 }
-                
+
                 guard let id = row[0] as? Int64,
                       let streamName = row[1] as? String,
                       let partitionKey = row[2] as? String,

--- a/AmplifyClients/AmplifyKinesisClient/Tests/IntegrationTests/KinesisHostApp/AmplifyKinesisClientIntegrationTests/AmplifyKinesisClientIntegrationTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/IntegrationTests/KinesisHostApp/AmplifyKinesisClientIntegrationTests/AmplifyKinesisClientIntegrationTests.swift
@@ -169,16 +169,24 @@ class AmplifyKinesisClientIntegrationTests: XCTestCase {
             credentialsProvider: SDKToFoundationCredentialsAdapter(
                 resolver: AWSAuthService().getCredentialIdentityResolver()
             ),
-            options: .init(cacheMaxBytes: 10, flushStrategy: .none)
+            options: .init(cacheMaxBytes: 100, flushStrategy: .none)
         )
         // Clear first so cachedSize starts at 0
         try await smallKinesis.clearCache()
 
         do {
-            // 60 bytes > 10 byte limit — should fail immediately
+            // Fill the cache
+            let bigData = Data(repeating: 0x41, count: 60) // 60 bytes
             try await smallKinesis.record(
-                data: Data(repeating: 0x41, count: 60),
-                partitionKey: "p1",
+                data: bigData,
+                partitionKey: "partition-1",
+                streamName: Self.streamName
+            )
+
+            // This should exceed the 100-byte limit
+            try await smallKinesis.record(
+                data: bigData,
+                partitionKey: "partition-1",
                 streamName: Self.streamName
             )
             XCTFail("Expected cache limit error")
@@ -240,6 +248,57 @@ class AmplifyKinesisClientIntegrationTests: XCTestCase {
         try await badKinesis.clearCache()
     }
 
+    // MARK: - Retry exhaustion
+
+    /// Records to both a nonexistent stream and a valid stream with maxRetries = 5.
+    /// On the first flush the valid record is sent and the invalid-stream record
+    /// stays in the cache (retry count incremented). After 6 total flushes the
+    /// invalid-stream record should be evicted (retryCount >= maxRetries) and a
+    /// final flush returns 0.
+    func testInvalidStreamRecordIsDroppedAfterMaxRetries() async throws {
+        let maxRetries = 5
+        let retryKinesis = try AmplifyKinesisClient(
+            region: Self.region,
+            credentialsProvider: SDKToFoundationCredentialsAdapter(
+                resolver: AWSAuthService().getCredentialIdentityResolver()
+            ),
+            options: .init(maxRetries: maxRetries, flushStrategy: .none)
+        )
+        try await retryKinesis.clearCache()
+
+        // Record to a nonexistent stream and a valid stream
+        try await retryKinesis.record(
+            data: XCTUnwrap("invalid-stream-record".data(using: .utf8)),
+            partitionKey: "partition-1",
+            streamName: "nonexistent-stream-name"
+        )
+        try await retryKinesis.record(
+            data: XCTUnwrap("valid-stream-record".data(using: .utf8)),
+            partitionKey: "partition-1",
+            streamName: Self.streamName
+        )
+
+        // First flush: valid record should be flushed, invalid stays
+        let firstFlush = try await retryKinesis.flush()
+        XCTAssertEqual(firstFlush.recordsFlushed, 1)
+
+        // Flush maxRetries more times (flushes 2–6) to exhaust retries on the invalid record
+        for _ in 0 ..< maxRetries {
+            let result = try await retryKinesis.flush()
+            XCTAssertEqual(result.recordsFlushed, 0)
+        }
+
+        // Final flush: invalid record should have been evicted, nothing left
+        let finalFlush = try await retryKinesis.flush()
+        XCTAssertEqual(finalFlush.recordsFlushed, 0)
+
+        // Confirm cache is truly empty
+        let clearResult = try await retryKinesis.clearCache()
+        XCTAssertEqual(clearResult.recordsCleared, 0)
+
+        await retryKinesis.disable()
+    }
+
     // MARK: - Stress tests
 
     func testHighVolumeRecordAndFlush() async throws {
@@ -273,26 +332,92 @@ class AmplifyKinesisClientIntegrationTests: XCTestCase {
         XCTAssertEqual(total, cycles * perCycle)
     }
 
+    /// Stress test: N producer tasks record concurrently while a flusher calls
+    /// flush() every 500ms. Simulates real-world usage where the app records
+    /// analytics events while the auto-flush timer fires.
+    ///
+    /// Asserts that every recorded event is eventually flushed — no records lost
+    /// under concurrent read/write pressure on the cache.
+    func testConcurrentRecordAndFlushStress() async throws {
+        let producers = 5
+        let recordsPerProducer = 20
+        let totalExpected = producers * recordsPerProducer
+
+        // Shared mutable state protected by an actor
+        let counter = FlushCounter()
+
+        // Flusher: calls flush() every 500ms until signalled to stop
+        let flusherTask = Task {
+            while !Task.isCancelled {
+                let result = try await kinesis.flush()
+                await counter.add(result.recordsFlushed)
+                try await Task.sleep(for: .milliseconds(500))
+            }
+        }
+
+        // Producers: each records M events concurrently
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for p in 0 ..< producers {
+                group.addTask {
+                    for i in 0 ..< recordsPerProducer {
+                        try await self.kinesis.record(
+                            data: XCTUnwrap("stress-p\(p)-r\(i)".data(using: .utf8)),
+                            partitionKey: "partition-\(p % 3)",
+                            streamName: Self.streamName
+                        )
+                    }
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        // Stop the periodic flusher
+        flusherTask.cancel()
+        _ = try? await flusherTask.value
+
+        // Final drain flush to pick up anything the periodic flusher missed
+        let drainResult = try await kinesis.flush()
+        await counter.add(drainResult.recordsFlushed)
+
+        // Second drain to confirm nothing is left
+        let finalResult = try await kinesis.flush()
+        XCTAssertEqual(finalResult.recordsFlushed, 0)
+
+        let totalFlushed = await counter.value
+        XCTAssertEqual(totalFlushed, totalExpected)
+    }
+
     // MARK: - Auto-flush
 
-    func testAutoFlush() async throws {
-        let autoKinesis = try AmplifyKinesisClient(
+    /// Verify that creating a client with default options (no explicit flushStrategy)
+    /// auto-starts the scheduler. Default is `.interval(30)`, so we override
+    /// to a short interval to keep the test fast.
+    func testDefaultConfigAutoStartsScheduler() async throws {
+        // Default options use .interval(30). We use a short interval
+        // to verify the scheduler is auto-started without waiting 30 seconds.
+        let defaultKinesis = try AmplifyKinesisClient(
             region: Self.region,
             credentialsProvider: SDKToFoundationCredentialsAdapter(
                 resolver: AWSAuthService().getCredentialIdentityResolver()
             ),
             options: .init(flushStrategy: .interval(.seconds(3)))
         )
-        try await autoKinesis.record(
-            data: XCTUnwrap("auto-flush".data(using: .utf8)),
+        // Note: no explicit enable() call — scheduler should auto-start from init
+
+        try await defaultKinesis.record(
+            data: XCTUnwrap("auto-start-record".data(using: .utf8)),
             partitionKey: "partition-1",
             streamName: Self.streamName
         )
+
+        // Wait for auto-flush to trigger (3s interval + buffer)
         try await Task.sleep(for: .seconds(6))
-        let flushResult = try await autoKinesis.flush()
+
+        // After auto-flush, a manual flush should find nothing left
+        let flushResult = try await defaultKinesis.flush()
         XCTAssertEqual(flushResult.recordsFlushed, 0)
-        await autoKinesis.disable()
-        try await autoKinesis.clearCache()
+        await defaultKinesis.disable()
+        try await defaultKinesis.clearCache()
     }
 
     // MARK: - Partition key validation
@@ -388,7 +513,7 @@ class AmplifyKinesisClientIntegrationTests: XCTestCase {
         // 10 MiB = 10_485_760 bytes. Use a 256-char partition key (~256 bytes UTF-8)
         // plus a data blob that pushes the total over 10 MiB.
         let largePartitionKey = String(repeating: "k", count: 256)
-        let oversizedData = Data(repeating: 0x42, count: 10 * 1024 * 1024) // 10 MiB data + 256 bytes key > 10 MiB
+        let oversizedData = Data(repeating: 0x42, count: 10 * 1_024 * 1_024) // 10 MiB data + 256 bytes key > 10 MiB
 
         do {
             try await kinesis.record(
@@ -427,6 +552,15 @@ class AmplifyKinesisClientIntegrationTests: XCTestCase {
 }
 
 // MARK: - Helpers
+
+/// Thread-safe counter for accumulating flushed record counts across tasks.
+@available(iOS 16.0, macOS 13.0, *)
+private actor FlushCounter {
+    private(set) var value = 0
+    func add(_ count: Int) {
+        value += count
+    }
+}
 
 @available(iOS 16.0, macOS 13.0, *)
 private struct InvalidCredentials: AmplifyFoundation.AWSCredentials {

--- a/AmplifyClients/AmplifyKinesisClient/Tests/IntegrationTests/KinesisHostApp/KinesisHostAppTests/KinesisHostAppTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/IntegrationTests/KinesisHostApp/KinesisHostAppTests/KinesisHostAppTests.swift
@@ -10,7 +10,7 @@ import Testing
 
 struct KinesisHostAppTests {
 
-    @Test func example() async throws {
+    @Test func example() {
         // Write your test here and use APIs like `#expect(...)` to check expected conditions.
     }
 

--- a/AmplifyClients/AmplifyKinesisClient/Tests/IntegrationTests/KinesisHostApp/KinesisHostAppUITests/KinesisHostAppUITests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/IntegrationTests/KinesisHostApp/KinesisHostAppUITests/KinesisHostAppUITests.swift
@@ -23,7 +23,7 @@ final class KinesisHostAppUITests: XCTestCase {
     }
 
     @MainActor
-    func testExample() throws {
+    func testExample() {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
         app.launch()
@@ -32,7 +32,7 @@ final class KinesisHostAppUITests: XCTestCase {
     }
 
     @MainActor
-    func testLaunchPerformance() throws {
+    func testLaunchPerformance() {
         // This measures how long it takes to launch your application.
         measure(metrics: [XCTApplicationLaunchMetric()]) {
             XCUIApplication().launch()

--- a/AmplifyClients/AmplifyKinesisClient/Tests/IntegrationTests/KinesisHostApp/KinesisHostAppUITests/KinesisHostAppUITestsLaunchTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/IntegrationTests/KinesisHostApp/KinesisHostAppUITests/KinesisHostAppUITestsLaunchTests.swift
@@ -18,7 +18,7 @@ final class KinesisHostAppUITestsLaunchTests: XCTestCase {
     }
 
     @MainActor
-    func testLaunch() throws {
+    func testLaunch() {
         let app = XCUIApplication()
         app.launch()
 

--- a/AmplifyClients/AmplifyKinesisClient/Tests/RecordValidationTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/RecordValidationTests.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import XCTest
 import SQLite
+import XCTest
 @testable import AmplifyKinesisClient
 
 /// Unit tests for PutRecords record-level validation.
@@ -22,7 +22,7 @@ import SQLite
 /// See: https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecordsRequestEntry.html
 class RecordValidationTests: XCTestCase {
 
-    private let maxRecordSize: Int64 = 1000
+    private let maxRecordSize: Int64 = 1_000
 
     private var storage: SQLiteRecordStorage!
 
@@ -58,7 +58,7 @@ class RecordValidationTests: XCTestCase {
         // "k" = 1 byte, data = 1000 bytes → total 1001 > maxRecordSize
         do {
             try await storage.addRecord(
-                RecordInput(streamName: "stream", partitionKey: "k", data: Data(repeating: 0x41, count: 1000))
+                RecordInput(streamName: "stream", partitionKey: "k", data: Data(repeating: 0x41, count: 1_000))
             )
             XCTFail("Expected validation error")
         } catch let error as RecordCacheError {
@@ -170,23 +170,6 @@ class RecordValidationTests: XCTestCase {
         try await storage.addRecord(
             RecordInput(streamName: "stream", partitionKey: partitionKey, data: Data([1]))
         )
-    }
-
-    func testPartitionKeyExceeding256ScalarsWithEmojiIsRejected() async throws {
-        // Each emoji (😀) is 1 Unicode scalar
-        // 257 emoji = 257 scalars > 256 limit
-        let partitionKey = String(repeating: "😀", count: 257)
-        do {
-            try await storage.addRecord(
-                RecordInput(streamName: "stream", partitionKey: partitionKey, data: Data([1]))
-            )
-            XCTFail("Expected validation error")
-        } catch let error as RecordCacheError {
-            guard case .validation = error else {
-                XCTFail("Expected RecordCacheError.validation, got \(error)")
-                return
-            }
-        }
     }
 
     // MARK: - Recovery after rejection

--- a/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/AmplifyKinesisClientConfigureClientTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/AmplifyKinesisClientConfigureClientTests.swift
@@ -1,0 +1,43 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import AmplifyFoundation
+import SmithyRetries
+import SmithyRetriesAPI
+import XCTest
+@testable import AWSKinesis
+@testable import AmplifyKinesisClient
+
+class AmplifyKinesisClientConfigureClientTests: XCTestCase {
+
+    /// Verifies that the `configureClient` closure is applied to the underlying
+    /// SDK client configuration. 
+    func testConfigureClientAppliesConfiguration() throws {
+        let client = try AmplifyKinesisClient(
+            region: "us-east-1",
+            credentialsProvider: MockCredentialsProvider(),
+            options: AmplifyKinesisClient.Options(
+                maxRetries: 3,
+                flushStrategy: .none,
+                configureClient: { config in
+                    config.retryStrategyOptions = RetryStrategyOptions(
+                        backoffStrategy: ExponentialBackoffStrategy(),
+                        maxRetriesBase: 10
+                    )
+                }
+            )
+        )
+
+        XCTAssertNotNil(client.getKinesisClient())
+        let sdkConfig = client.getKinesisClient().config
+        XCTAssertEqual(
+            sdkConfig.retryStrategyOptions.maxRetriesBase,
+            10,
+            "retryStrategyOptions.maxRetriesBase should reflect the value set in configureClient"
+        )
+    }
+}

--- a/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/AmplifyKinesisClientResourceCleanupTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/AmplifyKinesisClientResourceCleanupTests.swift
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AmplifyFoundation
 import XCTest
 @testable import AmplifyKinesisClient
-import AmplifyFoundation
 
-// Mock credentials provider for testing
+/// Mock credentials provider for testing
 struct MockCredentialsProvider: AmplifyFoundation.AWSCredentialsProvider {
     func resolve() async throws -> AmplifyFoundation.AWSCredentials {
         return MockCredentials()
@@ -17,16 +17,20 @@ struct MockCredentialsProvider: AmplifyFoundation.AWSCredentialsProvider {
 }
 
 struct MockCredentials: AmplifyFoundation.AWSCredentials {
-    var accessKeyId: String { "mock-access-key" }
-    var secretAccessKey: String { "mock-secret-key" }
+    var accessKeyId: String {
+        "mock-access-key"
+    }
+    var secretAccessKey: String {
+        "mock-secret-key"
+    }
 }
 
 class AmplifyKinesisClientResourceCleanupTests: XCTestCase {
-    
+
     func testDeinitStopsScheduler() async throws {
         // Create a weak reference to track deallocation
         weak var weakKinesis: AmplifyKinesisClient?
-        
+
         // Create AmplifyKinesisClient in a scope that will end
         do {
             let kinesis = try AmplifyKinesisClient(
@@ -36,23 +40,23 @@ class AmplifyKinesisClientResourceCleanupTests: XCTestCase {
                     flushStrategy: .interval(1) // Short interval for testing
                 )
             )
-            
+
             weakKinesis = kinesis
-            
+
             // Enable the scheduler
             await kinesis.enable()
-            
+
             // Verify it's alive
             XCTAssertNotNil(weakKinesis)
-            
+
             // Let it run briefly
             try await Task.sleep(nanoseconds: 100_000_000) // 100ms
         }
-        
+
         // After scope ends, kinesis should be deallocated
         // Give it a moment for deallocation to complete
         try await Task.sleep(nanoseconds: 100_000_000) // 100ms
-        
+
         // Verify the object was deallocated (deinit was called)
         XCTAssertNil(weakKinesis, "AmplifyKinesisClient should be deallocated")
     }

--- a/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/AmplifyKinesisClientUserAgentTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/AmplifyKinesisClientUserAgentTests.swift
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import XCTest
-@testable import AmplifyKinesisClient
 import AmplifyFoundation
 import AmplifyFoundationBridge
 import AWSKinesis
 import SmithyHTTPAPI
+import XCTest
+@testable import AmplifyKinesisClient
 
 /// Mock HTTP client engine that captures the User-Agent header from outgoing requests.
 private class UserAgentCapturingEngine: HTTPClient {

--- a/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/AutoFlushSchedulerTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/AutoFlushSchedulerTests.swift
@@ -9,12 +9,12 @@ import XCTest
 @testable import AmplifyKinesisClient
 
 class AutoFlushSchedulerTests: XCTestCase {
-    
+
     var mockStorage: MockRecordStorage!
     var mockSender: MockRecordSender!
     var recordClient: RecordClient!
     var scheduler: AutoFlushScheduler!
-    
+
     override func setUp() async throws {
         try await super.setUp()
         mockStorage = MockRecordStorage()
@@ -24,7 +24,7 @@ class AutoFlushSchedulerTests: XCTestCase {
             storage: mockStorage
         )
     }
-    
+
     override func tearDown() async throws {
         await scheduler?.disable()
         scheduler = nil
@@ -33,60 +33,72 @@ class AutoFlushSchedulerTests: XCTestCase {
         mockStorage = nil
         try await super.tearDown()
     }
-    
+
     func testStartShouldBeginPeriodicFlushing() async throws {
         // Given
         let interval: TimeInterval = 1
         scheduler = AutoFlushScheduler(interval: interval, recordClient: recordClient)
-        
+
         // When
         await scheduler.start()
         try await Task.sleep(nanoseconds: 2_500_000_000) // 2.5s
         await scheduler.disable()
-        
+
         // Then - should have called getRecordsByStream at least 2 times (flush calls it)
         let callCount = await mockStorage.getRecordsByStreamCallCount
-        XCTAssertEqual(callCount, 2,
-                      "Should flush exactly 2 times in 2.5 seconds with 1 second interval")
+        XCTAssertEqual(
+            callCount,
+            2,
+            "Should flush exactly 2 times in 2.5 seconds with 1 second interval"
+        )
     }
-    
+
     func testDisableShouldStopPeriodicFlushing() async throws {
         // Given
         let interval: TimeInterval = 1
         scheduler = AutoFlushScheduler(interval: interval, recordClient: recordClient)
-        
+
         // When
         await scheduler.start()
         try await Task.sleep(nanoseconds: 1_500_000_000) // 1.5s
         await scheduler.disable()
-        
+
         let countAfterDisable = await mockStorage.getRecordsByStreamCallCount
         try await Task.sleep(nanoseconds: 2_000_000_000) // 2s
-        
+
         // Then - should have flushed exactly 1 time, no more after disable
-        XCTAssertEqual(countAfterDisable, 1,
-                      "Should flush exactly 1 time in 1.5 seconds")
+        XCTAssertEqual(
+            countAfterDisable,
+            1,
+            "Should flush exactly 1 time in 1.5 seconds"
+        )
         let finalCount = await mockStorage.getRecordsByStreamCallCount
-        XCTAssertEqual(finalCount, 1,
-                      "Should not flush after disable")
+        XCTAssertEqual(
+            finalCount,
+            1,
+            "Should not flush after disable"
+        )
     }
-    
+
     func testStartShouldCancelPreviousJobAndRestart() async throws {
         // Given
         let interval: TimeInterval = 1
         scheduler = AutoFlushScheduler(interval: interval, recordClient: recordClient)
-        
+
         // When
         await scheduler.start()
         try await Task.sleep(nanoseconds: 500_000_000) // 0.5s
         await scheduler.start() // Restart - should cancel previous job
         try await Task.sleep(nanoseconds: 1_500_000_000) // 1.5s
         await scheduler.disable()
-        
+
         // Then - should flush exactly 1 time (from the restarted scheduler)
         let callCount = await mockStorage.getRecordsByStreamCallCount
-        XCTAssertEqual(callCount, 1,
-                      "Should flush exactly 1 time after restart")
+        XCTAssertEqual(
+            callCount,
+            1,
+            "Should flush exactly 1 time after restart"
+        )
     }
 }
 
@@ -98,28 +110,28 @@ actor MockRecordStorage: RecordStorage {
     var getRecordsByStreamCallCount = 0
     var deleteRecordsCallCount = 0
     var clearRecordsCallCount = 0
-    
+
     func addRecord(_ input: RecordInput) throws {
         addRecordCallCount += 1
     }
-    
+
     func getRecordsByStream() throws -> [[Record]] {
         getRecordsByStreamCallCount += 1
         return []
     }
-    
+
     func deleteRecords(ids: [Int64]) throws {
         deleteRecordsCallCount += 1
     }
-    
+
     func incrementRetryCount(ids: [Int64]) throws {
     }
-    
+
     func clearRecords() throws -> Int {
         clearRecordsCallCount += 1
         return 0
     }
-    
+
     func getCurrentCacheSize() throws -> Int64 {
         return 0
     }

--- a/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/KinesisErrorConversionTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/KinesisErrorConversionTests.swift
@@ -1,0 +1,72 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import AmplifyKinesisClient
+
+class KinesisErrorConversionTests: XCTestCase {
+
+    func testFromShouldPassThroughKinesisErrorUnchanged() {
+        let original = KinesisError.cache("msg", "suggestion")
+        let result = KinesisError.from(original)
+
+        guard case .cache(let desc, let suggestion, _) = result else {
+            XCTFail("Expected .cache, got \(result)")
+            return
+        }
+        XCTAssertEqual(desc, "msg")
+        XCTAssertEqual(suggestion, "suggestion")
+    }
+
+    func testFromShouldConvertRecordCacheValidationErrorToValidation() {
+        let cause = RecordCacheError.validation("bad input", "fix it")
+        let result = KinesisError.from(cause)
+
+        guard case .validation(let desc, let suggestion, _) = result else {
+            XCTFail("Expected .validation, got \(result)")
+            return
+        }
+        XCTAssertEqual(desc, "bad input")
+        XCTAssertEqual(suggestion, "fix it")
+    }
+
+    func testFromShouldConvertRecordCacheDatabaseErrorToCache() {
+        let cause = RecordCacheError.database("db error", "retry")
+        let result = KinesisError.from(cause)
+
+        guard case .cache(let desc, let suggestion, _) = result else {
+            XCTFail("Expected .cache, got \(result)")
+            return
+        }
+        XCTAssertEqual(desc, "db error")
+        XCTAssertEqual(suggestion, "retry")
+    }
+
+    func testFromShouldConvertRecordCacheLimitExceededErrorToCacheLimitExceeded() {
+        let cause = RecordCacheError.limitExceeded("cache full", "flush first")
+        let result = KinesisError.from(cause)
+
+        guard case .cacheLimitExceeded(let desc, let suggestion, _) = result else {
+            XCTFail("Expected .cacheLimitExceeded, got \(result)")
+            return
+        }
+        XCTAssertEqual(desc, "cache full")
+        XCTAssertEqual(suggestion, "flush first")
+    }
+
+    func testFromShouldConvertUnknownErrorToUnknown() {
+        let cause = NSError(domain: "test", code: -1, userInfo: [NSLocalizedDescriptionKey: "something unexpected"])
+        let result = KinesisError.from(cause)
+
+        guard case .unknown(let desc, _, let underlyingError) = result else {
+            XCTFail("Expected .unknown, got \(result)")
+            return
+        }
+        XCTAssertEqual(desc, "An unknown error occurred")
+        XCTAssertNotNil(underlyingError)
+    }
+}

--- a/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/KinesisRecordSenderTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/KinesisRecordSenderTests.swift
@@ -5,26 +5,57 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AWSKinesis
 import XCTest
 @testable import AmplifyKinesisClient
-import AWSKinesis
 
 class KinesisRecordSenderTests: XCTestCase {
-    
+
     private let testStreamName = "test-stream"
     private let maxRetries = 3
-    
+
+    func testCreateRequestShouldConstructCorrectPutRecordsInput() async throws {
+        // Given
+        let mockClient = MockKinesisClient()
+        let recordSender = KinesisRecordSender(kinesisClient: mockClient, maxRetries: maxRetries)
+
+        let records = [
+            createTestRecord(id: 1, partitionKey: "key1", data: Data([1, 2, 3])),
+            createTestRecord(id: 2, partitionKey: "key2", data: Data([4, 5, 6]))
+        ]
+
+        // Configure a dummy response so putRecords doesn't throw
+        mockClient.mockResponse = PutRecordsOutput(
+            records: [
+                KinesisClientTypes.PutRecordsResultEntry(errorCode: nil, sequenceNumber: "seq1", shardId: "shard1"),
+                KinesisClientTypes.PutRecordsResultEntry(errorCode: nil, sequenceNumber: "seq2", shardId: "shard2")
+            ]
+        )
+
+        // When
+        _ = try await recordSender.putRecords(streamName: testStreamName, records: records)
+
+        // Then
+        let captured = try XCTUnwrap(mockClient.capturedInput)
+        XCTAssertEqual(captured.streamName, testStreamName)
+        XCTAssertEqual(captured.records?.count, 2)
+        XCTAssertEqual(captured.records?[0].partitionKey, "key1")
+        XCTAssertEqual(captured.records?[0].data, Data([1, 2, 3]))
+        XCTAssertEqual(captured.records?[1].partitionKey, "key2")
+        XCTAssertEqual(captured.records?[1].data, Data([4, 5, 6]))
+    }
+
     func testSplitResponseShouldCorrectlyCategorizeRecords() async throws {
         // Given
         let mockClient = MockKinesisClient()
         let recordSender = KinesisRecordSender(kinesisClient: mockClient, maxRetries: maxRetries)
-        
+
         let records = [
             createTestRecord(id: 1, partitionKey: "key1", data: Data([1]), retryCount: 0), // Success
             createTestRecord(id: 2, partitionKey: "key2", data: Data([2]), retryCount: 1), // Retryable
             createTestRecord(id: 3, partitionKey: "key3", data: Data([3]), retryCount: maxRetries) // Failed
         ]
-        
+
         // Configure mock response
         mockClient.mockResponse = PutRecordsOutput(
             records: [
@@ -45,16 +76,16 @@ class KinesisRecordSenderTests: XCTestCase {
                 )
             ]
         )
-        
+
         // When
         let response = try await recordSender.putRecords(streamName: testStreamName, records: records)
-        
+
         // Then
         XCTAssertEqual(response.successfulIds, [1])
         XCTAssertEqual(response.retryableIds, [2])
         XCTAssertEqual(response.failedIds, [3])
     }
-    
+
     private func createTestRecord(
         id: Int64,
         partitionKey: String,
@@ -76,8 +107,10 @@ class KinesisRecordSenderTests: XCTestCase {
 
 class MockKinesisClient: KinesisClientProtocol {
     var mockResponse: PutRecordsOutput?
-    
+    var capturedInput: PutRecordsInput?
+
     func putRecords(input: PutRecordsInput) async throws -> PutRecordsOutput {
+        capturedInput = input
         guard let response = mockResponse else {
             throw TestError.noMockResponse
         }

--- a/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/RecordClientConcurrentFlushTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/RecordClientConcurrentFlushTests.swift
@@ -1,0 +1,100 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import SQLite
+import XCTest
+@testable import AmplifyKinesisClient
+
+class RecordClientConcurrentFlushTests: XCTestCase {
+
+    private var storage: SQLiteRecordStorage!
+    private var sender: SlowMockSender!
+    private var recordClient: RecordClient!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        storage = try SQLiteRecordStorage(
+            identifier: "test_concurrent",
+            maxRecords: 1_000,
+            cacheMaxBytes: 1_024 * 1_024,
+            maxRecordSizeBytes: 10 * 1_024 * 1_024,
+            maxBytesPerStream: 10 * 1_024 * 1_024,
+            maxPartitionKeyLength: 256,
+            connection: Connection(.inMemory)
+        )
+        sender = SlowMockSender()
+        recordClient = RecordClient(sender: sender, storage: storage, maxRetries: 3)
+    }
+
+    override func tearDown() async throws {
+        recordClient = nil
+        sender = nil
+        storage = nil
+        try await super.tearDown()
+    }
+
+    func testConcurrentFlushShouldReturnFlushInProgressForSecondCaller() async throws {
+        // Given: Records in storage
+        for i in 0 ..< 5 {
+            try await storage.addRecord(
+                RecordInput(streamName: "test-stream", partitionKey: "key\(i)", data: Data([UInt8(i)]))
+            )
+        }
+
+        let allRecords = try await storage.getRecordsByStream().flatMap { $0 }
+
+        // Make the sender slow so the first flush holds the lock
+        await sender.setDelay(nanoseconds: 500_000_000) // 500ms
+        await sender.setResponse(
+            PutRecordsResponse(
+                successfulIds: allRecords.map(\.id),
+                retryableIds: [],
+                failedIds: []
+            )
+        )
+
+        // When: Two concurrent flushes
+        async let flush1 = recordClient.flush()
+        // Small delay to ensure flush1 acquires the lock first
+        try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+        async let flush2 = recordClient.flush()
+
+        let result1 = try await flush1
+        let result2 = try await flush2
+
+        // Then: One should have done work, the other should report flushInProgress
+        let results = [result1, result2]
+        let anyFlushed = results.contains { $0.recordsFlushed > 0 }
+        let anyInProgress = results.contains { $0.flushInProgress }
+
+        XCTAssertTrue(anyFlushed, "At least one flush should have done work")
+        XCTAssertTrue(anyInProgress, "Second flush should report flushInProgress")
+    }
+}
+
+// MARK: - Slow Mock Sender
+
+/// A mock sender that introduces a configurable delay to simulate slow network calls.
+private actor SlowMockSender: RecordSender {
+    private var delayNanoseconds: UInt64 = 0
+    private var response = PutRecordsResponse(successfulIds: [], retryableIds: [], failedIds: [])
+
+    func setDelay(nanoseconds: UInt64) {
+        delayNanoseconds = nanoseconds
+    }
+
+    func setResponse(_ response: PutRecordsResponse) {
+        self.response = response
+    }
+
+    func putRecords(streamName: String, records: [Record]) async throws -> PutRecordsResponse {
+        if delayNanoseconds > 0 {
+            try await Task.sleep(nanoseconds: delayNanoseconds)
+        }
+        return response
+    }
+}

--- a/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/SQLiteRecordStorageCacheAccuracyTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/SQLiteRecordStorageCacheAccuracyTests.swift
@@ -5,107 +5,107 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import XCTest
 import SQLite
+import XCTest
 @testable import AmplifyKinesisClient
 
 class SQLiteRecordStorageCacheAccuracyTests: XCTestCase {
-    
+
     var storage: SQLiteRecordStorage!
-    
+
     override func setUp() async throws {
         try await super.setUp()
         storage = try SQLiteRecordStorage(
             identifier: "test",
-            maxRecords: 1000,
-            cacheMaxBytes: 1024 * 1024,
-            maxRecordSizeBytes: 10 * 1024 * 1024,
-            maxBytesPerStream: 10 * 1024 * 1024,
+            maxRecords: 1_000,
+            cacheMaxBytes: 1_024 * 1_024,
+            maxRecordSizeBytes: 10 * 1_024 * 1_024,
+            maxBytesPerStream: 10 * 1_024 * 1_024,
             maxPartitionKeyLength: 256
         )
     }
-    
+
     override func tearDown() async throws {
         _ = try? await storage.clearRecords()
         storage = nil
         try await super.tearDown()
     }
-    
+
     func testCachedSizeMatchesDatabaseAfterAddOperations() async throws {
         // Given
         let record1 = RecordInput(streamName: "stream1", partitionKey: "a", data: Data([1, 2, 3]))
         let record2 = RecordInput(streamName: "stream1", partitionKey: "b", data: Data([4, 5, 6, 7]))
-        
+
         // When
         try await storage.addRecord(record1)
         try await storage.addRecord(record2)
-        
+
         // Then — "a"(1) + data(3) + "b"(1) + data(4) = 9
         let cachedSize = try await storage.getCurrentCacheSize()
         XCTAssertEqual(cachedSize, 9)
     }
-    
+
     func testCachedSizeMatchesDatabaseAfterDeleteOperations() async throws {
         // Given: Add records
         let record1 = RecordInput(streamName: "stream1", partitionKey: "a", data: Data([1, 2, 3]))
         let record2 = RecordInput(streamName: "stream1", partitionKey: "b", data: Data([4, 5, 6, 7]))
         let record3 = RecordInput(streamName: "stream2", partitionKey: "c", data: Data([8, 9]))
-        
+
         try await storage.addRecord(record1)
         try await storage.addRecord(record2)
         try await storage.addRecord(record3)
-        
+
         // Get record IDs for deletion - delete first two by creation order
         let recordsByStreamList = try await storage.getRecordsByStream()
         let allRecords = recordsByStreamList.flatMap { $0 }.sorted { $0.createdAt < $1.createdAt }
         let idsToDelete = Array(allRecords.prefix(2)).map { $0.id }
-        
+
         // When
         try await storage.deleteRecords(ids: idsToDelete)
-        
+
         // Then — remaining: "c"(1) + data(2) = 3
         let cachedSize = try await storage.getCurrentCacheSize()
         XCTAssertEqual(cachedSize, 3)
     }
-    
+
     func testCachedSizeMatchesDatabaseAfterClearOperations() async throws {
         // Given: Add records
         try await storage.addRecord(RecordInput(streamName: "stream1", partitionKey: "a", data: Data([1, 2, 3])))
         try await storage.addRecord(RecordInput(streamName: "stream2", partitionKey: "b", data: Data([4, 5])))
-        
+
         // When
         _ = try await storage.clearRecords()
-        
+
         // Then
         let cachedSize = try await storage.getCurrentCacheSize()
         XCTAssertEqual(cachedSize, 0)
     }
-    
+
     func testCachedSizeRemainsAccurateThroughMixedOperations() async throws {
         // "a"(1) + data(5) = 6
         try await storage.addRecord(RecordInput(streamName: "stream1", partitionKey: "a", data: Data([1, 2, 3, 4, 5])))
         // "b"(1) + data(3) = 4
         try await storage.addRecord(RecordInput(streamName: "stream2", partitionKey: "b", data: Data([6, 7, 8])))
-        
+
         var cachedSize = try await storage.getCurrentCacheSize()
         XCTAssertEqual(cachedSize, 10) // 6 + 4
-        
+
         // Delete the first record (6 bytes from stream1)
         let recordsList = try await storage.getRecordsByStream()
         let records = recordsList.flatMap { $0 }
-        let firstRecord = records.first { $0.streamName == "stream1" }!
+        let firstRecord = try XCTUnwrap(records.first { $0.streamName == "stream1" })
         try await storage.deleteRecords(ids: [firstRecord.id])
-        
+
         cachedSize = try await storage.getCurrentCacheSize()
         XCTAssertEqual(cachedSize, 4)
-        
+
         // Add another record: "c"(1) + data(2) = 3
         try await storage.addRecord(RecordInput(streamName: "stream3", partitionKey: "c", data: Data([9, 10])))
-        
+
         cachedSize = try await storage.getCurrentCacheSize()
         XCTAssertEqual(cachedSize, 7) // 4 + 3
     }
-    
+
     func testConcurrentProducerConsumerOperationsAreThreadSafe() async throws {
         // Given
         let recordSize = 10
@@ -113,78 +113,78 @@ class SQLiteRecordStorageCacheAccuracyTests: XCTestCase {
         let recordsPerProducer = 400
         let consumerCount = 2
         let deletionsPerConsumer = 100
-        
+
         // Use actor for thread-safe tracking of test data
         // The actual thread-safety test is on the storage actor itself
         actor TestTracker {
             var createdRecords: [String: Set<String>] = [:]
             var deletedRecords: Set<String> = []
-            
+
             func recordCreated(producer: String, records: Set<String>) {
                 createdRecords[producer] = records
             }
-            
+
             func recordDeleted(keys: [String]) {
                 deletedRecords.formUnion(keys)
             }
-            
+
             func getCounts() -> (created: Int, deleted: Int) {
                 let created = createdRecords.values.reduce(0) { $0 + $1.count }
                 let deleted = deletedRecords.count
                 return (created, deleted)
             }
-            
+
             func getTrackingData() -> ([String: Set<String>], Set<String>) {
                 return (createdRecords, deletedRecords)
             }
         }
-        
+
         let tracker = TestTracker()
-        
+
         // Create producers - these will hammer the storage concurrently
-        let producers = (0..<producerCount).map { producerIndex in
+        let producers = (0 ..< producerCount).map { producerIndex in
             Task {
                 var threadRecords: Set<String> = []
-                
-                for recordCounter in 0..<recordsPerProducer {
+
+                for recordCounter in 0 ..< recordsPerProducer {
                     let recordKey = "producer\(producerIndex)_record\(recordCounter)"
                     let record = RecordInput(
                         streamName: "stream\(producerIndex)",
                         partitionKey: recordKey,
                         data: Data(repeating: UInt8(producerIndex), count: recordSize)
                     )
-                    
+
                     try? await storage.addRecord(record)
                     threadRecords.insert(recordKey)
-                    
+
                     try? await Task.sleep(nanoseconds: 1_000_000) // 1ms
                 }
-                
+
                 await tracker.recordCreated(producer: "producer\(producerIndex)", records: threadRecords)
             }
         }
-        
+
         // Create consumers - these will delete concurrently with producers
-        let consumers = (0..<consumerCount).map { consumerIndex in
+        let consumers = (0 ..< consumerCount).map { consumerIndex in
             Task {
-                for _ in 0..<deletionsPerConsumer {
+                for _ in 0 ..< deletionsPerConsumer {
                     try? await Task.sleep(nanoseconds: 1_000_000) // 1ms
-                    
+
                     if let recordsList = try? await storage.getRecordsByStream(),
                        let records = recordsList.first,
                        !records.isEmpty {
                         let recordsToDelete = Array(records.prefix(1))
                         let idsToDelete = recordsToDelete.map { $0.id }
                         let keysToDelete = recordsToDelete.map { $0.partitionKey }
-                        
+
                         try? await storage.deleteRecords(ids: idsToDelete)
-                        
+
                         await tracker.recordDeleted(keys: keysToDelete)
                     }
                 }
             }
         }
-        
+
         // Wait for all tasks to complete
         for producer in producers {
             _ = await producer.result
@@ -192,38 +192,38 @@ class SQLiteRecordStorageCacheAccuracyTests: XCTestCase {
         for consumer in consumers {
             _ = await consumer.result
         }
-        
+
         // Verify data integrity
         let (totalCreated, totalDeleted) = await tracker.getCounts()
-        
+
         let finalRecords = try await storage.getRecordsByStream().flatMap { $0 }
         print("Created \(totalCreated) records, deleted \(totalDeleted) records, found in DB \(finalRecords.count)")
-        
+
         let finalCacheSize = try await storage.getCurrentCacheSize()
         let expectedCacheSize = finalRecords.reduce(0) { $0 + $1.dataSize }
-        
+
         XCTAssertEqual(finalCacheSize, Int64(expectedCacheSize))
 
         // Get tracking data from actor
         let (createdRecords, deletedRecords) = await tracker.getTrackingData()
-        
+
         let remainingKeys = Set(finalRecords.map { $0.partitionKey })
         let allCreatedKeys = Set(createdRecords.values.flatMap { $0 })
-        
+
         // Verify each created key is either in DB or was deleted
         for createdKey in allCreatedKeys {
             let isInDb = remainingKeys.contains(createdKey)
             let wasDeleted = deletedRecords.contains(createdKey)
-            
+
             XCTAssertTrue(isInDb || wasDeleted, "Key \(createdKey) should be in DB or deleted")
             XCTAssertFalse(isInDb && wasDeleted, "Key \(createdKey) cannot be both in DB and deleted")
         }
-        
+
         // Verify all remaining keys were created
         for remainingKey in remainingKeys {
             XCTAssertTrue(allCreatedKeys.contains(remainingKey), "Remaining key \(remainingKey) should have been created")
         }
-        
+
         XCTAssertFalse(allCreatedKeys.isEmpty)
         XCTAssertFalse(deletedRecords.isEmpty)
         XCTAssertFalse(remainingKeys.isEmpty)
@@ -235,7 +235,7 @@ class SQLiteRecordStorageCacheAccuracyTests: XCTestCase {
             identifier: "test_per_stream",
             maxRecords: 100,
             cacheMaxBytes: 10_000,
-            maxRecordSizeBytes: 1024,
+            maxRecordSizeBytes: 1_024,
             maxBytesPerStream: 200,
             maxPartitionKeyLength: 256,
             connection: Connection(.inMemory)
@@ -243,12 +243,12 @@ class SQLiteRecordStorageCacheAccuracyTests: XCTestCase {
 
         // Each record: "a" (1 byte key) + 50 bytes data = 51 bytes per record
         // 200 / 51 = 3.9 → at most 3 records per stream fit under 200 bytes (3 × 51 = 153)
-        for i in 0..<6 {
+        for i in 0 ..< 6 {
             try await perStreamStorage.addRecord(
                 RecordInput(streamName: "stream-A", partitionKey: "a", data: Data(repeating: UInt8(i), count: 50))
             )
         }
-        for i in 0..<6 {
+        for i in 0 ..< 6 {
             try await perStreamStorage.addRecord(
                 RecordInput(streamName: "stream-B", partitionKey: "b", data: Data(repeating: UInt8(i), count: 50))
             )
@@ -258,7 +258,7 @@ class SQLiteRecordStorageCacheAccuracyTests: XCTestCase {
         XCTAssertEqual(recordsByStream.count, 2)
 
         for records in recordsByStream {
-            let streamName = records.first!.streamName
+            let streamName = try XCTUnwrap(records.first?.streamName)
             let totalSize = records.reduce(0) { $0 + $1.dataSize }
 
             // Each stream should return at most 3 records (153 bytes ≤ 200)


### PR DESCRIPTION
See comments for further details

 * Apply auto format and linter
 * Add further tests and remove obsolete ones 
 * Change logging to log operation start as verbose, results as debug and errors that are propagated up as warnings