### PR TITLE
fix(api): percent-encode semicolons in REST query parameter values

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/RESTOperationRequestUtils.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/RESTOperationRequestUtils.swift
@@ -35,8 +35,9 @@ final class RESTOperationRequestUtils {
 
         if let queryParameters {
             components.queryItems = prepareQueryParamsForSigning(params: queryParameters)
-            // `URLComponents` leaves `;` unencoded, so servers may treat it as a separator.
-            // Encode it — https://github.com/aws-amplify/amplify-swift/issues/3955
+            // `URLComponents` leaves `;` unencoded, but API Gateway treats it as a query
+            // parameter delimiter and drops everything after it, so encode it explicitly.
+            // https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-known-issues.html#api-gateway-known-issues-rest-apis
             if let percentEncodedQuery = components.percentEncodedQuery {
                 components.percentEncodedQuery = percentEncodedQuery.replacingOccurrences(of: ";", with: "%3B")
             }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/RESTOperationRequestUtils.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/RESTOperationRequestUtils.swift
@@ -35,6 +35,11 @@ final class RESTOperationRequestUtils {
 
         if let queryParameters {
             components.queryItems = prepareQueryParamsForSigning(params: queryParameters)
+            // `URLComponents` leaves `;` unencoded, so servers may treat it as a separator.
+            // Encode it — https://github.com/aws-amplify/amplify-swift/issues/3955
+            if let percentEncodedQuery = components.percentEncodedQuery {
+                components.percentEncodedQuery = percentEncodedQuery.replacingOccurrences(of: ";", with: "%3B")
+            }
         }
 
         guard let url = components.url else {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSRESTOperationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSRESTOperationTests.swift
@@ -120,6 +120,23 @@ class AWSRESTOperationTests: OperationTestBase {
         await fulfillment(of: [callbackInvoked, validated], timeout: 1.0)
     }
 
+    /// Asserts a `;` query value is percent-encoded on the outgoing request.
+    func testRESTGetPercentEncodesSemicolonInQueryValue() async throws {
+        let sentData = Data([0x00, 0x01, 0x02, 0x03])
+        try setUpPluginForSingleResponse(sending: sentData, for: .rest)
+
+        let validated = expectation(description: "Outgoing request query is validated")
+        try apiPlugin.add(interceptor: TestURLRequestInterceptor(validate: { request in
+            defer { validated.fulfill() }
+            return request.url?.query == "filter=X%3BY"
+        }), for: "Valid")
+
+        let callbackInvoked = expectation(description: "Callback was invoked")
+        let request = RESTRequest(apiName: "Valid", path: "/path", queryParameters: ["filter": "X;Y"])
+        _ = apiPlugin.get(request: request) { _ in callbackInvoked.fulfill() }
+        await fulfillment(of: [callbackInvoked, validated], timeout: 1.0)
+    }
+
 }
 
 private struct TestURLRequestInterceptor: URLRequestInterceptor {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/RESTRequestUtilsTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/RESTRequestUtilsTests.swift
@@ -119,6 +119,44 @@ class RESTRequestUtilsTests: XCTestCase {
             expected: queryParams
         )
     }
+
+    /// A `;` in a value must be percent-encoded so servers don't treat it as a separator.
+    func testConstructURLWithSemicolonInValue() throws {
+        let baseURL = URL(string: "https://aws.amazon.com")!
+        let queryParams = ["filter": "X;Y"]
+        let expected = ["filter": "X%3BY"]
+
+        let resultURL = try RESTOperationRequestUtils.constructURL(
+            for: baseURL,
+            withPath: "/items",
+            withParams: queryParams
+        )
+
+        try assertQueryParameters(
+            testCase: 0,
+            withURL: resultURL,
+            expected: expected
+        )
+    }
+
+    /// A pre-encoded `;` (`%3B`) must be preserved, not decoded and left bare.
+    func testConstructURLWithPreEncodedSemicolonInValue() throws {
+        let baseURL = URL(string: "https://aws.amazon.com")!
+        let queryParams = ["filter": "X%3BY"]
+        let expected = ["filter": "X%3BY"]
+
+        let resultURL = try RESTOperationRequestUtils.constructURL(
+            for: baseURL,
+            withPath: "/items",
+            withParams: queryParams
+        )
+
+        try assertQueryParameters(
+            testCase: 0,
+            withURL: resultURL,
+            expected: expected
+        )
+    }
 }
 
 extension RESTRequestUtilsTests {


### PR DESCRIPTION
## Description

`URLComponents` leaves `;` unencoded since it's a legal query sub-delimiter, but servers like API Gateway treat it as a separator, so a REST query value `"X;Y"` was truncated to `"X"`. This encodes `;` to `%3B` after the query is built so the value arrives intact.

## Testing

- Regression tests: `;` (raw and pre-encoded) percent-encoded in the URL and through the plugin request path. Both fail without the change.
- AWSAPIPlugin unit suite 227/227; `swiftformat`/`swiftlint` clean; builds on macOS and iOS.
- Couldn't run the REST integration tests locally since they need a provisioned AWS backend I don't have access to.

Fixes #3955
