### PR TITLE
fix: 'occured' -> 'occurred' in AmplifyBigInt fatalError messages

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AmplifyBigInteger/AmplifyBigInt+Operations.swift
+++ b/AmplifyPlugins/Auth/Sources/AmplifyBigInteger/AmplifyBigInt+Operations.swift
@@ -15,7 +15,7 @@ public extension AmplifyBigInt {
         let sum = AmplifyBigInt()
         let result = amplify_mp_add(&lhs.value, &rhs.value, &sum.value)
         if result != AMPLIFY_MP_OKAY {
-            fatalError("Error occured during + operation: \(result)")
+            fatalError("Error occurred during + operation: \(result)")
         }
         return sum
     }
@@ -42,7 +42,7 @@ public extension AmplifyBigInt {
         let difference = AmplifyBigInt()
         let result = amplify_mp_sub(&lhs.value, &rhs.value, &difference.value)
         if result != AMPLIFY_MP_OKAY {
-            fatalError("Error occured during - operation: \(result)")
+            fatalError("Error occurred during - operation: \(result)")
         }
         return difference
     }
@@ -65,7 +65,7 @@ public extension AmplifyBigInt {
         let product = AmplifyBigInt()
         let result = amplify_mp_mul(&lhs.value, &rhs.value, &product.value)
         if result != AMPLIFY_MP_OKAY {
-            fatalError("Error occured during * operation: \(result)")
+            fatalError("Error occurred during * operation: \(result)")
         }
         return product
     }
@@ -103,7 +103,7 @@ public extension AmplifyBigInt {
         let result = amplify_mp_div(&lhs.value, &rhs.value, &quotient.value, &remainder.value)
 
         if result != AMPLIFY_MP_OKAY {
-            fatalError("Error occured during % operation: \(result)")
+            fatalError("Error occurred during % operation: \(result)")
         }
         return remainder
     }
@@ -125,7 +125,7 @@ public extension AmplifyBigInt {
         let exponentialModulus = AmplifyBigInt()
         let result = amplify_mp_exptmod(&value, &power.value, &modulus.value, &exponentialModulus.value)
         guard result == AMPLIFY_MP_OKAY else {
-            fatalError("Error occured during pow(:modulus:) operation: \(result)")
+            fatalError("Error occurred during pow(:modulus:) operation: \(result)")
         }
         return exponentialModulus
     }


### PR DESCRIPTION
## Issue \#

N/A (string-only typo fix).

## Description

Fixes the spelling "Error occured" -> "Error occurred" in 5 `fatalError` messages inside `AmplifyBigInt+Operations.swift` (Auth plugin). Message-string-only change, no functional impact.

## General Checklist

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
