### PR TITLE
fix(auth): fix visionOS build failure in WebAuthn credential registration

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/WebAuthn/PlatformWebAuthnCredentials.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/WebAuthn/PlatformWebAuthnCredentials.swift
@@ -113,9 +113,12 @@ extension PlatformWebAuthnCredentials: CredentialRegistrantProtocol {
             name: options.user.name,
             userID: options.user.id
         )
+#if !os(visionOS)
+        // `excludedCredentials` is not available on visionOS
         platformKeyRequest.excludedCredentials = options.excludeCredentials.compactMap { credential in
             return .init(credentialID: credential.id)
         }
+#endif
 
         return try await withCheckedThrowingContinuation { continuation in
             registrationContinuation = continuation


### PR DESCRIPTION
## Issue #
Fixes #4237

## Description

Building `AWSCognitoAuthPlugin` for visionOS fails:

```
PlatformWebAuthnCredentials.swift:116:28: error: 'excludedCredentials' is only available in visionOS 1.1 or newer
```

(Wording varies by SDK; Xcode 26.x reports the symbol as unavailable on visionOS instead. Both reject it.)

**Root cause:** `excludedCredentials` is provided by the `ASAuthorizationWebBrowserPlatformPublicKeyCredentialRegistrationRequest` protocol, which AuthenticationServices marks `API_UNAVAILABLE(visionos)` when compiling for visionOS (verified in the Xcode 26.1.1 and Xcode 27 beta SDK headers; one earlier Xcode 27 beta annotated it `visionOS 1.1`, producing the error above). `PlatformWebAuthnCredentials` assigns it inside an `@available(iOS 17.4, macOS 13.5, visionOS 1.0, *)` context, and `Package.swift` declares no visionOS platform, so the availability floor is visionOS 1.0. Any visionOS build of the plugin fails.

**Fix:** compile the assignment out on visionOS with `#if !os(visionOS)`. A runtime `if #available(visionOS 1.1, *)` guard (suggested in #4237) does not compile against SDKs that mark the symbol `API_UNAVAILABLE(visionos)`, including the Xcode versions this repo's CI uses, so a compile-time guard is the only form that builds across current SDKs.

**Behavior impact:** none on iOS/macOS. On visionOS the registration request no longer sets the exclude list (the API isn't offered there), so the system won't pre-filter already-registered credentials during passkey registration. This restores the plugin compiling on visionOS at all.

**Verification:** built and ran the `AWSCognitoAuthPlugin` unit test suite on iOS 26.1, iOS 27.0, visionOS 26.1, and visionOS 27.0 simulators; all pass.

## General Checklist

- ~~Added new tests to cover change, if needed~~ (compile-time platform guard, no new runtime behavior to test)
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- ~~All integration tests pass~~ (require backend resources; not run)
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~Documentation update for the change if required~~ (not required)
- [x] PR title conforms to conventional commit style
- ~~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~~ (no new tests)
- ~~If breaking change, documentation/changelog update with migration instructions~~ (not a breaking change)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
