### PR TITLE
chore(deps): bump aws-sdk-swift from 1.6.71 to 1.7.27

### DIFF
--- a/.github/composite_actions/run_xcodebuild/action.yml
+++ b/.github/composite_actions/run_xcodebuild/action.yml
@@ -71,5 +71,5 @@ runs:
         fi
 
         xcodebuild -version
-        xcodebuild build -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' $otherFlags | xcbeautify --renderer github-actions && exit ${PIPESTATUS[0]}
+        xcodebuild build -scheme $SCHEME -destination '${{ inputs.destination }}' -skipPackagePluginValidation $otherFlags | xcbeautify --renderer github-actions && exit ${PIPESTATUS[0]}
       shell: bash

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -100,7 +100,7 @@ runs:
 
         xcode-select -p
         xcodebuild -version
-        xcodebuild $action -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $clonedSourcePackagesPath $derivedDataPath $coverageFlags | xcbeautify --renderer github-actions && exit ${PIPESTATUS[0]}
+        xcodebuild $action -scheme $SCHEME -destination '${{ inputs.destination }}' -skipPackagePluginValidation ${{ inputs.other_flags }} $clonedSourcePackagesPath $derivedDataPath $coverageFlags | xcbeautify --renderer github-actions && exit ${PIPESTATUS[0]}
       shell: bash
 
     - name: Generate Coverage report

--- a/AmplifyClients/Tests/IntegrationTests/KinesisFirehoseClientHostApp/KinesisFirehoseClientHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyClients/Tests/IntegrationTests/KinesisFirehoseClientHostApp/KinesisFirehoseClientHostApp.xcodeproj/project.pbxproj
@@ -7,17 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		EA3C8E912F5070AC003FF786 /* AmplifyKinesisClient in Frameworks */ = {isa = PBXBuildFile; productRef = EA3C8E902F5070AC003FF786 /* AmplifyKinesisClient */; };
-		EA3C8E932F5070AC003FF786 /* AWSPluginsCore in Frameworks */ = {isa = PBXBuildFile; productRef = EA3C8E922F5070AC003FF786 /* AWSPluginsCore */; };
-		EA3C8E952F5070AC003FF786 /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = EA3C8E942F5070AC003FF786 /* Amplify */; };
-		EA3C8E972F5070AC003FF786 /* AmplifyFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = EA3C8E962F5070AC003FF786 /* AmplifyFoundation */; };
-		EA3C8E992F5070AC003FF786 /* AmplifyFoundationBridge in Frameworks */ = {isa = PBXBuildFile; productRef = EA3C8E982F5070AC003FF786 /* AmplifyFoundationBridge */; };
-		EA3C8EA22F50809E003FF786 /* AmplifyKinesisClient in Frameworks */ = {isa = PBXBuildFile; productRef = EA3C8EA12F50809E003FF786 /* AmplifyKinesisClient */; };
-		EA3C8EA42F50809E003FF786 /* AWSPluginsCore in Frameworks */ = {isa = PBXBuildFile; productRef = EA3C8EA32F50809E003FF786 /* AWSPluginsCore */; };
-		EA3C8EA62F50809E003FF786 /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = EA3C8EA52F50809E003FF786 /* Amplify */; };
-		EA3C8EA82F50809E003FF786 /* AmplifyFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = EA3C8EA72F50809E003FF786 /* AmplifyFoundation */; };
-		EA3C8EAA2F50809E003FF786 /* AmplifyFoundationBridge in Frameworks */ = {isa = PBXBuildFile; productRef = EA3C8EA92F50809E003FF786 /* AmplifyFoundationBridge */; };
-		EA3C8EAE2F5080EA003FF786 /* AmplifyFirehoseClient in Frameworks */ = {isa = PBXBuildFile; productRef = EA3C8EAD2F5080EA003FF786 /* AmplifyFirehoseClient */; };
 		EA67FA502F7E893400D4A710 /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = EA67FA4F2F7E893400D4A710 /* AWSCognitoAuthPlugin */; };
 		EA67FA522F7E893400D4A710 /* AWSPluginsCore in Frameworks */ = {isa = PBXBuildFile; productRef = EA67FA512F7E893400D4A710 /* AWSPluginsCore */; };
 		EA67FA542F7E893400D4A710 /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = EA67FA532F7E893400D4A710 /* Amplify */; };
@@ -25,7 +14,6 @@
 		EA67FA582F7E893400D4A710 /* AmplifyFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = EA67FA572F7E893400D4A710 /* AmplifyFoundation */; };
 		EA67FA5A2F7E893400D4A710 /* AmplifyFoundationBridge in Frameworks */ = {isa = PBXBuildFile; productRef = EA67FA592F7E893400D4A710 /* AmplifyFoundationBridge */; };
 		EA67FA5C2F7E893400D4A710 /* AmplifyKinesisClient in Frameworks */ = {isa = PBXBuildFile; productRef = EA67FA5B2F7E893400D4A710 /* AmplifyKinesisClient */; };
