### PR TITLE
fix(auth): Use inputUsername for device metadata lookup in rememberDevice/forgetDevice and add e2e tests

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthForgetDeviceTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthForgetDeviceTask.swift
@@ -53,7 +53,7 @@ class AWSAuthForgetDeviceTask: AuthForgetDeviceTask, DefaultLogger {
         let authState = await authStateMachine.currentState
         if case .configured(let authenticationState, _, _) = authState,
            case .signedIn(let signInData) = authenticationState {
-           return signInData.username
+           return signInData.inputUsername ?? signInData.username
         }
         throw AuthError.unknown("Unable to get username for the signedIn user")
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthRememberDeviceTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthRememberDeviceTask.swift
@@ -52,7 +52,7 @@ class AWSAuthRememberDeviceTask: AuthRememberDeviceTask, DefaultLogger {
         let authState = await authStateMachine.currentState
         if case .configured(let authenticationState, _, _) = authState,
            case .signedIn(let signInData) = authenticationState {
-           return signInData.username
+           return signInData.inputUsername ?? signInData.username
         }
         throw AuthError.unknown("Unable to get username for the signedIn user")
     }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/DeviceAliasTokenRefreshIntegrationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/DeviceAliasTokenRefreshIntegrationTests.swift
@@ -169,4 +169,219 @@ class DeviceAliasTokenRefreshIntegrationTests: AWSAuthBaseTest {
             }
         }
     }
