### PR TITLE
fix(auth): Use inputUsername for device metadata lookup in rememberDevice/forgetDevice and add e2e tests

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/RefreshAuthorizationSession/UserPool/RefreshUserPoolTokens.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/RefreshAuthorizationSession/UserPool/RefreshUserPoolTokens.swift
@@ -82,7 +82,8 @@ struct RefreshUserPoolTokens: Action {
             let signedInData = SignedInData(
                 signedInDate: existingSignedIndata.signedInDate,
                 signInMethod: existingSignedIndata.signInMethod,
-                cognitoUserPoolTokens: userPoolTokens
+                cognitoUserPoolTokens: userPoolTokens,
+                inputUsername: existingSignedIndata.inputUsername
             )
             let event: RefreshSessionEvent
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/RefreshAuthorizationSession/UserPool/RefreshUserPoolTokens.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/RefreshAuthorizationSession/UserPool/RefreshUserPoolTokens.swift
@@ -33,7 +33,7 @@ struct RefreshUserPoolTokens: Action {
             let existingTokens = existingSignedIndata.cognitoUserPoolTokens
 
             let deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
-                for: existingSignedIndata.username,
+                for: existingSignedIndata.inputUsername ?? existingSignedIndata.username,
                 with: environment
             )
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthForgetDeviceTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthForgetDeviceTask.swift
@@ -53,7 +53,7 @@ class AWSAuthForgetDeviceTask: AuthForgetDeviceTask, DefaultLogger {
         let authState = await authStateMachine.currentState
         if case .configured(let authenticationState, _, _) = authState,
            case .signedIn(let signInData) = authenticationState {
-           return signInData.username
+           return signInData.inputUsername ?? signInData.username
         }
         throw AuthError.unknown("Unable to get username for the signedIn user")
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthRememberDeviceTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthRememberDeviceTask.swift
@@ -52,7 +52,7 @@ class AWSAuthRememberDeviceTask: AuthRememberDeviceTask, DefaultLogger {
         let authState = await authStateMachine.currentState
         if case .configured(let authenticationState, _, _) = authState,
            case .signedIn(let signInData) = authenticationState {
-           return signInData.username
+           return signInData.inputUsername ?? signInData.username
         }
         throw AuthError.unknown("Unable to get username for the signedIn user")
     }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
@@ -30,7 +30,6 @@
 		21F762B82BD6B1AA0048845A /* TOTPSetupWhenAuthenticatedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48916F372A412B2800E3E1B1 /* TOTPSetupWhenAuthenticatedTests.swift */; };
 		21F762B92BD6B1AA0048845A /* CredentialStoreConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484834BB27B6ED8700649D11 /* CredentialStoreConfigurationTests.swift */; };
 		21F762BA2BD6B1AA0048845A /* AuthRememberDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9737C74D287E208400DA0D2B /* AuthRememberDeviceTests.swift */; };
-		E9B56799769C60EAA3B3F1B7 /* DeviceKeyPersistenceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF106AB62BCE2F9D62D3CB0 /* DeviceKeyPersistenceIntegrationTests.swift */; };
 		21F762BB2BD6B1AA0048845A /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEAA28E747B80000C36A /* XCTestCase+AsyncTesting.swift */; };
 		21F762BC2BD6B1AA0048845A /* AuthResendSignUpCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43C26C927BC9D54003F3BF7 /* AuthResendSignUpCodeTests.swift */; };
 		21F762BD2BD6B1AA0048845A /* AuthResetPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97829200286B802E000DE190 /* AuthResetPasswordTests.swift */; };
@@ -41,6 +40,7 @@
 		21F762C22BD6B1AA0048845A /* AuthConfirmResetPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97829202286E41FA000DE190 /* AuthConfirmResetPasswordTests.swift */; };
 		21F762C32BD6B1AA0048845A /* AuthDeleteUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4821B2F1286B5F74000EC1D7 /* AuthDeleteUserTests.swift */; };
 		21F762C62BD6B1AA0048845A /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 485CB5AE27B61EAA006CCEC7 /* README.md */; };