-		EA67FA5E2F7E897100D4A710 /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = EA67FA5D2F7E897100D4A710 /* AWSCognitoAuthPlugin */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -115,18 +103,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EA3C8EA22F50809E003FF786 /* AmplifyKinesisClient in Frameworks */,
-				EA3C8EA62F50809E003FF786 /* Amplify in Frameworks */,
-				EA3C8EA82F50809E003FF786 /* AmplifyFoundation in Frameworks */,
-				EA3C8EAA2F50809E003FF786 /* AmplifyFoundationBridge in Frameworks */,
-				EA3C8EA42F50809E003FF786 /* AWSPluginsCore in Frameworks */,
-				EA3C8E952F5070AC003FF786 /* Amplify in Frameworks */,
-				EA3C8E932F5070AC003FF786 /* AWSPluginsCore in Frameworks */,
-				EA3C8E972F5070AC003FF786 /* AmplifyFoundation in Frameworks */,
-				EA3C8E992F5070AC003FF786 /* AmplifyFoundationBridge in Frameworks */,
-				EA3C8EAE2F5080EA003FF786 /* AmplifyFirehoseClient in Frameworks */,
-				EA3C8E912F5070AC003FF786 /* AmplifyKinesisClient in Frameworks */,
-				EA67FA5E2F7E897100D4A710 /* AWSCognitoAuthPlugin in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -260,18 +236,6 @@
 			);
 			name = AmplifyKinesisClientIntegrationTests;
 			packageProductDependencies = (
-				EA3C8E902F5070AC003FF786 /* AmplifyKinesisClient */,
-				EA3C8E922F5070AC003FF786 /* AWSPluginsCore */,
-				EA3C8E942F5070AC003FF786 /* Amplify */,
-				EA3C8E962F5070AC003FF786 /* AmplifyFoundation */,
-				EA3C8E982F5070AC003FF786 /* AmplifyFoundationBridge */,
-				EA3C8EA12F50809E003FF786 /* AmplifyKinesisClient */,
-				EA3C8EA32F50809E003FF786 /* AWSPluginsCore */,
-				EA3C8EA52F50809E003FF786 /* Amplify */,
-				EA3C8EA72F50809E003FF786 /* AmplifyFoundation */,
-				EA3C8EA92F50809E003FF786 /* AmplifyFoundationBridge */,
-				EA3C8EAD2F5080EA003FF786 /* AmplifyFirehoseClient */,
-				EA67FA5D2F7E897100D4A710 /* AWSCognitoAuthPlugin */,
 			);
 			productName = AmplifyKinesisClientIntegrationTests;
 			productReference = EA6AF6972F506E3500D372FB /* AmplifyKinesisClientIntegrationTests.xctest */;

--- a/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AnalyticsHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AnalyticsHostApp.xcodeproj/project.pbxproj
@@ -29,9 +29,6 @@
 		68DBE9592A3B6EAE002B73E3 /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9737697229519DEC0074B63A /* XCTestCase+AsyncTesting.swift */; };
 		68DBE95A2A3B6EAE002B73E3 /* AWSPinpointAnalyticsPluginIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6857647828AE95ED000CE2E9 /* AWSPinpointAnalyticsPluginIntegrationTests.swift */; };
 		68DBE95B2A3B6EAE002B73E3 /* TestConfigHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6857648828AE9951000CE2E9 /* TestConfigHelper.swift */; };
-		68DBE9662A3B6F2A002B73E3 /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = 68DBE9652A3B6F2A002B73E3 /* Amplify */; };
-		68DBE9682A3B6F2A002B73E3 /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 68DBE9672A3B6F2A002B73E3 /* AWSCognitoAuthPlugin */; };
-		68DBE96A2A3B6F2A002B73E3 /* AWSPinpointAnalyticsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 68DBE9692A3B6F2A002B73E3 /* AWSPinpointAnalyticsPlugin */; };
 		9737697629519E050074B63A /* AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9737697029519DEC0074B63A /* AsyncTesting.swift */; };
 		9737697729519E050074B63A /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9737697129519DEC0074B63A /* AsyncExpectation.swift */; };
 		9737697829519E050074B63A /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9737697229519DEC0074B63A /* XCTestCase+AsyncTesting.swift */; };
