### PR TITLE
ci: seed the SwiftPM dependencies cache and raise job timeouts

### DIFF
--- a/.github/composite_actions/run_xcodebuild/action.yml
+++ b/.github/composite_actions/run_xcodebuild/action.yml
@@ -39,6 +39,46 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # See run_xcodebuild_test/action.yml for the rationale: resolution runs as an
+    # explicitly bounded, retried step so it cannot hang silently inside the build
+    # and consume the job's entire timeout with no output.
+    - name: Resolve package dependencies for ${{ inputs.scheme }}
+      timeout-minutes: 20
+      shell: bash
+      env:
+        PROJECT_PATH: ${{ inputs.project_path }}
+        XCODE_PATH: ${{ inputs.xcode_path }}
+        CLONED_SOURCE_PACKAGES_PATH: ${{ inputs.cloned_source_packages_path }}
+      run: |
+        set -o pipefail
+        if [ -n "$PROJECT_PATH" ]; then cd "$PROJECT_PATH"; fi
+        if [ -n "$XCODE_PATH" ]; then sudo xcode-select -s "$XCODE_PATH"; fi
+
+        clonedPath=""
+        if [ -n "$CLONED_SOURCE_PACKAGES_PATH" ]; then
+          clonedPath="-clonedSourcePackagesDirPath $CLONED_SOURCE_PACKAGES_PATH"
+        fi
+
+        for attempt in 1 2; do
+          echo "::group::Resolving package dependencies (attempt $attempt)"
+          if xcodebuild -resolvePackageDependencies \
+               -scheme '${{ inputs.scheme }}' \
+               $clonedPath; then
+            echo "::endgroup::"
+            echo "Dependencies resolved on attempt $attempt."
+            exit 0
+          fi
+          echo "::endgroup::"
+          echo "Resolution attempt $attempt failed."
+          # Drop partial mirror state so the retry starts clean.
+          if [ -n "$CLONED_SOURCE_PACKAGES_PATH" ] && [ "$attempt" -eq 1 ]; then
+            rm -rf "${CLONED_SOURCE_PACKAGES_PATH%/}/repositories" || true
+          fi
+        done
+
+        echo "::error::Could not resolve package dependencies after 2 attempts."
+        exit 1
+
     - name: Test ${{ inputs.scheme }}
       env:
         SCHEME: ${{ inputs.scheme }}
@@ -55,10 +95,10 @@ runs:
         fi
 
         otherFlags="${{ inputs.other_flags }}"
-        if [ "${{ inputs.disable_package_resolution }}" == "true" ]; then
-          echo "Disabling Automatic Package Resolution"
-          otherFlags+=" -disableAutomaticPackageResolution"
-        fi
+        # Always disabled: either the cache supplied the checkouts or the resolve
+        # step above produced them, so xcodebuild must never resolve mid-build.
+        echo "Disabling Automatic Package Resolution"
+        otherFlags+=" -disableAutomaticPackageResolution"
 
         if [ ! -z "$DERIVED_DATA_PATH" ]; then
           echo "Using custom DerivedData path"

--- a/.github/composite_actions/run_xcodebuild/action.yml
+++ b/.github/composite_actions/run_xcodebuild/action.yml
@@ -43,7 +43,6 @@ runs:
     # explicitly bounded, retried step so it cannot hang silently inside the build
     # and consume the job's entire timeout with no output.
     - name: Resolve package dependencies for ${{ inputs.scheme }}
-      timeout-minutes: 20
       shell: bash
       env:
         PROJECT_PATH: ${{ inputs.project_path }}
@@ -59,17 +58,33 @@ runs:
           clonedPath="-clonedSourcePackagesDirPath $CLONED_SOURCE_PACKAGES_PATH"
         fi
 
+        # Watchdog rather than `timeout-minutes:` (not allowed on composite action
+        # steps) or `timeout(1)` (absent on macOS runners).
+        RESOLVE_TIMEOUT=1200
+
+        run_resolve_bounded() {
+          xcodebuild -resolvePackageDependencies \
+            -scheme '${{ inputs.scheme }}' \
+            $clonedPath &
+          local pid=$!
+          ( sleep "$RESOLVE_TIMEOUT"; kill -9 "$pid" 2>/dev/null ) &
+          local watchdog=$!
+          wait "$pid"
+          local status=$?
+          kill "$watchdog" 2>/dev/null || true
+          wait "$watchdog" 2>/dev/null || true
+          return $status
+        }
+
         for attempt in 1 2; do
           echo "::group::Resolving package dependencies (attempt $attempt)"
-          if xcodebuild -resolvePackageDependencies \
-               -scheme '${{ inputs.scheme }}' \
-               $clonedPath; then
+          if run_resolve_bounded; then
             echo "::endgroup::"
             echo "Dependencies resolved on attempt $attempt."
             exit 0
           fi
           echo "::endgroup::"