+		3ECC1FC593B6E582A1A88856 /* DeviceKeyPersistenceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF106AB62BCE2F9D62D3CB0 /* DeviceKeyPersistenceIntegrationTests.swift */; };
 		4821B2F2286B5F74000EC1D7 /* AuthDeleteUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4821B2F1286B5F74000EC1D7 /* AuthDeleteUserTests.swift */; };
 		4821B2F428737130000EC1D7 /* AuthCustomSignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4821B2F328737130000EC1D7 /* AuthCustomSignInTests.swift */; };
 		4834D7C128B0770800DD564B /* FederatedSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4834D7C028B0770800DD564B /* FederatedSessionTests.swift */; };
@@ -88,6 +88,7 @@
 		48DEF59B2CDB1FF500BDB995 /* PasswordlessSignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DEF5992CDB1FF500BDB995 /* PasswordlessSignInTests.swift */; };
 		48DEF59C2CDB1FF500BDB995 /* PasswordlessSignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DEF5992CDB1FF500BDB995 /* PasswordlessSignInTests.swift */; };
 		48E3AB3128E52590004EE395 /* GetCurrentUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48E3AB3028E52590004EE395 /* GetCurrentUserTests.swift */; };
+		4BF81384CA84205BCBC3A1DE /* DeviceKeyPersistenceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF106AB62BCE2F9D62D3CB0 /* DeviceKeyPersistenceIntegrationTests.swift */; };
 		681B76952A3CB8DA004B59D9 /* AuthHostAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB53D27B614CE006CCEC7 /* AuthHostAppApp.swift */; };
 		681B76962A3CB8DD004B59D9 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB53F27B614CE006CCEC7 /* ContentView.swift */; };
 		681B769A2A3CBA97004B59D9 /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = 681B76992A3CBA97004B59D9 /* Amplify */; };
@@ -110,7 +111,6 @@
 		681B76B22A3CBBAE004B59D9 /* AuthEnvironmentHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484834BD27B6FD9B00649D11 /* AuthEnvironmentHelper.swift */; };
 		681B76B32A3CBBAE004B59D9 /* CredentialStoreConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484834BB27B6ED8700649D11 /* CredentialStoreConfigurationTests.swift */; };
 		681B76B42A3CBBAE004B59D9 /* AuthRememberDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9737C74D287E208400DA0D2B /* AuthRememberDeviceTests.swift */; };
-		4BF81384CA84205BCBC3A1DE /* DeviceKeyPersistenceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF106AB62BCE2F9D62D3CB0 /* DeviceKeyPersistenceIntegrationTests.swift */; };
 		681B76B52A3CBBAE004B59D9 /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEAA28E747B80000C36A /* XCTestCase+AsyncTesting.swift */; };
 		681B76B62A3CBBAE004B59D9 /* AuthResendSignUpCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43C26C927BC9D54003F3BF7 /* AuthResendSignUpCodeTests.swift */; };
 		681B76B72A3CBBAE004B59D9 /* AuthResetPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97829200286B802E000DE190 /* AuthResetPasswordTests.swift */; };
@@ -125,7 +125,6 @@
 		681DFEAD28E747B80000C36A /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEAA28E747B80000C36A /* XCTestCase+AsyncTesting.swift */; };
 		970333F0295D793B0019981E /* AuthStressBaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970333EF295D793B0019981E /* AuthStressBaseTest.swift */; };
 		9737C74E287E208400DA0D2B /* AuthRememberDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9737C74D287E208400DA0D2B /* AuthRememberDeviceTests.swift */; };
-		3ECC1FC593B6E582A1A88856 /* DeviceKeyPersistenceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF106AB62BCE2F9D62D3CB0 /* DeviceKeyPersistenceIntegrationTests.swift */; };
 		9737C7502880BFD600DA0D2B /* AuthForgetDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9737C74F2880BFD600DA0D2B /* AuthForgetDeviceTests.swift */; };
 		97829201286B802E000DE190 /* AuthResetPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97829200286B802E000DE190 /* AuthResetPasswordTests.swift */; };
 		97829203286E41FA000DE190 /* AuthConfirmResetPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97829202286E41FA000DE190 /* AuthConfirmResetPasswordTests.swift */; };
