### PR TITLE
fix(ci): include Xcode version in cache keys to prevent stale artifacts

### DIFF
--- a/.github/composite_actions/get_platform_parameters/action.yml
+++ b/.github/composite_actions/get_platform_parameters/action.yml
@@ -62,56 +62,65 @@ runs:
       run: |
         INPUT_PLATFORM=${{ inputs.platform }}
         INPUT_DESTINATION='${{ inputs.destination }}'
-        INPUT_XCODE_VERSION=${{ inputs.xcode_version }}
+        XCODE_VERSION=${{ steps.get-xcode-version.outputs.xcode-version }}
 
-        case $INPUT_PLATFORM/$INPUT_XCODE_VERSION in
-          iOS/latest)
+        # Map resolved Xcode versions to simulator destinations.
+        # Only explicitly supported versions are allowed — unknown versions fail.
+        case $INPUT_PLATFORM/$XCODE_VERSION in
+          iOS/26.3)
             DEVICE="iPhone 16 Pro Max"
             OS_VERSION="26.2"
             ;;
-          iOS/minimum)
+          iOS/16.4.0)
+            DEVICE="iPhone 16 Pro Max"
+            OS_VERSION="18.5"
+            ;;
+          iOS/16.0.0)
             DEVICE="iPhone 16 Pro Max"
             OS_VERSION="18.0"
             ;;
