### PR TITLE
fix(auth): make AWSCredentials Sendable

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AuthAWSCredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AuthAWSCredentialsProvider.swift
@@ -44,7 +44,7 @@ public protocol AWSCredentialsProvider {
  - accessKeyId: A unique identifier.
  - secretAccessKey: A secret key used to sign requests cryptographically.
  */
-public protocol AWSCredentials {
+public protocol AWSCredentials: Sendable {
 
     /// A unique identifier.
     var accessKeyId: String { get }


### PR DESCRIPTION
## Issue #
https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/225

## Description

This change makes `AWSCredentials` inherit from `Sendable`.

Credentials are returned by the asynchronous `AWSCredentialsProvider` API and may cross actor and module boundaries. However, `AWSCredentials` currently does not require `Sendable`.

When a client target uses `MainActor` as its default actor isolation, a client-defined `AWSTemporaryCredentials` conformance can become implicitly `MainActor`-isolated. After the value is returned as an `AWSCredentials` existential, the liveness implementation attempts to cast it back to `AWSTemporaryCredentials` from a nonisolated context:

```swift
(credentials as? AWSTemporaryCredentials)?.sessionToken
```

Because the conformance is actor-isolated, the cast fails and the session token becomes `nil`, even though the underlying credential value contains a valid token.

Making `AWSCredentials` inherit from `Sendable` reflects how credential values are already used by the async provider API and makes their conformances safe to use across concurrency boundaries. It also allows the liveness signer to retrieve the session token from client-defined temporary credentials without requiring callers to add `nonisolated` to their types.

This change may require custom `AWSCredentials` implementations with non-`Sendable` stored state to update their concurrency model or explicitly use `@unchecked Sendable`.

## General Checklist
<!-- Check or cross out if not relevant -->
- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all targets using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc.)
- [ ] Documentation updated for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include Given When Then inline code documentation and are named accordingly: `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog updated with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.