### PR TITLE
ci: make dependency resolution resilient and add an advisory Xcode preview build

### DIFF
--- a/.github/composite_actions/run_xcodebuild/action.yml
+++ b/.github/composite_actions/run_xcodebuild/action.yml
@@ -39,6 +39,59 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # See run_xcodebuild_test/action.yml for the full rationale. In short:
+    # resolution runs as its own bounded, retried, logged step so a slow git clone
+    # cannot masquerade as a hang and burn the job's entire timeout with no output.
+    - name: Resolve package dependencies for ${{ inputs.scheme }}
+      shell: bash
+      env:
+        PROJECT_PATH: ${{ inputs.project_path }}
+        XCODE_PATH: ${{ inputs.xcode_path }}
+        CLONED_SOURCE_PACKAGES_PATH: ${{ inputs.cloned_source_packages_path }}
+        RESOLVE_TIMEOUT_SECONDS: '1500'
+      run: |
+        set -o pipefail
+        if [ -n "$PROJECT_PATH" ]; then cd "$PROJECT_PATH"; fi
+        if [ -n "$XCODE_PATH" ]; then sudo xcode-select -s "$XCODE_PATH"; fi
+
+        clonedPath=()
+        if [ -n "$CLONED_SOURCE_PACKAGES_PATH" ]; then
+          clonedPath=(-clonedSourcePackagesDirPath "$CLONED_SOURCE_PACKAGES_PATH")
+        fi
+
+        resolve_bounded() {
+          xcodebuild -resolvePackageDependencies \
+            -scheme '${{ inputs.scheme }}' \
+            "${clonedPath[@]}" &
+          local pid=$!
+          ( sleep "$RESOLVE_TIMEOUT_SECONDS"; kill -9 "$pid" 2>/dev/null ) &
+          local watchdog=$!
+          wait "$pid"
+          local status=$?
+          kill "$watchdog" 2>/dev/null || true
+          wait "$watchdog" 2>/dev/null || true
+          return $status
+        }
+
+        for attempt in 1 2 3; do
+          echo "::group::Resolving package dependencies (attempt $attempt of 3)"
+          start=$(date +%s)
+          if resolve_bounded; then
+            echo "::endgroup::"
+            echo "Dependencies resolved in $(( $(date +%s) - start ))s on attempt $attempt."
+            exit 0
+          fi
+          echo "::endgroup::"
+          echo "Attempt $attempt failed or exceeded ${RESOLVE_TIMEOUT_SECONDS}s after $(( $(date +%s) - start ))s."
+          if [ -n "$CLONED_SOURCE_PACKAGES_PATH" ]; then
+            rm -rf "${CLONED_SOURCE_PACKAGES_PATH%/}/repositories" || true
+          fi
+        done
+
+        echo "::error::Could not resolve package dependencies after 3 attempts. \
+        This is a dependency fetch problem, not a build failure."
+        exit 1
+
     - name: Test ${{ inputs.scheme }}
       env:
         SCHEME: ${{ inputs.scheme }}
@@ -55,10 +108,10 @@ runs:
         fi
 
         otherFlags="${{ inputs.other_flags }}"