@@ -145,6 +144,8 @@
 		B43C26CC27BC9D54003F3BF7 /* AuthResendSignUpCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43C26C927BC9D54003F3BF7 /* AuthResendSignUpCodeTests.swift */; };
 		B4B9F45828F47C0A004F346F /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = B4B9F45728F47C0A004F346F /* Amplify */; };
 		B4B9F45A28F47C0A004F346F /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = B4B9F45928F47C0A004F346F /* AWSCognitoAuthPlugin */; };
+		E9B56799769C60EAA3B3F1B7 /* DeviceKeyPersistenceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF106AB62BCE2F9D62D3CB0 /* DeviceKeyPersistenceIntegrationTests.swift */; };
+		EA3EEAF12FAA492B0011EF4D /* DeviceAliasTokenRefreshIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3EEAF02FAA492B0011EF4D /* DeviceAliasTokenRefreshIntegrationTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -193,6 +194,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0DF106AB62BCE2F9D62D3CB0 /* DeviceKeyPersistenceIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyPersistenceIntegrationTests.swift; sourceTree = "<group>"; };
 		21CFD7C52C7524570071C70F /* AppSyncSignerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncSignerTests.swift; sourceTree = "<group>"; };
 		21F762CB2BD6B1AA0048845A /* AuthGen2IntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AuthGen2IntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		21F762CC2BD6B1CD0048845A /* AuthGen2IntegrationTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = AuthGen2IntegrationTests.xctestplan; sourceTree = "<group>"; };
@@ -231,10 +233,8 @@
 		681DFEA828E747B80000C36A /* AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncTesting.swift; sourceTree = "<group>"; };
 		681DFEA928E747B80000C36A /* AsyncExpectation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncExpectation.swift; sourceTree = "<group>"; };
 		681DFEAA28E747B80000C36A /* XCTestCase+AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AsyncTesting.swift"; sourceTree = "<group>"; };
-		907EA7602A4B6F56005E3AA8 /* AuthHostApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AuthHostApp.entitlements; sourceTree = "<group>"; };
 		970333EF295D793B0019981E /* AuthStressBaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthStressBaseTest.swift; sourceTree = "<group>"; };
 		9737C74D287E208400DA0D2B /* AuthRememberDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRememberDeviceTests.swift; sourceTree = "<group>"; };
-		0DF106AB62BCE2F9D62D3CB0 /* DeviceKeyPersistenceIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyPersistenceIntegrationTests.swift; sourceTree = "<group>"; };
 		9737C74F2880BFD600DA0D2B /* AuthForgetDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthForgetDeviceTests.swift; sourceTree = "<group>"; };
 		97829200286B802E000DE190 /* AuthResetPasswordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthResetPasswordTests.swift; sourceTree = "<group>"; };
 		97829202286E41FA000DE190 /* AuthConfirmResetPasswordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthConfirmResetPasswordTests.swift; sourceTree = "<group>"; };
@@ -251,6 +251,7 @@
 		B4B9F45628F47B7B004F346F /* amplify-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-ios"; path = ../../../..; sourceTree = "<group>"; };
 		E2A7D1732C5D76CB00B06999 /* AuthHostApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AuthHostApp.entitlements; sourceTree = "<group>"; };
 		E2A7D1742C5D774200B06999 /* AuthWatchApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AuthWatchApp.entitlements; sourceTree = "<group>"; };
+		EA3EEAF02FAA492B0011EF4D /* DeviceAliasTokenRefreshIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAliasTokenRefreshIntegrationTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -535,6 +536,7 @@
 		97B370C32878DA3500F1C088 /* DeviceTests */ = {
 			isa = PBXGroup;
 			children = (
+				EA3EEAF02FAA492B0011EF4D /* DeviceAliasTokenRefreshIntegrationTests.swift */,
 				97B370C42878DA5A00F1C088 /* AuthFetchDeviceTests.swift */,
 				9737C74D287E208400DA0D2B /* AuthRememberDeviceTests.swift */,
 				9737C74F2880BFD600DA0D2B /* AuthForgetDeviceTests.swift */,
@@ -878,6 +880,7 @@
 				21F762AC2BD6B1AA0048845A /* AuthFetchDeviceTests.swift in Sources */,
 				21F762AD2BD6B1AA0048845A /* TOTPSetupWhenUnauthenticatedTests.swift in Sources */,
 				21F762AE2BD6B1AA0048845A /* AsyncExpectation.swift in Sources */,
+				EA3EEAF12FAA492B0011EF4D /* DeviceAliasTokenRefreshIntegrationTests.swift in Sources */,
 				21F762AF2BD6B1AA0048845A /* GetCurrentUserTests.swift in Sources */,
 				21F762B02BD6B1AA0048845A /* TOTPHelper.swift in Sources */,
 				21F762B12BD6B1AA0048845A /* AWSAuthBaseTest.swift in Sources */,

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/DeviceAliasTokenRefreshIntegrationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/DeviceAliasTokenRefreshIntegrationTests.swift
@@ -1,0 +1,172 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import AWSCognitoAuthPlugin
+import XCTest
+@testable import Amplify
+
+/// Integration tests for token refresh with device tracking and email alias login.
+///
+/// These tests verify that token refresh works correctly when a user signs in
+/// with an email alias (where inputUsername != JWT username/sub). This is a
+/// regression test for https://github.com/aws-amplify/amplify-swift/issues/4207.
+///
+/// Prerequisites:
+/// - Cognito User Pool with email as usernameAttribute (alias-based auth)
+/// - Device Tracking set to "Always Remember"
+/// - Short token validity (5 min) configured via CDK override
+/// - Pre-created test user (credentials in testconfiguration/AWSCognitoAuthPluginDeviceAliasTests-credentials.json)
+/// - Backend definition in infra/device-alias-test/ (not committed, see README)
+/// - Config: testconfiguration/AWSCognitoAuthPluginDeviceAliasTests-amplify_outputs.json
+class DeviceAliasTokenRefreshIntegrationTests: AWSAuthBaseTest {
+
+    var unsubscribeToken: UnsubscribeToken!
+
+    override func setUp() async throws {
+        onlyUseGen2Configuration = true
+        amplifyOutputsFile = "testconfiguration/AWSCognitoAuthPluginDeviceAliasTests-amplify_outputs"
+        try await super.setUp()
+        // Load credentials from our custom credentials file
+        let credentials = (try? TestConfigHelper.retrieveCredentials(
+            forResource: "testconfiguration/AWSCognitoAuthPluginDeviceAliasTests-credentials"
+        )) ?? [:]
+        defaultTestEmail = credentials["test_email_1"] ?? defaultTestEmail
+        defaultTestPassword = credentials["password"] ?? defaultTestPassword
+        AuthSessionHelper.clearSession()
+    }
+
+    override func tearDown() async throws {
+        try await super.tearDown()
+        AuthSessionHelper.clearSession()
+    }
+
+    // MARK: - Helpers
+
+    private func signInAndWait(
+        username: String,
+        password: String
+    ) async throws -> AuthSignInResult {
+        let signInExpectation = expectation(description: "Sign in")
+        unsubscribeToken = Amplify.Hub.listen(to: .auth) { payload in
+            if payload.eventName == HubPayload.EventName.Auth.signedIn {
+                signInExpectation.fulfill()
+            }
+        }
+
+        let result = try await Amplify.Auth.signIn(
+            username: username,
+            password: password,
+            options: .init(pluginOptions: AWSAuthSignInOptions(authFlowType: .userSRP))
+        )
+        await fulfillment(of: [signInExpectation], timeout: networkTimeout)
+        Amplify.Hub.removeListener(unsubscribeToken)
+        return result
+    }
+
+    // MARK: - Token Refresh with Email Alias Tests (issue #4207)
+
+    /// Test that token refresh succeeds when signed in with email alias and device tracking
+    ///
+    /// - Given: A user signed in with email alias (USER_SRP_AUTH) with device remembered
+    /// - When: fetchAuthSession is called with forceRefresh
+    /// - Then: The session should contain valid refreshed tokens (not "Invalid Refresh Token")
+    func testTokenRefreshSucceedsWithEmailAliasAndDeviceTracking() async throws {
+        let result = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(result.isSignedIn)
+
+        // Device is automatically remembered (pool configured with "always remember")
+        // Force refresh — this triggers the device metadata lookup
+        let session = try await Amplify.Auth.fetchAuthSession(options: .init(forceRefresh: true))
+        XCTAssertTrue(session.isSignedIn)
+
+        if let cognitoSession = session as? AWSAuthCognitoSession {
+            switch cognitoSession.userPoolTokensResult {
+            case .success(let tokens):
+                XCTAssertFalse(tokens.idToken.isEmpty)
+                XCTAssertFalse(tokens.accessToken.isEmpty)
+            case .failure(let error):
+                XCTFail("Token refresh failed with email alias + device tracking: \(error). " +
+                    "Device metadata keychain key mismatch (issue #4207)")
+            }
+        }
+    }
+
+    /// Test that consecutive token refreshes succeed with email alias and device tracking
+    ///
+    /// - Given: A user signed in with email alias (USER_SRP_AUTH) with device remembered
+    /// - When: fetchAuthSession is called with forceRefresh twice
+    /// - Then: Both refreshes succeed (inputUsername preserved across refreshes)
+    func testConsecutiveTokenRefreshesWithEmailAlias() async throws {
+        let result = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(result.isSignedIn)
+
+        // First refresh
+        let session1 = try await Amplify.Auth.fetchAuthSession(options: .init(forceRefresh: true))
+        if let cognitoSession = session1 as? AWSAuthCognitoSession {
+            switch cognitoSession.userPoolTokensResult {
+            case .success(let tokens):
+                XCTAssertFalse(tokens.idToken.isEmpty)
+            case .failure(let error):
+                XCTFail("First refresh failed: \(error)")
+            }
+        }
+
+        // Second refresh — fails if inputUsername not preserved after first refresh
+        let session2 = try await Amplify.Auth.fetchAuthSession(options: .init(forceRefresh: true))
+        if let cognitoSession = session2 as? AWSAuthCognitoSession {
+            switch cognitoSession.userPoolTokensResult {
+            case .success(let tokens):
+                XCTAssertFalse(tokens.idToken.isEmpty)
+            case .failure(let error):
+                XCTFail("Second refresh failed — inputUsername not preserved: \(error) (issue #4207)")
+            }
+        }
+    }
+
+    /// Test that token refresh succeeds after sign-out/sign-in with email alias
+    ///
+    /// - Given: A user who signed in with email, remembered device, signed out, signed back in
+    /// - When: fetchAuthSession is called with forceRefresh
+    /// - Then: Token refresh succeeds
+    func testTokenRefreshAfterReSignInWithEmailAlias() async throws {
+        // First sign-in + remember device
+        let firstResult = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(firstResult.isSignedIn)
+
+        // Sign out
+        _ = await Amplify.Auth.signOut()
+
+        // Second sign-in
+        let secondResult = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(secondResult.isSignedIn)
+
+        // Force refresh after re-sign-in
+        let session = try await Amplify.Auth.fetchAuthSession(options: .init(forceRefresh: true))
+        XCTAssertTrue(session.isSignedIn)
+
+        if let cognitoSession = session as? AWSAuthCognitoSession {
+            switch cognitoSession.userPoolTokensResult {
+            case .success(let tokens):
+                XCTAssertFalse(tokens.idToken.isEmpty)
+            case .failure(let error):
+                XCTFail("Token refresh after re-sign-in with email alias failed: \(error) (issue #4207)")
+            }
+        }
+    }
+}

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/DeviceAliasTokenRefreshIntegrationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/DeviceAliasTokenRefreshIntegrationTests.swift
@@ -169,4 +169,219 @@ class DeviceAliasTokenRefreshIntegrationTests: AWSAuthBaseTest {
             }
         }
     }