@@ -135,9 +132,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				68DBE9662A3B6F2A002B73E3 /* Amplify in Frameworks */,
-				68DBE96A2A3B6F2A002B73E3 /* AWSPinpointAnalyticsPlugin in Frameworks */,
-				68DBE9682A3B6F2A002B73E3 /* AWSCognitoAuthPlugin in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -334,9 +328,6 @@
 			);
 			name = AWSPinpointAnalyticsPluginIntegrationTestsWatch;
 			packageProductDependencies = (
-				68DBE9652A3B6F2A002B73E3 /* Amplify */,
-				68DBE9672A3B6F2A002B73E3 /* AWSCognitoAuthPlugin */,
-				68DBE9692A3B6F2A002B73E3 /* AWSPinpointAnalyticsPlugin */,
 			);
 			productName = AWSPinpointAnalyticsPluginIntegrationTests;
 			productReference = 68DBE9622A3B6EAE002B73E3 /* AWSPinpointAnalyticsPluginIntegrationTestsWatch.xctest */;

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
@@ -570,7 +570,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				21F762A02BD6B1AA0048845A /* PBXTargetDependency */,
 				21F762A22BD6B1AA0048845A /* PBXTargetDependency */,
 			);
 			name = AuthGen2IntegrationTests;
@@ -614,7 +613,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				681B76982A3CBA8C004B59D9 /* PBXTargetDependency */,
 				485CB5A427B61E04006CCEC7 /* PBXTargetDependency */,
 			);
 			name = AuthIntegrationTests;

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/PredictionsHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/PredictionsHostApp.xcodeproj/project.pbxproj
@@ -53,18 +53,6 @@
 		90542370291425630000D108 /* testImageCeleb.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 90542363291425630000D108 /* testImageCeleb.jpg */; };
 		90542371291425630000D108 /* testImageTextForms.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 90542364291425630000D108 /* testImageTextForms.jpg */; };
 		90542372291425630000D108 /* audio.wav in Resources */ = {isa = PBXBuildFile; fileRef = 90542365291425630000D108 /* audio.wav */; };
-		90CF304A2AD47A71006B6FF3 /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF30492AD47A71006B6FF3 /* Amplify */; };
-		90CF304C2AD47A74006B6FF3 /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF304B2AD47A74006B6FF3 /* Amplify */; };
-		90CF304E2AD47A78006B6FF3 /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF304D2AD47A78006B6FF3 /* Amplify */; };
-		90CF30502AD47B0E006B6FF3 /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF304F2AD47B0E006B6FF3 /* AWSCognitoAuthPlugin */; };
-		90CF30522AD47B0E006B6FF3 /* AWSPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF30512AD47B0E006B6FF3 /* AWSPredictionsPlugin */; };
-		90CF30542AD47B0E006B6FF3 /* CoreMLPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF30532AD47B0E006B6FF3 /* CoreMLPredictionsPlugin */; };
-		90CF30562AD47B19006B6FF3 /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF30552AD47B19006B6FF3 /* AWSCognitoAuthPlugin */; };
-		90CF30582AD47B19006B6FF3 /* AWSPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF30572AD47B19006B6FF3 /* AWSPredictionsPlugin */; };
-		90CF305A2AD47B19006B6FF3 /* CoreMLPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF30592AD47B19006B6FF3 /* CoreMLPredictionsPlugin */; };
-		90CF305C2AD47B24006B6FF3 /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF305B2AD47B24006B6FF3 /* AWSCognitoAuthPlugin */; };
-		90CF305E2AD47B24006B6FF3 /* AWSPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF305D2AD47B24006B6FF3 /* AWSPredictionsPlugin */; };
-		90CF30602AD47B24006B6FF3 /* CoreMLPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF305F2AD47B24006B6FF3 /* CoreMLPredictionsPlugin */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -139,10 +127,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				90CF30602AD47B24006B6FF3 /* CoreMLPredictionsPlugin in Frameworks */,
-				90CF304E2AD47A78006B6FF3 /* Amplify in Frameworks */,
-				90CF305E2AD47B24006B6FF3 /* AWSPredictionsPlugin in Frameworks */,
-				90CF305C2AD47B24006B6FF3 /* AWSCognitoAuthPlugin in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -161,10 +145,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				90CF30542AD47B0E006B6FF3 /* CoreMLPredictionsPlugin in Frameworks */,
-				90CF304A2AD47A71006B6FF3 /* Amplify in Frameworks */,
-				90CF30522AD47B0E006B6FF3 /* AWSPredictionsPlugin in Frameworks */,
-				90CF30502AD47B0E006B6FF3 /* AWSCognitoAuthPlugin in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -172,10 +152,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				90CF305A2AD47B19006B6FF3 /* CoreMLPredictionsPlugin in Frameworks */,
-				90CF304C2AD47A74006B6FF3 /* Amplify in Frameworks */,
-				90CF30582AD47B19006B6FF3 /* AWSPredictionsPlugin in Frameworks */,
-				90CF30562AD47B19006B6FF3 /* AWSCognitoAuthPlugin in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -339,10 +315,6 @@
 			);
 			name = AWSPredictionsPluginIntegrationTestsWatch;
 			packageProductDependencies = (
-				90CF304D2AD47A78006B6FF3 /* Amplify */,
-				90CF305B2AD47B24006B6FF3 /* AWSCognitoAuthPlugin */,
-				90CF305D2AD47B24006B6FF3 /* AWSPredictionsPlugin */,
-				90CF305F2AD47B24006B6FF3 /* CoreMLPredictionsPlugin */,
 			);
 			productName = AWSPredictionsPluginIntegrationTests;
 			productReference = 6875F9242A3CCCB7001C9AAF /* AWSPredictionsPluginIntegrationTestsWatch.xctest */;