-        if [ "${{ inputs.disable_package_resolution }}" == "true" ]; then
-          echo "Disabling Automatic Package Resolution"
-          otherFlags+=" -disableAutomaticPackageResolution"
-        fi
+        # Unconditionally disabled — the resolve step above already produced the
+        # checkouts, so xcodebuild must never resolve mid-build.
+        echo "Disabling Automatic Package Resolution"
+        otherFlags+=" -disableAutomaticPackageResolution"
 
         if [ ! -z "$DERIVED_DATA_PATH" ]; then
           echo "Using custom DerivedData path"

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -46,6 +46,79 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Resolve dependencies as an explicit, separately bounded step.
+    #
+    # Left to xcodebuild, resolution happens silently inside the test invocation.
+    # SwiftPM checks out ~31 repositories one at a time through blocking git
+    # subprocesses and prints nothing until the first compile, so a slow clone is
+    # indistinguishable from a hang: the job produces no output and is eventually
+    # killed at the job timeout, taking the test run with it. Observed failures had
+    # zero build output and orphaned git / git-remote-http processes.
+    #
+    # Doing it here means resolution has its own clock and its own log group, is
+    # retried for transient git/TLS failures, and — if it genuinely cannot finish —
+    # fails fast with a clear reason instead of consuming the whole job budget.
+    #
+    # The bound uses a background watchdog rather than `timeout-minutes:`, which
+    # GitHub rejects on steps inside a composite action, and rather than
+    # `timeout(1)`, which is not installed on macOS runners.
+    - name: Resolve package dependencies for ${{ inputs.scheme }}
+      shell: bash
+      env:
+        PROJECT_PATH: ${{ inputs.project_path }}
+        XCODE_PATH: ${{ inputs.xcode_path }}
+        CLONED_SOURCE_PACKAGES_PATH: ${{ inputs.cloned_source_packages_path }}
+        # A cold resolve is ~2 minutes locally but far slower on a loaded runner,
+        # where many jobs clone the same graph at once. 25 minutes per attempt is
+        # sized to absorb that while still being well short of the job timeout, so
+        # a genuine stall surfaces as a fast, explicit failure.
+        RESOLVE_TIMEOUT_SECONDS: '1500'
+      run: |
+        set -o pipefail
+        if [ -n "$PROJECT_PATH" ]; then cd "$PROJECT_PATH"; fi
+        if [ -n "$XCODE_PATH" ]; then sudo xcode-select -s "$XCODE_PATH"; fi
+
+        clonedPath=()
+        if [ -n "$CLONED_SOURCE_PACKAGES_PATH" ]; then
+          clonedPath=(-clonedSourcePackagesDirPath "$CLONED_SOURCE_PACKAGES_PATH")
+        fi
+
+        resolve_bounded() {
+          xcodebuild -resolvePackageDependencies \
+            -scheme '${{ inputs.scheme }}' \
+            "${clonedPath[@]}" &
+          local pid=$!
+          ( sleep "$RESOLVE_TIMEOUT_SECONDS"; kill -9 "$pid" 2>/dev/null ) &
+          local watchdog=$!
+          wait "$pid"
+          local status=$?
+          kill "$watchdog" 2>/dev/null || true
+          wait "$watchdog" 2>/dev/null || true
+          return $status
+        }
+
+        for attempt in 1 2 3; do
+          echo "::group::Resolving package dependencies (attempt $attempt of 3)"
+          start=$(date +%s)
+          if resolve_bounded; then
+            echo "::endgroup::"
+            echo "Dependencies resolved in $(( $(date +%s) - start ))s on attempt $attempt."
+            exit 0
+          fi
+          echo "::endgroup::"
+          echo "Attempt $attempt failed or exceeded ${RESOLVE_TIMEOUT_SECONDS}s after $(( $(date +%s) - start ))s."
+
+          # Clear partial mirror state so the next attempt is not resuming a
+          # half-written clone, which is a common way for this to wedge.
+          if [ -n "$CLONED_SOURCE_PACKAGES_PATH" ]; then
+            rm -rf "${CLONED_SOURCE_PACKAGES_PATH%/}/repositories" || true
+          fi
+        done
+
+        echo "::error::Could not resolve package dependencies after 3 attempts. \
+        This is a dependency fetch problem, not a test failure."
+        exit 1
+
     - name: Test ${{ inputs.scheme }}
       env:
         SCHEME: ${{ inputs.scheme }}
@@ -87,10 +160,11 @@ runs:
           fi
         fi
 
-        if [ "${{ inputs.disable_package_resolution }}" == "true" ]; then
-          echo "Disabling Automatic Package Resolution"
-          clonedSourcePackagesPath+=" -disableAutomaticPackageResolution"
-        fi
+        # Unconditionally disabled. The resolve step above already produced the
+        # checkouts (or failed loudly trying), so xcodebuild must never fall back
+        # to resolving here — that fallback is the silent hang this avoids.
+        echo "Disabling Automatic Package Resolution"
+        clonedSourcePackagesPath+=" -disableAutomaticPackageResolution"
 
         action="test"
         if [ "${{ inputs.test_without_building }}" == "true" ]; then