+
+    /// Test that rememberDevice succeeds with email alias login
+    ///
+    /// - Given: A user signed in with email alias (USER_SRP_AUTH)
+    /// - When: rememberDevice is called
+    /// - Then: It should succeed without "Unable to get device metadata" error
+    func testRememberDeviceSucceedsWithEmailAlias() async throws {
+        let result = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(result.isSignedIn)
+
+        // This should not throw — device metadata should be found using inputUsername
+        _ = try await Amplify.Auth.rememberDevice()
+
+        // Verify device is listed
+        let devices = try await Amplify.Auth.fetchDevices()
+        XCTAssertGreaterThanOrEqual(devices.count, 1,
+            "Should have at least 1 remembered device after rememberDevice()")
+    }
+
+    // MARK: - forgetDevice with Email Alias Tests
+
+    /// Test that forgetDevice succeeds with email alias login
+    ///
+    /// - Given: A user signed in with email alias with a remembered device
+    /// - When: forgetDevice is called
+    /// - Then: It should succeed without "Unable to get device metadata" error
+    func testForgetDeviceSucceedsWithEmailAlias() async throws {
+        let result = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(result.isSignedIn)
+
+        // Pool is "always remember" so device is auto-confirmed, but call remember
+        // explicitly to ensure it's in the remembered state
+        _ = try await Amplify.Auth.rememberDevice()
+
+        // This should not throw — device metadata lookup uses inputUsername
+        _ = try await Amplify.Auth.forgetDevice()
+
+        // Verify device is no longer listed
+        let devices = try await Amplify.Auth.fetchDevices()
+        XCTAssertEqual(devices.count, 0,
+            "Device list should be empty after forgetDevice()")
+    }
+
+    /// Test that forgetDevice works after a token refresh with email alias
+    ///
+    /// - Given: A user signed in with email alias who has performed a token refresh
+    /// - When: forgetDevice is called after the refresh
+    /// - Then: It should succeed (inputUsername preserved through refresh cycle)
+    func testForgetDeviceAfterTokenRefreshWithEmailAlias() async throws {
+        let result = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(result.isSignedIn)
+
+        _ = try await Amplify.Auth.rememberDevice()
+
+        // Force a token refresh first
+        let session = try await Amplify.Auth.fetchAuthSession(options: .init(forceRefresh: true))
+        XCTAssertTrue(session.isSignedIn)
+
+        // Now forget — inputUsername must still be available after refresh
+        _ = try await Amplify.Auth.forgetDevice()
+
+        let devices = try await Amplify.Auth.fetchDevices()
+        XCTAssertEqual(devices.count, 0,
+            "forgetDevice should work after token refresh with email alias")
+    }
+
+    // MARK: - fetchDevices with Email Alias Tests
+
+    /// Test that fetchDevices returns device details with email alias login
+    ///
+    /// - Given: A user signed in with email alias with a remembered device
+    /// - When: fetchDevices is called
+    /// - Then: It should return the device with valid metadata
+    func testFetchDevicesReturnsDetailsWithEmailAlias() async throws {
+        let result = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(result.isSignedIn)
+
+        _ = try await Amplify.Auth.rememberDevice()
+
+        let devices = try await Amplify.Auth.fetchDevices()
+        XCTAssertGreaterThanOrEqual(devices.count, 1)
+
+        guard let device = devices.first as? AWSAuthDevice else {
+            XCTFail("Should be able to cast to AWSAuthDevice")
+            return
+        }
+        XCTAssertFalse(device.id.isEmpty, "Device should have a non-empty ID")
+        XCTAssertNotNil(device.createdDate, "Device should have a creation date")
+        XCTAssertNotNil(device.lastAuthenticatedDate, "Device should have last authenticated date")
+    }
+
+    // MARK: - Device Persistence with Email Alias Tests
+
+    /// Test that device persists across sign-out/sign-in with email alias
+    ///
+    /// - Given: A user signed in with email alias who has a remembered device
+    /// - When: The user signs out and signs back in with the same email alias
+    /// - Then: fetchDevices should return the same device (not a new one)
+    func testDevicePersistsAcrossSignOutSignInWithEmailAlias() async throws {
+        let firstResult = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(firstResult.isSignedIn)
+
+        _ = try await Amplify.Auth.rememberDevice()
+        let devicesAfterFirst = try await Amplify.Auth.fetchDevices()
+        XCTAssertGreaterThanOrEqual(devicesAfterFirst.count, 1)
+        let firstDeviceId = devicesAfterFirst.first?.id
+        XCTAssertNotNil(firstDeviceId)
+
+        // Sign out and back in
+        _ = await Amplify.Auth.signOut()
+
+        let secondResult = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(secondResult.isSignedIn)
+
+        let devicesAfterSecond = try await Amplify.Auth.fetchDevices()
+        XCTAssertGreaterThanOrEqual(devicesAfterSecond.count, 1,
+            "Device should persist after sign-out/sign-in with email alias")
+        XCTAssertEqual(devicesAfterSecond.first?.id, firstDeviceId,
+            "Device ID should be the same after re-sign-in with email alias")
+    }
+
+    /// Test that token refresh works after sign-out/sign-in with email alias
+    ///
+    /// - Given: A user who signed in with email, signed out, and signed back in
+    /// - When: fetchAuthSession is called with forceRefresh
+    /// - Then: Token refresh succeeds (device metadata keychain key still resolves)
+    func testTokenRefreshAfterDevicePersistenceWithEmailAlias() async throws {
+        // First sign-in
+        let firstResult = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(firstResult.isSignedIn)
+
+        _ = try await Amplify.Auth.rememberDevice()
+
+        // Sign out and back in
+        _ = await Amplify.Auth.signOut()
+
+        let secondResult = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(secondResult.isSignedIn)
+
+        // Force refresh after re-sign-in — device metadata must be found
+        let session = try await Amplify.Auth.fetchAuthSession(options: .init(forceRefresh: true))
+        XCTAssertTrue(session.isSignedIn)
+
+        if let cognitoSession = session as? AWSAuthCognitoSession {
+            switch cognitoSession.userPoolTokensResult {
+            case .success(let tokens):
+                XCTAssertFalse(tokens.idToken.isEmpty)
+                XCTAssertFalse(tokens.accessToken.isEmpty)
+            case .failure(let error):
+                XCTFail("Token refresh after re-sign-in failed: \(error). " +
+                    "Device metadata not found after sign-out/sign-in cycle (issue #4207)")
+            }
+        }
+    }
+
+    // MARK: - Full Device Lifecycle with Email Alias
+
+    /// Test the full device lifecycle: remember → fetch → forget → fetch with email alias
+    ///
+    /// - Given: A user signed in with email alias
+    /// - When: The full device lifecycle is exercised
+    /// - Then: Each operation succeeds without "Unable to get device metadata" errors
+    func testFullDeviceLifecycleWithEmailAlias() async throws {
+        let result = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(result.isSignedIn)
+
+        // Remember
+        _ = try await Amplify.Auth.rememberDevice()
+
+        // Fetch — should show the device
+        let devicesAfterRemember = try await Amplify.Auth.fetchDevices()
+        XCTAssertGreaterThanOrEqual(devicesAfterRemember.count, 1,
+            "Should have at least 1 device after rememberDevice with email alias")
+        let deviceId = devicesAfterRemember.first?.id
+        XCTAssertNotNil(deviceId)
+
+        // Token refresh mid-lifecycle — should still work
+        let session = try await Amplify.Auth.fetchAuthSession(options: .init(forceRefresh: true))
+        XCTAssertTrue(session.isSignedIn)
+
+        // Forget — should succeed using inputUsername for metadata lookup
+        _ = try await Amplify.Auth.forgetDevice()
+
+        // Fetch — should be empty now
+        let devicesAfterForget = try await Amplify.Auth.fetchDevices()
+        XCTAssertEqual(devicesAfterForget.count, 0,
+            "Device list should be empty after forgetDevice with email alias")
+    }
 }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/DeviceKeyPersistenceIntegrationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/DeviceKeyPersistenceIntegrationTests.swift
