### PR TITLE
chore(deps): bump aws-sdk-swift from 1.7.27 to 1.7.53

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift",
       "state" : {
-        "revision" : "c71eb1515223bee2b2e4b96328655fd3bd9d442f",
-        "version" : "1.7.27"
+        "revision" : "59b5335952b825b480af0de32c48953f6607bb6e",
+        "version" : "1.7.53"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "9b090f61f696666fcb85e7428d7c316bd54d9cb4",
-        "version" : "0.223.0"
+        "revision" : "c3ec406867e570473e097344e64c3cfbcc5d36b9",
+        "version" : "0.238.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let platforms: [SupportedPlatform] = [
     .watchOS(.v9)
 ]
 let dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/awslabs/aws-sdk-swift", exact: "1.7.27"),
+    .package(url: "https://github.com/awslabs/aws-sdk-swift", exact: "1.7.53"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", exact: "0.15.4"),
     .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.1.0"),
     .package(url: "https://github.com/aws-amplify/amplify-swift-utils-notifications.git", from: "1.1.0")


### PR DESCRIPTION
## Issue \#
N/A — routine dependency maintenance.

## Description

Updates the `aws-sdk-swift` dependency to `1.7.53`, which moves the transitive dependency:

```
smithy-swift  0.223.0 -> 0.238.0
```

`aws-crt-swift` stays resolved at `0.64.1`: smithy-swift raised its floor from `from: "0.63.0"` to `from: "0.64.0"`, which the already-pinned `0.64.1` satisfies. No other transitive pins change, so the aws-crt-swift coexistence with the AWS IoT Device SDK for Swift established in #4234 is preserved.

### aws-sdk-swift 1.7.28 → 1.7.53

The range is almost entirely API and endpoint model regeneration. For the services Amplify depends on, the changes are additive only:

- **Cognito Identity Provider** — gains `GetProvisionedLimit` / `UpdateProvisionedLimit` (1.7.30), `EumsSms` in `SmsConfigurationType` (1.7.41), and `AdminGetUserAuthFactors` (1.7.46)
- **CloudWatch Logs** — gains storage-tier and lookup-table APIs
- **TranscribeStreaming** — gains an optional `TranscriptFormat` parameter
- **S3** — documentation-only changes

The one breaking entry in the range (1.7.28 removes SimSpaceWeaver, Panorama, IoT Events, and IoT Events Data) does not touch any Amplify dependency.

### smithy-swift 0.224.0 → 0.238.0

The breaking changes here are confined to the `@_spi(SchemaBasedSerde)` codegen surface that only the SDK's own generated code consumes:

- `ShapeDeserializer.readInteger` / `readLong` narrow to `Int32` / `Int64`
- `readDocument` returns `any SmithyDocument` instead of the concrete wrapper
- `ReadStructConsumer` is replaced by a `deserializeMember(_:_:)` requirement; traits became classes, so `getTrait` is no longer `throws`

The modules Amplify imports directly — `SmithyIdentity`, `SmithyRetries`, `SmithyHTTPAuth` and their API variants — are unchanged, and `Sources/Smithy/Document/` is identical between the two versions. `ClientRuntime`'s only behavioral delta is percent-encoding moving its implementation into `SmithyHTTPAPI.URLEncodingUtils` with the same allowed character sets (a pure refactor), plus a telemetry-only switch from `Date()` to `CLOCK_MONOTONIC_RAW` for serialization timing.

### Regression check on the #4234 blocker

The previous bump was gated on smithy-swift `0.223.0` because the schema-based JSON deserializer (introduced in `0.206.0`) regressed null handling for non-sparse maps, breaking deserialization of Cognito `RespondToAuthChallenge` responses whose `ChallengeParameters` contain a null value — e.g. `"FRIENDLY_DEVICE_NAME": null` in the `SELECT_MFA_TYPE` challenge.

Verified this has **not** returned in `0.238.0`. `Sources/SmithyJSON/Deserializer.swift` is byte-identical to `0.223.0` in the relevant blocks: `readMap` and `readList` still compact `UnexpectedNullError` out of non-sparse collections, and `readStruct` still skips null members. Confirmed empirically as well, by building a throwaway package against `1.7.53` with a stub `HTTPClient` returning that exact `SELECT_MFA_TYPE` payload — deserialization succeeds with the null key compacted out, matching `0.223.0` behavior.

### Follow-up worth tracking separately

Releases `1.7.50`+ carry an announcement that in **Fall 2026** the SDK will drop support for older Swift/Xcode versions and several Apple and Linux platforms ([aws-sdk-swift discussion #2140](https://github.com/awslabs/aws-sdk-swift/discussions/2140)). This does not affect the current bump — no new minimum Swift version or platform floor is introduced here — but it will eventually require raising Amplify's platform floors.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~ — dependency-only change, no behavioral surface added. See note below.
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] ~All integration tests pass~ — not run locally; needs a CI/maintainer run
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~ — no public API change
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~ — no new tests
- [ ] ~If breaking change, documentation/changelog update with migration instructions~ — not a breaking change for Amplify consumers

### Verification

- `swift build` — all 1131 modules compile, zero errors, no new warnings
- `swift test` — 1028 tests across all 21 test targets, zero failures
- `swiftformat --lint` — clean

### Note on test coverage

There is currently no regression test in this repo pinning the null-`ChallengeParameters` deserialization behavior described above. The existing `.selectMfaType` tests construct `challengeParameters` as already-decoded Swift dictionaries, so they exercise the state machines rather than the JSON deserializer — meaning a future smithy-swift bump could silently reintroduce this bug, as it did once already. Adding a test that feeds a raw JSON body with a null map value through the Cognito client would close that gap; happy to add it here or in a follow-up.