@@ -387,10 +359,6 @@
 			);
 			name = CoreMLPredictionsPluginIntegrationTests;
 			packageProductDependencies = (
-				90CF30492AD47A71006B6FF3 /* Amplify */,
-				90CF304F2AD47B0E006B6FF3 /* AWSCognitoAuthPlugin */,
-				90CF30512AD47B0E006B6FF3 /* AWSPredictionsPlugin */,
-				90CF30532AD47B0E006B6FF3 /* CoreMLPredictionsPlugin */,
 			);
 			productName = CoreMLPredictionsPluginIntegrationTests;
 			productReference = 90283033291402D500897087 /* CoreMLPredictionsPluginIntegrationTests.xctest */;
@@ -411,10 +379,6 @@
 			);
 			name = AWSPredictionsPluginIntegrationTests;
 			packageProductDependencies = (
-				90CF304B2AD47A74006B6FF3 /* Amplify */,
-				90CF30552AD47B19006B6FF3 /* AWSCognitoAuthPlugin */,
-				90CF30572AD47B19006B6FF3 /* AWSPredictionsPlugin */,
-				90CF30592AD47B19006B6FF3 /* CoreMLPredictionsPlugin */,
 			);
 			productName = AWSPredictionsPluginIntegrationTests;
 			productReference = 903555F829141355004B83C2 /* AWSPredictionsPluginIntegrationTests.xctest */;

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift",
       "state" : {
-        "revision" : "d754d289d594adc240f55c90eab212bac818509c",
-        "version" : "0.58.1"
+        "revision" : "a7920e74721ccff5683a1e9ff276cfa71dff9a71",
+        "version" : "0.63.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift",
       "state" : {
-        "revision" : "6518f3491768180ff4c89f5c6425c4fc04713772",
-        "version" : "1.6.71"
+        "revision" : "c71eb1515223bee2b2e4b96328655fd3bd9d442f",
+        "version" : "1.7.27"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "60bc71892ac8c206df0cc2e14c987455d45ace68",
-        "version" : "0.191.0"
+        "revision" : "9b090f61f696666fcb85e7428d7c316bd54d9cb4",
+        "version" : "0.223.0"
       }
     },
     {
@@ -79,6 +79,15 @@
       "state" : {
         "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
         "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -124,6 +133,15 @@
       "state" : {
         "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
         "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let platforms: [SupportedPlatform] = [
     .watchOS(.v9)
 ]
 let dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/awslabs/aws-sdk-swift", exact: "1.6.71"),
+    .package(url: "https://github.com/awslabs/aws-sdk-swift", exact: "1.7.27"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", exact: "0.15.4"),
     .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.1.0"),
     .package(url: "https://github.com/aws-amplify/amplify-swift-utils-notifications.git", from: "1.1.0")


### PR DESCRIPTION
## Issue #
Resolves #4233
Upstream tracking: awslabs/aws-sdk-swift#2181 (resolved)

## Description

Bumps the `aws-sdk-swift` dependency from `1.6.71` to `1.7.21`. This moves the transitive dependencies:

| Package | Before | After |
|---|---|---|
| aws-sdk-swift | 1.6.71 | 1.7.21 |
| aws-crt-swift | 0.58.1 | 0.63.0 |
| smithy-swift | 0.191.0 | 0.219.0 |

## Why this resolves #4233

#4233 reported that Amplify Swift and the AWS IoT Device SDK for Swift could not coexist in the same project because of conflicting `aws-crt-swift` versions. The IoT SDK requires `aws-crt-swift >= 0.61.2`, while `aws-sdk-swift` pinned `aws-crt-swift` with a hard `exact:` constraint.

As of [`aws-sdk-swift 1.7.21`](https://github.com/awslabs/aws-sdk-swift/releases/tag/1.7.21), that constraint was relaxed from `exact: "0.61.1"` to `from: "0.63.0"` (tracked in awslabs/aws-sdk-swift#2181, now closed as resolved). With this bump, Amplify resolves `aws-crt-swift 0.63.0` via a floating range, so SPM can satisfy both Amplify and the AWS IoT Device SDK for Swift in a single project.

## Testing

- `swift package resolve` succeeds and regenerates `Package.resolved` with the versions above.