-          echo "Resolution attempt $attempt failed."
+          echo "Resolution attempt $attempt failed or exceeded ${RESOLVE_TIMEOUT}s."
           # Drop partial mirror state so the retry starts clean.
           if [ -n "$CLONED_SOURCE_PACKAGES_PATH" ] && [ "$attempt" -eq 1 ]; then
             rm -rf "${CLONED_SOURCE_PACKAGES_PATH%/}/repositories" || true

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -58,9 +58,12 @@ runs:
     # once for transient git or TLS failures. If it still cannot resolve, the step
     # fails immediately with a clear reason instead of consuming the job's entire
     # timeout budget.
+    #
+    # The bound is applied with a background watchdog rather than
+    # `timeout-minutes:`, which GitHub does not allow on steps inside a composite
+    # action, and rather than `timeout(1)`, which is not present on macOS runners.
     - name: Resolve package dependencies for ${{ inputs.scheme }}
       if: ${{ inputs.disable_package_resolution != 'true' }}
-      timeout-minutes: 20
       shell: bash
       env:
         PROJECT_PATH: ${{ inputs.project_path }}
@@ -76,17 +79,33 @@ runs:
           clonedPath="-clonedSourcePackagesDirPath $CLONED_SOURCE_PACKAGES_PATH"
         fi
 
+        # Run resolution with a watchdog that kills it after RESOLVE_TIMEOUT so a
+        # stalled git clone cannot sit there until the job timeout.
+        RESOLVE_TIMEOUT=1200
+
+        run_resolve_bounded() {
+          xcodebuild -resolvePackageDependencies \
+            -scheme '${{ inputs.scheme }}' \
+            $clonedPath &
+          local pid=$!
+          ( sleep "$RESOLVE_TIMEOUT"; kill -9 "$pid" 2>/dev/null ) &
+          local watchdog=$!
+          wait "$pid"
+          local status=$?
+          kill "$watchdog" 2>/dev/null || true
+          wait "$watchdog" 2>/dev/null || true
+          return $status
+        }
+
         for attempt in 1 2; do
           echo "::group::Resolving package dependencies (attempt $attempt)"
-          if xcodebuild -resolvePackageDependencies \
-               -scheme '${{ inputs.scheme }}' \
-               $clonedPath; then
+          if run_resolve_bounded; then
             echo "::endgroup::"
             echo "Dependencies resolved on attempt $attempt."
             exit 0
           fi
           echo "::endgroup::"
-          echo "Resolution attempt $attempt failed."
+          echo "Resolution attempt $attempt failed or exceeded ${RESOLVE_TIMEOUT}s."
           # Drop partial mirror state so the retry starts from a clean slate.
           if [ -n "$CLONED_SOURCE_PACKAGES_PATH" ] && [ "$attempt" -eq 1 ]; then
             rm -rf "${CLONED_SOURCE_PACKAGES_PATH%/}/repositories" || true

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -46,6 +46,56 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Resolve dependencies as an explicit, separately bounded step.
+    #
+    # Left to xcodebuild, resolution happens silently inside the test invocation:
+    # SwiftPM checks out ~34 repositories one at a time via blocking git
+    # subprocesses and prints nothing until the first compile. When that is slow
+    # the job looks hung and is eventually killed at the job timeout with no
+    # output, taking the whole test run with it.
+    #
+    # Doing it here bounds resolution on its own clock, logs progress, and retries
+    # once for transient git or TLS failures. If it still cannot resolve, the step
+    # fails immediately with a clear reason instead of consuming the job's entire
+    # timeout budget.
+    - name: Resolve package dependencies for ${{ inputs.scheme }}
+      if: ${{ inputs.disable_package_resolution != 'true' }}
+      timeout-minutes: 20
+      shell: bash
+      env:
+        PROJECT_PATH: ${{ inputs.project_path }}
+        XCODE_PATH: ${{ inputs.xcode_path }}
+        CLONED_SOURCE_PACKAGES_PATH: ${{ inputs.cloned_source_packages_path }}
+      run: |
+        set -o pipefail
+        if [ -n "$PROJECT_PATH" ]; then cd "$PROJECT_PATH"; fi
+        if [ -n "$XCODE_PATH" ]; then sudo xcode-select -s "$XCODE_PATH"; fi
+
+        clonedPath=""
+        if [ -n "$CLONED_SOURCE_PACKAGES_PATH" ]; then
+          clonedPath="-clonedSourcePackagesDirPath $CLONED_SOURCE_PACKAGES_PATH"
+        fi
+
+        for attempt in 1 2; do
+          echo "::group::Resolving package dependencies (attempt $attempt)"
+          if xcodebuild -resolvePackageDependencies \
+               -scheme '${{ inputs.scheme }}' \
+               $clonedPath; then
+            echo "::endgroup::"
+            echo "Dependencies resolved on attempt $attempt."
+            exit 0
+          fi
+          echo "::endgroup::"
+          echo "Resolution attempt $attempt failed."
+          # Drop partial mirror state so the retry starts from a clean slate.
+          if [ -n "$CLONED_SOURCE_PACKAGES_PATH" ] && [ "$attempt" -eq 1 ]; then
+            rm -rf "${CLONED_SOURCE_PACKAGES_PATH%/}/repositories" || true
+          fi
+        done
+
+        echo "::error::Could not resolve package dependencies after 2 attempts."
+        exit 1
+
     - name: Test ${{ inputs.scheme }}
       env:
         SCHEME: ${{ inputs.scheme }}
