### PR TITLE
fix(auth): defer keychain-sharing reconfigure during in-flight sign-in

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
@@ -136,13 +136,13 @@ extension AWSCognitoAuthPlugin: AuthCategoryBehavior {
     public func fetchAuthSession(options: AuthFetchSessionRequest.Options?) async throws -> AuthSession {
         let options = options ?? AuthFetchSessionRequest.Options()
         let request = AuthFetchSessionRequest(options: options)
-        let forceReconfigure = secureStoragePreferences?.accessGroup?.name != nil
+        let isKeychainSharingEnabled = secureStoragePreferences?.accessGroup?.name != nil
         let task = AWSAuthFetchSessionTask(
             request,
             authStateMachine: authStateMachine,
             configuration: authConfiguration,
             environment: authEnvironment,
-            forceReconfigure: forceReconfigure
+            isKeychainSharingEnabled: isKeychainSharingEnabled
         )
         return try await taskQueue.sync {
             return try await task.value

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AmplifyCredentials.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AmplifyCredentials.swift
@@ -57,3 +57,14 @@ extension AmplifyCredentials: CustomDebugStringConvertible {
     }
 
 }
+
+extension AmplifyCredentials {
+    var hasUserPoolTokens: Bool {
+        switch self {
+        case .userPoolOnly, .userPoolAndIdentityPool:
+            return true
+        case .identityPoolOnly, .identityPoolWithFederation, .noCredentials:
+            return false
+        }
+    }
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInTask.swift
@@ -52,8 +52,19 @@ class AWSAuthConfirmSignInTask: AuthConfirmSignInTask, DefaultLogger {
             AuthPluginErrorConstants.invalidStateError, nil
         )
 
-        guard case .configured(let authNState, _, _) = await authStateMachine.currentState,
-              case .signingIn(let signInState) = authNState else {
+        guard case .configured(let authNState, let authZState, _) = await authStateMachine.currentState else {
+            throw invalidStateError
+        }
+
+        // If the shared keychain reconcile adopted a sibling app's sign-in
+        // while this flow was waiting for an answer, the auth state is now
+        // .signedIn. Surface that as a successful sign-in result so callers
+        // don't get a spurious invalidState error.
+        if case .signedIn = authNState, case .sessionEstablished = authZState {
+            return AuthSignInResult(nextStep: .done)
+        }
+
+        guard case .signingIn(let signInState) = authNState else {
             throw invalidStateError
         }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInTask.swift
@@ -56,18 +56,7 @@ class AWSAuthConfirmSignInTask: AuthConfirmSignInTask, DefaultLogger {
             throw invalidStateError
         }
 
-        switch authNState {
-        case .signingIn(let signInState):
-            try await analyzeCurrentStateAndCreateEvent(signInState, invalidStateError)
-        case .signedIn:
-            // The shared keychain reconcile adopted a sibling app's sign-in
-            // while this flow was waiting for an answer. No event needs to
-            // be dispatched; the listener loop below observes .signedIn and
-            // returns .done.
-            break
-        default:
-            throw invalidStateError
-        }
+        try await analyzeCurrentStateAndCreateEvent(authNState, invalidStateError)
 
         let stateSequences = await authStateMachine.listen()
         log.verbose("Waiting for response")
@@ -101,7 +90,19 @@ class AWSAuthConfirmSignInTask: AuthConfirmSignInTask, DefaultLogger {
         throw invalidStateError
     }
 
-    fileprivate func analyzeCurrentStateAndCreateEvent(_ signInState: SignInState, _ invalidStateError: AuthError) async throws {
+    fileprivate func analyzeCurrentStateAndCreateEvent(_ authNState: AuthenticationState, _ invalidStateError: AuthError) async throws {
+        // The shared keychain reconcile may have adopted a sibling app's
+        // sign-in while this flow was waiting for an answer. No event needs
+        // to be dispatched; the listener loop in execute() observes
+        // .signedIn and returns .done.
+        if case .signedIn = authNState {
+            return
+        }
+
+        guard case .signingIn(let signInState) = authNState else {
+            throw invalidStateError
+        }
+
         switch signInState {
         case .resolvingChallenge(let challengeState, let challengeType, _):
             // Validate if request valid MFA selection

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInTask.swift
@@ -52,23 +52,22 @@ class AWSAuthConfirmSignInTask: AuthConfirmSignInTask, DefaultLogger {
             AuthPluginErrorConstants.invalidStateError, nil
         )
 
-        guard case .configured(let authNState, let authZState, _) = await authStateMachine.currentState else {
+        guard case .configured(let authNState, _, _) = await authStateMachine.currentState else {
             throw invalidStateError
         }
 
-        // If the shared keychain reconcile adopted a sibling app's sign-in
-        // while this flow was waiting for an answer, the auth state is now
-        // .signedIn. Surface that as a successful sign-in result so callers
-        // don't get a spurious invalidState error.
-        if case .signedIn = authNState, case .sessionEstablished = authZState {
-            return AuthSignInResult(nextStep: .done)
-        }
-
-        guard case .signingIn(let signInState) = authNState else {
+        switch authNState {
+        case .signingIn(let signInState):
+            try await analyzeCurrentStateAndCreateEvent(signInState, invalidStateError)
+        case .signedIn:
+            // The shared keychain reconcile adopted a sibling app's sign-in
+            // while this flow was waiting for an answer. No event needs to
+            // be dispatched; the listener loop below observes .signedIn and
+            // returns .done.
+            break
+        default:
             throw invalidStateError
         }
-
-        try await analyzeCurrentStateAndCreateEvent(signInState, invalidStateError)
 
         let stateSequences = await authStateMachine.listen()
         log.verbose("Waiting for response")

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFetchSessionTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFetchSessionTask.swift
@@ -70,19 +70,18 @@ class AWSAuthFetchSessionTask: AuthFetchSessionTask, DefaultLogger {
     ///   .clearingFederation: defer (in-flight side effects must run; same end
     ///   state is reached by the local flow)
     func reconcileWithSharedKeychainIfNeeded() async {
-        guard let remoteCredentials = await fetchRemoteCredentials() else {
+        guard let keychainCredentials = await fetchCredentialsFromKeychain() else {
             return
         }
-        let currentState = await authStateMachine.currentState
-        guard case .configured(let authNState, let authZState, _) = currentState else {
+        guard case .configured(let authNState, let authZState, _) = await authStateMachine.currentState else {
             return
         }
-        let localCredentials = localCredentials(from: authZState)
-        if let localCredentials, localCredentials == remoteCredentials {
+        let stateMachineCredentials = fetchCredentialsFromStateMachine(authZState)
+        if let stateMachineCredentials, stateMachineCredentials == keychainCredentials {
             return
         }
 
-        if shouldDeferReconcile(authNState: authNState, remote: remoteCredentials) {
+        if shouldDeferReconcile(authNState: authNState, remote: keychainCredentials) {
             log.verbose("Deferring keychain reconcile while auth flow is in progress")
             return
         }
@@ -93,7 +92,7 @@ class AWSAuthFetchSessionTask: AuthFetchSessionTask, DefaultLogger {
         await taskHelper.didStateMachineConfigured()
     }
 
-    private func fetchRemoteCredentials() async -> AmplifyCredentials? {
+    private func fetchCredentialsFromKeychain() async -> AmplifyCredentials? {
         do {
             let data = try await credentialsClient?.fetchData(type: .amplifyCredentials)
             if case .amplifyCredentials(let credentials) = data {
@@ -112,7 +111,7 @@ class AWSAuthFetchSessionTask: AuthFetchSessionTask, DefaultLogger {
     /// observed. Returns nil for transient authZ states where we can't make a
     /// reliable comparison; in those cases callers fall back to deferring (the
     /// transient state will resolve shortly and a later fetch will reconcile).
-    private func localCredentials(from authZState: AuthorizationState) -> AmplifyCredentials? {
+    private func fetchCredentialsFromStateMachine(_ authZState: AuthorizationState) -> AmplifyCredentials? {
         switch authZState {
         case .sessionEstablished(let credentials),
              .storingCredentials(let credentials):

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFetchSessionTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFetchSessionTask.swift
@@ -7,6 +7,7 @@
 
 import Amplify
 import Foundation
+@_spi(KeychainStore) import AWSPluginsCore
 
 class AWSAuthFetchSessionTask: AuthFetchSessionTask, DefaultLogger {
     private let request: AuthFetchSessionRequest
@@ -14,7 +15,8 @@ class AWSAuthFetchSessionTask: AuthFetchSessionTask, DefaultLogger {
     private let fetchAuthSessionHelper: FetchAuthSessionOperationHelper
     private let taskHelper: AWSAuthTaskHelper
     private let configuration: AuthConfiguration
-    private let forceReconfigure: Bool
+    private let credentialsClient: CredentialStoreStateBehavior?
+    private let isKeychainSharingEnabled: Bool
 
     var eventName: HubPayloadEventName {
         HubPayload.EventName.Auth.fetchSessionAPI
@@ -25,7 +27,7 @@ class AWSAuthFetchSessionTask: AuthFetchSessionTask, DefaultLogger {
         authStateMachine: AuthStateMachine,
         configuration: AuthConfiguration,
         environment: Environment,
-        forceReconfigure: Bool = false
+        isKeychainSharingEnabled: Bool = false
     ) {
         self.request = request
         self.authStateMachine = authStateMachine
@@ -33,22 +35,127 @@ class AWSAuthFetchSessionTask: AuthFetchSessionTask, DefaultLogger {
         fetchAuthSessionHelper.environment = environment
         self.taskHelper = AWSAuthTaskHelper(authStateMachine: authStateMachine)
         self.configuration = configuration
-        self.forceReconfigure = forceReconfigure
+        self.credentialsClient = (environment as? AuthEnvironment)?.credentialsClient
+        self.isKeychainSharingEnabled = isKeychainSharingEnabled
     }
 
     func execute() async throws -> AuthSession {
         log.verbose("Starting execution")
-        if forceReconfigure {
-            log.verbose("Reconfiguring auth state machine for keychain sharing")
-            let event = AuthEvent(eventType: .reconfigure(configuration))
-            await authStateMachine.send(event)
-        }
         await taskHelper.didStateMachineConfigured()
+        if isKeychainSharingEnabled {
+            await reconcileWithSharedKeychainIfNeeded()
+        }
         let doesNeedForceRefresh = request.options.forceRefresh
         return try await fetchAuthSessionHelper.fetch(
             authStateMachine,
             forceRefresh: doesNeedForceRefresh
         )
+    }
+
+    /// When the plugin is configured with a shared keychain access group, the
+    /// keychain is the source of truth across processes. Reconcile the local
+    /// state machine with whatever is currently in the keychain — but only
+    /// when doing so won't destroy locally-originated in-flight work.
+    ///
+    /// Decision matrix (auth state vs. remote-vs-local credentials):
+    /// - quiescent (.signedIn / .signedOut / .error / .configured / .notConfigured)
+    ///     - differ: reconfigure (sibling wrote — pick it up)
+    ///     - match: no-op
+    /// - .signingIn
+    ///     - remote has user-pool tokens: reconfigure (adopt sibling's sign-in;
+    ///       confirmSignIn will resolve to .done)
+    ///     - remote has no user-pool tokens: defer (sign-in flow finishes;
+    ///       last-writer-wins on the keychain)
+    /// - .signingOut / .deletingUser / .federatingToIdentityPool /
+    ///   .clearingFederation: defer (in-flight side effects must run; same end
+    ///   state is reached by the local flow)
+    func reconcileWithSharedKeychainIfNeeded() async {
+        guard let remoteCredentials = await fetchRemoteCredentials() else {
+            return
+        }
+        let currentState = await authStateMachine.currentState
+        guard case .configured(let authNState, let authZState, _) = currentState else {
+            return
+        }
+        let localCredentials = localCredentials(from: authZState)
+        if let localCredentials, localCredentials == remoteCredentials {
+            return
+        }
+
+        if shouldDeferReconcile(authNState: authNState, remote: remoteCredentials) {
+            log.verbose("Deferring keychain reconcile while auth flow is in progress")
+            return
+        }
+
+        log.verbose("Reconfiguring auth state machine for keychain sharing")
+        let event = AuthEvent(eventType: .reconfigure(configuration))
+        await authStateMachine.send(event)
+        await taskHelper.didStateMachineConfigured()
+    }
+
+    private func fetchRemoteCredentials() async -> AmplifyCredentials? {
+        do {
+            let data = try await credentialsClient?.fetchData(type: .amplifyCredentials)
+            if case .amplifyCredentials(let credentials) = data {
+                return credentials
+            }
+            return nil
+        } catch KeychainStoreError.itemNotFound {
+            return .noCredentials
+        } catch {
+            log.verbose("Could not read shared keychain credentials: \(error)")
+            return nil
+        }
+    }
+
+    /// Best-effort snapshot of the credentials the local state machine last
+    /// observed. Returns nil for transient authZ states where we can't make a
+    /// reliable comparison; in those cases callers fall back to deferring (the
+    /// transient state will resolve shortly and a later fetch will reconcile).
+    private func localCredentials(from authZState: AuthorizationState) -> AmplifyCredentials? {
+        switch authZState {
+        case .sessionEstablished(let credentials),
+             .storingCredentials(let credentials):
+            return credentials
+        case .refreshingSession(existingCredentials: let credentials, _):
+            return credentials
+        case .federatingToIdentityPool(_, _, existingCredentials: let credentials):
+            return credentials
+        case .signingOut(let credentials):
+            return credentials ?? .noCredentials
+        case .configured:
+            return .noCredentials
+        case .notConfigured,
+             .clearingFederation,
+             .fetchingUnAuthSession,
+             .fetchingAuthSessionWithUserPool,
+             .deletingUser,
+             .error:
+            return nil
+        }
+    }
+
+    private func shouldDeferReconcile(
+        authNState: AuthenticationState,
+        remote: AmplifyCredentials
+    ) -> Bool {
+        switch authNState {
+        case .signingIn:
+            // Adopt sibling sign-in; otherwise defer until local flow completes
+            return !remote.hasUserPoolTokens
+        case .signingOut,
+             .deletingUser,
+             .federatingToIdentityPool,
+             .clearingFederation:
+            return true
+        case .notConfigured,
+             .configured,
+             .signedIn,
+             .signedOut,
+             .federatedToIdentityPool,
+             .error:
+            return false
+        }
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFetchSessionTaskKeychainSharingTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFetchSessionTaskKeychainSharingTests.swift
@@ -1,0 +1,205 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+@testable import AWSCognitoAuthPlugin
+@_spi(KeychainStore) import AWSPluginsCore
+
+/// Verifies that when a shared keychain access group is enabled, the
+/// fetchAuthSession reconcile path does not destroy locally-originated
+/// in-flight sign-in/sign-out work, and only reconfigures when the
+/// shared keychain genuinely diverges from the in-memory state machine.
+class AWSAuthFetchSessionTaskKeychainSharingTests: XCTestCase {
+
+    private actor StateRecorder {
+        private(set) var seenStateTypes: Set<String> = []
+
+        func record(_ type: String) {
+            seenStateTypes.insert(type)
+        }
+
+        func observed(_ type: String) -> Bool {
+            seenStateTypes.contains(type)
+        }
+    }
+
+    private struct StubCredentialStore: CredentialStoreStateBehavior {
+        let remote: AmplifyCredentials?
+
+        func fetchData(type: CredentialStoreDataType) async throws -> CredentialStoreData {
+            switch type {
+            case .amplifyCredentials:
+                guard let remote else { throw KeychainStoreError.itemNotFound }
+                return .amplifyCredentials(remote)
+            case .deviceMetadata(let username):
+                return .deviceMetadata(.noData, username)
+            case .asfDeviceId(let username):
+                return .asfDeviceId("", username)
+            }
+        }
+
+        func storeData(data: CredentialStoreData) async throws { }
+        func deleteData(type: CredentialStoreDataType) async throws { }
+    }
+
+    private func makeEnvironment(remote: AmplifyCredentials?) -> AuthEnvironment {
+        let baseEnv = Defaults.makeDefaultAuthEnvironment()
+        return AuthEnvironment(
+            configuration: baseEnv.configuration,
+            userPoolConfigData: baseEnv.userPoolConfigData,
+            identityPoolConfigData: baseEnv.identityPoolConfigData,
+            authenticationEnvironment: baseEnv.authenticationEnvironment,
+            authorizationEnvironment: baseEnv.authorizationEnvironment,
+            credentialsClient: StubCredentialStore(remote: remote),
+            logger: baseEnv.logger
+        )
+    }
+
+    private func runReconcile(initial: AuthState, remote: AmplifyCredentials?) async -> StateRecorder {
+        let environment = makeEnvironment(remote: remote)
+        let stateMachine = AuthStateMachine(
+            resolver: AuthState.Resolver(),
+            environment: environment,
+            initialState: initial
+        )
+        let recorder = StateRecorder()
+        let stream = await stateMachine.listen()
+        let listener = Task {
+            for await state in stream {
+                await recorder.record(state.type)
+            }
+        }
+
+        let task = AWSAuthFetchSessionTask(
+            AuthFetchSessionRequest(options: AuthFetchSessionRequest.Options()),
+            authStateMachine: stateMachine,
+            configuration: Defaults.makeDefaultAuthConfigData(),
+            environment: environment,
+            isKeychainSharingEnabled: true
+        )
+        await task.reconcileWithSharedKeychainIfNeeded()
+
+        // Allow the listener task one tick to drain queued state changes
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        listener.cancel()
+        return recorder
+    }
+
+    private func makeWaitingForCustomChallengeState() -> SignInState {
+        let challenge = RespondToAuthChallenge.testData(challenge: .customChallenge)
+        let method = SignInMethod.apiBased(.customWithoutSRP)
+        return SignInState.resolvingChallenge(
+            .waitingForAnswer(challenge, method, .confirmSignInWithCustomChallenge(nil)),
+            .customChallenge,
+            method
+        )
+    }
+
+    // MARK: - Tests
+
+    /// Given: state machine is `.signingIn(.resolvingChallenge(.waitingForAnswer))`,
+    ///        remote keychain has no signed-in credentials.
+    /// Then:  reconcile defers — state machine never transitions to `.configuringAuth`.
+    func testInflightSigningInWithRemoteSignedOut_doesNotReconfigure() async {
+        let initial = AuthState.configured(
+            .signingIn(makeWaitingForCustomChallengeState()),
+            .configured,
+            .notStarted
+        )
+
+        let recorder = await runReconcile(initial: initial, remote: .noCredentials)
+        let observed = await recorder.observed("AuthState.configuringAuth")
+        XCTAssertFalse(
+            observed,
+            "Reconfigure must not run while sign-in is in flight and remote is signed out"
+        )
+    }
+
+    /// Given: state machine is `.signingIn(...)`, remote keychain has fresh
+    ///        signed-in user-pool credentials (sibling app signed in).
+    /// Then:  reconcile adopts — state machine transitions through
+    ///        `.configuringAuth`.
+    func testInflightSigningInWithRemoteSignedIn_adoptsViaReconfigure() async {
+        let initial = AuthState.configured(
+            .signingIn(makeWaitingForCustomChallengeState()),
+            .configured,
+            .notStarted
+        )
+
+        let recorder = await runReconcile(initial: initial, remote: AmplifyCredentials.testData)
+        let observed = await recorder.observed("AuthState.configuringAuth")
+        XCTAssertTrue(
+            observed,
+            "Reconfigure must run to adopt remote sign-in mid-flow"
+        )
+    }
+
+    /// Given: state machine is `.signedIn`, remote keychain matches local
+    ///        (no sibling activity).
+    /// Then:  reconcile is a no-op.
+    func testQuiescentSignedInWithMatchingRemote_doesNotReconfigure() async {
+        // Capture once — `AmplifyCredentials.testData` and `SignedInData.testData`
+        // generate fresh `Date()` values on each access, so reading them twice
+        // yields !=.
+        let credentials = AmplifyCredentials.testData
+        let signedInData: SignedInData
+        if case .userPoolAndIdentityPool(let data, _, _) = credentials {
+            signedInData = data
+        } else {
+            XCTFail("testData should be userPoolAndIdentityPool")
+            return
+        }
+        let initial = AuthState.configured(
+            .signedIn(signedInData),
+            .sessionEstablished(credentials),
+            .notStarted
+        )
+
+        let recorder = await runReconcile(initial: initial, remote: credentials)
+        let observed = await recorder.observed("AuthState.configuringAuth")
+        XCTAssertFalse(
+            observed,
+            "Reconfigure must not run when remote already matches local state"
+        )
+    }
+
+    /// Given: state machine is `.signedIn`, remote keychain is `.noCredentials`
+    ///        (sibling signed the user out).
+    /// Then:  reconcile runs — sibling sign-out is picked up.
+    func testQuiescentSignedInWithRemoteSignedOut_reconfigures() async {
+        let initial = AuthState.configured(
+            .signedIn(.testData),
+            .sessionEstablished(.testData),
+            .notStarted
+        )
+
+        let recorder = await runReconcile(initial: initial, remote: .noCredentials)
+        let observed = await recorder.observed("AuthState.configuringAuth")
+        XCTAssertTrue(
+            observed,
+            "Reconfigure must run when remote diverges from a quiescent signed-in state"
+        )
+    }
+
+    /// Given: state machine is `.signingOut`, remote keychain mismatches.
+    /// Then:  reconcile defers — sign-out side effects must run to completion.
+    func testInflightSigningOut_doesNotReconfigure() async {
+        let initial = AuthState.configured(
+            .signingOut(.notStarted),
+            .signingOut(AmplifyCredentials.testData),
+            .notStarted
+        )
+
+        let recorder = await runReconcile(initial: initial, remote: .noCredentials)
+        let observed = await recorder.observed("AuthState.configuringAuth")
+        XCTAssertFalse(
+            observed,
+            "Reconfigure must not run while sign-out is in flight"
+        )
+    }
+}

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthConfirmSignInTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthConfirmSignInTaskTests.swift
@@ -824,4 +824,40 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             }
         }
     }
+
+    /// Test that confirmSignIn returns `.done` when the auth state has already
+    /// transitioned to `.signedIn` (e.g., a shared keychain reconcile adopted a
+    /// sibling app's sign-in while this flow was waiting for an answer).
+    /// Without the relaxed guard the call would throw `.invalidState`.
+    ///
+    /// - Given: state machine is in `.signedIn` / `.sessionEstablished` (the
+    ///          end state after a reconcile-driven adopt)
+    /// - When:  confirmSignIn is invoked
+    /// - Then:  result is `.done`, no error is thrown, no Cognito call is made
+    func testConfirmSignInReturnsDoneWhenStateIsAlreadySignedIn() async {
+        let signedInPlugin = configureCustomPluginWith(
+            initialState: .configured(
+                .signedIn(.testData),
+                .sessionEstablished(.testData),
+                .notStarted
+            )
+        )
+
+        mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                XCTFail("Cognito service should not be called when already signed in")
+                return .testData()
+            })
+
+        do {
+            let result = try await signedInPlugin.confirmSignIn(challengeResponse: "code")
+            guard case .done = result.nextStep else {
+                XCTFail("Result should be .done; got \(result.nextStep)")
+                return
+            }
+            XCTAssertTrue(result.isSignedIn, "Result should report signed-in")
+        } catch {
+            XCTFail("Should not throw when state is already .signedIn; got \(error)")
+        }
+    }
 }


### PR DESCRIPTION
## Issue
Fixes #4224

## Description
When `AWSCognitoAuthPlugin` is configured with a shared keychain access group, every call to `Amplify.Auth.fetchAuthSession` unconditionally sent a `.reconfigure` event to the auth state machine. If the call landed between a sign-in step that returned `.confirmSignInWithCustomChallenge` and the caller's `confirmSignIn`, the reconfigure tore down the in-flight `.signingIn` substate and the subsequent `confirmSignIn` threw:

```
AuthError.invalidState(
  "User is not attempting signIn operation",
  "Operation performed is not a valid operation for the current auth state"
)
```

The user could not complete sign-in until the entire flow was restarted. The repro is most visible with Custom Auth flows (which routinely park `.signingIn` for tens of seconds while waiting for human approval, push delivery, or third-party verification), but it affects any in-flight sign-in flow.

## Why was the reconfigure there?
The keychain-sharing feature (#3947) needs sibling-app keychain mutations to be picked up without an app relaunch. The original implementation answered "did anything change?" with a coarse proxy: `accessGroup != nil`. That predicate is `true` for the lifetime of the process, so reconfigure fires on every `fetchAuthSession` regardless of whether the keychain actually changed — and regardless of whether the local state machine has work in flight.

## Fix
Replace the unconditional reconfigure with a reconcile that:

1. **Reads the shared keychain credentials and compares to local state** — skip reconfigure when they match. Eliminates wasted reconfigures on every fetch.
2. **Defers reconfigure during locally-originated in-flight flows** when the remote keychain has no signed-in credentials:
   - `.signingIn` — would destroy the user's pending `confirmSignIn` flow
   - `.signingOut`, `.deletingUser`, `.federatingToIdentityPool`, `.clearingFederation` — would skip in-flight side effects (token revoke, HostedUI session clearing, credential clearing, Hub events)
   The local flow runs to completion; the next `fetchAuthSession` reconciles with whatever is in the keychain at that point.
3. **Adopts a sibling app's sign-in mid-flow** when remote has user-pool tokens. The reconfigure runs even during `.signingIn` because the new credentials are strictly more useful than the in-flight challenge. To make the adoption succeed end-to-end, `AWSAuthConfirmSignInTask` now accepts `.signedIn` at its top-level guard and returns `AuthSignInResult(nextStep: .done)` instead of throwing `invalidState`.

### Decision matrix

| Local `AuthenticationState` | Remote vs local | Action |
|---|---|---|
| `.signedIn` / `.signedOut` / `.error` / etc. | match | no-op |
| `.signedIn` / `.signedOut` / `.error` / etc. | differ | reconfigure |
| `.signingIn` | remote has user-pool tokens | reconfigure (adopt) |
| `.signingIn` | remote = `noCredentials` | defer |
| `.signingOut` / `.deletingUser` / `.federatingToIdentityPool` / `.clearingFederation` | any | defer |

## Files changed
- `AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFetchSessionTask.swift` — replace `forceReconfigure` boolean with `isKeychainSharingEnabled` + `reconcileWithSharedKeychainIfNeeded()` decision logic.
- `AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInTask.swift` — accept `.signedIn` at top-level guard, return `.done` so adoption resolves cleanly.
- `AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift` — rename `forceReconfigure` → `isKeychainSharingEnabled` at the call site.
- `AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AmplifyCredentials.swift` — add `hasUserPoolTokens` helper for the adopt predicate.

## Tests
New `AWSAuthFetchSessionTaskKeychainSharingTests` covers:
- `.signingIn` + remote signed-out → no reconfigure (defer; the regression scenario from #4224)
- `.signingIn` + remote signed-in → reconfigure runs (adopt sibling sign-in)
- `.signedIn` + matching remote → no reconfigure (eliminates wasted work)
- `.signedIn` + remote signed-out → reconfigure runs (sibling sign-out picked up)
- `.signingOut` + mismatched remote → no reconfigure (sign-out side effects must run)

`testConfirmSignInReturnsDoneWhenStateIsAlreadySignedIn` covers the relaxed `confirmSignIn` guard producing `.done` after adoption.

All existing `AWSCognitoAuthPluginUnitTests` continue to pass.

## General Checklist
- [x] Added new tests to cover change
- [x] Build succeeds with all targets using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Security oriented best practices and standards are followed
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.