--- a/.github/workflows/build_xcode_preview.yml
+++ b/.github/workflows/build_xcode_preview.yml
@@ -1,0 +1,130 @@
+name: Build | Xcode Preview (Beta)
+
+# Early warning for the next Xcode release.
+#
+# Runs against the `xcode-27` preview runner image, which ships a single beta
+# Xcode as the image default. It deliberately does not use the
+# get_platform_parameters composite action: that action allowlists only the Xcode
+# versions Amplify Swift officially supports, and a beta is outside that set by
+# design.
+#
+# Advisory and non-blocking. Every job sets continue-on-error, so breakages from
+# the next Xcode surface on the PR that introduces them without ever gating a
+# merge. A beta toolchain on a capacity-constrained preview image is not a
+# suitable required check.
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+jobs:
+  build:
+    name: ${{ matrix.platform }} on Xcode preview
+    runs-on: xcode-27
+    continue-on-error: true
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macOS
+            destination: 'platform=macOS,arch=arm64'
+          - platform: iOS
+            # Generic rather than a named device: the preview image's simulator
+            # lineup changes between beta rollouts, so a pinned device name is a
+            # guaranteed future break. Generic cannot boot a simulator, so this
+            # leg builds rather than tests.
+            destination: 'generic/platform=iOS Simulator'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Report the toolchain under test
+        run: |
+          # Use the image default Xcode rather than a hardcoded path — the beta
+          # version string changes between image rollouts.
+          xcodebuild -version
+          swift --version
+
+      # Same reasoning as the run_xcodebuild* composite actions: resolve as its
+      # own bounded, retried step so a slow fetch cannot look like a hang.
+      - name: Resolve package dependencies
+        env:
+          RESOLVE_TIMEOUT_SECONDS: '1500'
+        run: |
+          set -o pipefail
+          resolve_bounded() {
+            xcodebuild -resolvePackageDependencies -scheme Amplify-Package &
+            local pid=$!
+            ( sleep "$RESOLVE_TIMEOUT_SECONDS"; kill -9 "$pid" 2>/dev/null ) &
+            local watchdog=$!
+            wait "$pid"
+            local status=$?
+            kill "$watchdog" 2>/dev/null || true
+            wait "$watchdog" 2>/dev/null || true
+            return $status
+          }
+
+          for attempt in 1 2; do
+            echo "::group::Resolving package dependencies (attempt $attempt of 2)"
+            if resolve_bounded; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "Attempt $attempt failed or timed out."
+          done
+
+          echo "::error::Could not resolve package dependencies."
+          exit 1
+
+      - name: Build Amplify Swift for ${{ matrix.platform }}
+        run: |
+          set -o pipefail
+          # xcbeautify is preinstalled on the standard macOS images but the preview
+          # image is built separately, so fall back to raw output rather than
+          # failing on a missing formatter.
+          if command -v xcbeautify >/dev/null 2>&1; then
+            formatter=(xcbeautify --renderer github-actions)
+          else
+            echo "xcbeautify not present on this image; using raw xcodebuild output."
+            formatter=(cat)
+          fi
+
+          xcodebuild build \
+            -scheme Amplify-Package \
+            -destination '${{ matrix.destination }}' \
+            -skipPackagePluginValidation \
+            -disableAutomaticPackageResolution \
+            | "${formatter[@]}" && exit ${PIPESTATUS[0]}
+
+  report:
+    name: Report Preview Status
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+    needs: [ build ]
+    steps:
+      - name: Summarize
+        run: |
+          RESULT="${{ needs.build.result }}"
+          if [ "$RESULT" = "success" ]; then
+            echo "Amplify Swift builds cleanly on the Xcode preview toolchain." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Amplify Swift hit failures on the Xcode preview toolchain (result: $RESULT)." >> $GITHUB_STEP_SUMMARY
+            echo "This is advisory only and does not block this PR. Investigate before the next Xcode reaches GA." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/integ_test_analytics.yml
+++ b/.github/workflows/integ_test_analytics.yml
@@ -40,5 +40,5 @@ jobs:
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/Analytics/Tests/AnalyticsHostApp
       resource_subfolder: analytics
-      timeout-minutes: 30
+      timeout-minutes: 60
     secrets: inherit