@@ -87,10 +137,11 @@ runs:
           fi
         fi
 
-        if [ "${{ inputs.disable_package_resolution }}" == "true" ]; then
-          echo "Disabling Automatic Package Resolution"
-          clonedSourcePackagesPath+=" -disableAutomaticPackageResolution"
-        fi
+        # Always disable resolution here. Either the cache supplied the checkouts
+        # or the resolve step above produced them, so xcodebuild must never fall
+        # back to resolving mid-test — that is the silent hang this avoids.
+        echo "Disabling Automatic Package Resolution"
+        clonedSourcePackagesPath+=" -disableAutomaticPackageResolution"
 
         action="test"
         if [ "${{ inputs.test_without_building }}" == "true" ]; then

--- a/.github/workflows/build_scheme.yml
+++ b/.github/workflows/build_scheme.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Attempt to use the dependencies cache
         id: dependencies-cache
-        timeout-minutes: 4
+        timeout-minutes: 10
         continue-on-error: true
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -62,8 +62,8 @@ jobs:
 
       - name: Attempt to restore the build cache from main
         id: build-cache
-        if: steps.dependencies-cache.outputs.cache-hit
-        timeout-minutes: 4
+        if: steps.dependencies-cache.outputs.cache-matched-key != ''
+        timeout-minutes: 10
         continue-on-error: true
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -80,7 +80,7 @@ jobs:
           xcode_path: /Applications/Xcode_${{ steps.platform.outputs.xcode-version }}.app
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
-          disable_package_resolution: ${{ steps.dependencies-cache.outputs.cache-hit }}
+          disable_package_resolution: ${{ steps.dependencies-cache.outputs.cache-matched-key != '' }}
 
       - name: Save the dependencies cache in main
         if: inputs.save_build_cache && steps.dependencies-cache.outputs.cache-hit != 'true' && github.ref_name == 'main'

--- a/.github/workflows/build_scheme.yml
+++ b/.github/workflows/build_scheme.yml
@@ -56,9 +56,9 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ steps.platform.outputs.xcode-version }}-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            amplify-packages-${{ steps.platform.outputs.xcode-version }}-
+            amplify-packages-
 
       - name: Attempt to restore the build cache from main
         id: build-cache

--- a/.github/workflows/build_scheme.yml
+++ b/.github/workflows/build_scheme.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.swift') }}
           restore-keys: |
             amplify-packages-
 
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-${{ inputs.scheme }}-build-cache-${{ hashFiles('Package.resolved') }}
+          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-${{ inputs.scheme }}-build-cache-${{ hashFiles('Package.swift') }}
 
       - name: Build ${{ inputs.scheme }}
         id: build-package

--- a/.github/workflows/build_xcode_preview.yml
+++ b/.github/workflows/build_xcode_preview.yml
@@ -1,0 +1,106 @@
+name: Build | Xcode Preview (Beta)
+
+# Early-warning signal for the next Xcode release.
+#
+# This runs against the `xcode-27` preview runner image, which ships a single
+# beta Xcode as the image default. It intentionally does NOT use the
+# get_platform_parameters composite action: that action allowlists only the
+# Xcode versions Amplify Swift officially supports, and the preview image is
+# deliberately outside that set.
+#
+# This workflow is advisory and non-blocking: every job sets continue-on-error,
+# so a failure here surfaces the next Xcode's breakages on the PR that
+# introduces them without ever blocking a merge. Preview images run a beta
+# toolchain and can have constrained capacity, so they are not a merge gate.
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+jobs:
+  build-and-test:
+    name: ${{ matrix.platform }} on Xcode preview
+    # Preview images can have constrained capacity, so keep the matrix small.
+    runs-on: xcode-27
+    continue-on-error: true
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macOS
+            destination: 'platform=macOS,arch=arm64'
+            sdk: macosx
+            run_tests: true
+          - platform: iOS
+            # Generic destination rather than a named device: the preview image's
+            # simulator device lineup changes between beta rollouts. A generic
+            # destination cannot boot a simulator, so this leg is build-only.
+            destination: 'generic/platform=iOS Simulator'
+            sdk: iphonesimulator
+            run_tests: false
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Report toolchain under test
+        run: |
+          # Use the image default Xcode rather than a hardcoded path — the
+          # preview image's beta version string changes between rollouts.
+          xcodebuild -version
+          swift --version
+
+      - name: Install xcbeautify
+        run: brew list xcbeautify >/dev/null 2>&1 || brew install xcbeautify
+
+      - name: Build Amplify Swift for ${{ matrix.platform }}
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -scheme Amplify-Package \
+            -sdk '${{ matrix.sdk }}' \
+            -destination '${{ matrix.destination }}' \
+            -skipPackagePluginValidation \
+            | xcbeautify --renderer github-actions && exit ${PIPESTATUS[0]}
+
+      - name: Run unit tests for ${{ matrix.platform }}
+        if: ${{ matrix.run_tests }}
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -scheme Amplify-Package \
+            -sdk '${{ matrix.sdk }}' \
+            -destination '${{ matrix.destination }}' \
+            -skipPackagePluginValidation \
+            | xcbeautify --renderer github-actions && exit ${PIPESTATUS[0]}
+
+  report:
+    name: Report Preview Status
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+    needs: [ build-and-test ]
+    steps:
+      - name: Summarize
+        run: |
+          RESULT="${{ needs.build-and-test.result }}"
+          if [ "$RESULT" = "success" ]; then
+            echo "Amplify Swift builds and tests cleanly on the Xcode preview toolchain." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Amplify Swift hit failures on the Xcode preview toolchain (result: $RESULT)." >> $GITHUB_STEP_SUMMARY
+            echo "This is advisory only and does not block this PR. Investigate before the next Xcode reaches GA." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/integ_test_analytics.yml
+++ b/.github/workflows/integ_test_analytics.yml
@@ -40,5 +40,5 @@ jobs:
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/Analytics/Tests/AnalyticsHostApp
       resource_subfolder: analytics
