### PR TITLE
fix(kinesis): fix retry logic for request-level errors

### DIFF
--- a/AmplifyClients/AmplifyKinesisClient/Sources/Support/RecordClient.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Sources/Support/RecordClient.swift
@@ -93,8 +93,8 @@ actor RecordClient {
   }
 
   private func handleFailedRequest(_ records: [Record]) async {
-    let retryable = records.filter { $0.retryCount + 1 < maxRetries }
-    let expired = records.filter { $0.retryCount + 1 >= maxRetries }
+    let retryable = records.filter { $0.retryCount < maxRetries }
+    let expired = records.filter { $0.retryCount >= maxRetries }
 
     do {
       try await storage.incrementRetryCount(ids: retryable.map(\.id))
@@ -104,7 +104,7 @@ actor RecordClient {
         let streamName = records[0].streamName
         logger.warn(
           "Deleted \(expired.count) records from stream \(streamName) "
-            + "that exceeded retry limit of \(maxRetries) after failed request"
+            + "that exceeded retry limit of \(maxRetries) after failed retries"
         )
       }
     } catch {

--- a/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/RecordClientFlushTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/RecordClientFlushTests.swift
@@ -102,6 +102,9 @@ class RecordClientFlushTests: XCTestCase {
         let allRecords = try await storage.getRecordsByStream().flatMap { $0 }
         let record2Id = allRecords[1].id
         let record3Id = allRecords[2].id
+
+        // Increment to maxRetries (3) so they are expired on next failed flush
+        try await storage.incrementRetryCount(ids: [record2Id, record3Id])
         try await storage.incrementRetryCount(ids: [record2Id, record3Id])
         try await storage.incrementRetryCount(ids: [record2Id, record3Id])
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
Fix an issue where retry count k lead to k instead of k+1 attempts

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
