### PR TITLE
fix(auth): disable URL caching in FoundationClientEngine to prevent credentials being persisted to Cache.db

### DIFF
--- a/AmplifyPlugins/Core/AmplifyCredentials/CustomHttpClientEngine/FoundationClientEngine.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentials/CustomHttpClientEngine/FoundationClientEngine.swift
@@ -11,10 +11,12 @@ import SmithyHTTPAPI
 
 @_spi(FoundationClientEngine)
 public struct FoundationClientEngine: HTTPClient {
+    let urlSession: URLSession
+
     public func send(request: SmithyHTTPAPI.HTTPRequest) async throws -> SmithyHTTPAPI.HTTPResponse {
         let urlRequest = try await URLRequest(from: request)
 
-        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+        let (data, response) = try await urlSession.data(for: urlRequest)
         guard let httpURLResponse = response as? HTTPURLResponse else {
             // This shouldn't be necessary because we're only making HTTP requests.
             // `URLResponse` should always be a `HTTPURLResponse`.
@@ -30,7 +32,16 @@ public struct FoundationClientEngine: HTTPClient {
         return httpResponse
     }
 
-    public init() {}
+    public init() {
+        // These requests carry Cognito tokens and AWS credentials. Disable URL
+        // caching so that responses are never persisted to disk (e.g. Cache.db),
+        // where they could be recovered by inspecting the app container. This
+        // mirrors the cache-disabling behavior used for the Hosted UI session.
+        let configuration = URLSessionConfiguration.default
+        configuration.urlCache = nil
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        self.urlSession = URLSession(configuration: configuration)
+    }
 
     /// no-op
     func close() async {}

--- a/AmplifyPlugins/Core/AmplifyCredentialsTests/Utils/FoundationClientEngineTests.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentialsTests/Utils/FoundationClientEngineTests.swift
@@ -1,0 +1,32 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@_spi(FoundationClientEngine)
+@testable import InternalAmplifyCredentials
+import XCTest
+
+class FoundationClientEngineTests: XCTestCase {
+
+    /// Given: A `FoundationClientEngine`.
+    /// When: The engine is initialized.
+    /// Then: Its `URLSession` has URL caching disabled so that responses
+    ///       carrying Cognito tokens / AWS credentials are never persisted
+    ///       to disk (e.g. Cache.db).
+    func test_urlSession_disablesCaching() {
+        let engine = FoundationClientEngine()
+        let configuration = engine.urlSession.configuration
+
+        XCTAssertNil(
+            configuration.urlCache,
+            "URLSession must not have a URLCache, otherwise credential responses are persisted to disk."
+        )
+        XCTAssertEqual(
+            configuration.requestCachePolicy,
+            .reloadIgnoringLocalCacheData
+        )
+    }
+}


### PR DESCRIPTION
## Issue \#
<!-- Reported via pen test: Cognito tokens and AWS credentials persisted to Cache.db -->

## Description

A test found that user credentials and Cognito tokens were being persisted to `Cache.db` in the app container of iOS applications using this library.

The root cause is in `FoundationClientEngine`, the base HTTP client used by the AWS SDK Swift service clients (Cognito Identity / Identity Provider, etc.) through `PluginClientEngine.baseClientEngine(for:)`. It used `URLSession.shared`, whose default configuration includes an on-disk `URLCache`. As a result, responses carrying tokens and AWS credentials were written to `Cache.db`, where they could be recovered by inspecting the device.

This fix uses a dedicated `URLSession` configured with `urlCache = nil` and a `reloadIgnoringLocalCacheData` request cache policy, so these responses are never persisted to disk. This mirrors the cache-disabling behavior already applied to the Hosted UI `URLSession` in `AWSCognitoAuthPlugin+Configure.swift` (`makeURLSession()`).

The fix is applied at the library level and requires no app-side changes.

> Note for adopters: this stops future caching. Tokens already written to `Cache.db` on existing installs remain until that cache is cleared; apps may wish to call `URLCache.shared.removeAllCachedResponses()` once on upgrade to purge anything already persisted.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