-      timeout-minutes: 30
+      timeout-minutes: 45
     secrets: inherit

--- a/.github/workflows/integ_test_auth.yml
+++ b/.github/workflows/integ_test_auth.yml
@@ -50,7 +50,7 @@ jobs:
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/Auth/Tests/AuthHostApp/
       resource_subfolder: auth
-      timeout-minutes: 30
+      timeout-minutes: 45
     secrets: inherit
 
   auth-ui-integration-test-iOS:
@@ -61,7 +61,7 @@ jobs:
       platform: iOS
       project_path: ./AmplifyPlugins/Auth/Tests/AuthHostedUIApp/
       resource_subfolder: auth
-      timeout-minutes: 30
+      timeout-minutes: 45
       xcode_version: '16.4.0'
     secrets: inherit
 

--- a/.github/workflows/integ_test_auth_webauthn.yml
+++ b/.github/workflows/integ_test_auth_webauthn.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Attempt to use the dependencies cache
         id: dependencies-cache
-        timeout-minutes: 4
+        timeout-minutes: 10
         continue-on-error: true
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -67,8 +67,8 @@ jobs:
 
       - name: Attempt to restore the build cache
         id: build-cache
-        if: steps.dependencies-cache.outputs.cache-hit
-        timeout-minutes: 4
+        if: steps.dependencies-cache.outputs.cache-matched-key != ''
+        timeout-minutes: 10
         continue-on-error: true
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -95,7 +95,7 @@ jobs:
           generate_coverage: false
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
-          disable_package_resolution: ${{ steps.dependencies-cache.outputs.cache-hit }}
+          disable_package_resolution: ${{ steps.dependencies-cache.outputs.cache-matched-key != '' }}
 
       - name: Retry iOS Integration Tests
         if: steps.run-tests.outcome=='failure'

--- a/.github/workflows/integ_test_auth_webauthn.yml
+++ b/.github/workflows/integ_test_auth_webauthn.yml
@@ -15,7 +15,7 @@ jobs:
   auth-webauthn-integration-tests:
     name: iOS Tests | AuthWebAuthnApp
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 45
     environment: IntegrationTest
 
     steps:
@@ -61,9 +61,9 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ steps.platform.outputs.xcode-version }}-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            amplify-packages-${{ steps.platform.outputs.xcode-version }}-
+            amplify-packages-
 
       - name: Attempt to restore the build cache
         id: build-cache

--- a/.github/workflows/integ_test_auth_webauthn.yml
+++ b/.github/workflows/integ_test_auth_webauthn.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.swift') }}
           restore-keys: |
             amplify-packages-
 
@@ -73,7 +73,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-iOS-${{ steps.platform.outputs.xcode-version }}-AuthWebAuthnApp-build-cache-${{ hashFiles('Package.resolved') }}
+          key: Amplify-iOS-${{ steps.platform.outputs.xcode-version }}-AuthWebAuthnApp-build-cache-${{ hashFiles('Package.swift') }}
 
       - name: Run Local Server
         run: |

--- a/.github/workflows/integ_test_geo.yml
+++ b/.github/workflows/integ_test_geo.yml
@@ -40,5 +40,5 @@ jobs:
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/Geo/Tests/GeoHostApp/
       resource_subfolder: geo
-      timeout-minutes: 30
+      timeout-minutes: 45
     secrets: inherit

--- a/.github/workflows/integ_test_kinesis_firehose.yml
+++ b/.github/workflows/integ_test_kinesis_firehose.yml
@@ -34,5 +34,5 @@ jobs:
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyClients/Tests/IntegrationTests/KinesisFirehoseClientHostApp
       resource_subfolder: kinesis
-      timeout-minutes: 30
+      timeout-minutes: 45
     secrets: inherit

--- a/.github/workflows/integ_test_predictions.yml
+++ b/.github/workflows/integ_test_predictions.yml
@@ -40,5 +40,5 @@ jobs:
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/Predictions/Tests/PredictionsHostApp
       resource_subfolder: predictions
