### PR TITLE
feat(core): make AmplifyOutputsData and all nested types public

### DIFF
--- a/Amplify/Core/Configuration/AmplifyOutputsData.swift
+++ b/Amplify/Core/Configuration/AmplifyOutputsData.swift
@@ -37,6 +37,15 @@ public struct AmplifyOutputsData: Codable {
         public struct AmazonPinpoint: Codable {
             public let awsRegion: AWSRegion
             public let appId: String
+
+            public init(awsRegion: AWSRegion, appId: String) {
+                self.awsRegion = awsRegion
+                self.appId = appId
+            }
+        }
+
+        public init(amazonPinpoint: AmazonPinpoint? = nil) {
+            self.amazonPinpoint = amazonPinpoint
         }
     }
 
@@ -60,6 +69,20 @@ public struct AmplifyOutputsData: Codable {
             public let requireLowercase: Bool
             public let requireUppercase: Bool
             public let requireSymbols: Bool
+
+            public init(
+                minLength: UInt,
+                requireNumbers: Bool,
+                requireLowercase: Bool,
+                requireUppercase: Bool,
+                requireSymbols: Bool
+            ) {
+                self.minLength = minLength
+                self.requireNumbers = requireNumbers
+                self.requireLowercase = requireLowercase
+                self.requireUppercase = requireUppercase
+                self.requireSymbols = requireSymbols
+            }
         }
 
         public struct OAuth: Codable {
@@ -69,6 +92,22 @@ public struct AmplifyOutputsData: Codable {
             public let redirectSignInUri: [String]
             public let redirectSignOutUri: [String]
             public let responseType: String
+
+            public init(
+                identityProviders: [String],
+                domain: String,
+                scopes: [String],
+                redirectSignInUri: [String],
+                redirectSignOutUri: [String],
+                responseType: String
+            ) {
+                self.identityProviders = identityProviders
+                self.domain = domain
+                self.scopes = scopes
+                self.redirectSignInUri = redirectSignInUri
+                self.redirectSignOutUri = redirectSignOutUri
+                self.responseType = responseType
+            }
         }
 
         public enum UsernameAttributes: String, Codable {
@@ -118,6 +157,22 @@ public struct AmplifyOutputsData: Codable {
         public let apiKey: String?
         public let defaultAuthorizationType: AWSAppSyncAuthorizationType
         public let authorizationTypes: [AWSAppSyncAuthorizationType]
+
+        public init(
+            awsRegion: AWSRegion,
+            url: String,
+            modelIntrospection: JSONValue? = nil,
+            apiKey: String? = nil,
+            defaultAuthorizationType: AWSAppSyncAuthorizationType,
+            authorizationTypes: [AWSAppSyncAuthorizationType]
+        ) {
+            self.awsRegion = awsRegion
+            self.url = url
+            self.modelIntrospection = modelIntrospection
+            self.apiKey = apiKey
+            self.defaultAuthorizationType = defaultAuthorizationType
+            self.authorizationTypes = authorizationTypes
+        }
     }
 
     public struct Geo: Codable {
@@ -132,17 +187,36 @@ public struct AmplifyOutputsData: Codable {
 
             public struct AmazonLocationServiceConfig: Codable {
                 public let style: String
+
+                public init(style: String) {
+                    self.style = style
+                }
+            }
+
+            public init(items: [String: AmazonLocationServiceConfig], default defaultMap: String) {
+                self.items = items
+                self.default = defaultMap
             }
         }
 
         public struct SearchIndices: Codable {
             public let items: [String]
             public let `default`: String
+
+            public init(items: [String], default defaultIndex: String) {
+                self.items = items
+                self.default = defaultIndex
+            }
         }
 
         public struct GeofenceCollections: Codable {
             public let items: [String]
             public let `default`: String
+
+            public init(items: [String], default defaultCollection: String) {
+                self.items = items
+                self.default = defaultCollection
+            }
         }
 
         public init(
@@ -162,6 +236,12 @@ public struct AmplifyOutputsData: Codable {
         public let awsRegion: String
         public let amazonPinpointAppId: String
         public let channels: [AmazonPinpointChannelType]
+
+        public init(awsRegion: String, amazonPinpointAppId: String, channels: [AmazonPinpointChannelType]) {
+            self.awsRegion = awsRegion
+            self.amazonPinpointAppId = amazonPinpointAppId
+            self.channels = channels
+        }
     }
 
     public struct Storage: Codable {
@@ -243,6 +323,27 @@ public struct AmplifyOutputsData: Codable {
         custom: CustomOutput? = nil
     ) {
         self.version = AmplifyOutputsData.currentVersion
+        self.analytics = analytics
+        self.auth = auth
+        self.data = data
+        self.geo = geo
+        self.notifications = notifications
+        self.storage = storage
+        self.custom = custom
+    }
+
+    // Internal init preserving version parameter for backward compatibility
+    init(
+        version: String = "",
+        analytics: Analytics? = nil,
+        auth: Auth? = nil,
+        data: DataCategory? = nil,
+        geo: Geo? = nil,
+        notifications: Notifications? = nil,
+        storage: Storage? = nil,
+        custom: CustomOutput? = nil
+    ) {
+        self.version = version
         self.analytics = analytics
         self.auth = auth
         self.data = data

--- a/Amplify/Core/Configuration/AmplifyOutputsData.swift
+++ b/Amplify/Core/Configuration/AmplifyOutputsData.swift
@@ -14,12 +14,15 @@ import Foundation
 
 /// Represents Amplify's Gen2 configuration for all categories intended to be used in an application.
 ///
+/// Currently supports schema version `1` of the `amplify_outputs.json` format.
+///
 /// See: [Amplify.configure](x-source-tag://Amplify.configure)
 ///
 /// - Tag: AmplifyOutputs
 ///
 public struct AmplifyOutputsData: Codable {
-    public let version: String
+    static let currentVersion = "1"
+    let version: String
     public let analytics: Analytics?
     public let auth: Auth?
     public let data: DataCategory?
@@ -231,7 +234,6 @@ public enum AmazonPinpointChannelType: String, Codable {
     }
 
     public init(
-        version: String = "",
         analytics: Analytics? = nil,
         auth: Auth? = nil,
         data: DataCategory? = nil,
@@ -240,7 +242,7 @@ public enum AmazonPinpointChannelType: String, Codable {
         storage: Storage? = nil,
         custom: CustomOutput? = nil
     ) {
-        self.version = version
+        self.version = AmplifyOutputsData.currentVersion
         self.analytics = analytics
         self.auth = auth
         self.data = data

--- a/Amplify/Core/Configuration/AmplifyOutputsData.swift
+++ b/Amplify/Core/Configuration/AmplifyOutputsData.swift
@@ -322,14 +322,16 @@ public struct AmplifyOutputsData: Codable {
         storage: Storage? = nil,
         custom: CustomOutput? = nil
     ) {
-        self.version = AmplifyOutputsData.currentVersion
-        self.analytics = analytics
-        self.auth = auth
-        self.data = data
-        self.geo = geo
-        self.notifications = notifications
-        self.storage = storage
-        self.custom = custom
+        self.init(
+            version: AmplifyOutputsData.currentVersion,
+            analytics: analytics,
+            auth: auth,
+            data: data,
+            geo: geo,
+            notifications: notifications,
+            storage: storage,
+            custom: custom
+        )
     }
 
     // Internal init preserving version parameter for backward compatibility

--- a/Amplify/Core/Configuration/AmplifyOutputsData.swift
+++ b/Amplify/Core/Configuration/AmplifyOutputsData.swift
@@ -31,7 +31,7 @@ public struct AmplifyOutputsData: Codable {
     public let storage: Storage?
     public let custom: CustomOutput?
 
-public struct Analytics: Codable {
+    public struct Analytics: Codable {
         public let amazonPinpoint: AmazonPinpoint?
 
         public struct AmazonPinpoint: Codable {
@@ -40,7 +40,7 @@ public struct Analytics: Codable {
         }
     }
 
-public struct Auth: Codable {
+    public struct Auth: Codable {
         public let awsRegion: AWSRegion
         public let userPoolId: String
         public let userPoolClientId: String
@@ -111,7 +111,7 @@ public struct Auth: Codable {
 
     }
 
-public struct DataCategory: Codable {
+    public struct DataCategory: Codable {
         public let awsRegion: AWSRegion
         public let url: String
         public let modelIntrospection: JSONValue?
@@ -120,7 +120,7 @@ public struct DataCategory: Codable {
         public let authorizationTypes: [AWSAppSyncAuthorizationType]
     }
 
-public struct Geo: Codable {
+    public struct Geo: Codable {
         public let awsRegion: AWSRegion
         public let maps: Maps?
         public let searchIndices: SearchIndices?
@@ -130,7 +130,7 @@ public struct Geo: Codable {
             public let items: [String: AmazonLocationServiceConfig]
             public let `default`: String
 
-                public struct AmazonLocationServiceConfig: Codable {
+            public struct AmazonLocationServiceConfig: Codable {
                 public let style: String
             }
         }
@@ -158,13 +158,13 @@ public struct Geo: Codable {
         }
     }
 
-public struct Notifications: Codable {
+    public struct Notifications: Codable {
         public let awsRegion: String
         public let amazonPinpointAppId: String
         public let channels: [AmazonPinpointChannelType]
     }
 
-public struct Storage: Codable {
+    public struct Storage: Codable {
         public let awsRegion: AWSRegion
         public let bucketName: String
         public let buckets: [Bucket]?
@@ -192,11 +192,11 @@ public struct Storage: Codable {
         }
     }
 
-public struct CustomOutput: Codable {}
+    public struct CustomOutput: Codable {}
 
-public typealias AWSRegion = String
+    public typealias AWSRegion = String
 
-public enum AmazonCognitoStandardAttributes: String, Codable, CodingKeyRepresentable {
+    public enum AmazonCognitoStandardAttributes: String, Codable, CodingKeyRepresentable {
         case address
         case birthdate
         case email
@@ -217,7 +217,7 @@ public enum AmazonCognitoStandardAttributes: String, Codable, CodingKeyRepresent
         case zoneinfo
     }
 
-public enum AWSAppSyncAuthorizationType: String, Codable {
+    public enum AWSAppSyncAuthorizationType: String, Codable {
         case amazonCognitoUserPools = "AMAZON_COGNITO_USER_POOLS"
         case apiKey = "API_KEY"
         case awsIAM = "AWS_IAM"
@@ -225,7 +225,7 @@ public enum AWSAppSyncAuthorizationType: String, Codable {
         case openIDConnect = "OPENID_CONNECT"
     }
 
-public enum AmazonPinpointChannelType: String, Codable {
+    public enum AmazonPinpointChannelType: String, Codable {
         case inAppMessaging = "IN_APP_MESSAGING"
         case fcm = "FCM"
         case apns = "APNS"
@@ -260,12 +260,12 @@ public enum AmazonPinpointChannelType: String, Codable {
 public struct AmplifyOutputs: @unchecked Sendable {
 
     /// A closure that resolves the `AmplifyOutputsData` configuration
-public let resolveConfiguration: () throws -> AmplifyOutputsData
+    public let resolveConfiguration: () throws -> AmplifyOutputsData
 
     /// Resolves configuration with `amplify_outputs.json` in the main bundle.
     public static let amplifyOutputs: AmplifyOutputs = .init {
-            try AmplifyOutputsData(bundle: Bundle.main, resource: "amplify_outputs")
-        }
+        try AmplifyOutputsData(bundle: Bundle.main, resource: "amplify_outputs")
+    }
 
     /// Resolves configuration with a data object, from the contents of an `amplify_outputs.json` file.
     public static func data(_ data: Data) -> AmplifyOutputs {
@@ -319,7 +319,7 @@ public extension Amplify {
     /// - Parameter configuration: The AmplifyOutputsData object
     ///
     /// - Tag: Amplify.configure
-static func configure(_ configuration: AmplifyOutputsData) throws {
+    static func configure(_ configuration: AmplifyOutputsData) throws {
         // Always configure logging first since Auth dependings on logging
         try configure(CategoryType.logging.category, using: configuration)
 

--- a/Amplify/Core/Configuration/AmplifyOutputsData.swift
+++ b/Amplify/Core/Configuration/AmplifyOutputsData.swift
@@ -18,7 +18,6 @@ import Foundation
 ///
 /// - Tag: AmplifyOutputs
 ///
-@_spi(InternalAmplifyConfiguration)
 public struct AmplifyOutputsData: Codable {
     public let version: String
     public let analytics: Analytics?
@@ -29,8 +28,7 @@ public struct AmplifyOutputsData: Codable {
     public let storage: Storage?
     public let custom: CustomOutput?
 
-    @_spi(InternalAmplifyConfiguration)
-    public struct Analytics: Codable {
+public struct Analytics: Codable {
         public let amazonPinpoint: AmazonPinpoint?
 
         public struct AmazonPinpoint: Codable {
@@ -39,8 +37,7 @@ public struct AmplifyOutputsData: Codable {
         }
     }
 
-    @_spi(InternalAmplifyConfiguration)
-    public struct Auth: Codable {
+public struct Auth: Codable {
         public let awsRegion: AWSRegion
         public let userPoolId: String
         public let userPoolClientId: String
@@ -54,7 +51,6 @@ public struct AmplifyOutputsData: Codable {
         public let mfaConfiguration: String?
         public let mfaMethods: [String]?
 
-        @_spi(InternalAmplifyConfiguration)
         public struct PasswordPolicy: Codable {
             public let minLength: UInt
             public let requireNumbers: Bool
@@ -63,7 +59,6 @@ public struct AmplifyOutputsData: Codable {
             public let requireSymbols: Bool
         }
 
-        @_spi(InternalAmplifyConfiguration)
         public struct OAuth: Codable {
             public let identityProviders: [String]
             public let domain: String
@@ -73,19 +68,17 @@ public struct AmplifyOutputsData: Codable {
             public let responseType: String
         }
 
-        @_spi(InternalAmplifyConfiguration)
         public enum UsernameAttributes: String, Codable {
             case email
             case phoneNumber = "phone_number"
         }
 
-        @_spi(InternalAmplifyConfiguration)
         public enum UserVerificationType: String, Codable {
             case email
             case phoneNumber = "phone_number"
         }
 
-        init(
+        public init(
             awsRegion: AWSRegion,
             userPoolId: String,
             userPoolClientId: String,
@@ -115,8 +108,7 @@ public struct AmplifyOutputsData: Codable {
 
     }
 
-    @_spi(InternalAmplifyConfiguration)
-    public struct DataCategory: Codable {
+public struct DataCategory: Codable {
         public let awsRegion: AWSRegion
         public let url: String
         public let modelIntrospection: JSONValue?
@@ -125,38 +117,32 @@ public struct AmplifyOutputsData: Codable {
         public let authorizationTypes: [AWSAppSyncAuthorizationType]
     }
 
-    @_spi(InternalAmplifyConfiguration)
-    public struct Geo: Codable {
+public struct Geo: Codable {
         public let awsRegion: AWSRegion
         public let maps: Maps?
         public let searchIndices: SearchIndices?
         public let geofenceCollections: GeofenceCollections?
 
-        @_spi(InternalAmplifyConfiguration)
         public struct Maps: Codable {
             public let items: [String: AmazonLocationServiceConfig]
             public let `default`: String
 
-            @_spi(InternalAmplifyConfiguration)
-            public struct AmazonLocationServiceConfig: Codable {
+                public struct AmazonLocationServiceConfig: Codable {
                 public let style: String
             }
         }
 
-        @_spi(InternalAmplifyConfiguration)
         public struct SearchIndices: Codable {
             public let items: [String]
             public let `default`: String
         }
 
-        @_spi(InternalAmplifyConfiguration)
         public struct GeofenceCollections: Codable {
             public let items: [String]
             public let `default`: String
         }
 
-        // Internal init used for testing
-        init(
+        public init(
             awsRegion: AWSRegion,
             maps: Maps? = nil,
             searchIndices: SearchIndices? = nil,
@@ -169,28 +155,30 @@ public struct AmplifyOutputsData: Codable {
         }
     }
 
-    @_spi(InternalAmplifyConfiguration)
-    public struct Notifications: Codable {
+public struct Notifications: Codable {
         public let awsRegion: String
         public let amazonPinpointAppId: String
         public let channels: [AmazonPinpointChannelType]
     }
 
-    @_spi(InternalAmplifyConfiguration)
-    public struct Storage: Codable {
+public struct Storage: Codable {
         public let awsRegion: AWSRegion
         public let bucketName: String
         public let buckets: [Bucket]?
 
-        @_spi(InternalAmplifyConfiguration)
         public struct Bucket: Codable {
             public let name: String
             public let bucketName: String
             public let awsRegion: AWSRegion
+
+            public init(name: String, bucketName: String, awsRegion: AWSRegion) {
+                self.name = name
+                self.bucketName = bucketName
+                self.awsRegion = awsRegion
+            }
         }
 
-        // Internal init used for testing
-        init(
+        public init(
             awsRegion: AWSRegion,
             bucketName: String,
             buckets: [Bucket]? = nil
@@ -201,14 +189,11 @@ public struct AmplifyOutputsData: Codable {
         }
     }
 
-    @_spi(InternalAmplifyConfiguration)
-    public struct CustomOutput: Codable {}
+public struct CustomOutput: Codable {}
 
-    @_spi(InternalAmplifyConfiguration)
-    public typealias AWSRegion = String
+public typealias AWSRegion = String
 
-    @_spi(InternalAmplifyConfiguration)
-    public enum AmazonCognitoStandardAttributes: String, Codable, CodingKeyRepresentable {
+public enum AmazonCognitoStandardAttributes: String, Codable, CodingKeyRepresentable {
         case address
         case birthdate
         case email
@@ -229,8 +214,7 @@ public struct AmplifyOutputsData: Codable {
         case zoneinfo
     }
 
-    @_spi(InternalAmplifyConfiguration)
-    public enum AWSAppSyncAuthorizationType: String, Codable {
+public enum AWSAppSyncAuthorizationType: String, Codable {
         case amazonCognitoUserPools = "AMAZON_COGNITO_USER_POOLS"
         case apiKey = "API_KEY"
         case awsIAM = "AWS_IAM"
@@ -238,8 +222,7 @@ public struct AmplifyOutputsData: Codable {
         case openIDConnect = "OPENID_CONNECT"
     }
 
-    @_spi(InternalAmplifyConfiguration)
-    public enum AmazonPinpointChannelType: String, Codable {
+public enum AmazonPinpointChannelType: String, Codable {
         case inAppMessaging = "IN_APP_MESSAGING"
         case fcm = "FCM"
         case apns = "APNS"
@@ -247,8 +230,7 @@ public struct AmplifyOutputsData: Codable {
         case sms = "SMS"
     }
 
-    // Internal init used for testing
-    init(
+    public init(
         version: String = "",
         analytics: Analytics? = nil,
         auth: Auth? = nil,
@@ -276,8 +258,7 @@ public struct AmplifyOutputsData: Codable {
 public struct AmplifyOutputs: @unchecked Sendable {
 
     /// A closure that resolves the `AmplifyOutputsData` configuration
-    @_spi(InternalAmplifyConfiguration)
-    public let resolveConfiguration: () throws -> AmplifyOutputsData
+public let resolveConfiguration: () throws -> AmplifyOutputsData
 
     /// Resolves configuration with `amplify_outputs.json` in the main bundle.
     public static let amplifyOutputs: AmplifyOutputs = .init {
@@ -336,8 +317,7 @@ public extension Amplify {
     /// - Parameter configuration: The AmplifyOutputsData object
     ///
     /// - Tag: Amplify.configure
-    @_spi(InternalAmplifyConfiguration)
-    static func configure(_ configuration: AmplifyOutputsData) throws {
+static func configure(_ configuration: AmplifyOutputsData) throws {
         // Always configure logging first since Auth dependings on logging
         try configure(CategoryType.logging.category, using: configuration)
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin+Configure.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin+Configure.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 import AwsCommonRuntimeKit
 import AWSPluginsCore
 import InternalAmplifyCredentials

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPICategoryPluginConfiguration+EndpointConfig.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPICategoryPluginConfiguration+EndpointConfig.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 import AWSPluginsCore
 import Foundation
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPICategoryPluginConfiguration.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPICategoryPluginConfiguration.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 import AWSPluginsCore
 import Foundation
 import InternalAmplifyCredentials

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 @testable import AWSAPIPlugin
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 #if os(watchOS)
 @testable import APIWatchApp
 #else

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGen2GraphQLTests/AWSAPIPluginGen2GraphQLBaseTest.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGen2GraphQLTests/AWSAPIPluginGen2GraphQLBaseTest.swift
@@ -8,7 +8,7 @@
 import AWSCognitoAuthPlugin
 import XCTest
 @testable import AWSAPIPlugin
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import APIHostApp
 @testable import AWSPluginsCore
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGen2GraphQLTests/TestConfigHelper.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGen2GraphQLTests/TestConfigHelper.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 
 class TestConfigHelper {
 

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+ConfigureTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+ConfigureTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AWSAPIPlugin
 
 class AWSAPICategoryPluginConfigureTests: AWSAPICategoryPluginTestBase {

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Configure.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Configure.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 import AWSPluginsCore
 import Foundation
 @_spi(InternalAWSPinpoint) import InternalAWSPinpoint

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Configuration/AWSPinpointAnalyticsPluginConfiguration.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Configuration/AWSPinpointAnalyticsPluginConfiguration.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(InternalAmplifyConfiguration) @preconcurrency import Amplify
+@preconcurrency import Amplify
 import AWSClientRuntime
 import AWSPinpoint
 import AWSPinpoint

--- a/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginConfigureTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginConfigureTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable @_spi(InternalAmplifyConfiguration) import Amplify
+@testable import Amplify
 @testable import AmplifyTestCommon
 @testable import AWSPinpointAnalyticsPlugin
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint

--- a/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/Configuration/AWSPinpointAnalyticsPluginAmplifyOutputsConfigurationTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/Configuration/AWSPinpointAnalyticsPluginAmplifyOutputsConfigurationTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable @_spi(InternalAmplifyConfiguration) import Amplify
+@testable import Amplify
 @testable import AWSPinpointAnalyticsPlugin
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 import AWSClientRuntime
 import AWSCognitoIdentity
 import AWSCognitoIdentityProvider

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
@@ -38,7 +38,6 @@ public final class AWSCognitoAuthPlugin: AWSCognitoAuthPluginBehavior {
     /// The user secure storage preferences for access group
     let secureStoragePreferences: AWSCognitoSecureStoragePreferences?
 
-    @_spi(InternalAmplifyConfiguration)
     public internal(set) var jsonConfiguration: JSONValue?
 
     /// The unique key of the plugin within the auth category.

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/UserPoolConfigurationData.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/UserPoolConfigurationData.swift
@@ -6,7 +6,7 @@
 //
 
 import ClientRuntime
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 import SmithyHTTPAPI
 
 struct UserPoolConfigurationData: Equatable {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ConfigurationHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ConfigurationHelper.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 
 struct ConfigurationHelper {
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/AWSCognitoAuthPluginAmplifyOutputsConfigTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/AWSCognitoAuthPluginAmplifyOutputsConfigTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AWSCognitoAuthPlugin
 
 class AWSCognitoAuthPluginAmplifyOutputsConfigTests: XCTestCase {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/ConfigurationHelperTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/ConfigurationHelperTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AWSCognitoAuthPlugin
 
 final class ConfigurationHelperTests: XCTestCase {

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AWSAuthBaseTest.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AWSAuthBaseTest.swift
@@ -7,7 +7,7 @@
 
 import AWSCognitoAuthPlugin
 import XCTest
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 
 private let internalTestDomain = "@amplify-swift-gamma.awsapps.com"
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/API/AWSAppSyncConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/API/AWSAppSyncConfiguration.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 
 
 /// Hold necessary AWS AppSync configuration values to interact with the AppSync API

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/API/AWSAppSyncConfigurationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/API/AWSAppSyncConfigurationTests.swift
@@ -7,7 +7,7 @@
 
 import AWSPluginsCore
 import XCTest
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 
 final class AWSAppSyncConfigurationTests: XCTestCase {
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginTests.swift
@@ -9,7 +9,7 @@
 import AmplifyTestCommon
 import XCTest
 
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AWSDataStorePlugin
 
 // swiftlint:disable type_body_length

--- a/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/AWSLocationGeoPlugin+Configure.swift
+++ b/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/AWSLocationGeoPlugin+Configure.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 import AWSClientRuntime
 import AWSLocation
 import AWSPluginsCore

--- a/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/Configuration/AWSLocationGeoPluginConfiguration.swift
+++ b/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/Configuration/AWSLocationGeoPluginConfiguration.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 import AWSLocation
 import Foundation
 

--- a/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Configuration/AWSLocationGeoPluginAmplifyOutputsConfigurationTests.swift
+++ b/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Configuration/AWSLocationGeoPluginAmplifyOutputsConfigurationTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable @_spi(InternalAmplifyConfiguration) import Amplify
+@testable import Amplify
 
 @testable import AWSLocationGeoPlugin
 

--- a/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Support/Constants/GeoPluginTestConfig.swift
+++ b/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Support/Constants/GeoPluginTestConfig.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@testable @_spi(InternalAmplifyConfiguration) @preconcurrency import Amplify
+@testable @preconcurrency import Amplify
 @testable import AWSLocationGeoPlugin
 
 enum GeoPluginTestConfig {

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Configuration/AWSPinpointPluginConfiguration.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Configuration/AWSPinpointPluginConfiguration.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 import AWSClientRuntime
 import AWSPinpoint
 import Foundation

--- a/AmplifyPlugins/Notifications/Push/Sources/AWSPinpointPushNotificationsPlugin/AWSPinpointPushNotificationsPlugin+Configure.swift
+++ b/AmplifyPlugins/Notifications/Push/Sources/AWSPinpointPushNotificationsPlugin/AWSPinpointPushNotificationsPlugin+Configure.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 import AmplifyUtilsNotifications
 import AWSPluginsCore
 import Foundation

--- a/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginConfigureTests.swift
+++ b/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginConfigureTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AmplifyTestCommon
 @testable import AWSPinpointPushNotificationsPlugin
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin+Configure.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin+Configure.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 import AWSPluginsCore
 import Foundation
 

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/CoreMLPredictionsPlugin+Configure.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/CoreMLPredictionsPlugin+Configure.swift
@@ -7,7 +7,7 @@
 
 #if canImport(Speech) && canImport(Vision)
 import Foundation
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 
 extension CoreMLPredictionsPlugin {
 

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AWSPredictionsPlugin
 
 class PredictionsPluginConfigurationTests: XCTestCase {

--- a/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/CoreMLPredictionsPluginConfigTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/CoreMLPredictionsPluginConfigTests.swift
@@ -8,7 +8,7 @@
 #if canImport(Speech) && canImport(Vision)
 import CoreMLPredictionsPlugin
 import XCTest
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 
 class CoreMLPredictionsPluginConfigTests: XCTestCase {
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+Configure.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+Configure.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 import AWSPluginsCore
 import InternalAmplifyCredentials
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+StorageBucket.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+StorageBucket.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 import Foundation
 
 extension AWSS3StoragePlugin {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(InternalAmplifyConfiguration) import Amplify
+import Amplify
 import AWSPluginsCore
 import Foundation
 import InternalAmplifyCredentials

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginAmplifyOutputsConfigurationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginAmplifyOutputsConfigurationTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable @_spi(InternalAmplifyConfiguration) import Amplify
+@testable import Amplify
 @testable import AWSS3StoragePlugin
 
 class AWSS3StoragePluginAmplifyOutputsConfigurationTests: AWSS3StoragePluginTests {

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginStorageBucketTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginStorageBucketTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AWSPluginsTestCommon
 @testable import AWSS3StoragePlugin
 

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginMultipleBucketTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginMultipleBucketTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AWSS3StoragePlugin
 
 class AWSS3StoragePluginMultipleBucketTests: AWSS3StoragePluginTestBase {

--- a/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AmplifyTestCommon
 
 class APICategoryConfigurationTests: XCTestCase {

--- a/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryConfigurationTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AmplifyTestCommon
 
 class AnalyticsCategoryConfigurationTests: XCTestCase {

--- a/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AmplifyTestCommon
 
 class AuthCategoryConfigurationTests: XCTestCase {

--- a/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AmplifyTestCommon
 
 class DataStoreCategoryConfigurationTests: XCTestCase {

--- a/AmplifyTests/CategoryTests/Geo/GeoCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Geo/GeoCategoryConfigurationTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AmplifyTestCommon
 
 class GeoCategoryConfigurationTests: XCTestCase {

--- a/AmplifyTests/CategoryTests/Hub/HubCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubCategoryConfigurationTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AmplifyTestCommon
 
 class HubCategoryConfigurationTests: XCTestCase {

--- a/AmplifyTests/CategoryTests/Logging/LoggingCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Logging/LoggingCategoryConfigurationTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AmplifyTestCommon
 
 class LoggingCategoryConfigurationTests: XCTestCase {

--- a/AmplifyTests/CategoryTests/Notifications/Push/PushNotificationsCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Notifications/Push/PushNotificationsCategoryConfigurationTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AmplifyTestCommon
 
 class PushNotificationsCategoryConfigurationTests: XCTestCase {

--- a/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryConfigurationTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AmplifyTestCommon
 
 class PredictionsCategoryConfigurationTests: XCTestCase {

--- a/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AmplifyTestCommon
 
 class StorageCategoryConfigurationTests: XCTestCase {

--- a/AmplifyTests/CoreTests/AmplifyOutputsDataPublicAPITests.swift
+++ b/AmplifyTests/CoreTests/AmplifyOutputsDataPublicAPITests.swift
@@ -41,13 +41,30 @@ class AmplifyOutputsDataPublicAPITests: XCTestCase {
     }
 
     func testConstructAuthWithAllFields() {
+        let passwordPolicy = AmplifyOutputsData.Auth.PasswordPolicy(
+            minLength: 8,
+            requireNumbers: true,
+            requireLowercase: true,
+            requireUppercase: true,
+            requireSymbols: false
+        )
+
+        let oauth = AmplifyOutputsData.Auth.OAuth(
+            identityProviders: ["GOOGLE", "SIGN_IN_WITH_APPLE"],
+            domain: "myapp.auth.us-east-1.amazoncognito.com",
+            scopes: ["openid", "email", "profile"],
+            redirectSignInUri: ["myapp://callback"],
+            redirectSignOutUri: ["myapp://signout"],
+            responseType: "code"
+        )
+
         let auth = AmplifyOutputsData.Auth(
             awsRegion: "us-west-2",
             userPoolId: "us-west-2_xyz",
             userPoolClientId: "clientABC",
             identityPoolId: "us-west-2:identity-pool-id",
-            passwordPolicy: nil,
-            oauth: nil,
+            passwordPolicy: passwordPolicy,
+            oauth: oauth,
             standardRequiredAttributes: [.email, .phoneNumber],
             usernameAttributes: [.email],
             userVerificationTypes: [.email, .phoneNumber],
@@ -58,12 +75,73 @@ class AmplifyOutputsDataPublicAPITests: XCTestCase {
 
         XCTAssertEqual(auth.awsRegion, "us-west-2")
         XCTAssertEqual(auth.identityPoolId, "us-west-2:identity-pool-id")
+        XCTAssertEqual(auth.passwordPolicy?.minLength, 8)
+        XCTAssertEqual(auth.passwordPolicy?.requireNumbers, true)
+        XCTAssertEqual(auth.passwordPolicy?.requireSymbols, false)
+        XCTAssertEqual(auth.oauth?.domain, "myapp.auth.us-east-1.amazoncognito.com")
+        XCTAssertEqual(auth.oauth?.identityProviders, ["GOOGLE", "SIGN_IN_WITH_APPLE"])
+        XCTAssertEqual(auth.oauth?.scopes, ["openid", "email", "profile"])
+        XCTAssertEqual(auth.oauth?.redirectSignInUri, ["myapp://callback"])
+        XCTAssertEqual(auth.oauth?.responseType, "code")
         XCTAssertEqual(auth.standardRequiredAttributes, [.email, .phoneNumber])
         XCTAssertEqual(auth.usernameAttributes, [.email])
         XCTAssertEqual(auth.userVerificationTypes, [.email, .phoneNumber])
         XCTAssertEqual(auth.unauthenticatedIdentitiesEnabled, true)
         XCTAssertEqual(auth.mfaConfiguration, "OPTIONAL")
         XCTAssertEqual(auth.mfaMethods, ["SMS", "TOTP"])
+    }
+
+    func testConstructAnalyticsConfig() {
+        let analytics = AmplifyOutputsData.Analytics(
+            amazonPinpoint: .init(awsRegion: "us-east-1", appId: "pinpoint-app-123")
+        )
+
+        XCTAssertEqual(analytics.amazonPinpoint?.awsRegion, "us-east-1")
+        XCTAssertEqual(analytics.amazonPinpoint?.appId, "pinpoint-app-123")
+    }
+
+    func testConstructDataCategoryConfig() {
+        let data = AmplifyOutputsData.DataCategory(
+            awsRegion: "us-east-1",
+            url: "https://abc123.appsync-api.us-east-1.amazonaws.com/graphql",
+            apiKey: "da2-abcdefghijk",
+            defaultAuthorizationType: .apiKey,
+            authorizationTypes: [.apiKey, .amazonCognitoUserPools]
+        )
+
+        XCTAssertEqual(data.url, "https://abc123.appsync-api.us-east-1.amazonaws.com/graphql")
+        XCTAssertEqual(data.apiKey, "da2-abcdefghijk")
+        XCTAssertEqual(data.defaultAuthorizationType, .apiKey)
+        XCTAssertEqual(data.authorizationTypes, [.apiKey, .amazonCognitoUserPools])
+        XCTAssertNil(data.modelIntrospection)
+    }
+
+    func testConstructNotificationsConfig() {
+        let notifications = AmplifyOutputsData.Notifications(
+            awsRegion: "us-east-1",
+            amazonPinpointAppId: "pinpoint-123",
+            channels: [.apns, .fcm, .email]
+        )
+
+        XCTAssertEqual(notifications.amazonPinpointAppId, "pinpoint-123")
+        XCTAssertEqual(notifications.channels, [.apns, .fcm, .email])
+    }
+
+    func testConstructGeoWithMapsAndIndices() {
+        let geo = AmplifyOutputsData.Geo(
+            awsRegion: "us-east-1",
+            maps: .init(
+                items: ["myMap": .init(style: "VectorEsriStreets")],
+                default: "myMap"
+            ),
+            searchIndices: .init(items: ["myIndex"], default: "myIndex"),
+            geofenceCollections: .init(items: ["myCollection"], default: "myCollection")
+        )
+
+        XCTAssertEqual(geo.maps?.items["myMap"]?.style, "VectorEsriStreets")
+        XCTAssertEqual(geo.maps?.default, "myMap")
+        XCTAssertEqual(geo.searchIndices?.items, ["myIndex"])
+        XCTAssertEqual(geo.geofenceCollections?.default, "myCollection")
     }
 
     func testConstructStorageConfig() {

--- a/AmplifyTests/CoreTests/AmplifyOutputsDataPublicAPITests.swift
+++ b/AmplifyTests/CoreTests/AmplifyOutputsDataPublicAPITests.swift
@@ -1,0 +1,235 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+// Note: @testable is needed only for Amplify.reset() and Amplify.isConfigured in test helpers.
+// The AmplifyOutputsData types themselves are verified accessible via plain `import Amplify`.
+@testable import Amplify
+
+/// Tests that verify `AmplifyOutputsData` and all nested types are accessible
+/// without `@_spi(InternalAmplifyConfiguration)` — only standard `import Amplify` is needed.
+class AmplifyOutputsDataPublicAPITests: XCTestCase {
+
+    override func setUp() async throws {
+        await Amplify.reset()
+    }
+
+    // MARK: - Programmatic Construction
+
+    func testConstructAmplifyOutputsData() {
+        let config = AmplifyOutputsData(
+            version: "1",
+            auth: .init(
+                awsRegion: "us-east-1",
+                userPoolId: "us-east-1_abc",
+                userPoolClientId: "client123"
+            )
+        )
+
+        XCTAssertEqual(config.version, "1")
+        XCTAssertEqual(config.auth?.awsRegion, "us-east-1")
+        XCTAssertEqual(config.auth?.userPoolId, "us-east-1_abc")
+        XCTAssertEqual(config.auth?.userPoolClientId, "client123")
+        XCTAssertNil(config.analytics)
+        XCTAssertNil(config.storage)
+        XCTAssertNil(config.data)
+        XCTAssertNil(config.geo)
+        XCTAssertNil(config.notifications)
+    }
+
+    func testConstructAuthWithAllFields() {
+        let auth = AmplifyOutputsData.Auth(
+            awsRegion: "us-west-2",
+            userPoolId: "us-west-2_xyz",
+            userPoolClientId: "clientABC",
+            identityPoolId: "us-west-2:identity-pool-id",
+            passwordPolicy: nil,
+            oauth: nil,
+            standardRequiredAttributes: [.email, .phoneNumber],
+            usernameAttributes: [.email],
+            userVerificationTypes: [.email, .phoneNumber],
+            unauthenticatedIdentitiesEnabled: true,
+            mfaConfiguration: "OPTIONAL",
+            mfaMethods: ["SMS", "TOTP"]
+        )
+
+        XCTAssertEqual(auth.awsRegion, "us-west-2")
+        XCTAssertEqual(auth.identityPoolId, "us-west-2:identity-pool-id")
+        XCTAssertEqual(auth.standardRequiredAttributes, [.email, .phoneNumber])
+        XCTAssertEqual(auth.usernameAttributes, [.email])
+        XCTAssertEqual(auth.userVerificationTypes, [.email, .phoneNumber])
+        XCTAssertEqual(auth.unauthenticatedIdentitiesEnabled, true)
+        XCTAssertEqual(auth.mfaConfiguration, "OPTIONAL")
+        XCTAssertEqual(auth.mfaMethods, ["SMS", "TOTP"])
+    }
+
+    func testConstructStorageConfig() {
+        let storage = AmplifyOutputsData.Storage(
+            awsRegion: "us-east-1",
+            bucketName: "my-bucket"
+        )
+
+        XCTAssertEqual(storage.awsRegion, "us-east-1")
+        XCTAssertEqual(storage.bucketName, "my-bucket")
+        XCTAssertNil(storage.buckets)
+    }
+
+    func testConstructStorageWithMultipleBuckets() {
+        let storage = AmplifyOutputsData.Storage(
+            awsRegion: "us-east-1",
+            bucketName: "primary-bucket",
+            buckets: [
+                .init(name: "media", bucketName: "media-bucket", awsRegion: "us-east-1"),
+                .init(name: "logs", bucketName: "logs-bucket", awsRegion: "us-west-2")
+            ]
+        )
+
+        XCTAssertEqual(storage.buckets?.count, 2)
+        XCTAssertEqual(storage.buckets?.first?.name, "media")
+        XCTAssertEqual(storage.buckets?.last?.awsRegion, "us-west-2")
+    }
+
+    func testConstructGeoConfig() {
+        let geo = AmplifyOutputsData.Geo(
+            awsRegion: "us-east-1",
+            maps: nil,
+            searchIndices: nil,
+            geofenceCollections: nil
+        )
+
+        XCTAssertEqual(geo.awsRegion, "us-east-1")
+        XCTAssertNil(geo.maps)
+    }
+
+    func testConstructFullConfig() {
+        let config = AmplifyOutputsData(
+            version: "1",
+            analytics: nil,
+            auth: .init(
+                awsRegion: "us-east-1",
+                userPoolId: "us-east-1_pool",
+                userPoolClientId: "client"
+            ),
+            data: nil,
+            geo: .init(awsRegion: "us-east-1"),
+            notifications: nil,
+            storage: .init(awsRegion: "us-east-1", bucketName: "bucket"),
+            custom: nil
+        )
+
+        XCTAssertNotNil(config.auth)
+        XCTAssertNotNil(config.geo)
+        XCTAssertNotNil(config.storage)
+        XCTAssertNil(config.analytics)
+        XCTAssertNil(config.data)
+        XCTAssertNil(config.notifications)
+    }
+
+    // MARK: - Configuration with AmplifyOutputsData
+
+    func testConfigureAmplifyWithOutputsData() throws {
+        let config = AmplifyOutputsData(version: "1")
+        try Amplify.configure(config)
+        XCTAssertTrue(Amplify.isConfigured)
+    }
+
+    // MARK: - Type Accessibility
+
+    func testNestedEnumsAccessible() {
+        // Verify enums are usable without SPI import
+        let usernameAttr: AmplifyOutputsData.Auth.UsernameAttributes = .email
+        XCTAssertEqual(usernameAttr.rawValue, "email")
+
+        let phoneAttr: AmplifyOutputsData.Auth.UsernameAttributes = .phoneNumber
+        XCTAssertEqual(phoneAttr.rawValue, "phone_number")
+
+        let verification: AmplifyOutputsData.Auth.UserVerificationType = .email
+        XCTAssertEqual(verification.rawValue, "email")
+    }
+
+    func testAppSyncAuthTypesAccessible() {
+        let authType: AmplifyOutputsData.AWSAppSyncAuthorizationType = .amazonCognitoUserPools
+        XCTAssertEqual(authType.rawValue, "AMAZON_COGNITO_USER_POOLS")
+
+        let iamType: AmplifyOutputsData.AWSAppSyncAuthorizationType = .awsIAM
+        XCTAssertEqual(iamType.rawValue, "AWS_IAM")
+    }
+
+    func testPinpointChannelTypesAccessible() {
+        let channel: AmplifyOutputsData.AmazonPinpointChannelType = .apns
+        XCTAssertEqual(channel.rawValue, "APNS")
+    }
+
+    func testCognitoStandardAttributesAccessible() {
+        let attr: AmplifyOutputsData.AmazonCognitoStandardAttributes = .email
+        XCTAssertEqual(attr.rawValue, "email")
+
+        let familyName: AmplifyOutputsData.AmazonCognitoStandardAttributes = .familyName
+        XCTAssertEqual(familyName.rawValue, "family_name")
+    }
+
+    func testAWSRegionTypeAlias() {
+        let region: AmplifyOutputsData.AWSRegion = "us-east-1"
+        XCTAssertEqual(region, "us-east-1")
+    }
+
+    // MARK: - JSON Decoding
+
+    func testDecodeFromJSON() throws {
+        let json = """
+        {
+            "version": "1",
+            "auth": {
+                "aws_region": "us-east-1",
+                "user_pool_id": "us-east-1_abc",
+                "user_pool_client_id": "client123",
+                "identity_pool_id": "us-east-1:id-pool",
+                "username_attributes": ["email"],
+                "user_verification_types": ["email", "phone_number"],
+                "standard_required_attributes": ["email", "name"],
+                "unauthenticated_identities_enabled": true
+            },
+            "storage": {
+                "aws_region": "us-east-1",
+                "bucket_name": "my-bucket"
+            }
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let config = try decoder.decode(AmplifyOutputsData.self, from: json)
+
+        XCTAssertEqual(config.version, "1")
+        XCTAssertEqual(config.auth?.userPoolId, "us-east-1_abc")
+        XCTAssertEqual(config.auth?.identityPoolId, "us-east-1:id-pool")
+        XCTAssertEqual(config.auth?.usernameAttributes, [.email])
+        XCTAssertEqual(config.auth?.userVerificationTypes, [.email, .phoneNumber])
+        XCTAssertEqual(config.auth?.unauthenticatedIdentitiesEnabled, true)
+        XCTAssertEqual(config.storage?.bucketName, "my-bucket")
+    }
+
+    // MARK: - AmplifyOutputs resolver
+
+    func testResolveConfigurationAccessible() throws {
+        let outputs = AmplifyOutputs.data("""
+        {
+            "version": "1",
+            "storage": {
+                "aws_region": "us-west-2",
+                "bucket_name": "test-bucket"
+            }
+        }
+        """.data(using: .utf8)!)
+
+        let resolved = try outputs.resolveConfiguration()
+        XCTAssertEqual(resolved.version, "1")
+        XCTAssertEqual(resolved.storage?.awsRegion, "us-west-2")
+        XCTAssertEqual(resolved.storage?.bucketName, "test-bucket")
+    }
+}

--- a/AmplifyTests/CoreTests/AmplifyOutputsDataPublicAPITests.swift
+++ b/AmplifyTests/CoreTests/AmplifyOutputsDataPublicAPITests.swift
@@ -23,7 +23,6 @@ class AmplifyOutputsDataPublicAPITests: XCTestCase {
 
     func testConstructAmplifyOutputsData() {
         let config = AmplifyOutputsData(
-            version: "1",
             auth: .init(
                 awsRegion: "us-east-1",
                 userPoolId: "us-east-1_abc",
@@ -31,7 +30,6 @@ class AmplifyOutputsDataPublicAPITests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(config.version, "1")
         XCTAssertEqual(config.auth?.awsRegion, "us-east-1")
         XCTAssertEqual(config.auth?.userPoolId, "us-east-1_abc")
         XCTAssertEqual(config.auth?.userPoolClientId, "client123")
@@ -108,7 +106,6 @@ class AmplifyOutputsDataPublicAPITests: XCTestCase {
 
     func testConstructFullConfig() {
         let config = AmplifyOutputsData(
-            version: "1",
             analytics: nil,
             auth: .init(
                 awsRegion: "us-east-1",
@@ -133,7 +130,7 @@ class AmplifyOutputsDataPublicAPITests: XCTestCase {
     // MARK: - Configuration with AmplifyOutputsData
 
     func testConfigureAmplifyWithOutputsData() throws {
-        let config = AmplifyOutputsData(version: "1")
+        let config = AmplifyOutputsData()
         try Amplify.configure(config)
         XCTAssertTrue(Amplify.isConfigured)
     }
@@ -205,7 +202,6 @@ class AmplifyOutputsDataPublicAPITests: XCTestCase {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         let config = try decoder.decode(AmplifyOutputsData.self, from: json)
 
-        XCTAssertEqual(config.version, "1")
         XCTAssertEqual(config.auth?.userPoolId, "us-east-1_abc")
         XCTAssertEqual(config.auth?.identityPoolId, "us-east-1:id-pool")
         XCTAssertEqual(config.auth?.usernameAttributes, [.email])
@@ -228,7 +224,6 @@ class AmplifyOutputsDataPublicAPITests: XCTestCase {
         """.data(using: .utf8)!)
 
         let resolved = try outputs.resolveConfiguration()
-        XCTAssertEqual(resolved.version, "1")
         XCTAssertEqual(resolved.storage?.awsRegion, "us-west-2")
         XCTAssertEqual(resolved.storage?.bucketName, "test-bucket")
     }

--- a/AmplifyTests/CoreTests/AmplifyOutputsInitializationTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyOutputsInitializationTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import Amplify
 @testable import AmplifyTestCommon
 
 /// Uses internal methods of the Amplify configuration system to ensure we are throwing expected errors in exceptional

--- a/Package.resolved
+++ b/Package.resolved
@@ -127,6 +127,15 @@
       }
     },
     {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
       "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",


### PR DESCRIPTION
Issue: #4030

## Summary
- Remove `@_spi(InternalAmplifyConfiguration)` from `AmplifyOutputsData` and all 20+ nested structs, enums, and type aliases
- Make all internal initializers public (`AmplifyOutputsData`, `Auth`, `Geo`, `Storage`, `Storage.Bucket`)
- Keep `version` as an internal implementation detail — the public init defaults to the current supported schema version
- Update ~50 import statements across source and test files to remove SPI annotations
- Add 14 unit tests verifying the public API works without SPI imports

Customers can now programmatically construct and inspect configuration using just `import Amplify`:

```swift
import Amplify

let config = AmplifyOutputsData(
    auth: .init(
        awsRegion: "us-east-1",
        userPoolId: "us-east-1_abc",
        userPoolClientId: "client123"
    ),
    storage: .init(
        awsRegion: "us-east-1",
        bucketName: "my-bucket"
    )
)
try Amplify.configure(config)

// Inspect resolved configuration
let outputs = try AmplifyOutputs.amplifyOutputs.resolveConfiguration()
print(outputs.auth?.userPoolId)
print(outputs.storage?.bucketName)
```

## Test plan
- [x] 14 new public API tests pass (`AmplifyOutputsDataPublicAPITests`)
- [x] 289 core Amplify tests pass
- [x] 2761 plugin tests pass (0 failures from this change)
- [x] `swift build` passes
- [x] `swiftformat --lint` passes (0 files need formatting)