### PR TITLE
chore(auth): fix web authn and push notifications integration tests

### DIFF
--- a/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AnalyticsHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AnalyticsHostApp.xcodeproj/project.pbxproj
@@ -902,7 +902,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazon.aws.amplify.swift.AnalyticsHostAppWatch.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
@@ -932,7 +932,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazon.aws.amplify.swift.AnalyticsHostAppWatch.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;

--- a/AmplifyPlugins/Auth/Tests/AuthWebAuthnApp/AuthWebAuthnAppUITests/AuthWebAuthnAppUITests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthWebAuthnApp/AuthWebAuthnAppUITests/AuthWebAuthnAppUITests.swift
@@ -72,20 +72,14 @@ final class AuthWebAuthnAppUITests: XCTestCase {
     @MainActor
     func testWebAuthnAPIs() async throws {
         // 1. Associate new WebAuthn Credential
+        let associateContinueButton = springboard.otherElements["ASAuthorizationControllerContinueButton"]
         let associateAttempt = await attempt {
             associateButton.tap()
-            return !waitForResult("Associate WebAuthn Credential failed:", timeout: 1)
+            return associateContinueButton.waitForExistence(timeout: timeout)
         }
 
         guard associateAttempt else {
-            XCTFail("Failed to trigger the Associate WebAuthn Credential workflow: \(lastResult)")
-            return
-        }
-
-        // Wait for the "Continue" button to appear in the FaceID popover and tap it
-        let associateContinueButton = springboard.otherElements["ASAuthorizationControllerContinueButton"]
-        guard associateContinueButton.waitForExistence(timeout: timeout) else {
-            XCTFail("Failed to find the 'Continue' button to Associate new WebAuthn credential")
+            XCTFail("Failed to find the 'Continue' button to Associate new WebAuthn credential: \(lastResult)")
             return
         }
         associateContinueButton.tap()
@@ -112,20 +106,14 @@ final class AuthWebAuthnAppUITests: XCTestCase {
         }
 
         // 4. Sign in with WebAuthn
+        let signInContinueButton = springboard.otherElements["ASAuthorizationControllerContinueButton"]
         let signInAttempt = await attempt {
             signInButton.tap()
-            return !waitForResult("Sign In failed:", timeout: 1)
+            return signInContinueButton.waitForExistence(timeout: timeout)
         }
 
         guard signInAttempt else {
-            XCTFail("Failed to trigger the Assert WebAuthn Credential workflow: \(lastResult)")
-            return
-        }
-
-        // Wait for the "Continue" button to appear in the FaceID popover
-        let signInContinueButton = springboard.otherElements["ASAuthorizationControllerContinueButton"]
-        guard signInContinueButton.waitForExistence(timeout: timeout) else {
-            XCTFail("Failed to find the 'Continue' button to Sign In with WebAuthn")
+            XCTFail("Failed to find the 'Continue' button to Sign In with WebAuthn: \(lastResult)")
             return
         }
 

--- a/AmplifyPlugins/Auth/Tests/AuthWebAuthnApp/AuthWebAuthnAppUITests/AuthWebAuthnAppUITests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthWebAuthnApp/AuthWebAuthnAppUITests/AuthWebAuthnAppUITests.swift
@@ -8,7 +8,7 @@
 import XCTest
 
 final class AuthWebAuthnAppUITests: XCTestCase {
-    private let timeout = TimeInterval(6)
+    private let timeout = TimeInterval(30)
     private let app = XCUIApplication()
     private var username: String!
     private var signUpButton: XCUIElement!

--- a/AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp/PushNotificationHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp/PushNotificationHostApp.xcodeproj/project.pbxproj
@@ -868,7 +868,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.aws.amplify.notification.PushNotificationHostApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
@@ -899,7 +899,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.aws.amplify.notification.PushNotificationHostApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
Failing WebAuthN and Push Notification Integration tests

## Description
<!-- Why is this change required? What problem does it solve? -->

Fixes three failing integration tests on CI caused by the Xcode 26.3 / watchOS 26.2 upgrade and the aws-sdk-swift 1.7.27 bump.

## Changes

### 1. AuthWebAuthnApp — fix flaky system dialog detection

The test previously checked for an API error (1s timeout) and the system Continue button (6s timeout) as two separate sequential steps. If the Cognito `startWebAuthnRegistration` call was slow or transiently failed after the 1s window, the test would proceed to wait for a button that would never appear.

Restructured to wait for the `ASAuthorizationControllerContinueButton` directly inside the `attempt` retry loop (30s per attempt, up to 3 retries). This handles both slow network responses and transient API failures in a single pass.

### 2. PushNotificationsWatchApp / AnalyticsWatchApp — fix simulator installation on watchOS 26.2

Both standalone watch app targets had `SKIP_INSTALL = YES`. In Xcode 26.3, this prevents `WKWatchOnly` apps from being installed on the watchOS 26.2 simulator, causing `FBSApplicationLibrary` to return nil when the test runner attempts to launch them. Changed to `SKIP_INSTALL = NO`.

## Files changed

- `AmplifyPlugins/Auth/Tests/AuthWebAuthnApp/AuthWebAuthnAppUITests/AuthWebAuthnAppUITests.swift`
- `AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AnalyticsHostApp.xcodeproj/project.pbxproj`
- `AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp/PushNotificationHostApp.xcodeproj/project.pbxproj`

## Test plan

- [ ] `AuthWebAuthnApp` UI test passes on iOS 18.5 (Xcode 16.4)
- [ ] `PushNotificationWatchTests` passes on watchOS 26.2 (Xcode 26.3)
- [ ] `AnalyticsWatchApp` tests pass on watchOS 26.2 (Xcode 26.3)
- [ ] No regressions on iOS/tvOS integration tests

## Test plan

- [ ] `AuthWebAuthnApp` integration test passes on iOS 18.5 (Xcode 16.4)
- [ ] `PushNotificationWatchTests` integration test passes on watchOS 26.2 (Xcode 26.3)
- [ ] No regressions on iOS/tvOS push notification tests


## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