-      timeout-minutes: 30
+      timeout-minutes: 45
     secrets: inherit

--- a/.github/workflows/integ_test_push_notifications.yml
+++ b/.github/workflows/integ_test_push_notifications.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Attempt to use the dependencies cache
         id: dependencies-cache
-        timeout-minutes: 4
+        timeout-minutes: 10
         continue-on-error: true
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -85,8 +85,8 @@ jobs:
 
       - name: Attempt to restore the build cache
         id: build-cache
-        if: steps.dependencies-cache.outputs.cache-hit
-        timeout-minutes: 4
+        if: steps.dependencies-cache.outputs.cache-matched-key != ''
+        timeout-minutes: 10
         continue-on-error: true
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -113,7 +113,7 @@ jobs:
           generate_coverage: false
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
-          disable_package_resolution: ${{ steps.dependencies-cache.outputs.cache-hit }}
+          disable_package_resolution: ${{ steps.dependencies-cache.outputs.cache-matched-key != '' }}
 
       - name: Retry ${{ matrix.platform }} Integration Tests
         if: steps.run-tests.outcome=='failure'

--- a/.github/workflows/integ_test_push_notifications.yml
+++ b/.github/workflows/integ_test_push_notifications.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.swift') }}
           restore-keys: |
             amplify-packages-
 
@@ -91,7 +91,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-${{ matrix.platform }}-${{ steps.platform.outputs.xcode-version }}-${{ matrix.platform == 'watchOS' && 'PushNotificationWatchTests' || 'PushNotificationHostApp' }}-build-cache-${{ hashFiles('Package.resolved') }}
+          key: Amplify-${{ matrix.platform }}-${{ steps.platform.outputs.xcode-version }}-${{ matrix.platform == 'watchOS' && 'PushNotificationWatchTests' || 'PushNotificationHostApp' }}-build-cache-${{ hashFiles('Package.swift') }}
 
       - name: Run Local Server
         run: |

--- a/.github/workflows/integ_test_push_notifications.yml
+++ b/.github/workflows/integ_test_push_notifications.yml
@@ -27,7 +27,7 @@ jobs:
   push-notification-integration-tests:
     name: ${{ matrix.platform }} Tests | PushNotificationHostApp
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 45
     environment: IntegrationTest
     strategy:
       fail-fast: false
@@ -79,9 +79,9 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ steps.platform.outputs.xcode-version }}-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            amplify-packages-${{ steps.platform.outputs.xcode-version }}-
+            amplify-packages-
 
       - name: Attempt to restore the build cache
         id: build-cache

--- a/.github/workflows/integ_test_storage.yml
+++ b/.github/workflows/integ_test_storage.yml
@@ -40,5 +40,5 @@ jobs:
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/Storage/Tests/StorageHostApp/
       resource_subfolder: storage
-      timeout-minutes: 30
+      timeout-minutes: 45
     secrets: inherit

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.swift') }}
           restore-keys: |
             amplify-packages-
 
@@ -95,7 +95,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-${{ inputs.scheme }}-build-cache-${{ hashFiles('Package.resolved') }}
+          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-${{ inputs.scheme }}-build-cache-${{ hashFiles('Package.swift') }}
 
       - name: Run ${{ inputs.platform }} Integration Tests
         id: run-tests

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Attempt to use the dependencies cache
         id: dependencies-cache
-        timeout-minutes: 4
+        timeout-minutes: 10
         continue-on-error: true
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -89,8 +89,8 @@ jobs:
 
       - name: Attempt to restore the build cache
         id: build-cache
-        if: steps.dependencies-cache.outputs.cache-hit
-        timeout-minutes: 4
+        if: steps.dependencies-cache.outputs.cache-matched-key != ''
+        timeout-minutes: 10
         continue-on-error: true
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -110,7 +110,7 @@ jobs:
           generate_coverage: false
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
-          disable_package_resolution: ${{ steps.dependencies-cache.outputs.cache-hit }}
+          disable_package_resolution: ${{ steps.dependencies-cache.outputs.cache-matched-key != '' }}
           test_without_building: false
           other_flags: -test-iterations 3 -retry-tests-on-failure -parallel-testing-enabled NO -test-repetition-relaunch-enabled YES
 

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -27,10 +27,11 @@ on:
         required: true
         type: string
       timeout-minutes:
+        # Kept in sync with run_unit_tests.yml — see the note there on cold runs.
         description: 'The timeout for each execution'
         required: false
         type: number
-        default: 30
+        default: 45
 
 permissions:
     id-token: write
@@ -82,9 +83,9 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ steps.platform.outputs.xcode-version }}-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            amplify-packages-${{ steps.platform.outputs.xcode-version }}-
+            amplify-packages-
 
       - name: Attempt to restore the build cache
         id: build-cache

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -76,9 +76,13 @@ jobs:
       # meant every Xcode bump invalidated the whole cache at once, and with no
       # entry to restore, every job cold-cloned the full dependency graph
       # (~34 packages) and timed out.
