### PR TITLE
chore(logging): add 'none' case to FlushStrategy

### DIFF
--- a/AmplifyClients/AmplifyCloudWatchClient/Sources/Domain/FlushStrategy.swift
+++ b/AmplifyClients/AmplifyCloudWatchClient/Sources/Domain/FlushStrategy.swift
@@ -12,4 +12,6 @@ import Foundation
 public enum FlushStrategy: Sendable {
     /// Automatically flush at a regular interval. Default is 60 seconds.
     case interval(TimeInterval = 60)
+    /// Disable automatic flushing. Log events are only sent when flushLogs() is called manually.
+    case none
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
NA

## Description
<!-- Why is this change required? What problem does it solve? -->
Add `.none` case to `FlushStrategy` to disable automatic flushing. Log events are only sent when flushLogs() is called manually.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