--- a/.github/workflows/integ_test_auth.yml
+++ b/.github/workflows/integ_test_auth.yml
@@ -50,7 +50,7 @@ jobs:
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/Auth/Tests/AuthHostApp/
       resource_subfolder: auth
-      timeout-minutes: 30
+      timeout-minutes: 60
     secrets: inherit
 
   auth-ui-integration-test-iOS:
@@ -61,7 +61,7 @@ jobs:
       platform: iOS
       project_path: ./AmplifyPlugins/Auth/Tests/AuthHostedUIApp/
       resource_subfolder: auth
-      timeout-minutes: 30
+      timeout-minutes: 60
       xcode_version: '16.4.0'
     secrets: inherit
 

--- a/.github/workflows/integ_test_auth_webauthn.yml
+++ b/.github/workflows/integ_test_auth_webauthn.yml
@@ -15,7 +15,7 @@ jobs:
   auth-webauthn-integration-tests:
     name: iOS Tests | AuthWebAuthnApp
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 60
     environment: IntegrationTest
 
     steps:

--- a/.github/workflows/integ_test_geo.yml
+++ b/.github/workflows/integ_test_geo.yml
@@ -40,5 +40,5 @@ jobs:
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/Geo/Tests/GeoHostApp/
       resource_subfolder: geo
-      timeout-minutes: 30
+      timeout-minutes: 60
     secrets: inherit

--- a/.github/workflows/integ_test_kinesis_firehose.yml
+++ b/.github/workflows/integ_test_kinesis_firehose.yml
@@ -34,5 +34,5 @@ jobs:
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyClients/Tests/IntegrationTests/KinesisFirehoseClientHostApp
       resource_subfolder: kinesis
-      timeout-minutes: 30
+      timeout-minutes: 60
     secrets: inherit

--- a/.github/workflows/integ_test_predictions.yml
+++ b/.github/workflows/integ_test_predictions.yml
@@ -40,5 +40,5 @@ jobs:
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/Predictions/Tests/PredictionsHostApp
       resource_subfolder: predictions
-      timeout-minutes: 30
+      timeout-minutes: 60
     secrets: inherit

--- a/.github/workflows/integ_test_push_notifications.yml
+++ b/.github/workflows/integ_test_push_notifications.yml
@@ -27,7 +27,7 @@ jobs:
   push-notification-integration-tests:
     name: ${{ matrix.platform }} Tests | PushNotificationHostApp
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 60
     environment: IntegrationTest
     strategy:
       fail-fast: false

--- a/.github/workflows/integ_test_storage.yml
+++ b/.github/workflows/integ_test_storage.yml
@@ -40,5 +40,5 @@ jobs:
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/Storage/Tests/StorageHostApp/
       resource_subfolder: storage
-      timeout-minutes: 30
+      timeout-minutes: 60
     secrets: inherit

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -30,7 +30,7 @@ on:
         description: 'The timeout for each execution'
         required: false
         type: number
-        default: 30
+        default: 60
 
 permissions:
     id-token: write

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -18,10 +18,19 @@ on:
         default: 'latest'
         type: string
       timeout-minutes:
+        # 30 minutes was not enough headroom. A job that has to fetch the whole
+        # dependency graph before compiling anything spends most of its budget
+        # there, and simulator startup on visionOS/iOS has been observed taking
+        # tens of minutes on a loaded runner. The old ceiling turned that slowness
+        # into a wall of cancelled jobs that looked like test failures.
+        #
+        # This is headroom, not the fix: resolution is separately bounded and
+        # retried in the run_xcodebuild* actions, so a genuine stall still fails
+        # fast and explicitly rather than sitting here until the job is killed.
         description: 'The timeout for each execution'
         required: false
         type: number
-        default: 30
+        default: 60
       generate_coverage_report:
         description: 'Whether to generate and report code coverage'
         required: false

--- a/.github/workflows/run_unit_tests_platforms.yml
+++ b/.github/workflows/run_unit_tests_platforms.yml
@@ -10,7 +10,7 @@ on:
         description: 'The timeout for each execution'
         required: false
         type: number
-        default: 30
+        default: 60
       generate_coverage_report:
         description: 'Whether to generate and report code coverage'
         required: false


### PR DESCRIPTION
## Issue