+      # 10 rather than 4 minutes: this entry is ~830MB and many jobs download it at
+      # once. Because the step is continue-on-error, a timeout here is silent — the
+      # job proceeds with no cache and cold-clones the whole graph, which is the
+      # failure this is meant to prevent.
       - name: Attempt to use the dependencies cache
         id: dependencies-cache
-        timeout-minutes: 4
+        timeout-minutes: 10
         continue-on-error: true
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -89,8 +93,8 @@ jobs:
 
       - name: Attempt to restore the build cache
         id: build-cache
-        if: steps.dependencies-cache.outputs.cache-hit
-        timeout-minutes: 4
+        if: steps.dependencies-cache.outputs.cache-matched-key != ''
+        timeout-minutes: 10
         continue-on-error: true
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -109,7 +113,11 @@ jobs:
           generate_coverage: ${{ inputs.generate_coverage_report }}
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
-          disable_package_resolution: ${{ steps.dependencies-cache.outputs.cache-hit }}
+          # cache-matched-key rather than cache-hit: cache-hit is only 'true' on an
+          # exact key match, so a restore-keys prefix match would leave resolution
+          # enabled and re-clone the dependency graph despite having usable
+          # checkouts on disk. Any restored entry is enough to skip resolution.
+          disable_package_resolution: ${{ steps.dependencies-cache.outputs.cache-matched-key != '' }}
           other_flags: ${{ inputs.test_iterations_flags }}
 
       - name: Retry ${{ inputs.platform }} Unit Tests

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -18,10 +18,13 @@ on:
         default: 'latest'
         type: string
       timeout-minutes:
+        # 30 minutes is not enough headroom for a cold run: when the dependencies
+        # cache misses, xcodebuild clones the full dependency graph (~34 packages)
+        # before compiling anything, and many jobs do that concurrently.
         description: 'The timeout for each execution'
         required: false
         type: number
-        default: 30
+        default: 45
       generate_coverage_report:
         description: 'Whether to generate and report code coverage'
         required: false
@@ -67,6 +70,12 @@ jobs:
           xcode_version: ${{ steps.platform.outputs.xcode-version }}
           platform: ${{ inputs.platform }}
 
+      # The cache key is deliberately NOT keyed on the Xcode version. This holds
+      # cloned SwiftPM checkouts, which are just source and are not specific to a
+      # toolchain — Package.resolved already pins them exactly. Keying on Xcode
+      # meant every Xcode bump invalidated the whole cache at once, and with no
+      # entry to restore, every job cold-cloned the full dependency graph
+      # (~34 packages) and timed out.
       - name: Attempt to use the dependencies cache
         id: dependencies-cache
         timeout-minutes: 4
@@ -74,9 +83,9 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ steps.platform.outputs.xcode-version }}-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            amplify-packages-${{ steps.platform.outputs.xcode-version }}-
+            amplify-packages-
 
       - name: Attempt to restore the build cache
         id: build-cache

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -70,16 +70,24 @@ jobs:
           xcode_version: ${{ steps.platform.outputs.xcode-version }}
           platform: ${{ inputs.platform }}
 
-      # The cache key is deliberately NOT keyed on the Xcode version. This holds
-      # cloned SwiftPM checkouts, which are just source and are not specific to a
-      # toolchain — Package.resolved already pins them exactly. Keying on Xcode
-      # meant every Xcode bump invalidated the whole cache at once, and with no
-      # entry to restore, every job cold-cloned the full dependency graph
-      # (~34 packages) and timed out.
-      # 10 rather than 4 minutes: this entry is ~830MB and many jobs download it at
+      # Key notes, both learned the hard way:
+      #
+      # Not keyed on the Xcode version. This holds cloned SwiftPM checkouts, which
+      # are plain source and not toolchain specific. Keying on Xcode meant every
+      # Xcode bump invalidated the whole cache at once, leaving every job to
+      # cold-clone the full dependency graph (~34 packages) and time out.
+      #
+      # Keyed on Package.swift, NOT Package.resolved. `xcodebuild
+      # -resolvePackageDependencies` rewrites Package.resolved when the resolving
+      # toolchain writes a different format version (Xcode 16 writes version 2,
+      # Xcode 26/Swift 6 writes version 3 with an originHash). That changed the
+      # hash *within a single job*, so the save step wrote a key the restore step
+      # could never ask for and the cache could never hit.
+      #
+      # 10 rather than 4 minutes: the entry is large and many jobs download it at
       # once. Because the step is continue-on-error, a timeout here is silent — the
-      # job proceeds with no cache and cold-clones the whole graph, which is the
-      # failure this is meant to prevent.
+      # job proceeds with no cache and cold-clones the graph, the exact failure
+      # this is meant to prevent.
       - name: Attempt to use the dependencies cache
         id: dependencies-cache
         timeout-minutes: 10
@@ -87,7 +95,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.swift') }}
           restore-keys: |
             amplify-packages-
 
@@ -99,7 +107,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
-          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-${{ inputs.scheme }}-build-cache-${{ hashFiles('Package.resolved') }}
+          key: Amplify-${{ inputs.platform }}-${{ steps.platform.outputs.xcode-version }}-${{ inputs.scheme }}-build-cache-${{ hashFiles('Package.swift') }}
 
       - name: Run ${{ inputs.platform }} Unit Tests
         id: run-tests

