### PR TITLE
fix(predictions): fix Face Liveness with temporary credentials on iOS 26 (URL signing + Sendable credentials)

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AuthAWSCredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AuthAWSCredentialsProvider.swift
@@ -44,7 +44,7 @@ public protocol AWSCredentialsProvider {
  - accessKeyId: A unique identifier.
  - secretAccessKey: A secret key used to sign requests cryptographically.
  */
-public protocol AWSCredentials {
+public protocol AWSCredentials: Sendable {
 
     /// A unique identifier.
     var accessKeyId: String { get }

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Signing/SigV4Signer.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Signing/SigV4Signer.swift
@@ -202,8 +202,13 @@ struct SigV4Signer {
             serviceName: serviceName
         )
 
+        let existingQuery = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .map { "\($0.name)=\($0.value ?? "")" }
+            .joined(separator: "&")
+
         let canonicalQueryString = _canonicalQueryString(
-            query: url.query,
+            query: existingQuery,
             signedHeaders: signedHeaders,
             timestamp: timestamp,
             credentialScope: credentialScope,
@@ -325,7 +330,7 @@ struct SigV4Signer {
 
         let sorted = canonicalQueryString.split(separator: "&")
             .map {
-                String($0).split(separator: "=")
+                String($0).split(separator: "=", maxSplits: 1)
                     .map(String.init)
                     .map(PercentEncoding.uri.encode)
                     .joined(separator: "=")

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/SigV4SignerTests/SigV4URLSigningTestCase.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/SigV4SignerTests/SigV4URLSigningTestCase.swift
@@ -157,4 +157,132 @@ class SigV4URLSigningTestCase: XCTestCase {
         XCTAssertEqual(try queryValue(for: "X-Amz-Expires", from: queryItems), String(expiration))
         XCTAssertEqual(try queryValue(for: "X-Amz-Signature", from: queryItems), "eb2d084e14a165e42c47d1ad0369b1ea91d31561e6a57d939b071a8f1c3fc18f")
     }
+
+    // MARK: - Session token with base64 padding (contains '=' characters)
+
+    func testSignWithSessionTokenContainingEquals() throws {
+        let url = try url()
+
+        let credential = SigV4Signer.Credential(
+            accessKey: "AKIAIOSFODNN7EXAMPLE",
+            secretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            sessionToken: "FwoGZXIvYXdzEBYaDHQa7IU/xL+SomeBase64Token+With/Slashes==")
+
+        let signer = SigV4Signer(
+            credential: credential,
+            serviceName: "rekognition",
+            region: "us-east-1"
+        )
+
+        let signedURL = signer.sign(
+            url: url,
+            method: .get,
+            date: { date }
+        )
+
+        let components = URLComponents(url: signedURL, resolvingAgainstBaseURL: false)
+        let queryItems = try XCTUnwrap(components?.queryItems)
+
+        let token = queryItems.first(where: { $0.name == "X-Amz-Security-Token" })?.value
+        XCTAssertEqual(token, "FwoGZXIvYXdzEBYaDHQa7IU/xL+SomeBase64Token+With/Slashes==",
+                       "Session token with '=' padding must be preserved intact")
+
+        // Verify signature is present (not nil/empty) — proves the signing completed without error
+        let signature = queryItems.first(where: { $0.name == "X-Amz-Signature" })?.value
+        XCTAssertNotNil(signature)
+        XCTAssertFalse(signature!.isEmpty)
+    }
+
+    func testSignWithSessionTokenContainingEqualsProducesDeterministicSignature() throws {
+        let url = try url()
+
+        let credential = SigV4Signer.Credential(
+            accessKey: "AKIAIOSFODNN7EXAMPLE",
+            secretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            sessionToken: "IQoJb3JpZ2luX2VjEKz//////////wEaCXVzLWVhc3QtMSJHMEUCIQC+base64padding==")
+
+        let signer = SigV4Signer(
+            credential: credential,
+            serviceName: "rekognition",
+            region: "us-east-1"
+        )
+
+        let signedURL1 = signer.sign(url: url, method: .get, date: { date })
+        let signer2 = SigV4Signer(credential: credential, serviceName: "rekognition", region: "us-east-1")
+        let signedURL2 = signer2.sign(url: url, method: .get, date: { date })
+
+        let sig1 = URLComponents(url: signedURL1, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { $0.name == "X-Amz-Signature" })?.value
+        let sig2 = URLComponents(url: signedURL2, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { $0.name == "X-Amz-Signature" })?.value
+
+        XCTAssertEqual(sig1, sig2, "Signing must be deterministic for session tokens with '=' characters")
+    }
+
+    // MARK: - URL with query parameters containing special characters
+
+    func testSignURLWithSpecialCharactersInQueryParams() throws {
+        let baseURL = try XCTUnwrap(
+            URL(string: "wss://streaming-rekognition.us-east-1.amazon.com/start-face-liveness-session-websocket")
+        )
+
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)!
+        components.queryItems = [
+            URLQueryItem(name: "session-id", value: "abc-123"),
+            URLQueryItem(name: "x-amz-user-agent", value: "amplify-swift/2.53.2 api/rekognition os/iOS/26.0")
+        ]
+        let url = try XCTUnwrap(components.url)
+
+        let signer = SigV4Signer(
+            credential: temporaryCredential,
+            serviceName: "rekognition",
+            region: "us-east-1"
+        )
+
+        let signedURL = signer.sign(url: url, method: .get, date: { date })
+
+        let signedComponents = URLComponents(url: signedURL, resolvingAgainstBaseURL: false)
+        let queryItems = try XCTUnwrap(signedComponents?.queryItems)
+
+        // Verify the user-agent value survived encoding round-trip intact
+        let userAgent = queryItems.first(where: { $0.name == "x-amz-user-agent" })?.value
+        XCTAssertEqual(userAgent, "amplify-swift/2.53.2 api/rekognition os/iOS/26.0")
+
+        // Verify signature exists
+        let signature = queryItems.first(where: { $0.name == "X-Amz-Signature" })?.value
+        XCTAssertNotNil(signature)
+        XCTAssertFalse(signature!.isEmpty)
+    }
+
+    func testSignURLWithQueryParamsProducesDeterministicSignature() throws {
+        let baseURL = try XCTUnwrap(
+            URL(string: "wss://streaming-rekognition.us-east-1.amazon.com/start-face-liveness-session-websocket")
+        )
+
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)!
+        components.queryItems = [
+            URLQueryItem(name: "session-id", value: "test-session-id"),
+            URLQueryItem(name: "x-amz-user-agent", value: "amplify-swift/2.53.2 os/iOS/26.0 lang/swift/6.x")
+        ]
+        let url = try XCTUnwrap(components.url)
+
+        let credential = SigV4Signer.Credential(
+            accessKey: "AKIAIOSFODNN7EXAMPLE",
+            secretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            sessionToken: "TokenWith+Plus/Slash==")
+
+        let signer1 = SigV4Signer(credential: credential, serviceName: "rekognition", region: "us-east-1")
+        let signer2 = SigV4Signer(credential: credential, serviceName: "rekognition", region: "us-east-1")
+
+        let signedURL1 = signer1.sign(url: url, method: .get, date: { date })
+        let signedURL2 = signer2.sign(url: url, method: .get, date: { date })
+
+        let sig1 = URLComponents(url: signedURL1, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { $0.name == "X-Amz-Signature" })?.value
+        let sig2 = URLComponents(url: signedURL2, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { $0.name == "X-Amz-Signature" })?.value
+
+        XCTAssertEqual(sig1, sig2,
+                       "Signing must produce identical signatures regardless of how Foundation encodes the URL internally")
+    }
 }


### PR DESCRIPTION
## Issue

Fixes [aws-amplify/amplify-ui-swift-liveness#225](https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/225)

FaceLiveness fails with `FaceLivenessDetectionError.unknown` (Rekognition returns `UnrecognizedClientException`, websocket close code 4005) when the caller supplies **temporary credentials** via a custom `AWSCredentialsProvider`. Long-term credentials are unaffected.

## Root Cause

Two independent bugs contributed to signing failures with temporary credentials:

### 1. SigV4 URL signing

The canonical query string was built from `url.query`, which drops/round-trips query items incorrectly, and the query-item split on `=` used the default (unbounded) `maxSplits`, which corrupted values that themselves contain `=` (e.g. base64 padding in a `X-Amz-Security-Token`). This produced an invalid signature.

- Build the canonical query from `URLComponents.queryItems` so existing items are preserved verbatim.
- Split each `key=value` pair with `maxSplits: 1` so values containing `=` survive percent-encoding intact.

### 2. Actor-isolated `AWSTemporaryCredentials` conformance

`credential(from:)` in `LivenessCredentials.swift` extracts the session token with:

```swift
sessionToken: (credentials as? AWSTemporaryCredentials)?.sessionToken
```

When a caller declares their credential type in a target that uses `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` (an increasingly common default in new Xcode projects) and the type does not opt into `Sendable`/`nonisolated`, its conformance to `AWSTemporaryCredentials` becomes **actor-isolated to `MainActor`**. The `as?` cast is performed from a `nonisolated` async context, so it fails and returns `nil`, silently dropping the session token.

This was confirmed with a minimal reproduction: a `MainActor`-isolated credential struct cast from a nonisolated function returns `nil` for the session token, even though the value carries it.

Making `AWSCredentials` inherit from `Sendable` prevents the conformance from becoming actor-isolated, so the cast succeeds from any isolation context. This is also semantically correct — credentials are returned from an `async` provider and cross concurrency boundaries, so they should be `Sendable`.

## Changes

- `SigV4Signer.swift`: build canonical query from `URLComponents.queryItems`; use `maxSplits: 1` when splitting query pairs.
- `AuthAWSCredentialsProvider.swift`: `public protocol AWSCredentials: Sendable`.

## Testing

- Added `SigV4URLSigningTestCase` covering query strings with `=`-containing values and session tokens.
- Verified end-to-end against a reproduction app supplying a custom temporary-credentials provider: session token is now signed correctly and the liveness stream initializes.

## Credit

The `Sendable` fix and root-cause analysis of the actor-isolated conformance were contributed by @nenseso via #4253.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