-          iOS/*)
-            DEVICE="iPhone 16 Pro Max"
-            OS_VERSION="26.2"
-            ;;
-          tvOS/latest)
+          tvOS/26.3)
             DEVICE="Apple TV 4K (3rd generation)"
             OS_VERSION="26.2"
             ;;
-          tvOS/minimum)
+          tvOS/16.4.0)
+            DEVICE="Apple TV 4K (3rd generation)"
+            OS_VERSION="18.5"
+            ;;
+          tvOS/16.0.0)
             DEVICE="Apple TV 4K (3rd generation)"
             OS_VERSION="18.0"
             ;;
-          tvOS/*)
-            DEVICE="Apple TV 4K (3rd generation)"
-            OS_VERSION="26.2"
-            ;;
-          watchOS/latest)
+          watchOS/26.3)
             DEVICE="Apple Watch Series 10 (46mm)"
             OS_VERSION="26.2"
             ;;
-          watchOS/minimum)
+          watchOS/16.4.0)
+            DEVICE="Apple Watch Series 10 (46mm)"
+            OS_VERSION="11.5"
+            ;;
+          watchOS/16.0.0)
             DEVICE="Apple Watch SE (44mm) (2nd generation)"
             OS_VERSION="11.0"
             ;;
-          watchOS/*)
-            DEVICE="Apple Watch Series 10 (46mm)"
-            OS_VERSION="26.2"
-            ;;
-          visionOS/latest)
+          visionOS/26.3)
             DEVICE="Apple Vision Pro"
             OS_VERSION="26.2"
             ;;
-          visionOS/minimum)
+          visionOS/16.4.0)
+            DEVICE="Apple Vision Pro"
+            OS_VERSION="2.5"
+            ;;
+          visionOS/16.0.0)
             DEVICE="Apple Vision Pro"
             OS_VERSION="2.0"
             ;;
-          visionOS/*)
-            DEVICE="Apple Vision Pro"
-            OS_VERSION="26.2"
+          macOS/*)
+            ;;
+          *)
+            echo "Unsupported platform/Xcode combination: $INPUT_PLATFORM/$XCODE_VERSION"
+            echo "Supported Xcode versions: 26.3, 16.4.0, 16.0.0"
+            exit 1
             ;;
         esac
 

--- a/.github/composite_actions/install_simulators_if_needed/action.yml
+++ b/.github/composite_actions/install_simulators_if_needed/action.yml
@@ -19,10 +19,17 @@ runs:
       run: |
         XCODE_VERSION="${{ inputs.xcode_version }}"
         PLATFORM="${{ inputs.platform }}"
+        DEFAULT_XCODE_VERSION="16.4.0"
 
         # Skip for macOS as it doesn't need simulators
         if [[ "$PLATFORM" == "macOS" ]]; then
           echo "macOS doesn't need simulator downloads"
+          exit 0
+        fi
+
+        # Skip for the default Xcode version — simulators are pre-installed
+        if [[ "$XCODE_VERSION" == "$DEFAULT_XCODE_VERSION" ]]; then
+          echo "Using default Xcode ${DEFAULT_XCODE_VERSION}, simulators are pre-installed"
           exit 0
         fi
 
@@ -37,18 +44,10 @@ runs:
         sudo xcode-select -switch "${XCODE_PATH}/Contents/Developer"
         xcodebuild -version
 
-        # Check if the simulator runtime is already available
-        echo "Checking available simulator runtimes..."
-        RUNTIMES=$(xcrun simctl list runtimes 2>/dev/null || true)
-        echo "$RUNTIMES"
+        echo "Simulators before download:"
+        xcrun simctl list runtimes || true
 
-        PLATFORM_LOWER=$(echo "$PLATFORM" | tr '[:upper:]' '[:lower:]')
-        if echo "$RUNTIMES" | grep -qi "$PLATFORM"; then
-          echo "$PLATFORM simulator runtime is already available"
-          exit 0
-        fi
-
-        echo "$PLATFORM simulator runtime not found, downloading..."
+        echo "Downloading $PLATFORM runtime for Xcode ${XCODE_VERSION}..."
         sudo xcodebuild -downloadPlatform "$PLATFORM" || echo "Failed to download $PLATFORM platform"
 
         echo "Simulators after download:"

--- a/.github/composite_actions/install_simulators_if_needed/action.yml
+++ b/.github/composite_actions/install_simulators_if_needed/action.yml
@@ -1,5 +1,5 @@
 name: 'Install Simulators if Needed'
-description: 'Downloads and installs simulator runtimes for Xcode 16.0'
+description: 'Downloads and installs simulator runtimes for non-default Xcode versions'
 
 inputs:
   xcode_version:
@@ -14,55 +14,42 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install Simulators for Xcode 16.0
+    - name: Install Simulators if Needed
       shell: bash
       run: |
         XCODE_VERSION="${{ inputs.xcode_version }}"
         PLATFORM="${{ inputs.platform }}"
-        
-        # Only run for Xcode 16.0.0
-        if [[ "$XCODE_VERSION" != "16.0.0" ]]; then
-          echo "Not Xcode 16.0.0 (current: $XCODE_VERSION), skipping simulator installation"
-          exit 0
-        fi
-        
+
         # Skip for macOS as it doesn't need simulators
         if [[ "$PLATFORM" == "macOS" ]]; then
           echo "macOS doesn't need simulator downloads"
           exit 0
         fi
-        
-        echo "Installing simulators for $PLATFORM with Xcode 16.0.0..."
-        
-        # Ensure we're using Xcode 16.0.0 for simulator downloads
-        echo "Switching to Xcode 16.0.0..."
-        sudo xcode-select -switch /Applications/Xcode_16.0.0.app/Contents/Developer
-        
-        # Verify the switch worked
-        echo "Current Xcode version:"
+
+        # Switch to the target Xcode version
+        XCODE_PATH="/Applications/Xcode_${XCODE_VERSION}.app"
+        if [[ ! -d "$XCODE_PATH" ]]; then
+          echo "Xcode not found at $XCODE_PATH"
+          exit 1
+        fi
+
+        echo "Switching to Xcode ${XCODE_VERSION}..."
+        sudo xcode-select -switch "${XCODE_PATH}/Contents/Developer"
         xcodebuild -version
-        
-        # Show what's available before download
-        echo "Simulators before download:"
-        xcrun simctl list runtimes || true
-        
-        # Download the platform runtime for Xcode 16.0.0
-        echo "Downloading $PLATFORM runtime for Xcode 16.0..."
-        case $PLATFORM in
-          iOS)
-            sudo xcodebuild -downloadPlatform iOS || echo "Failed to download iOS platform"
-            ;;
-          tvOS)
-            sudo xcodebuild -downloadPlatform tvOS || echo "Failed to download tvOS platform"
-            ;;
-          watchOS)
-            sudo xcodebuild -downloadPlatform watchOS || echo "Failed to download watchOS platform"
-            ;;
-          visionOS)
-            sudo xcodebuild -downloadPlatform visionOS || echo "Failed to download visionOS platform"
-            ;;
-        esac
-        
-        # Show what's available after download
+
+        # Check if the simulator runtime is already available
+        echo "Checking available simulator runtimes..."
+        RUNTIMES=$(xcrun simctl list runtimes 2>/dev/null || true)
+        echo "$RUNTIMES"
+
+        PLATFORM_LOWER=$(echo "$PLATFORM" | tr '[:upper:]' '[:lower:]')
+        if echo "$RUNTIMES" | grep -qi "$PLATFORM"; then
+          echo "$PLATFORM simulator runtime is already available"
+          exit 0
+        fi
+
+        echo "$PLATFORM simulator runtime not found, downloading..."
+        sudo xcodebuild -downloadPlatform "$PLATFORM" || echo "Failed to download $PLATFORM platform"
+
         echo "Simulators after download:"
         xcrun simctl list runtimes || true

--- a/.github/workflows/build_scheme.yml
+++ b/.github/workflows/build_scheme.yml
@@ -56,9 +56,9 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ steps.platform.outputs.xcode-version }}-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            amplify-packages-
+            amplify-packages-${{ steps.platform.outputs.xcode-version }}-
 
       - name: Attempt to restore the build cache from main
         id: build-cache
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-${{ inputs.platform }}-build-cache
+          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache
 
       - name: Build ${{ inputs.scheme }}
         id: build-package

--- a/.github/workflows/integ_test_auth.yml
+++ b/.github/workflows/integ_test_auth.yml
@@ -62,10 +62,13 @@ jobs:
       project_path: ./AmplifyPlugins/Auth/Tests/AuthHostedUIApp/
       resource_subfolder: auth
       timeout-minutes: 30
+      xcode_version: '16.4.0'
     secrets: inherit
 
   auth-webauthn-integration-test-iOS:
     if: ${{ inputs.webauthn-ios != 'false' }}
     name: Auth WebAuthn Integration Tests (iOS)
     uses: ./.github/workflows/integ_test_auth_webauthn.yml
+    with:
+      xcode_version: '16.4.0'
     secrets: inherit

--- a/.github/workflows/integ_test_auth_webauthn.yml
+++ b/.github/workflows/integ_test_auth_webauthn.yml
@@ -50,9 +50,9 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ steps.platform.outputs.xcode-version }}-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            amplify-packages-
+            amplify-packages-${{ steps.platform.outputs.xcode-version }}-
 
       - name: Attempt to restore the build cache
         id: build-cache
@@ -62,7 +62,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-iOS-build-cache
+          key: Amplify-iOS-${{ steps.platform.outputs.xcode-version }}-build-cache
 
       - name: Run Local Server
         run: |

--- a/.github/workflows/integ_test_auth_webauthn.yml
+++ b/.github/workflows/integ_test_auth_webauthn.yml
@@ -2,6 +2,10 @@ name: Integration Tests | Auth - WebAuthn
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      xcode_version:
+        type: string
+        default: 'latest'
 
 permissions:
     id-token: write
@@ -25,6 +29,7 @@ jobs:
         uses: ./.github/composite_actions/get_platform_parameters
         with:
           platform: iOS
+          xcode_version: ${{ inputs.xcode_version || 'latest' }}
 
       - name: Install simulators if needed
         uses: ./.github/composite_actions/install_simulators_if_needed

--- a/.github/workflows/integ_test_auth_webauthn.yml
+++ b/.github/workflows/integ_test_auth_webauthn.yml
@@ -26,6 +26,12 @@ jobs:
         with:
           platform: iOS
 
+      - name: Install simulators if needed
+        uses: ./.github/composite_actions/install_simulators_if_needed
+        with:
+          xcode_version: ${{ steps.platform.outputs.xcode-version }}
+          platform: iOS
+
       - name: Create the test configuration directory
         run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
 

--- a/.github/workflows/integ_test_push_notifications.yml
+++ b/.github/workflows/integ_test_push_notifications.yml
@@ -49,6 +49,12 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
 
+      - name: Install simulators if needed
+        uses: ./.github/composite_actions/install_simulators_if_needed
+        with:
+          xcode_version: ${{ steps.platform.outputs.xcode-version }}
+          platform: ${{ matrix.platform }}
+
       - name: Create the test configuration directory
         run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
 

--- a/.github/workflows/integ_test_push_notifications.yml
+++ b/.github/workflows/integ_test_push_notifications.yml
@@ -73,9 +73,9 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ steps.platform.outputs.xcode-version }}-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            amplify-packages-
+            amplify-packages-${{ steps.platform.outputs.xcode-version }}-
 
       - name: Attempt to restore the build cache
         id: build-cache
@@ -85,7 +85,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-${{ matrix.platform }}-build-cache
+          key: Amplify-${{ matrix.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache
 
       - name: Run Local Server
         run: |

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -57,6 +57,12 @@ jobs:
           xcode_version: ${{ inputs.xcode_version }}
           destination: ${{ inputs.destination }}
 
+      - name: Install simulators if needed
+        uses: ./.github/composite_actions/install_simulators_if_needed
+        with:
+          xcode_version: ${{ steps.platform.outputs.xcode-version }}
+          platform: ${{ inputs.platform }}
+
       - name: Create the test configuration directory
         run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
 

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -76,9 +76,9 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ steps.platform.outputs.xcode-version }}-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            amplify-packages-
+            amplify-packages-${{ steps.platform.outputs.xcode-version }}-
 
       - name: Attempt to restore the build cache
         id: build-cache
@@ -88,7 +88,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-${{ inputs.platform }}-build-cache
+          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache
 
       - name: Run ${{ inputs.platform }} Integration Tests
         id: run-tests

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -61,6 +61,12 @@ jobs:
           platform: ${{ inputs.platform }}
           xcode_version: ${{ inputs.xcode_version }}
 
+      - name: Install simulators if needed
+        uses: ./.github/composite_actions/install_simulators_if_needed
+        with:
+          xcode_version: ${{ steps.platform.outputs.xcode-version }}
+          platform: ${{ inputs.platform }}
+
       - name: Attempt to use the dependencies cache
         id: dependencies-cache
         timeout-minutes: 4

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -68,9 +68,9 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ steps.platform.outputs.xcode-version }}-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            amplify-packages-
+            amplify-packages-${{ steps.platform.outputs.xcode-version }}-
 
       - name: Attempt to restore the build cache
         id: build-cache
@@ -80,7 +80,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-${{ inputs.platform }}-build-cache
+          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache
 
       - name: Run ${{ inputs.platform }} Unit Tests
         id: run-tests


### PR DESCRIPTION
## Summary
- Cache keys for dependencies and build artifacts did not include the Xcode version
- After upgrading `LATEST_XCODE_VERSION` from 16.4 to 26.3, stale cached artifacts from Xcode 16.4 were restored, causing linker failures (`Undefined symbol: SmithyXML.Reader.from`)
- Add `${{ steps.platform.outputs.xcode-version }}` to all cache keys across 5 workflows so caches are automatically invalidated on Xcode version changes

**New key format:**
- `amplify-packages-<xcode-version>-<Package.resolved hash>`
- `Amplify-<platform>-<xcode-version>-build-cache`

**Note:** First CI run after merge will be a cold build (no cache hit) since the key format changed. Subsequent runs will cache normally.

## Test plan
- [ ] Verify builds pass without cache hits on first run
- [ ] Verify cache is saved and restored correctly on subsequent runs
- [ ] Confirm no more `SmithyXML` linker failures