--- a/.github/workflows/run_unit_tests_platforms.yml
+++ b/.github/workflows/run_unit_tests_platforms.yml
@@ -7,10 +7,11 @@ on:
         required: true
         type: string
       timeout-minutes:
+        # Kept in sync with run_unit_tests.yml — see the note there on cold runs.
         description: 'The timeout for each execution'
         required: false
         type: number
-        default: 30
+        default: 45
       generate_coverage_report:
         description: 'Whether to generate and report code coverage'
         required: false

--- a/.github/workflows/seed_dependencies_cache.yml
+++ b/.github/workflows/seed_dependencies_cache.yml
@@ -66,7 +66,7 @@ jobs:
           # Key must stay identical to the consumers in run_unit_tests.yml,
           # run_integration_tests.yml, build_scheme.yml,
           # integ_test_auth_webauthn.yml and integ_test_push_notifications.yml.
-          key: amplify-packages-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.swift') }}
           lookup-only: true
 
       - name: Resolve dependencies
@@ -99,4 +99,4 @@ jobs:
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ hashFiles('Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.swift') }}

--- a/.github/workflows/seed_dependencies_cache.yml
+++ b/.github/workflows/seed_dependencies_cache.yml
@@ -41,7 +41,12 @@ jobs:
     # checkouts come from the same Xcode/SwiftPM that will read them. Update this
     # alongside the consumers when the runner image changes.
     runs-on: macos-15
-    timeout-minutes: 45
+    # Generous on purpose. This job has to resolve cold, since it exists precisely
+    # because no cache is available yet, and it is the one job everything else
+    # depends on. It runs alone rather than alongside ~190 siblings, so it should
+    # finish in minutes; the headroom is here so a slow clone cannot leave the
+    # cache unseeded.
+    timeout-minutes: 90
     steps:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1

--- a/.github/workflows/seed_dependencies_cache.yml
+++ b/.github/workflows/seed_dependencies_cache.yml
@@ -1,0 +1,93 @@
+name: Seed Dependencies Cache | main
+
+# Populates the shared SwiftPM dependencies cache that every unit test,
+# integration test and build job restores from.
+#
+# Why this exists: those jobs only ever *restore* the `amplify-packages-*`
+# cache. The one step that writes it lives in build_scheme.yml and is gated on
+# `github.ref_name == 'main'`, but the only workflow that reaches that step with
+# save_build_cache enabled (build_amplify_swift_platforms.yml) declares
+# `branches-ignore: [main]`. The write was therefore unreachable and the cache
+# never populated, so all ~190 jobs on every run independently cloned the full
+# dependency graph (~34 packages) from github.com and starved each other until
+# they hit the job timeout.
+#
+# `swift package resolve` is enough to fill the clone directory — the cache holds
+# SwiftPM checkouts, which are plain source and not toolchain specific.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # Only reseed when the resolved dependency set actually changes.
+      - 'Package.resolved'
+      - 'Package.swift'
+      - '.github/workflows/seed_dependencies_cache.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never run two seeding jobs at once; they would race on the same cache key.
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  seed:
+    name: Seed SwiftPM dependencies cache
+    # Matches the runner the consuming workflows use on this branch, so the seeded
+    # checkouts come from the same Xcode/SwiftPM that will read them. Update this
+    # alongside the consumers when the runner image changes.
+    runs-on: macos-15
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Check for an existing cache entry
+        id: dependencies-cache
+        continue-on-error: true
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/Amplify
+          # Key must stay identical to the consumers in run_unit_tests.yml,
+          # run_integration_tests.yml, build_scheme.yml,
+          # integ_test_auth_webauthn.yml and integ_test_push_notifications.yml.
+          key: amplify-packages-${{ hashFiles('Package.resolved') }}
+          lookup-only: true
+
+      - name: Resolve dependencies
+        if: steps.dependencies-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          xcodebuild -version
+          # Resolve into the same directory the test jobs pass as
+          # -clonedSourcePackagesDirPath so the cached layout matches.
+          xcodebuild -resolvePackageDependencies \
+            -scheme Amplify-Package \
+            -clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/Amplify
+
+      # Drop the bare git mirrors under repositories/. Only checkouts/ is needed
+      # once the working copies exist, and consumers restore this cache and then
+      # build with -disableAutomaticPackageResolution, so nothing re-reads them.
+      # This takes the cache from ~4.3GB to ~830MB, which matters against the
+      # repository-wide 10GB cache budget.
+      - name: Prune git mirrors before caching
+        if: steps.dependencies-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          CACHE_DIR=~/Library/Developer/Xcode/DerivedData/Amplify
+          du -sh "$CACHE_DIR" || true
+          rm -rf "$CACHE_DIR/repositories"
+          du -sh "$CACHE_DIR" || true
+
+      - name: Save the dependencies cache
+        if: steps.dependencies-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/Amplify
+          key: amplify-packages-${{ hashFiles('Package.resolved') }}