@@ -260,7 +260,10 @@ class DeviceKeyPersistenceIntegrationTests: AWSAuthBaseTest {
         }
     }
 
-    // MARK: - Token Refresh Tests (regression tests for issue #4207)
+    // MARK: - Token Refresh with Device Tracking Tests
+    // Note: These tests run against a non-alias pool (username == sub UUID),
+    // so they verify token refresh works with device tracking in the baseline case.
+    // For the alias-specific regression test (issue #4207), see DeviceAliasTokenRefreshIntegrationTests.
 
     /// Test that token refresh succeeds with device tracking enabled
     ///

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/DeviceKeyPersistenceIntegrationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/DeviceKeyPersistenceIntegrationTests.swift
@@ -259,6 +259,94 @@ class DeviceKeyPersistenceIntegrationTests: AWSAuthBaseTest {
                 "Cycle \(index + 1) (\(flow)): device ID should remain the same")
         }
     }
+
+    // MARK: - Token Refresh Tests (regression tests for issue #4207)
+
+    /// Test that token refresh succeeds with device tracking enabled
+    ///
+    /// - Given: A user signed in with USER_SRP_AUTH with device remembered
+    /// - When: fetchAuthSession is called with forceRefresh
+    /// - Then: The session should contain valid refreshed tokens
+    func testTokenRefreshSucceedsWithDeviceTracking() async throws {
+        let username = "integTest\(UUID().uuidString)"
+        let password = "P123@\(UUID().uuidString)"
+
+        _ = try await AuthSignInHelper.signUpUser(
+            username: username,
+            password: password,
+            email: defaultTestEmail
+        )
+
+        let result = try await signInAndWait(
+            username: username,
+            password: password,
+            authFlowType: .userSRP
+        )
+        XCTAssertTrue(result.isSignedIn)
+        _ = try await Amplify.Auth.rememberDevice()
+
+        let session = try await Amplify.Auth.fetchAuthSession(options: .init(forceRefresh: true))
+        XCTAssertTrue(session.isSignedIn)
+
+        if let cognitoSession = session as? AWSAuthCognitoSession {
+            switch cognitoSession.userPoolTokensResult {
+            case .success(let tokens):
+                XCTAssertFalse(tokens.idToken.isEmpty)
+                XCTAssertFalse(tokens.accessToken.isEmpty)
+            case .failure(let error):
+                XCTFail("Token refresh failed with device tracking: \(error) (issue #4207)")
+            }
+        }
+    }
+
+    /// Test that multiple consecutive token refreshes succeed with device tracking
+    ///
+    /// - Given: A user signed in with USER_SRP_AUTH with device remembered
+    /// - When: fetchAuthSession is called with forceRefresh twice consecutively
+    /// - Then: Both refreshes should succeed (inputUsername must be preserved across refreshes)
+    func testConsecutiveTokenRefreshesSucceedWithDeviceTracking() async throws {
+        let username = "integTest\(UUID().uuidString)"
+        let password = "P123@\(UUID().uuidString)"
+
+        _ = try await AuthSignInHelper.signUpUser(
+            username: username,
+            password: password,
+            email: defaultTestEmail
+        )
+
+        let result = try await signInAndWait(
+            username: username,
+            password: password,
+            authFlowType: .userSRP
+        )
+        XCTAssertTrue(result.isSignedIn)
+        _ = try await Amplify.Auth.rememberDevice()
+
+        // First refresh
+        let session1 = try await Amplify.Auth.fetchAuthSession(options: .init(forceRefresh: true))
+        XCTAssertTrue(session1.isSignedIn)
+        if let cognitoSession = session1 as? AWSAuthCognitoSession {
+            switch cognitoSession.userPoolTokensResult {
+            case .success(let tokens):
+                XCTAssertFalse(tokens.idToken.isEmpty)
+            case .failure(let error):
+                XCTFail("First token refresh failed: \(error)")
+            }
+        }
+
+        // Second refresh — fails if inputUsername is not preserved after first refresh
+        let session2 = try await Amplify.Auth.fetchAuthSession(options: .init(forceRefresh: true))
+        XCTAssertTrue(session2.isSignedIn)
+        if let cognitoSession = session2 as? AWSAuthCognitoSession {
+            switch cognitoSession.userPoolTokensResult {
+            case .success(let tokens):
+                XCTAssertFalse(tokens.idToken.isEmpty, "Second refresh should also return valid tokens")
+            case .failure(let error):
+                XCTFail("Second token refresh failed: \(error). " +
+                    "inputUsername was not preserved after first refresh (issue #4207)")
+            }
+        }
+    }
 }
 
 private extension AuthFlowType {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

 * Use inputUsername for device metadata lookup in rememberDevice/forgetDevice and add e2e tests
 * Add token refresh integration tests for device tracking (see #4208)

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