+
+    /// Test that rememberDevice succeeds with email alias login
+    ///
+    /// - Given: A user signed in with email alias (USER_SRP_AUTH)
+    /// - When: rememberDevice is called
+    /// - Then: It should succeed without "Unable to get device metadata" error
+    func testRememberDeviceSucceedsWithEmailAlias() async throws {
+        let result = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(result.isSignedIn)
+
+        // This should not throw — device metadata should be found using inputUsername
+        _ = try await Amplify.Auth.rememberDevice()
+
+        // Verify device is listed
+        let devices = try await Amplify.Auth.fetchDevices()
+        XCTAssertGreaterThanOrEqual(devices.count, 1,
+            "Should have at least 1 remembered device after rememberDevice()")
+    }
+
+    // MARK: - forgetDevice with Email Alias Tests
+
+    /// Test that forgetDevice succeeds with email alias login
+    ///
+    /// - Given: A user signed in with email alias with a remembered device
+    /// - When: forgetDevice is called
+    /// - Then: It should succeed without "Unable to get device metadata" error
+    func testForgetDeviceSucceedsWithEmailAlias() async throws {
+        let result = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(result.isSignedIn)
+
+        // Pool is "always remember" so device is auto-confirmed, but call remember
+        // explicitly to ensure it's in the remembered state
+        _ = try await Amplify.Auth.rememberDevice()
+
+        // This should not throw — device metadata lookup uses inputUsername
+        _ = try await Amplify.Auth.forgetDevice()
+
+        // Verify device is no longer listed
+        let devices = try await Amplify.Auth.fetchDevices()
+        XCTAssertEqual(devices.count, 0,
+            "Device list should be empty after forgetDevice()")
+    }
+
+    /// Test that forgetDevice works after a token refresh with email alias
+    ///
+    /// - Given: A user signed in with email alias who has performed a token refresh
+    /// - When: forgetDevice is called after the refresh
+    /// - Then: It should succeed (inputUsername preserved through refresh cycle)
+    func testForgetDeviceAfterTokenRefreshWithEmailAlias() async throws {
+        let result = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(result.isSignedIn)
+
+        _ = try await Amplify.Auth.rememberDevice()
+
+        // Force a token refresh first
+        let session = try await Amplify.Auth.fetchAuthSession(options: .init(forceRefresh: true))
+        XCTAssertTrue(session.isSignedIn)
+
+        // Now forget — inputUsername must still be available after refresh
+        _ = try await Amplify.Auth.forgetDevice()
+
+        let devices = try await Amplify.Auth.fetchDevices()
+        XCTAssertEqual(devices.count, 0,
+            "forgetDevice should work after token refresh with email alias")
+    }
+
+    // MARK: - fetchDevices with Email Alias Tests
+
+    /// Test that fetchDevices returns device details with email alias login
+    ///
+    /// - Given: A user signed in with email alias with a remembered device
+    /// - When: fetchDevices is called
+    /// - Then: It should return the device with valid metadata
+    func testFetchDevicesReturnsDetailsWithEmailAlias() async throws {
+        let result = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(result.isSignedIn)
+
+        _ = try await Amplify.Auth.rememberDevice()
+
+        let devices = try await Amplify.Auth.fetchDevices()
+        XCTAssertGreaterThanOrEqual(devices.count, 1)
+
+        guard let device = devices.first as? AWSAuthDevice else {
+            XCTFail("Should be able to cast to AWSAuthDevice")
+            return
+        }
+        XCTAssertFalse(device.id.isEmpty, "Device should have a non-empty ID")
+        XCTAssertNotNil(device.createdDate, "Device should have a creation date")
+        XCTAssertNotNil(device.lastAuthenticatedDate, "Device should have last authenticated date")
+    }
+
+    // MARK: - Device Persistence with Email Alias Tests
+
+    /// Test that device persists across sign-out/sign-in with email alias
+    ///
+    /// - Given: A user signed in with email alias who has a remembered device
+    /// - When: The user signs out and signs back in with the same email alias
+    /// - Then: fetchDevices should return the same device (not a new one)
+    func testDevicePersistsAcrossSignOutSignInWithEmailAlias() async throws {
+        let firstResult = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(firstResult.isSignedIn)
+
+        _ = try await Amplify.Auth.rememberDevice()
+        let devicesAfterFirst = try await Amplify.Auth.fetchDevices()
+        XCTAssertGreaterThanOrEqual(devicesAfterFirst.count, 1)
+        let firstDeviceId = devicesAfterFirst.first?.id
+        XCTAssertNotNil(firstDeviceId)
+
+        // Sign out and back in
+        _ = await Amplify.Auth.signOut()
+
+        let secondResult = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(secondResult.isSignedIn)
+
+        let devicesAfterSecond = try await Amplify.Auth.fetchDevices()
+        XCTAssertGreaterThanOrEqual(devicesAfterSecond.count, 1,
+            "Device should persist after sign-out/sign-in with email alias")
+        XCTAssertEqual(devicesAfterSecond.first?.id, firstDeviceId,
+            "Device ID should be the same after re-sign-in with email alias")
+    }
+
+    /// Test that token refresh works after sign-out/sign-in with email alias
+    ///
+    /// - Given: A user who signed in with email, signed out, and signed back in
+    /// - When: fetchAuthSession is called with forceRefresh
+    /// - Then: Token refresh succeeds (device metadata keychain key still resolves)
+    func testTokenRefreshAfterDevicePersistenceWithEmailAlias() async throws {
+        // First sign-in
+        let firstResult = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(firstResult.isSignedIn)
+
+        _ = try await Amplify.Auth.rememberDevice()
+
+        // Sign out and back in
+        _ = await Amplify.Auth.signOut()
+
+        let secondResult = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(secondResult.isSignedIn)
+
+        // Force refresh after re-sign-in — device metadata must be found
+        let session = try await Amplify.Auth.fetchAuthSession(options: .init(forceRefresh: true))
+        XCTAssertTrue(session.isSignedIn)
+
+        if let cognitoSession = session as? AWSAuthCognitoSession {
+            switch cognitoSession.userPoolTokensResult {
+            case .success(let tokens):
+                XCTAssertFalse(tokens.idToken.isEmpty)
+                XCTAssertFalse(tokens.accessToken.isEmpty)
+            case .failure(let error):
+                XCTFail("Token refresh after re-sign-in failed: \(error). " +
+                    "Device metadata not found after sign-out/sign-in cycle (issue #4207)")
+            }
+        }
+    }
+
+    // MARK: - Full Device Lifecycle with Email Alias
+
+    /// Test the full device lifecycle: remember → fetch → forget → fetch with email alias
+    ///
+    /// - Given: A user signed in with email alias
+    /// - When: The full device lifecycle is exercised
+    /// - Then: Each operation succeeds without "Unable to get device metadata" errors
+    func testFullDeviceLifecycleWithEmailAlias() async throws {
+        let result = try await signInAndWait(
+            username: defaultTestEmail,
+            password: defaultTestPassword
+        )
+        XCTAssertTrue(result.isSignedIn)
+
+        // Remember
+        _ = try await Amplify.Auth.rememberDevice()
+
+        // Fetch — should show the device
+        let devicesAfterRemember = try await Amplify.Auth.fetchDevices()
+        XCTAssertGreaterThanOrEqual(devicesAfterRemember.count, 1,
+            "Should have at least 1 device after rememberDevice with email alias")
+        let deviceId = devicesAfterRemember.first?.id
+        XCTAssertNotNil(deviceId)
+
+        // Token refresh mid-lifecycle — should still work
+        let session = try await Amplify.Auth.fetchAuthSession(options: .init(forceRefresh: true))
+        XCTAssertTrue(session.isSignedIn)
+
+        // Forget — should succeed using inputUsername for metadata lookup
+        _ = try await Amplify.Auth.forgetDevice()
+
+        // Fetch — should be empty now
+        let devicesAfterForget = try await Amplify.Auth.fetchDevices()
+        XCTAssertEqual(devicesAfterForget.count, 0,
+            "Device list should be empty after forgetDevice with email alias")
+    }
 }


### PR DESCRIPTION


## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