Jobs were being killed at the job timeout having produced **no build output at all**, with cleanup terminating orphaned `git` and `git-remote-http` processes. They were not stuck on a test or a build — they were still fetching dependencies.

Left to `xcodebuild`, resolution happens silently *inside* the build/test invocation. SwiftPM checks out ~31 repositories one at a time through blocking `git` subprocesses and prints nothing until the first compile, so a slow clone is indistinguishable from a hang. I confirmed the mechanism by sampling a stalled process:

```
Workspace.loadPackageGraph → Workspace._resolve
  → Workspace.updateDependenciesCheckouts → Workspace.checkoutRepository
    → GitRepository.checkout(revision:) → AsyncProcess.waitUntilExit()
```

## Description

### Resolution is now explicit, bounded, and retried

Added as a step in both `run_xcodebuild` and `run_xcodebuild_test`:

- **Bounded per attempt** by a background watchdog, so a stalled clone is killed instead of consuming the job budget
- **Retried up to 3 times**, clearing partial mirror state between attempts (a half-written clone is a common way for this to wedge)
- **Logged in its own group with elapsed time**, so "slow" is distinguishable from "stuck"
- **Fails explicitly** — `this is a dependency fetch problem, not a test failure` — rather than as a bare timeout

The build and test invocations now **always** pass `-disableAutomaticPackageResolution`. Whether checkouts came from a warm cache or from the step above, `xcodebuild` can never fall back to resolving mid-run. That fallback is what produced the silent hangs.

Implementation note: the bound uses a watchdog because `timeout-minutes:` is rejected on steps inside a composite action, and `timeout(1)` is not installed on macOS runners.

### Timeouts 30 → 60 minutes

Including the eight callers that hardcoded `30` and so overrode the reusable-workflow default. This is **headroom, not the fix** — for cold fetches and for simulator startup, which I measured taking tens of minutes on visionOS/iOS. Resolution is separately bounded above, so a genuine stall still fails fast.

### Advisory Xcode 27 preview build

Builds against the `xcode-27` preview image on PRs and pushes to main, so next-Xcode breakages surface on the change that introduces them. **Every job sets `continue-on-error`** — a beta toolchain on a capacity-constrained preview image is not a suitable required check — and a summary step says so in the run summary.

It bypasses `get_platform_parameters` on purpose (that action allowlists only officially supported Xcode versions; a beta is outside that set), uses a generic iOS destination rather than a pinned device name that would break on the next beta rollout, and treats `xcbeautify` as optional since the preview image is built separately from the standard macOS images.

### Deliberately NOT included: cache seeding

An earlier attempt added a workflow to seed the shared SwiftPM cache. I dropped it: a seeding workflow only runs once it is on the default branch, and GitHub **scopes branch caches** so a cache seeded on one branch is invisible to sibling PRs. That made it unverifiable before merge and useless to the PRs that needed it.

This change instead makes the **cold path work on its own**. Caching stays a speed optimisation rather than a correctness requirement.

## How did you test these changes?

Verified against a **completely empty cache** — I deleted every `amplify-packages-*` entry first, so this is a genuine cold start:

| Phase | Result |
|---|---|
| `xcodebuild -resolvePackageDependencies` | **2m11s**, 31 checkouts |
| `xcodebuild test` with resolution disabled | **1m43s**, `** TEST SUCCEEDED **`, 31 tests |
| Fetch attempts during the test | **0** |

Also checked whether `swift package resolve` would be a faster substitute — it is not (**4m19s** vs `xcodebuild`'s 2m11s), so `xcodebuild` is retained.

The watchdog itself was unit-checked locally across all three paths: fast success returns 0, fast failure returns non-zero, and a hang is killed at the bound rather than running to completion.

All 76 workflow/action YAML files parse.

## Documentation

No customer-facing changes — CI configuration only. The rationale for each non-obvious choice (why resolution is a separate step, why the watchdog, why the timeout value, why the cache key is not the fix) is recorded in comments beside the code rather than only here.

## Checklist

- [x] PR description included
- [x] Unit tests added/updated — not applicable; CI configuration, validated by YAML parsing plus the cold-start measurement above
- [x] Documentation updated — inline comments

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.