### PR TITLE
chore(ci): scope build cache key to Package.resolved hash

### DIFF
--- a/.github/workflows/build_scheme.yml
+++ b/.github/workflows/build_scheme.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache
+          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache-${{ hashFiles('Package.resolved') }}
 
       - name: Build ${{ inputs.scheme }}
         id: build-package

--- a/.github/workflows/integ_test_auth_webauthn.yml
+++ b/.github/workflows/integ_test_auth_webauthn.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-iOS-${{ steps.platform.outputs.xcode-version }}-build-cache
+          key: Amplify-iOS-${{ steps.platform.outputs.xcode-version }}-build-cache-${{ hashFiles('Package.resolved') }}
 
       - name: Run Local Server
         run: |

--- a/.github/workflows/integ_test_push_notifications.yml
+++ b/.github/workflows/integ_test_push_notifications.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-${{ matrix.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache
+          key: Amplify-${{ matrix.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache-${{ hashFiles('Package.resolved') }}
 
       - name: Run Local Server
         run: |

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache
+          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache-${{ hashFiles('Package.resolved') }}
 
       - name: Run ${{ inputs.platform }} Integration Tests
         id: run-tests

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache
+          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache-${{ hashFiles('Package.resolved') }}
 
       - name: Run ${{ inputs.platform }} Unit Tests
         id: run-tests


### PR DESCRIPTION
### Issue

Integration-test jobs routinely fail with linker errors after an `aws-sdk-swift` (or any SPM dependency) bump on main, e.g.:

```
Undefined symbol: static SmithyXML.Reader.from(data: Foundation.Data) throws -> SmithyXML.Reader
Undefined symbol: type metadata accessor for SmithyXML.Reader
Ld .../AWSClientRuntime.framework/AWSClientRuntime normal
```

Example: PR #4194, job https://github.com/aws-amplify/amplify-swift/actions/runs/24545265553/job/71759310444. The cache restore succeeds ("Cache restored successfully"), so the failure is misread as a cache hit; the actual problem is that the restored build artifacts reference symbols that no longer exist in the SPM modules freshly resolved from the current `Package.resolved`.

### Root cause

Two caches are in play:

1. **Dependencies cache** — `~/Library/Developer/Xcode/DerivedData/Amplify`, keyed on `amplify-packages-<xcode>-${{ hashFiles('Package.resolved') }}`. Self-invalidates correctly when `Package.resolved` changes.
2. **Build cache** — `$GITHUB_WORKSPACE/Build` (DerivedData output), keyed on `Amplify-<platform>-<xcode>-build-cache`. **No content hash.** This key is stable per platform + Xcode version forever.

When `main` merges an `aws-sdk-swift` bump, the build cache is updated by `build_scheme.yml` (save-on-main logic), but until that save completes on every platform, and for any PR running in parallel or before the save, the restored build artifacts reflect the *old* module graph. The linker then fails against the *new* SPM source the dependencies cache produces.

Unit tests don't exhibit this because `run_unit_tests.yml` also lacks a save step — it always rebuilds from scratch. Integration-test runs actually exercise the restored artifacts, so the mismatch surfaces there.

### Fix

Include `hashFiles('Package.resolved')` in every build-cache key so cache buckets are bound to the exact module graph they were compiled against. A dependency bump routes to a fresh bucket automatically, and stale buckets expire via GitHub's 7-day LRU.

### Changes

Updated every workflow that reads or writes the build cache:

- `.github/workflows/build_scheme.yml`
- `.github/workflows/run_integration_tests.yml`
- `.github/workflows/run_unit_tests.yml`
- `.github/workflows/integ_test_auth_webauthn.yml`
- `.github/workflows/integ_test_push_notifications.yml`

The save step in `build_scheme.yml` references `steps.build-cache.outputs.cache-primary-key`, so it automatically writes to the new hashed bucket without further changes. The "Delete the old build cache" step continues to remove only the matching bucket before overwriting.

### Test plan

- [ ] Integration-test jobs on this PR hit the new cache key and either restore cleanly or miss and rebuild.
- [ ] Merge to `main` populates a fresh build cache under the hashed key via `build_scheme.yml`.
- [ ] Subsequent `aws-sdk-swift` bump automatically routes to a new bucket without manual cache eviction.