### PR TITLE
chore(ci): scope build cache per scheme and save from each workflow

### DIFF
--- a/.github/workflows/build_scheme.yml
+++ b/.github/workflows/build_scheme.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache-${{ hashFiles('Package.resolved') }}
+          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-${{ inputs.scheme }}-build-cache-${{ hashFiles('Package.resolved') }}
 
       - name: Build ${{ inputs.scheme }}
         id: build-package

--- a/.github/workflows/integ_test_auth_webauthn.yml
+++ b/.github/workflows/integ_test_auth_webauthn.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-iOS-${{ steps.platform.outputs.xcode-version }}-build-cache-${{ hashFiles('Package.resolved') }}
+          key: Amplify-iOS-${{ steps.platform.outputs.xcode-version }}-AuthWebAuthnApp-build-cache-${{ hashFiles('Package.resolved') }}
 
       - name: Run Local Server
         run: |
@@ -111,3 +111,10 @@ jobs:
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: true
+
+      - name: Save the build cache
+        if: steps.build-cache.outputs.cache-hit != 'true' && (steps.run-tests.outcome == 'success' || steps.retry-tests.outcome == 'success')
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ${{ github.workspace }}/Build
+          key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/integ_test_push_notifications.yml
+++ b/.github/workflows/integ_test_push_notifications.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-${{ matrix.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache-${{ hashFiles('Package.resolved') }}
+          key: Amplify-${{ matrix.platform }}-${{ steps.platform.outputs.xcode-version }}-${{ matrix.platform == 'watchOS' && 'PushNotificationWatchTests' || 'PushNotificationHostApp' }}-build-cache-${{ hashFiles('Package.resolved') }}
 
       - name: Run Local Server
         run: |
@@ -129,3 +129,10 @@ jobs:
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: true
+
+      - name: Save the build cache
+        if: steps.build-cache.outputs.cache-hit != 'true' && (steps.run-tests.outcome == 'success' || steps.retry-tests.outcome == 'success')
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ${{ github.workspace }}/Build
+          key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache-${{ hashFiles('Package.resolved') }}
+          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-${{ inputs.scheme }}-build-cache-${{ hashFiles('Package.resolved') }}
 
       - name: Run ${{ inputs.platform }} Integration Tests
         id: run-tests
@@ -130,3 +130,10 @@ jobs:
           # Only attempt to test without building when we are not using any cache.
           test_without_building: ${{ !steps.build-cache.outputs.cache-hit }}
           other_flags: -test-iterations 3 -retry-tests-on-failure -parallel-testing-enabled NO -test-repetition-relaunch-enabled YES
+
+      - name: Save the build cache
+        if: steps.build-cache.outputs.cache-hit != 'true' && (steps.run-tests.outcome == 'success' || steps.retry-tests.outcome == 'success')
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ${{ github.workspace }}/Build
+          key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache-${{ hashFiles('Package.resolved') }}
+          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-${{ inputs.scheme }}-build-cache-${{ hashFiles('Package.resolved') }}
 
       - name: Run ${{ inputs.platform }} Unit Tests
         id: run-tests
@@ -118,6 +118,13 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: true
           other_flags: ${{ inputs.test_iterations_flags }}
+
+      - name: Save the build cache
+        if: steps.build-cache.outputs.cache-hit != 'true' && (steps.run-tests.outcome == 'success' || steps.retry-tests.outcome == 'success')
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ${{ github.workspace }}/Build
+          key: ${{ steps.build-cache.outputs.cache-primary-key }}
 
       - name: Store Coverage Report File
         if: ${{ inputs.generate_coverage_report == true }}


### PR DESCRIPTION
### Issue

Integration-test jobs still fail with linker errors after #4195 despite paired cache hashes, e.g. PR #4196 run https://github.com/aws-amplify/amplify-swift/actions/runs/24581983815/job/71882046114:

```
Undefined symbol: static SmithyXML.Reader.from(data: Foundation.Data) throws -> SmithyXML.Reader
Undefined symbol: type metadata accessor for SmithyXML.Reader
Ld .../AWSClientRuntime.framework/AWSClientRuntime normal
```

### Root cause

PR #4195 scoped the cache key to `hashFiles('Package.resolved')`, which eliminated cross-dependency poisoning. A second failure mode was still present:

The build cache is populated exclusively by `build_scheme.yml` on `main`, which builds **scheme `Amplify-Package`**. Integration-test schemes link frameworks that `Amplify-Package` does not — for example Predictions pulls `SmithyXML` via Rekognition/Polly, Storage pulls it via S3. Restoring the `Amplify-Package`-flavoured cache into an integration-test build leaves those frameworks absent, and the linker fails.

One platform-scoped cache bucket cannot serve multiple schemes with different module graphs.

### Fix

Scope the build cache per scheme, and have each test workflow save its own bucket from `main` after a successful run.

#### Changes

**Restore key gets `${{ inputs.scheme }}` appended:**

```yaml
# before
key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-build-cache-${{ hashFiles('Package.resolved') }}
# after
key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-${{ inputs.scheme }}-build-cache-${{ hashFiles('Package.resolved') }}
```

Applied to:
- `build_scheme.yml`
- `run_integration_tests.yml`
- `run_unit_tests.yml`
- `integ_test_auth_webauthn.yml` (literal `AuthWebAuthnApp`)
- `integ_test_push_notifications.yml` (literal `PushNotificationHostApp` / `PushNotificationWatchTests` depending on platform)

**New save step** at the end of each test workflow (integration and unit), gated so it only runs on `main` after a successful test:

```yaml
- name: Save the build cache
  if: github.ref_name == 'main' && steps.build-cache.outputs.cache-hit != 'true' && (steps.run-tests.outcome == 'success' || steps.retry-tests.outcome == 'success')
  uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
  with:
    path: \${{ github.workspace }}/Build
    key: \${{ steps.build-cache.outputs.cache-primary-key }}
```

This writes only from `main`, skips when the restore already matched, and never saves artifacts from a failed run.

### Cost

Cache footprint grows from 5 buckets per dep-graph version (platform-only) to roughly one bucket per scheme × platform. GitHub's 10 GB/repo LRU will evict the oldest buckets first; PR branches still read caches produced on `main`.

### Test plan

- [ ] On merge, `build_scheme.yml` populates the `Amplify-Package` bucket under the new key.
- [ ] Integration test workflows on `main` populate their own per-scheme buckets after a successful run.
- [ ] Subsequent PR integration runs restore the correct per-scheme cache and link cleanly (no `SmithyXML` linker errors).
- [ ] Cache list (`gh cache list`) shows per-scheme buckets rather than a single shared bucket.