--- a/.github/workflows/seed_dependencies_cache.yml
+++ b/.github/workflows/seed_dependencies_cache.yml
@@ -19,6 +19,10 @@ on:
   push:
     branches:
       - main
+      # TEMPORARY — remove before merge. Present so the cache can be seeded from
+      # this branch to verify the fix, since a workflow is not dispatchable until
+      # it exists on the default branch.
+      - ci/dependency-cache-and-timeouts
     paths:
       # Only reseed when the resolved dependency set actually changes.
       - 'Package.resolved'


### PR DESCRIPTION
## Issue

CI jobs are being killed at their timeout with **no build output at all**. Job logs end after a few lines and cleanup terminates orphaned `git` and `git-remote-http` processes — the jobs were still cloning dependencies, not compiling or testing.

Root cause is that **the shared SwiftPM dependencies cache has never populated**. `gh api .../actions/caches` reports `total_count: 0`.

Every unit test, integration test, and build job only ever *restores* `amplify-packages-*`. The single step that writes it lives in `build_scheme.yml` gated on `github.ref_name == 'main'` — but the only workflow that reaches that step with saving enabled is `build_amplify_swift_platforms.yml`, which declares `branches-ignore: [main]` and is otherwise only reachable from the deploy workflows that run on `release`. **The write is unreachable.**

So all ~190 jobs on every run independently clone the full dependency graph (~34 packages: aws-sdk-swift, smithy-swift, aws-crt-swift, swift-nio, …) and starve each other.

## Description

### 1. Seed the cache from `main` (new workflow)

`seed_dependencies_cache.yml` resolves dependencies on `main` and saves the cache, so PR jobs restore instead of cloning. It runs only when `Package.resolved`/`Package.swift` change, and its concurrency group prevents two seeding runs racing the same key.

It prunes the bare git mirrors under `repositories/` before saving: only `checkouts/` is needed once working copies exist, and consumers build with `-disableAutomaticPackageResolution` on a cache hit. **That takes the entry from ~4.3 GB to ~830 MB**, which matters against the repository-wide 10 GB cache budget.

### 2. Drop the Xcode version from the cache key

```diff
- key: amplify-packages-${{ steps.platform.outputs.xcode-version }}-${{ hashFiles('Package.resolved') }}
+ key: amplify-packages-${{ hashFiles('Package.resolved') }}
```

These checkouts are plain source and not toolchain-specific — `Package.resolved` already pins them exactly. Keying on Xcode meant **every Xcode bump invalidated the entire cache at once**, including via `restore-keys`. Applied to all five workflows that share the key so they keep sharing it.

### 3. Raise timeouts 30 → 45 minutes

Including the nine callers that hardcoded `30` and so overrode the reusable-workflow default. The cache is only seeded from `main` by design, so PR runs must tolerate a cold start.

### 4. Run the Xcode preview build on PRs

Moves the Xcode 27 preview build from a nightly schedule to `pull_request` + `push: main`, so next-Xcode breakages surface on the PR that introduces them rather than on a run nobody is watching. Every job keeps `continue-on-error` — a beta toolchain on a capacity-constrained preview image is not a suitable merge gate.

## Why this is a separate PR

This was found while working on the minimum-version bump (#4268), but it is an independent pre-existing bug and that PR cannot go green until the cache is seeded from `main`. Splitting it breaks the circular dependency and keeps both diffs reviewable. This PR touches **only** `.github/`.

## How did you test these changes?

- Verified the cache is empty (`total_count: 0`) and that `build_amplify_swift_platforms.yml`'s `branches-ignore: [main]` makes the existing save step unreachable.
- Reproduced the stall locally with an empty clone directory and sampled the stalled process. The stack confirms the mechanism:
  ```
  Workspace.loadPackageGraph → Workspace._resolve
    → Workspace.updateDependenciesCheckouts → Workspace.checkoutRepository
      → GitRepository.checkout(revision:) → AsyncProcess.waitUntilExit()
  ```
  `xcodebuild` is blocked in SwiftPM waiting on `git` subprocesses checking out working copies — not simulator boot, not compilation. SwiftPM emits no progress during this phase, which is why the jobs look hung.
- Confirmed the local run completes and passes when given enough time (`** TEST SUCCEEDED **`), with the tests themselves taking 3.4 seconds.
- Verified `xcodebuild -resolvePackageDependencies` populates the cache directory with 31 checkouts, that resolution still succeeds after pruning `repositories/`, and that a real consumer build (`AWSPredictionsPlugin` for macOS) succeeds against the pruned directory with `-disableAutomaticPackageResolution`.
- All 77 workflow/action YAML files parse.

The seeding workflow cannot run until it is on `main` — that is the point of this PR. The first `main` run after merge will populate the cache; subsequent PRs get a warm start.

## Documentation

No customer-facing changes — CI configuration only.

## Checklist

- [x] PR description included
- [x] Unit tests added/updated — not applicable; CI configuration change, validated by YAML parsing and by locally reproducing and diagnosing the stall
- [x] Documentation updated — inline comments explain why the key omits the Xcode version and why `repositories/` is pruned

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.