### PR TITLE
fix(api): remove custom REST query parameter allowlist

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/RESTOperationRequestUtils.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/RESTOperationRequestUtils.swift
@@ -34,7 +34,7 @@ final class RESTOperationRequestUtils {
         }
 
         if let queryParameters {
-            components.queryItems = try prepareQueryParamsForSigning(params: queryParameters)
+            components.queryItems = prepareQueryParamsForSigning(params: queryParameters)
         }
 
         guard let url = components.url else {
@@ -64,42 +64,16 @@ final class RESTOperationRequestUtils {
         return baseRequest
     }
 
-    private static let permittedQueryParamCharacters = CharacterSet.alphanumerics
-        .union(.init(charactersIn: "/_-.~+"))
-
-    private static func prepareQueryParamsForSigning(params: [String: String]) throws -> [URLQueryItem] {
-        // remove percent encoding to prepare for request signing
-        // `removingPercentEncoding` is a no-op if the query isn't encoded
-        func removePercentEncoding(key: String, value: String) -> (String, String) {
-            (key.removingPercentEncoding ?? key, value.removingPercentEncoding ?? value)
+    private static func prepareQueryParamsForSigning(params: [String: String]) -> [URLQueryItem] {
+        // Remove percent encoding to prepare for request signing. `URLComponents` will
+        // re-encode canonically when the URL is assembled, and the SigV4 signer works
+        // off the decoded values. `removingPercentEncoding` is a no-op if the value
+        // isn't encoded.
+        params.map { key, value in
+            URLQueryItem(
+                name: key.removingPercentEncoding ?? key,
+                value: value.removingPercentEncoding ?? value
+            )
         }
-
-        // Disallowed characters are checked for in the Swift SDK. However it effectively silently fails
-        // there by removing any invalid parameters. We're conducting this check here to inform the call-
-        // site.
-        func confirmOnlyPermittedCharactersPresent(key: String, value: String) throws -> (String, String) {
-            // Check if there are any characters that are NOT in the permitted set.
-            // If rangeOfCharacter(from: invertedSet) returns nil, it means ALL characters are permitted.
-            guard value.rangeOfCharacter(from: permittedQueryParamCharacters.inverted) == nil,
-                key.rangeOfCharacter(from: permittedQueryParamCharacters.inverted) == nil
-            else {
-                throw APIError.invalidURL(
-                    "Invalid query parameter.",
-                    """
-                    Review your Amplify.API call to make sure you are passing \
-                    valid UTF-8 query parameters in your request.
-                    The value passed was '\(key)=\(value)'
-                    """
-                )
-            }
-            return (key, value)
-        }
-
-        let queryItems = try params
-            .map(removePercentEncoding)
-            .map(confirmOnlyPermittedCharactersPresent)
-            .map(URLQueryItem.init)
-
-        return queryItems
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/RESTRequestUtilsTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/RESTRequestUtilsTests.swift
@@ -79,38 +79,44 @@ class RESTRequestUtilsTests: XCTestCase {
         XCTAssertFalse(urlRequest.allHTTPHeaderFields!.isEmpty)
     }
 
-    func testConstructURLRequestFailsWithInvalidQueryParams() throws {
-        let baseURL = URL(string: "https://aws.amazon.com")!
-        let validUTF16Bytes: [UInt8] = [0xd8, 0x34, 0xdd, 0x1e] // Surrogate pair for '𝄞'
-        let paramValue = String(
-            bytes: validUTF16Bytes,
-            encoding: String.Encoding.utf16BigEndian
-        )!
-        let invalidQueryParams: [String: String] = ["param": paramValue]
-        XCTAssertThrowsError(
-            try RESTOperationRequestUtils.constructURL(
-                for: baseURL,
-                withPath: "/projects",
-                withParams: invalidQueryParams
-            )
-        )
-    }
-
     func testConstructURLWithPlusSign() throws {
         let baseURL = URL(string: "https://aws.amazon.com")!
         let queryParams = ["q": "swift+amplify"]
         let expected = ["q": "swift+amplify"]
-        
+
         let resultURL = try RESTOperationRequestUtils.constructURL(
             for: baseURL,
             withPath: "/search",
             withParams: queryParams
         )
-        
+
         try assertQueryParameters(
             testCase: 0,
             withURL: resultURL,
             expected: expected
+        )
+    }
+
+    /// Characters like `@`, `:`, and sub-delims are valid in RFC 3986 query components
+    /// and are accepted by AppSync and API Gateway. Aligns behavior with Amplify JS
+    /// and Amplify Android, which delegate query encoding to the platform URL API.
+    func testConstructURLWithRFC3986QueryCharacters() throws {
+        let baseURL = URL(string: "https://aws.amazon.com")!
+        let queryParams = [
+            "user": "hello@email.com",
+            "created": "2021-06-18T09:00:00Z"
+        ]
+
+        let resultURL = try RESTOperationRequestUtils.constructURL(
+            for: baseURL,
+            withPath: "/items",
+            withParams: queryParams
+        )
+
+        try assertQueryParameters(
+            testCase: 0,
+            withURL: resultURL,
+            expected: queryParams
         )
     }
 }


### PR DESCRIPTION
### Issue

PR #4137 fixed a latent bug in the REST query parameter validator (the old check passed if *any* permitted character was present, not *all*). That fix was correct, but it exposed a second problem: the `permittedQueryParamCharacters` allowlist itself is too narrow. Common values like `hello@email.com` and `2021-06-18T09:00:00Z` contain characters (`@`, `:`) that are valid per RFC 3986 and accepted by AppSync and API Gateway, but were not in the allowlist.

Before #4137 these values slipped through the no-op check. After #4137, they correctly trip the validator — which broke the `RESTWithUserPoolIntegrationTests` and `RESTWithIAMIntegrationTests` integration test suites on `main`:

```
testGetAPIWithEncodedQueryParamsSuccess, failed: caught error: "APIError: Invalid query parameter."
testGetAPIWithQueryParamsSuccess, failed: caught error: "APIError: Invalid query parameter."
```

Example failing run: https://github.com/aws-amplify/amplify-swift/actions/runs/24523970576/job/71689043095

### Approach

Rather than expand the allowlist character-by-character, remove it entirely and align with the sibling Amplify libraries:

- **Amplify JS** (`resolveApiUrl.ts`) delegates to `URL` / `URLSearchParams`.
- **Amplify Android** (`RestRequestFactory.java`) delegates to OkHttp's `HttpUrl.Builder.addQueryParameter()`.

Neither maintains a custom allowlist. `URLComponents` handles canonical percent-encoding when the URL is assembled, and the SigV4 signer operates on the decoded values (preserved via `removingPercentEncoding`).

### Changes

- Remove `permittedQueryParamCharacters` and `confirmOnlyPermittedCharactersPresent` from `RESTOperationRequestUtils`.
- `prepareQueryParamsForSigning` no longer throws; call site updated.
- Drop `testConstructURLRequestFailsWithInvalidQueryParams` — the invalid-UTF-16 case is no longer this layer's responsibility and matches Android/JS behavior.
- Add `testConstructURLWithRFC3986QueryCharacters` to pin acceptance of `@` and `:` in query values.

### Verification

- Unit tests: `AWSAPIPluginTests/RESTRequestUtilsTests` — 4/4 passing locally (`testConstructURL`, `testConstructURLRequest`, `testConstructURLWithPlusSign`, `testConstructURLWithRFC3986QueryCharacters`).
- Integration tests in `RESTWithUserPoolIntegrationTests` / `RESTWithIAMIntegrationTests` now execute the real network path with `@` and `:` in query values, which is what they were always intended to cover.

### Test plan

- [ ] `AWSAPIPluginTests/RESTRequestUtilsTests` passes in CI
- [ ] `RESTWithUserPoolIntegrationTests` integration suite passes in CI
- [ ] `RESTWithIAMIntegrationTests` integration suite passes in CI