### PR TITLE
fix: prevent command injection in WebAuthn/Push test LocalServers

### DIFF
--- a/AmplifyPlugins/Auth/Tests/AuthWebAuthnApp/LocalServer/index.mjs
+++ b/AmplifyPlugins/Auth/Tests/AuthWebAuthnApp/LocalServer/index.mjs
@@ -6,11 +6,21 @@ app.use(express.json())
 
 const bundleId = "com.amazon.aws.amplify.swift.AuthWebAuthnApp"
 
-const run = (cmd) => {
+// Simulator device identifiers are either a UUID (UDID) or the literal "booted".
+// Validating up front rejects any value that could be used to smuggle shell
+// metacharacters into the commands below.
+const deviceIdPattern = /^([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}|booted)$/
+
+const isValidDeviceId = (deviceId) => typeof deviceId === "string" && deviceIdPattern.test(deviceId)
+
+// Run a command without invoking a shell. Arguments are passed as an array so
+// user-supplied values (e.g. deviceId) are never interpreted by /bin/sh,
+// preventing command injection.
+const run = (file, args) => {
     return new Promise((resolve, reject) => {
-        childProcess.exec(cmd, (error, stdout, stderror) => {
+        childProcess.execFile(file, args, (error, stdout, stderror) => {
             if (error) {
-                console.warn("Failed to execute cmd:", cmd)
+                console.warn("Failed to execute:", file, args)
                 reject(stderror)
             } else {
                 resolve(stdout)
@@ -22,9 +32,11 @@ const run = (cmd) => {
 app.post('/uninstall', async (req, res) => {
     console.log("POST /uninstall ")
     const { deviceId } = req.body
+    if (!isValidDeviceId(deviceId)) {
+        return res.status(400).send("Invalid deviceId")
+    }
     try {
-        const cmd = `xcrun simctl uninstall ${deviceId} ${bundleId}`
-        await run(cmd)
+        await run("xcrun", ["simctl", "uninstall", deviceId, bundleId])
         res.send("Done")
     } catch (error) {
         console.error("Failed to uninstall app", error)
@@ -35,9 +47,11 @@ app.post('/uninstall', async (req, res) => {
 app.post('/boot', async (req, res) => {
     console.log("POST /boot ")
     const { deviceId } = req.body
+    if (!isValidDeviceId(deviceId)) {
+        return res.status(400).send("Invalid deviceId")
+    }
     try {
-        const cmd = `xcrun simctl bootstatus ${deviceId} -b`
-        await run(cmd)
+        await run("xcrun", ["simctl", "bootstatus", deviceId, "-b"])
         res.send("Done")
     } catch (error) {
         console.error("Failed to boot the device", error)
@@ -48,9 +62,12 @@ app.post('/boot', async (req, res) => {
 app.post('/enroll', async (req, res) => {
     console.log("POST /enroll ")
     const { deviceId } = req.body
+    if (!isValidDeviceId(deviceId)) {
+        return res.status(400).send("Invalid deviceId")
+    }
     try {
-        const cmd = `xcrun simctl spawn ${deviceId} notifyutil -s com.apple.BiometricKit.enrollmentChanged '1' && xcrun simctl spawn ${deviceId} notifyutil -p com.apple.BiometricKit.enrollmentChanged`
-        await run(cmd)
+        await run("xcrun", ["simctl", "spawn", deviceId, "notifyutil", "-s", "com.apple.BiometricKit.enrollmentChanged", "1"])
+        await run("xcrun", ["simctl", "spawn", deviceId, "notifyutil", "-p", "com.apple.BiometricKit.enrollmentChanged"])
         res.send("Done")
     } catch (error) {
         console.error("Failed to enroll biometrics in the device", error)
@@ -62,9 +79,11 @@ app.post('/enroll', async (req, res) => {
 app.post('/match', async (req, res) => {
     console.log("POST /match ")
     const { deviceId } = req.body
+    if (!isValidDeviceId(deviceId)) {
+        return res.status(400).send("Invalid deviceId")
+    }
     try {
-        const cmd = `xcrun simctl spawn ${deviceId} notifyutil -p com.apple.BiometricKit_Sim.fingerTouch.match`
-        await run(cmd)
+        await run("xcrun", ["simctl", "spawn", deviceId, "notifyutil", "-p", "com.apple.BiometricKit_Sim.fingerTouch.match"])
         res.send("Done")
     } catch (error) {
         console.error("Failed to match biometrics", error)

--- a/AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp/LocalServer/index.mjs
+++ b/AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp/LocalServer/index.mjs
@@ -6,16 +6,43 @@ app.use(express.json())
 
 const bundleId = "com.aws.amplify.notification.PushNotificationHostApp"
 
-const run = (cmd) => {
+// Simulator device identifiers are either a UUID (UDID) or the literal "booted".
+// Validating up front rejects any value that could be used to smuggle shell
+// metacharacters into the commands below.
+const deviceIdPattern = /^([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}|booted)$/
+
+const isValidDeviceId = (deviceId) => typeof deviceId === "string" && deviceIdPattern.test(deviceId)
+
+// Run a command without invoking a shell. Arguments are passed as an array so
+// user-supplied values (e.g. deviceId) are never interpreted by /bin/sh,
+// preventing command injection.
+const run = (file, args) => {
     return new Promise((resolve, reject) => {
-        childProcess.exec(cmd, (error, stdout, stderror) => {
+        childProcess.execFile(file, args, (error, stdout, stderror) => {
             if (error) {
-                console.warn("Failed to execute cmd:", cmd)
+                console.warn("Failed to execute:", file, args)
                 reject(stderror)
             } else {
                 resolve(stdout)
             }
         })
+    })
+}
+
+// Run a command without a shell and feed the given string to its stdin.
+// Used in place of `echo '<json>' | xcrun simctl push ... -` so the payload
+// never passes through a shell.
+const runWithStdin = (file, args, input) => {
+    return new Promise((resolve, reject) => {
+        const child = childProcess.execFile(file, args, (error, stdout, stderror) => {
+            if (error) {
+                console.warn("Failed to execute:", file, args)
+                reject(stderror)
+            } else {
+                resolve(stdout)
+            }
+        })
+        child.stdin.end(input)
     })
 }
 
@@ -35,6 +62,10 @@ app.post("/notifications", async (req, res) => {
         deviceId
     } = req.body
 
+    if (!isValidDeviceId(deviceId)) {
+        return res.status(400).send("Invalid deviceId")
+    }
+
     const apns = {
         aps: {
             alert: {
@@ -46,8 +77,9 @@ app.post("/notifications", async (req, res) => {
         data: data ?? {}
     }
     try {
-        const cmd = `echo '${JSON.stringify(apns)}' | xcrun simctl push ${deviceId} ${bundleId} -`
-        await run(cmd)
+        // Read the payload from stdin ("-") rather than interpolating it into a
+        // shell pipeline.
+        await runWithStdin("xcrun", ["simctl", "push", deviceId, bundleId, "-"], JSON.stringify(apns))
         res.send("Done")
     } catch (error) {
         console.log("Failed to trigger notification", error)
@@ -59,9 +91,11 @@ app.post("/notifications", async (req, res) => {
 app.post('/uninstall', async (req, res) => {
     console.log("POST /uninstall ")
     const { deviceId } = req.body
+    if (!isValidDeviceId(deviceId)) {
+        return res.status(400).send("Invalid deviceId")
+    }
     try {
-        const cmd = `xcrun simctl uninstall ${deviceId} ${bundleId}`
-        await run(cmd)
+        await run("xcrun", ["simctl", "uninstall", deviceId, bundleId])
         res.send("Done")
     } catch (error) {
         console.error("Failed to uninstall app", error)
@@ -72,9 +106,11 @@ app.post('/uninstall', async (req, res) => {
 app.post('/boot', async (req, res) => {
     console.log("POST /boot ")
     const { deviceId } = req.body
+    if (!isValidDeviceId(deviceId)) {
+        return res.status(400).send("Invalid deviceId")
+    }
     try {
-        const cmd = `xcrun simctl bootstatus ${deviceId} -b`
-        await run(cmd)
+        await run("xcrun", ["simctl", "bootstatus", deviceId, "-b"])
         res.send("Done")
     } catch (error) {
         console.error("Failed to boot the device", error)


### PR DESCRIPTION
## Issue

The Node test utilities under `AmplifyPlugins/.../LocalServer/index.mjs` (used only to drive the iOS Simulator during WebAuthn and Push Notification UI tests) built shell command strings by interpolating request-body input and executed them with `child_process.exec`, which spawns `/bin/sh`.

For example:

```js
const cmd = `xcrun simctl bootstatus ${deviceId} -b`
childProcess.exec(cmd, ...)
```

A `deviceId` such as `booted; <command>` posted to the localhost endpoints would therefore run arbitrary shell commands. The push server was additionally affected on `/notifications`, where the notification payload was piped through `echo '<json>' | xcrun simctl push ...` in a shell.

Impact is limited to developer machines that manually start these localhost-only test servers; no shipped SDK code is affected. Fixing it removes the footgun and keeps the test tooling safe.

## Changes

Both test servers (`AuthWebAuthnApp` and `PushNotificationHostApp`):

- Replace `exec()` with `execFile()`, passing arguments as an array so no shell is invoked and inputs are never interpreted as shell syntax.
- `/enroll`: split the `&&`-chained command into two sequential `execFile` calls.
- `/notifications`: write the APNS JSON payload to the child process's **stdin** instead of piping it through `echo | ...`.
- Add `deviceId` validation (UUID or `booted`) as defense-in-depth.

No dependency or `package.json` changes — `execFile` is part of core `node:child_process`.

## Verification

Ran both servers locally against a stubbed `xcrun` that records its argv/stdin:

- Valid `deviceId` (`booted` / UUID): commands run with the expected argument vector.
- `deviceId` containing shell metacharacters: rejected with `400`, no command executed.
- Malicious `title` on `/notifications`: delivered verbatim as JSON via stdin, not executed.

A payload designed to `touch /tmp/pwned` produced no file in any case.
