### PR TITLE
fix(predictions): fallback to reflection for extracting sessionToken …

### DIFF
--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/SPI/LivenessCredentials.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/SPI/LivenessCredentials.swift
@@ -25,11 +25,30 @@ func credential(from credentialsProvider: AWSCredentialsProvider?) async throws 
         }
     }
 
+    let sessionToken = temporarySessionToken(from: credentials)
+
     let signerCredential = SigV4Signer.Credential(
         accessKey: credentials.accessKeyId,
         secretKey: credentials.secretAccessKey,
-        sessionToken: (credentials as? AWSTemporaryCredentials)?.sessionToken
+        sessionToken: sessionToken
     )
 
     return signerCredential
+}
+
+private func temporarySessionToken(from credentials: AWSCredentials) -> String? {
+    if let temporaryCredentials = credentials as? AWSTemporaryCredentials {
+        return temporaryCredentials.sessionToken
+    }
+
+    let mirror = Mirror(reflecting: credentials)
+    for child in mirror.children {
+        if child.label == "sessionToken",
+           let value = child.value as? String,
+           !value.isEmpty {
+            return value
+        }
+    }
+
+    return nil
 }


### PR DESCRIPTION
## Issue #
https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/225

## Description
When running Face Liveness with temporary credentials, the session initialization fails with `UnrecognizedClientException` (close code `4005`).

### The Problem & How to Reproduce
When developers define their custom credentials provider using a Swift `struct` (value type) conforming to `AWSTemporaryCredentials` like this:

```swift
struct TemporaryCredentials: AWSTemporaryCredentials {
    let sessionToken: String
    let expiration: Date
    let accessKeyId: String
    let secretAccessKey: String
}
```
The conditional cast in LivenessCredentials.swift fails:
```swift
sessionToken: (credentials as? AWSTemporaryCredentials)?.sessionToken
```
The cast credentials as? AWSTemporaryCredentials returns nil when the underlying concrete type is a struct, which causes the sessionToken to be lost during signing.

## The Fix
This PR introduces a fallback helper function temporarySessionToken(from:) utilizing Swift Reflection (Mirror). If the direct cast to AWSTemporaryCredentials returns nil, we inspect the credentials object via reflection to check if a sessionToken property is present and non-empty. This guarantees that sessionToken can be successfully retrieved regardless of whether the credentials are implemented as a struct or a class.

## General Checklist
 

- [x] Build succeeds with all target using Swift Package Manager
- [x]  All unit tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ]  Added new tests to cover change, if needed
- [ ]  All integration tests pass
- [ ]  Documentation update for the change if required
- [x]  PR title conforms to conventional commit style (fix(predictions): fallback to reflection for extracting sessionToken from credentials)
- [ ]  New or updated tests include Given When Then inline code documentation and are named accordingly testThing_condition_expectation()
- [ ]  If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

